### PR TITLE
fix(v2): Add missing imports to fix mypy errors

### DIFF
--- a/src/armodel/v2/models/utils/uuid_mgr.py
+++ b/src/armodel/v2/models/utils/uuid_mgr.py
@@ -1,4 +1,6 @@
 
+from typing import Dict, List
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )


### PR DESCRIPTION
Add missing imports in V2 models to resolve mypy name-defined errors.

## Changes

Fixed critical import errors in 4 files:
- `utils/uuid_mgr.py`: Add Dict, List imports
- `MSR/DataDictionary/Axis.py`: Add RefType, List, ARFloat, ARNumerical imports
- `MSR/Documentation/TextModel/BlockElements/PaginationAndView.py`: Add ChapterEnumBreak, KeepWithPreviousEnum imports
- `MSR/DataDictionary/CalibrationParameter.py`: Add ARFloat and enum imports

## Status

This fixes a subset of mypy errors. There are still approximately 2026 remaining mypy errors, mostly:
- Type annotation issues (None assigned to non-optional types)
- Missing imports in other files
- Type incompatibility issues

## Next Steps

This PR addresses the most critical import errors. Subsequent PRs will address:
- Remaining missing imports
- Type annotation improvements
- Optional type annotations where None is allowed