### PR TITLE
refactor: Add Union type import to V2 model typing statements

### DIFF
--- a/src/armodel/v2/models/M2/AUTOSARTemplates/EcuResourceTemplate/HwElementCategory.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/EcuResourceTemplate/HwElementCategory.py
@@ -4,8 +4,10 @@ in the EcuResourceTemplate module.
 """
 
 from typing import (
+    
     List,
     Optional,
+    Union
 )
 
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/EcuResourceTemplate/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/EcuResourceTemplate/__init__.py
@@ -7,8 +7,10 @@ and connections between hardware elements.
 """
 
 from typing import (
+    
     List,
     Optional,
+    Union
 )
 
 from armodel.v2.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import (

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/AbstractStructure.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/AbstractStructure.py
@@ -6,8 +6,10 @@ in the GenericStructure module.
 
 from abc import ABC
 from typing import (
+    
     List,
     Optional,
+    Union
 )
 
 from armodel.v2.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.AbstractBlueprintStructure import (

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
@@ -7,10 +7,12 @@ components, interfaces, data types, and other packages.
 """
 
 from typing import (
+    
     Any,
     Dict,
     List,
     Optional,
+    Union
 )
 
 from armodel.v2.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import (

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/AnyInstanceRef.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/AnyInstanceRef.py
@@ -4,8 +4,10 @@ in the GenericStructure module.
 """
 
 from typing import (
+    
     List,
     Optional,
+    Union
 )
 
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import (

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ArObject.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ArObject.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from typing import (
     Dict,
     Optional,
+    Union,
 )
 
 

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ElementCollection.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ElementCollection.py
@@ -5,9 +5,11 @@ in the GenericStructure module.
 
 from abc import ABC
 from typing import (
+    
     Dict,
     List,
     Optional,
+    Union
 )
 
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import (

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/EngineeringObject.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/EngineeringObject.py
@@ -5,8 +5,10 @@ in the GenericStructure module.
 
 from abc import ABC
 from typing import (
+    
     Any,
     Optional,
+    Union
 )
 
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py
@@ -5,10 +5,12 @@ in the GenericStructure module.
 
 from abc import ABC
 from typing import (
+    
     Any,
     Dict,
     List,
     Optional,
+    Union
 )
 
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/LifeCycles.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/LifeCycles.py
@@ -5,8 +5,10 @@ in the GenericStructure module.
 
 from datetime import datetime
 from typing import (
+    
     List,
     Optional,
+    Union
 )
 
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (


### PR DESCRIPTION
## Summary

This pull request adds the Union type to typing import statements across multiple V2 model files to support more flexible type annotations. The Union type is essential for representing optional or multiple possible types in type hints.

## Changes

- Added Union to typing imports in 10 V2 model files
- This enables proper type annotations for fields that can accept multiple types
- Part of ongoing V2 model type annotation improvements

## Files Modified

- src/armodel/v2/models/M2/AUTOSARTemplates/EcuResourceTemplate/HwElementCategory.py
- src/armodel/v2/models/M2/AUTOSARTemplates/EcuResourceTemplate/__init__.py
- src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/AbstractStructure.py
- src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
- src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/AnyInstanceRef.py
- src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ArObject.py
- src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ElementCollection.py
- src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/EngineeringObject.py
- src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py
- src/armodel/v2/models/M2/AUTOSARTemplates/GenericStructure/LifeCycles.py

## Test Coverage

The changes are minimal import additions that do not affect runtime behavior. Existing tests should continue to pass.

## Requirements

- Part of V2 model type annotation improvements
- Supports better type checking with mypy

Closes #401