### PR TITLE
fix: Relocate FlexrayChannelName, CommunicationDirectionType, and IPduSignalProcessingEnum enumerations to comply with CODING_RULE_STYLE_00008 and CODING_RULE_STYLE_00009

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DataMapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DataMapping.py
@@ -8,7 +8,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.InstanceRefs import Varia
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import TextTableMapping
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer, RefType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CommunicationDirectionType
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import CommunicationDirectionType
 
 
 class DataMapping(ARObject, ABC):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Flexray/FlexrayTopology.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Flexray/FlexrayTopology.py
@@ -1,8 +1,25 @@
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, Float, Integer, PositiveInteger
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveUnlimitedInteger, TimeValue
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CommunicationCluster, CommunicationConnector
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CommunicationController
+
+
+class FlexrayChannelName(AREnum):
+    """
+    Enumeration defining names for FlexRay channels,
+    specifying the available channel designations
+    in FlexRay communication systems.
+    """
+    CHANNEL_A = "channelA"
+    channel_B = "channelB"
+
+    def __init__(self):
+        super().__init__([
+            FlexrayChannelName.CHANNEL_A,
+            FlexrayChannelName.channel_B
+        ])
 
 
 class FlexrayCommunicationController(CommunicationController):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/__init__.py
@@ -1,12 +1,37 @@
 from abc import ABC
 from typing import List
+from enum import Enum
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Identifiable, Describable, PackageableElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, ARPositiveInteger, Boolean, ByteOrderEnum
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer, PositiveInteger, RefType, ARBoolean
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import TimeValue, UnlimitedInteger
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import TimeValue, UnlimitedInteger, AREnum
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication.Timing import TransmissionModeDeclaration
+
+
+class CommunicationDirectionType(AREnum):
+    """
+    Enumeration defining communication direction types,
+    specifying whether communication is inbound or outbound.
+    """
+    ENUM_IN = "in"
+    ENUM_OUT = "out"
+
+    def __init__(self):
+        super().__init__([
+            CommunicationDirectionType.ENUM_IN,
+            CommunicationDirectionType.ENUM_OUT
+        ])
+
+
+class IPduSignalProcessingEnum(Enum):
+    """
+    Enumeration defining types of IPDU signal processing,
+    specifying whether signal processing is deferred or immediate.
+    """
+    ENUM_DEFERRED = "deferred"
+    ENUM_IMMEDIATE = "immediate"
 
 
 class FibexElement(PackageableElement, ABC):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
@@ -16,8 +16,9 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommu
 if TYPE_CHECKING:
     from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetTopology import EthernetCommunicationConnector, EthernetCommunicationController
     from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import CanCommunicationConnector, CanCommunicationController
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology import FlexrayCommunicationConnector, FlexrayCommunicationController
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology import FlexrayCommunicationConnector, FlexrayCommunicationController, FlexrayChannelName
     from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import LinCommunicationConnector, LinMaster
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import CommunicationDirectionType, IPduSignalProcessingEnum
 
 
 class CommunicationCycle(ARObject, ABC):
@@ -280,22 +281,6 @@ class EthernetPhysicalChannel(PhysicalChannel):
         return self.getElement(short_name)
 
 
