### PR TITLE
refactor: Remove CollectableElement from Identifiable inheritance

### DIFF
--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_CommonStructure.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_CommonStructure.py
@@ -26,7 +26,6 @@ class Test_M2_AUTOSARTemplates_CommonStructure_Constants:
 
         assert (isinstance(spec, ARElement))
         assert (isinstance(spec, ARObject))
-        assert (isinstance(spec, CollectableElement))
         assert (isinstance(spec, Identifiable))
         assert (isinstance(spec, MultilanguageReferrable))
         assert (isinstance(spec, PackageableElement))

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/test_PortInterface.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/test_PortInterface.py
@@ -35,7 +35,6 @@ class Test_M2_AUTOSARTemplates_SWComponentTemplate_PortInterface:
 
         assert (isinstance(data_if, ARObject))
         assert (isinstance(data_if, AtpType))
-        assert (isinstance(data_if, CollectableElement))
         assert (isinstance(data_if, DataInterface))
         assert (isinstance(data_if, Identifiable))
         assert (isinstance(data_if, MultilanguageReferrable))
@@ -53,7 +52,6 @@ class Test_M2_AUTOSARTemplates_SWComponentTemplate_PortInterface:
 
         assert (isinstance(data_if, ARObject))
         assert (isinstance(data_if, AtpType))
-        assert (isinstance(data_if, CollectableElement))
         assert (isinstance(data_if, DataInterface))
         assert (isinstance(data_if, Identifiable))
         assert (isinstance(data_if, MultilanguageReferrable))
@@ -71,7 +69,6 @@ class Test_M2_AUTOSARTemplates_SWComponentTemplate_PortInterface:
 
         assert (isinstance(sr_if, ARObject))
         assert (isinstance(sr_if, AtpType))
-        assert (isinstance(sr_if, CollectableElement))
         assert (isinstance(sr_if, DataInterface))
         assert (isinstance(sr_if, Identifiable))
         assert (isinstance(sr_if, MultilanguageReferrable))
@@ -159,7 +156,6 @@ class Test_M2_AUTOSARTemplates_SWComponentTemplate_PortInterface:
         cs_if = ClientServerInterface(ar_root, "client_server_interface")
         assert (isinstance(cs_if, ARObject))
         assert (isinstance(cs_if, AtpType))
-        assert (isinstance(cs_if, CollectableElement))
         assert (isinstance(cs_if, Identifiable))
         assert (isinstance(cs_if, MultilanguageReferrable))
         assert (isinstance(cs_if, PortInterface))


### PR DESCRIPTION
## Summary

This pull request refactors the `Identifiable` class to remove `CollectableElement` from its multiple inheritance chain while preserving all collection functionality through direct method implementation.

## Changes

### Core Refactoring
- **Removed** `CollectableElement` from `Identifiable`'s inheritance
- **Changed** inheritance from `class Identifiable(MultilanguageReferrable, CollectableElement, ABC)` to `class Identifiable(MultilanguageReferrable, ABC)`
- **Added** collection methods directly to `Identifiable` class:
  - `getTotalElement()` - Returns total number of elements in collection
  - `removeElement()` - Removes an element from the collection
  - `getElements()` - Gets list of elements in the collection
  - `addElement()` - Adds an element to the collection
  - `getElement()` - Gets an element by short name and type
  - `IsElementExists()` - Checks if an element exists in the collection

### Test Updates
Updated tests to remove `isinstance(obj, CollectableElement)` checks since `Identifiable` no longer inherits from `CollectableElement`:
- `tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_CommonStructure.py`
- `tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/test_PortInterface.py`

## Files Modified

- `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py` (95 lines added)
- `tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_CommonStructure.py` (1 line removed)
- `tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/test_PortInterface.py` (4 lines removed)

## Test Coverage

✅ **All 2209 tests pass successfully**

Quality checks:
- ✅ Flake8: No syntax errors
- ✅ Pytest: 2209/2209 tests passed

## Benefits

- **Cleaner architecture**: Removes unnecessary multiple inheritance
- **Preserved functionality**: All collection methods still work through direct implementation in `Identifiable`
- **No breaking changes**: All tests pass, functionality is fully maintained
- **Better maintainability**: Single inheritance pattern is easier to understand and maintain

Closes #321