### PR TITLE
refactor: Fix EcucModuleDef package structure

### DIFF
--- a/docs/requirements/deviation.md
+++ b/docs/requirements/deviation.md
@@ -5,12 +5,12 @@ and the actual Python implementation.
 
 ## Summary
 
-- ✓ **Match**: 68 classes correctly implemented
+- ✓ **Match**: 69 classes correctly implemented
 - ✗ **Missing**: 23 classes documented but not found
-- ⚠ **Path Mismatch**: 5 classes in wrong location
+- ⚠ **Path Mismatch**: 4 classes in wrong location
 - + **Extra**: 625 undocumented classes
 - **Total Documented Classes**: 96
-- **Total Deviations**: 653
+- **Total Deviations**: 652
 
 ## Deviations Table
 
@@ -23,7 +23,6 @@ and the actual Python implementation.
 | ✗ MISSING | M2: M2::AUTOSARTemplates::ECUCParameterDefTemplate::EcucDestinationUriDefSet<br>Expected: armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate.EcucDestinationUriDefSet<br>Actual: Not Found | Class EcucDestinationUriDefSet not found in source code |
 | ✗ MISSING | M2: M2::AUTOSARTemplates::ECUCParameterDefTemplate::EcucDestinationUriPolicy<br>Expected: armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate.EcucDestinationUriPolicy<br>Actual: Not Found | Class EcucDestinationUriPolicy not found in source code |
 | ✗ MISSING | M2: M2::AUTOSARTemplates::ECUCParameterDefTemplate::EcucLinkerSymbolDef<br>Expected: armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate.EcucLinkerSymbolDef<br>Actual: Not Found | Class EcucLinkerSymbolDef not found in source code |
-| ⚠ PATH_MISMATCH | M2: M2::AUTOSARTemplates::ECUCParameterDefTemplate::EcucModuleDef<br>Expected: armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate.EcucModuleDef<br>Actual: armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate.EcucModuleDef | Class exists but in different location |
 | ✗ MISSING | M2: M2::AUTOSARTemplates::ECUCParameterDefTemplate::EcucMultilineStringParamDef<br>Expected: armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate.EcucMultilineStringParamDef<br>Actual: Not Found | Class EcucMultilineStringParamDef not found in source code |
 | ✗ MISSING | M2: M2::AUTOSARTemplates::ECUCParameterDefTemplate::EcucParameterDerivationFormula<br>Expected: armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate.EcucParameterDerivationFormula<br>Actual: Not Found | Class EcucParameterDerivationFormula not found in source code |
 | ✗ MISSING | M2: M2::AUTOSARTemplates::ECUCParameterDefTemplate::EcucQuery<br>Expected: armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate.EcucQuery<br>Actual: Not Found | Class EcucQuery not found in source code |

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta
 from typing import List
 
-from ...M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucChoiceContainerDef, EcucContainerDef, EcucDefinitionElement, EcucParamConfContainerDef
+from ...M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucChoiceContainerDef, EcucContainerDef, EcucDefinitionElement, EcucModuleDef, EcucParamConfContainerDef
 from ...M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
 from ...M2.MSR.Documentation.Annotation import Annotation
 from ...M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import AnyInstanceRef
@@ -284,63 +284,3 @@ class EcucConditionSpecification(ARObject):
 class EcucConfigurationVariantEnum(AREnum):
     def __init__(self):
         super().__init__([])
-
-
-class EcucModuleDef(EcucDefinitionElement):
-    def __init__(self, parent: ARObject, short_name: str):
-        super().__init__(parent, short_name)
-
-        self.apiServicePrefix: CIdentifier = None
-        self.containers: List[EcucContainerDef] = []
-        self.postBuildVariantSupport: Boolean = None
-        self.refinedModuleDefRef: RefType = None
-        self.supportedConfigVariants: List[EcucConfigurationVariantEnum] = []
-
-    def getApiServicePrefix(self) -> CIdentifier:
-        return self.apiServicePrefix
-
-    def setApiServicePrefix(self, value: CIdentifier):
-        if value is not None:
-            self.apiServicePrefix = value
-        return self
-
-    def getContainers(self) -> List[EcucContainerDef]:
-        return self.containers
-
-    def createEcucParamConfContainerDef(self, short_name: str) -> EcucParamConfContainerDef:
-        if (not self.IsElementExists(short_name)):
-            container_def = EcucParamConfContainerDef(self, short_name)
-            self.addElement(container_def)
-            self.containers.append(container_def)
-        return self.getElement(short_name)
-    
-    def createEcucChoiceContainerDef(self, short_name: str) -> EcucChoiceContainerDef:
-        if (not self.IsElementExists(short_name)):
-            container_def = EcucChoiceContainerDef(self, short_name)
-            self.addElement(container_def)
-            self.containers.append(container_def)
-        return self.getElement(short_name)
-
-    def getPostBuildVariantSupport(self) -> Boolean:
-        return self.postBuildVariantSupport
-
-    def setPostBuildVariantSupport(self, value: Boolean):
-        if value is not None:
-            self.postBuildVariantSupport = value
-        return self
-
-    def getRefinedModuleDefRef(self) -> RefType:
-        return self.refinedModuleDefRef
-
-    def setRefinedModuleDefRef(self, value: RefType):
-        if value is not None:
-            self.refinedModuleDefRef = value
-        return self
-
-    def getSupportedConfigVariants(self) -> List[EcucConfigurationVariantEnum]:
-        return self.supportedConfigVariants
-
-    def addSupportedConfigVariant(self, value: EcucConfigurationVariantEnum):
-        if value is not None:
-            self.supportedConfigVariants.append(value)
-        return self

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta
 from typing import List
 
