### PR TITLE
fix: Resolve UnicodeDecodeError in setup.py for Windows GBK encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 import sys
 import os
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
Fixes UnicodeDecodeError when running pip install on Windows with GBK encoding