-class FlexrayChannelName(AREnum):
-    """
-    Enumeration defining names for FlexRay channels,
-    specifying the available channel designations
-    in FlexRay communication systems.
-    """
-    CHANNEL_A = "channelA"
-    channel_B = "channelB"
-
-    def __init__(self):
-        super().__init__([
-            FlexrayChannelName.CHANNEL_A,
-            FlexrayChannelName.channel_B
-        ])
-
-
 class FlexrayPhysicalChannel(PhysicalChannel):
     """
     Represents a FlexRay physical channel in the communication system,
@@ -305,7 +290,7 @@ class FlexrayPhysicalChannel(PhysicalChannel):
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.channelName = None                                     # type: FlexrayChannelName
+        self.channelName = None                                     # type: "FlexrayChannelName"
 
     def getChannelName(self):
         return self.channelName
@@ -558,21 +543,6 @@ class PncGatewayTypeEnum(AREnum):
         ])
 
 
-class CommunicationDirectionType(AREnum):
-    """
-    Enumeration defining communication direction types,
-    specifying whether communication is inbound or outbound.
-    """
-    ENUM_IN = "in"
-    ENUM_OUT = "out"
-
-    def __init__(self):
-        super().__init__([
-            CommunicationDirectionType.ENUM_IN,
-            CommunicationDirectionType.ENUM_OUT
-        ])
-
-
 class CommConnectorPort(Identifiable, ABC):
     """
     Abstract base class for communication connector ports,
@@ -605,15 +575,6 @@ class FramePort(CommConnectorPort):
         super().__init__(parent, short_name)
 
 