-from ....models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Boolean, Float, Identifier, Limit
+from ....models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Boolean, CIdentifier, Float, Identifier, Limit
 from ....models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger, RefType, UnlimitedInteger
 from ....models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RegularExpression, String, VerbatimString
 from ....models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
@@ -1247,3 +1247,64 @@ class EcucParamConfContainerDef(EcucContainerDef):
             self.addElement(container)
             self.subContainers.append(container)
         return self.getElement(short_name)
+
+
+class EcucModuleDef(EcucDefinitionElement):
+    def __init__(self, parent: ARObject, short_name: str):
+        super().__init__(parent, short_name)
+
+        self.apiServicePrefix: CIdentifier = None
+        self.containers: List[EcucContainerDef] = []
+        self.postBuildVariantSupport: Boolean = None
+        self.refinedModuleDefRef: RefType = None
+        self.supportedConfigVariants: List[EcucConfigurationVariantEnum] = []
+
+    def getApiServicePrefix(self) -> CIdentifier:
+        return self.apiServicePrefix
+
+    def setApiServicePrefix(self, value: CIdentifier):
+        if value is not None:
+            self.apiServicePrefix = value
+        return self
+
+    def getContainers(self) -> List[EcucContainerDef]:
+        return self.containers
+
+    def createEcucParamConfContainerDef(self, short_name: str) -> EcucParamConfContainerDef:
+        if (not self.IsElementExists(short_name)):
+            container_def = EcucParamConfContainerDef(self, short_name)
+            self.addElement(container_def)
+            self.containers.append(container_def)
+        return self.getElement(short_name)
+
+    def createEcucChoiceContainerDef(self, short_name: str) -> EcucChoiceContainerDef:
+        if (not self.IsElementExists(short_name)):
+            container_def = EcucChoiceContainerDef(self, short_name)
+            self.addElement(container_def)
+            self.containers.append(container_def)
+        return self.getElement(short_name)
+
+    def getPostBuildVariantSupport(self) -> Boolean:
+        return self.postBuildVariantSupport
+
+    def setPostBuildVariantSupport(self, value: Boolean):
+        if value is not None:
+            self.postBuildVariantSupport = value
+        return self
+
+    def getRefinedModuleDefRef(self) -> RefType:
+        return self.refinedModuleDefRef
+
+    def setRefinedModuleDefRef(self, value: RefType):
+        if value is not None:
+            self.refinedModuleDefRef = value
+        return self
+
+    def getSupportedConfigVariants(self) -> List[EcucConfigurationVariantEnum]:
+        return self.supportedConfigVariants
+
+    def addSupportedConfigVariant(self, value: EcucConfigurationVariantEnum):
+        if value is not None:
+            self.supportedConfigVariants.append(value)
+        return self
+

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
@@ -29,8 +29,9 @@ from .....M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintD
 from .....M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword import KeywordSet
 from .....M2.AUTOSARTemplates.CommonStructure.Timing.TimingConstraint.TimingExtensions import SwcTiming
 from .....M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticContribution import DiagnosticServiceTable
-from .....M2.AUTOSARTemplates.ECUCDescriptionTemplate import EcucModuleConfigurationValues, EcucModuleDef, EcucValueCollection
+from .....M2.AUTOSARTemplates.ECUCDescriptionTemplate import EcucModuleConfigurationValues, EcucValueCollection
 from .....M2.AUTOSARTemplates.EcuResourceTemplate import HwElement
+from .....M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucModuleDef
 from .....M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwCategory, HwType
 from .....M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from .....M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import Collection


### PR DESCRIPTION
## Summary

Move the `EcucModuleDef` class from `ECUCDescriptionTemplate.py` to `ECUCParameterDefTemplate.py` to align with the AUTOSAR M2 meta-model specification.

## Changes

- **Relocated `EcucModuleDef` class**: Moved from `ECUCDescriptionTemplate` to `ECUCParameterDefTemplate` module
- **Updated imports**: Fixed import statement in `ARPackage.py` to reference the correct module path
- **Updated documentation**: Revised deviation documentation to reflect corrected package structure

## Files Modified

- `src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate.py` - Removed `EcucModuleDef` class
- `src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py` - Added `EcucModuleDef` class
- `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py` - Updated import statement
- `docs/requirements/deviation.md` - Updated deviation statistics

## Test Coverage

✅ All quality checks passed:
- Ruff: No syntax errors
- Pytest: 2191 tests passed in 9.67s

## Requirements

N/A - This is a structural refactoring to align with AUTOSAR M2 meta-model specification.

## Impact

- Reduces path mismatches from 5 to 4 in deviation tracking
- Improves compliance with AUTOSAR M2 meta-model organization
- No functional changes - pure refactoring

Closes #277