-class IPduSignalProcessingEnum(Enum):
-    """
-    Enumeration defining types of IPDU signal processing,
-    specifying whether signal processing is deferred or immediate.
-    """
-    ENUM_DEFERRED = "deferred"
-    ENUM_IMMEDIATE = "immediate"
-
-
 class IPduPort(CommConnectorPort):
     """
     Represents an IPDU port for communication connectors,
@@ -623,7 +584,7 @@ class IPduPort(CommConnectorPort):
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
         
-        self.iPduSignalProcessing: IPduSignalProcessingEnum = None
+        self.iPduSignalProcessing: "IPduSignalProcessingEnum" = None
         self.keyId: PositiveInteger = None
         self.rxSecurityVerification: Boolean = None
         self.timestampRxAcceptanceWindow: TimeValue = None

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreTopology.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreTopology.py
@@ -1,5 +1,7 @@
 import pytest
 
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology import FlexrayChannelName
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import CommunicationDirectionType, IPduSignalProcessingEnum
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import (
     CommunicationCycle,
     CycleCounter,
@@ -11,7 +13,6 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopol
     LinPhysicalChannel,
     VlanConfig,
     EthernetPhysicalChannel,
-    FlexrayChannelName,
     FlexrayPhysicalChannel,
     CommunicationCluster,
     CanClusterBusOffRecovery,
@@ -20,10 +21,8 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopol
     LinCluster,
     CommunicationController,
     PncGatewayTypeEnum,
-    CommunicationDirectionType,
     CommConnectorPort,
     FramePort,
-    IPduSignalProcessingEnum,
     IPduPort,
     ISignalPort,
     CommunicationConnector

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_DataMapping.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_DataMapping.py
@@ -12,7 +12,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DataMapping import (
     SenderReceiverToSignalGroupMapping
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CommunicationDirectionType
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import CommunicationDirectionType
 
 
 class Test_DataMapping:


### PR DESCRIPTION
## Summary

Relocates the `FlexrayChannelName`, `CommunicationDirectionType`, and `IPduSignalProcessingEnum` enumeration classes to comply with AUTOSAR mapping specification (CODING_RULE_STYLE_00009) and fixes package structure violations (CODING_RULE_STYLE_00008).

## Changes

### Class Relocation (CODING_RULE_STYLE_00009)

#### 1. FlexrayChannelName
- **Moved**: `FlexrayChannelName` from `FibexCore/CoreTopology.py` → `Fibex4Flexray/FlexrayTopology.py`
- **Rationale**: Per `docs/requirements/mapping.json`, `FlexrayChannelName` must be importable from `armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology`

#### 2. CommunicationDirectionType
- **Moved**: `CommunicationDirectionType` from `FibexCore/CoreTopology.py` → `FibexCore/CoreCommunication/__init__.py`
- **Rationale**: Per `docs/requirements/mapping.json`, `CommunicationDirectionType` must be importable from `armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication`

#### 3. IPduSignalProcessingEnum
- **Moved**: `IPduSignalProcessingEnum` from `FibexCore/CoreTopology.py` → `FibexCore/CoreCommunication/__init__.py`
- **Rationale**: Per `docs/requirements/mapping.json`, `IPduSignalProcessingEnum` must be importable from `armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication`

### Package Structure Fixes (CODING_RULE_STYLE_00008)
- **Removed**: Empty `FlexrayTopology/` directory (redundant with .py file)

### Import Updates
Updated 4 files to import enumerations from their new locations:
- `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DataMapping.py`
- `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py`
- `tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreTopology.py`
- `tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_DataMapping.py`

### Circular Import Resolution
**Problem**: Moving enumerations exposed circular dependencies between topology modules:
- `CoreTopology.py` ↔ `FlexrayTopology.py`
- `CoreTopology.py` ↔ `CoreCommunication/__init__.py`

**Solution**: Used `TYPE_CHECKING` and string type annotations to break circular dependencies
```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology import FlexrayChannelName
    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import CommunicationDirectionType, IPduSignalProcessingEnum

class FlexrayPhysicalChannel(PhysicalChannel):
    def __init__(self, parent: ARObject, short_name: str):
        super().__init__(parent, short_name)
        # String type annotations avoid circular imports
        self.channelName = None  # type: "FlexrayChannelName"

class IPduPort(CommConnectorPort):
    def __init__(self, parent: ARObject, short_name: str):
        super().__init__(parent, short_name)
        self.iPduSignalProcessing: "IPduSignalProcessingEnum" = None
```

## Files Modified

```
Modified:
  src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Flexray/FlexrayTopology.py
  src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/__init__.py
  src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
  src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DataMapping.py
  tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreTopology.py
  tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_DataMapping.py

Deleted:
  src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Flexray/FlexrayTopology/
```

## Test Coverage

- ✅ **All 2347 tests pass** (pytest)
- ✅ **FlexrayChannelName import successful** from new location
- ✅ **CommunicationDirectionType import successful** from new location
- ✅ **IPduSignalProcessingEnum import successful** from new location
- ✅ **Module locations verified**: 
  - `armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology`
  - `armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication`

## Compliance

### ✅ CODING_RULE_STYLE_00008: Python Package Structure
- Removed redundant empty directory alongside .py file
- Clean package structure without ambiguity

### ✅ CODING_RULE_STYLE_00009: Class Organization per AUTOSAR Mapping
- All three enumerations now in correct modules per `mapping.json`
- Enumerations importable from mapped locations

## Class Mapping Impact

**Before:**
- Verified Correct Location: 734 (37.9%)
- Wrong Location (Fixable): 50

**After:**
- Verified Correct Location: **737 (38.0%)** ⬆️ +3
- Wrong Location (Fixable): **47** ⬇️ -3

**Progress**: Fixed 7 of 54 class location violations (13.0% complete)

## Related Work

- PR #372: Fixed EcuInstance and SwcToEcuMapping class locations
- PR #373: Fixed ExternalTriggeringPointIdent and AtpBlueprintMapping class locations
- This PR: Fixes FlexrayChannelName, CommunicationDirectionType, and IPduSignalProcessingEnum enumeration locations

## Next Steps

Remaining violations to fix (47 classes):
- High Priority: EndToEndTransformationComSpecProps, RoleBasedDataTypeAssignment, SwServiceImplPolicyEnum
- Medium Priority: EthernetTopology (17 classes), CanTopology (5 classes), LinTopology (2 classes)
- Lower Priority: ARElement, PackageableElement, CollectableElement, FibexElement, AtpBlueprintable

## Quality Checks

| Check | Status | Details |
|-------|--------|---------|
| Flake8 | ✅ Pass | No critical errors in project code |
| Pytest | ✅ Pass | 2347 tests passed |
| Import | ✅ Pass | All three enumerations importable from correct locations |

🤖 Generated with [Claude Code](https://claude.com/claude-code)