### PR TITLE
refactor: Add Union type import to V2 model typing statements

### DIFF
--- a/src/armodel/v2/models/M2/AUTOSARTemplates/AdaptivePlatform/PlatformModuleDeployment/Firewall/FirewallRuleProps.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/AdaptivePlatform/PlatformModuleDeployment/Firewall/FirewallRuleProps.py
@@ -19,9 +19,9 @@ class FirewallRuleProps(ARObject):
         Initializes the FirewallRuleProps with default values.
         """
         super().__init__()
-        self.allowAny: bool = None
-        self.direction: str = None
-        self.protocol: str = None
+        self.allowAny: Union[bool, None] = None
+        self.direction: Union[str, None] = None
+        self.protocol: Union[str, None] = None
 
     def getAllowAny(self) -> bool:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/__init__.py
@@ -155,12 +155,12 @@ class AbstractAUTOSAR(CollectableElement):
         self.systems = {}                                   # type: Dict[str, System]
         self.compositionSwComponentTypes = {}               # type: Dict[str, CompositionSwComponentType]
 
-        self.rootSwCompositionPrototype = None              # type: RootSwCompositionPrototype
+        self.rootSwCompositionPrototype: Union[RootSwCompositionPrototype, None] = None
 
-        self.adminData = None                               # type: AdminData
+        self.adminData: Union[AdminData, None] = None
         self.arPackages = {}                                # type: Dict[str, ARPackage]
-        self.fileInfoComment = None                         # type: FileInfoComment
-        self.introduction = None                            # type: DocumentationBlock
+        self.fileInfoComment: Union[FileInfoComment, None] = None
+        self.introduction: Union[DocumentationBlock, None] = None
 
     def getElement(self, short_name: str) -> Referrable:
         if (short_name in self.arPackages):

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior.py
@@ -2399,7 +2399,7 @@ class BswSchedulerNamePrefix(ARObject):
         Initializes the BswSchedulerNamePrefix with default values.
         """
         super().__init__()
-        self.prefix: str = None
+        self.prefix: Union[str, None] = None
 
     def getPrefix(self):
         return self.prefix

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py
@@ -635,7 +635,7 @@ class BswEntryRelationship(ARObject):
         Initializes the BswEntryRelationship with default values.
         """
         super().__init__()
-        self.relationType: str = None
+        self.relationType: Union[str, None] = None
 
     def getRelationType(self):
         return self.relationType

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Constants/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Constants/__init__.py
@@ -581,7 +581,7 @@ class NotAvailableValueSpecification(ValueSpecification):
 
     def __init__(self) -> None:
         super().__init__()
-        self.reason: str = None
+        self.reason: Union[str, None] = None
 
     def getReason(self):
         return self.reason
@@ -628,7 +628,7 @@ class NumericalRuleBasedValueSpecification(AbstractRuleBasedValueSpecification):
 
     def __init__(self) -> None:
         super().__init__()
-        self.expression: str = None
+        self.expression: Union[str, None] = None
 
     def getExpression(self):
         return self.expression
@@ -688,7 +688,7 @@ class RuleBasedAxisCont(ARObject):
 
     def __init__(self) -> None:
         super().__init__()
-        self.axisId: str = None
+        self.axisId: Union[str, None] = None
 
     def getAxisId(self):
         return self.axisId
@@ -710,7 +710,7 @@ class RuleBasedValueCont(ARObject):
 
     def __init__(self) -> None:
         super().__init__()
-        self.value: str = None
+        self.value: Union[str, None] = None
 
     def getValue(self):
         return self.value
@@ -727,7 +727,7 @@ class RuleBasedValueSpecification(AbstractRuleBasedValueSpecification):
 
     def __init__(self) -> None:
         super().__init__()
-        self.rule: str = None
+        self.rule: Union[str, None] = None
 
     def getRule(self):
         return self.rule

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/FlatMap.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/FlatMap.py
@@ -225,7 +225,7 @@ class AliasNameAssignment(ARObject):
         Initializes the AliasNameAssignment with default values.
         """
         super().__init__()
-        self.aliasName: str = None
+        self.aliasName: Union[str, None] = None
         self.elementRef: Union[Union[AnyInstanceRef, None] , None] = None
 
     def getAliasName(self):
@@ -283,8 +283,8 @@ class RtePluginProps(ARObject):
         Initializes the RtePluginProps with default values.
         """
         super().__init__()
-        self.pluginName: str = None
-        self.pluginVersion: str = None
+        self.pluginName: Union[str, None] = None
+        self.pluginVersion: Union[str, None] = None
 
     def getPluginName(self):
         return self.pluginName

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Implementation.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Implementation.py
@@ -742,8 +742,8 @@ class Linker(ARObject):
         Initializes the Linker with default values.
         """
         super().__init__()
-        self.linkerName: str = None
-        self.linkerOptions: str = None
+        self.linkerName: Union[str, None] = None
+        self.linkerOptions: Union[str, None] = None
 
     def getLinkerName(self):
         return self.linkerName

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior.py
@@ -425,7 +425,7 @@ class ExclusiveAreaNestingOrder(ARObject):
         Initializes the ExclusiveAreaNestingOrder with default values.
         """
         super().__init__()
-        self.order: int = None
+        self.order: Union[int, None] = None
 
     def getOrder(self):
         return self.order
@@ -450,7 +450,7 @@ class ExecutableEntityActivationReason(ARObject):
         Initializes the ExecutableEntityActivationReason with default values.
         """
         super().__init__()
-        self.reason: str = None
+        self.reason: Union[str, None] = None
 
     def getReason(self):
         return self.reason

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/McGroups.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/McGroups.py
@@ -23,8 +23,8 @@ class McGroup(ARObject):
         Initializes the McGroup with default values.
         """
         super().__init__()
-        self.groupName: str = None
-        self.groupId: str = None
+        self.groupName: Union[str, None] = None
+        self.groupId: Union[str, None] = None
 
     def getGroupName(self):
         return self.groupName

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McDataAccessDetails.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McDataAccessDetails.py
@@ -19,8 +19,8 @@ class McDataAccessDetails(ARObject):
         Initializes the McDataAccessDetails with default values.
         """
         super().__init__()
-        self.accessType: str = None
-        self.address: str = None
+        self.accessType: Union[str, None] = None
+        self.address: Union[str, None] = None
 
     def getAccessType(self) -> str:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McFunction.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McFunction.py
@@ -25,7 +25,7 @@ class McFunction(ARObject):
         """
         super().__init__()
         self.dataRefs: List[RefType] = []
-        self.functionName: str = None
+        self.functionName: Union[str, None] = None
 
     def addDataRef(self, ref: RefType):
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McSwEmulationMethodSupport.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McSwEmulationMethodSupport.py
@@ -19,7 +19,7 @@ class McSwEmulationMethodSupport(ARObject):
         Initializes the McSwEmulationMethodSupport with default values.
         """
         super().__init__()
-        self.emulationMethodName: str = None
+        self.emulationMethodName: Union[str, None] = None
 
     def getEmulationMethodName(self) -> str:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RoleBasedMcDataAssignment.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RoleBasedMcDataAssignment.py
@@ -25,7 +25,7 @@ class RoleBasedMcDataAssignment(ARObject):
         """
         super().__init__()
         self.dataRef: Union[Union[RefType, None] , None] = None
-        self.role: str = None
+        self.role: Union[str, None] = None
 
     def getDataRef(self) -> RefType:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RptSupport/RptComponent.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RptSupport/RptComponent.py
@@ -19,8 +19,8 @@ class RptComponent(ARObject):
         Initializes the RptComponent with default values.
         """
         super().__init__()
-        self.componentRef: str = None
-        self.portRef: str = None
+        self.componentRef: Union[str, None] = None
+        self.portRef: Union[str, None] = None
 
     def getComponentRef(self) -> str:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/ModeDeclaration.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/ModeDeclaration.py
@@ -373,7 +373,7 @@ class ModeDeclarationGroupPrototype(AtpPrototype):
         super().__init__(parent, short_name)
 
         # Private storage for software calibration access setting
-        self._swCalibrationAccess: str = None
+        self._swCalibrationAccess: Union[str, None] = None
         # Type reference to the mode declaration group
         self.typeTRef: Union[Union[TRefType, None] , None] = None
 
@@ -467,7 +467,7 @@ class ModeErrorBehavior(ARObject):
         Initializes the ModeErrorBehavior with default values.
         """
         super().__init__()
-        self.errorPolicy: str = None
+        self.errorPolicy: Union[str, None] = None
 
     def getErrorPolicy(self):
         return self.errorPolicy

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/ExecutionTime/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/ExecutionTime/__init__.py
@@ -78,7 +78,7 @@ class MeasuredExecutionTime(ARObject):
     def __init__(self) -> None:
         super().__init__()
         self.executionTime: Union[Union[TimeValue, None] , None] = None
-        self.sampleSize: int = None
+        self.sampleSize: Union[int, None] = None
 
     def getExecutionTime(self):
         return self.executionTime
@@ -107,7 +107,7 @@ class MemorySectionLocation(ARObject):
 
     def __init__(self) -> None:
         super().__init__()
-        self.sectionName: str = None
+        self.sectionName: Union[str, None] = None
 
     def getSectionName(self):
         return self.sectionName
@@ -130,7 +130,7 @@ class RoughEstimateOfExecutionTime(ARObject):
     def __init__(self) -> None:
         super().__init__()
         self.executionTime: Union[Union[TimeValue, None] , None] = None
-        self.confidenceLevel: str = None
+        self.confidenceLevel: Union[str, None] = None
 
     def getExecutionTime(self):
         return self.executionTime
@@ -160,7 +160,7 @@ class SimulatedExecutionTime(ARObject):
     def __init__(self) -> None:
         super().__init__()
         self.executionTime: Union[Union[TimeValue, None] , None] = None
-        self.simulationModel: str = None
+        self.simulationModel: Union[str, None] = None
 
     def getExecutionTime(self):
         return self.executionTime

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/HeapUsage.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/HeapUsage.py
@@ -40,7 +40,7 @@ class MeasuredHeapUsage(HeapUsage):
 
     def __init__(self) -> None:
         super().__init__()
-        self.sampleSize: int = None
+        self.sampleSize: Union[int, None] = None
 
     def getSampleSize(self):
         return self.sampleSize
@@ -57,7 +57,7 @@ class RoughEstimateHeapUsage(HeapUsage):
 
     def __init__(self) -> None:
         super().__init__()
-        self.confidenceLevel: str = None
+        self.confidenceLevel: Union[str, None] = None
 
     def getConfidenceLevel(self):
         return self.confidenceLevel
@@ -74,7 +74,7 @@ class WorstCaseHeapUsage(HeapUsage):
 
     def __init__(self) -> None:
         super().__init__()
-        self.confidenceLevel: str = None
+        self.confidenceLevel: Union[str, None] = None
 
     def getConfidenceLevel(self):
         return self.confidenceLevel

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/MemorySectionUsage.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/MemorySectionUsage.py
@@ -228,7 +228,7 @@ class SectionNamePrefix(ARObject):
         Initializes the SectionNamePrefix with default values.
         """
         super().__init__()
-        self.prefix: str = None
+        self.prefix: Union[str, None] = None
 
     def getPrefix(self) -> str:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/SignalServiceTranslation/SignalServiceTranslationElementProps.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/SignalServiceTranslation/SignalServiceTranslationElementProps.py
@@ -19,7 +19,7 @@ class SignalServiceTranslationElementProps(ARObject):
         Initializes the SignalServiceTranslationElementProps with default values.
         """
         super().__init__()
-        self.elementRef: str = None
+        self.elementRef: Union[str, None] = None
 
     def getElementRef(self) -> str:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/SignalServiceTranslation/SignalServiceTranslationEventProps.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/SignalServiceTranslation/SignalServiceTranslationEventProps.py
@@ -19,7 +19,7 @@ class SignalServiceTranslationEventProps(ARObject):
         Initializes the SignalServiceTranslationEventProps with default values.
         """
         super().__init__()
-        self.eventRef: str = None
+        self.eventRef: Union[str, None] = None
 
     def getEventRef(self) -> str:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py
@@ -19,7 +19,7 @@ class BlueprintGenerator(ARObject):
         Initializes the BlueprintGenerator with default values.
         """
         super().__init__()
-        self.generatorName: str = None
+        self.generatorName: Union[str, None] = None
 
     def getGeneratorName(self) -> str:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingClock/TimingClock.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingClock/TimingClock.py
@@ -19,8 +19,8 @@ class TimingClock(ARObject):
         Initializes the TimingClock with default values.
         """
         super().__init__()
-        self.clockName: str = None
-        self.clockType: str = None
+        self.clockName: Union[str, None] = None
+        self.clockType: Union[str, None] = None
 
     def getClockName(self) -> str:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingClock/TimingClockSyncAccuracy.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingClock/TimingClockSyncAccuracy.py
@@ -19,8 +19,8 @@ class TimingClockSyncAccuracy(ARObject):
         Initializes the TimingClockSyncAccuracy with default values.
         """
         super().__init__()
-        self.accuracy: str = None
-        self.unit: str = None
+        self.accuracy: Union[str, None] = None
+        self.unit: Union[str, None] = None
 
     def getAccuracy(self) -> str:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingCondition.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingCondition.py
@@ -21,7 +21,7 @@ class TimingCondition(ARObject):
         Initializes the TimingCondition with default values.
         """
         super().__init__()
-        self.conditionFormula: str = None
+        self.conditionFormula: Union[str, None] = None
         self.modeInstances: List[str] = []
 
     def getConditionFormula(self) -> str:

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingConditionFormula.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingConditionFormula.py
@@ -19,7 +19,7 @@ class TimingConditionFormula(ARObject):
         Initializes the TimingConditionFormula with default values.
         """
         super().__init__()
-        self.expression: str = None
+        self.expression: Union[str, None] = None
 
     def getExpression(self) -> str:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingExtensionResource.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingExtensionResource.py
@@ -19,8 +19,8 @@ class TimingExtensionResource(ARObject):
         Initializes the TimingExtensionResource with default values.
         """
         super().__init__()
-        self.resourceName: str = None
-        self.resourceType: str = None
+        self.resourceName: Union[str, None] = None
+        self.resourceType: Union[str, None] = None
 
     def getResourceName(self) -> str:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingModeInstance.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingModeInstance.py
@@ -25,7 +25,7 @@ class TimingModeInstance(ARObject):
         """
         super().__init__()
         self.modeRef: Union[Union[RefType, None] , None] = None
-        self.modeValue: str = None
+        self.modeValue: Union[str, None] = None
 
     def getModeRef(self) -> RefType:
         """

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/EventTriggeringConstraint.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/EventTriggeringConstraint.py
@@ -132,7 +132,7 @@ class BurstPatternEventTriggering(EventTriggeringConstraint):
         super().__init__(parent, short_name)
 
         # Number of events in burst
-        self.burst_size: int = None
+        self.burst_size: Union[int, None] = None
         # Burst interval
         self.burst_interval: Union[Union[TimeValue, None] , None] = None
 

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate/__init__.py
@@ -62,8 +62,8 @@ class EcucParameterValue(EcucIndexableValue, ABC):
         super().__init__()
 
         self.annotations = []                       # type: List[Annotation]
-        self.definitionRef = None                   # type: RefType
-        self.isAutoValue = None                     # type: ARBoolean
+        self.definitionRef: Union[RefType, None] = None
+        self.isAutoValue: Union[ARBoolean, None] = None
 
     def getAnnotations(self) -> List[Annotation]:
         return self.annotations
@@ -91,7 +91,7 @@ class EcucAddInfoParamValue(EcucParameterValue):
     def __init__(self) -> None:
         super().__init__()
 
-        self.value = None                           # type: DocumentationBlock
+        self.value: Union[DocumentationBlock, None] = None
 
     def getValue(self) -> DocumentationBlock:
         return self.value
@@ -104,7 +104,7 @@ class EcucTextualParamValue(EcucParameterValue):
     def __init__(self) -> None:
         super().__init__()
 
-        self.value = None                           # type: ARLiteral
+        self.value: Union[ARLiteral, None] = None
 
     def getValue(self) -> ARLiteral:
         return self.value
@@ -117,7 +117,7 @@ class EcucNumericalParamValue(EcucParameterValue):
     def __init__(self) -> None:
         super().__init__()
 
-        self.value = None                           # type: ARNumerical
+        self.value: Union[ARNumerical, None] = None
 
     def getValue(self) -> ARNumerical:
         return self.value
@@ -134,8 +134,8 @@ class EcucAbstractReferenceValue(EcucIndexableValue, ABC):
         super().__init__()
 
         self.annotations = []                       # type: List[Annotation]
-        self.definitionRef = None                   # type: RefType
-        self.isAutoValue = None                     # type: ARBoolean
+        self.definitionRef: Union[RefType, None] = None
+        self.isAutoValue: Union[ARBoolean, None] = None
 
     def getAnnotations(self) -> List[Annotation]:
         return self.annotations
@@ -163,7 +163,7 @@ class EcucInstanceReferenceValue(EcucAbstractReferenceValue):
     def __init__(self) -> None:
         super().__init__()
 
-        self.valueIRef = None        # type: AnyInstanceRef
+        self.valueIRef: Union[AnyInstanceRef, None] = None
 
     def getValueIRef(self) -> AnyInstanceRef:
         return self.valueRef
@@ -177,7 +177,7 @@ class EcucReferenceValue(EcucAbstractReferenceValue):
     def __init__(self) -> None:
         super().__init__()
 
-        self.valueRef = None        # type: RefType
+        self.valueRef: Union[RefType, None] = None
 
     def getValueRef(self) -> RefType:
         return self.valueRef
@@ -191,7 +191,7 @@ class EcucContainerValue(Identifiable, EcucIndexableValue):
     def __init__(self, parent: ARObject, short_name: str) -> None:
         Identifiable.__init__(self, parent, short_name)
 
-        self.definitionRef = None                   # type: RefType
+        self.definitionRef: Union[RefType, None] = None
         self.parameterValues = []                   # type: List[EcucParameterValue]
         self.referenceValues = []                   # type: List[EcucAbstractReferenceValue]
         self.subContainers = []                     # type: List[EcucContainerValue]
@@ -233,11 +233,11 @@ class EcucModuleConfigurationValues(ARElement):
         super().__init__(parent, short_name)
 
         self.containers = []                        # type: List[EcucContainerValue]
-        self.definitionRef = None                   # type: RefType
-        self.ecucDefEdition = None                  # type: ARLiteral
-        self.implementationConfigVariant = None     # type: ARLiteral
-        self.moduleDescriptionRef = None            # type: RefType
-        self.postBuildVariantUsed = None            # type: ARBoolean
+        self.definitionRef: Union[RefType, None] = None
+        self.ecucDefEdition: Union[ARLiteral, None] = None
+        self.implementationConfigVariant: Union[ARLiteral, None] = None
+        self.moduleDescriptionRef: Union[RefType, None] = None
+        self.postBuildVariantUsed: Union[ARBoolean, None] = None
 
     def createContainer(self, short_name: str) -> EcucContainerValue:
         if not self.IsElementExists(short_name):

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/Communication/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/Communication/__init__.py
@@ -118,7 +118,7 @@ class TransmissionAcknowledgementRequest(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.timeout: float = None
+        self.timeout: Union[float, None] = None
 
 
 class SenderComSpec(PPortComSpec, ABC):
@@ -131,7 +131,7 @@ class SenderComSpec(PPortComSpec, ABC):
         self.compositeNetworkRepresentations: List[CompositeNetworkRepresentation] = []
         self.dataElementRef: Union[Union[RefType, None] , None] = None
         self.networkRepresentation: Union[Union[SwDataDefProps, None] , None] = None
-        self.handleOutOfRange: str = None
+        self.handleOutOfRange: Union[str, None] = None
         self.transmissionAcknowledge: Union[Union[TransmissionAcknowledgementRequest, None] , None] = None
         self.usesEndToEndProtection: Union[Union[ARBoolean, None] , None] = None
 
@@ -294,13 +294,13 @@ class ReceiverComSpec(RPortComSpec, ABC):
         super().__init__()
 
         self.compositeNetworkRepresentations = []                            # type: List[CompositeNetworkRepresentation]
-        self.dataElementRef = None                                           # type: RefType
-        self.networkRepresentation = None                                    # type: SwDataDefProps
-        self.handleOutOfRange = None                                         # type: HandleOutOfRangeEnum
-        self.handleOutOfRangeStatus = None                                   # type: HandleOutOfRangeStatusEnum
-        self.maxDeltaCounterInit = None                                      # type: PositiveInteger
-        self.maxNoNewOrRepeatedData = None                                   # type: PositiveInteger
-        self.usesEndToEndProtection = None                                   # type: ARBoolean
+        self.dataElementRef: Union[RefType, None] = None
+        self.networkRepresentation: Union[SwDataDefProps, None] = None
+        self.handleOutOfRange: Union[HandleOutOfRangeEnum, None] = None
+        self.handleOutOfRangeStatus: Union[HandleOutOfRangeStatusEnum, None] = None
+        self.maxDeltaCounterInit: Union[PositiveInteger, None] = None
+        self.maxNoNewOrRepeatedData: Union[PositiveInteger, None] = None
+        self.usesEndToEndProtection: Union[ARBoolean, None] = None
 
     def getDataElementRef(self):
         return self.dataElementRef

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
@@ -188,7 +188,7 @@ class PPortPrototype(AbstractProvidedPortPrototype):
     def __init__(self, parent: ARObject, short_name: str) -> None:
         super().__init__(parent, short_name)
 
-        self.providedInterfaceTRef = None           # type: TRefType
+        self.providedInterfaceTRef: Union[TRefType, None] = None
 
     def getProvidedInterfaceTRef(self):
         return self.providedInterfaceTRef
@@ -202,8 +202,8 @@ class RPortPrototype(AbstractRequiredPortPrototype):
     def __init__(self, parent: ARObject, short_name: str) -> None:
         super().__init__(parent, short_name)
 
-        self.mayBeUnconnected = None                # type: ARBoolean
-        self.requiredInterfaceTRef = None           # type: TRefType
+        self.mayBeUnconnected: Union[ARBoolean, None] = None
+        self.requiredInterfaceTRef: Union[TRefType, None] = None
 
     def getMayBeUnconnected(self):
         return self.mayBeUnconnected
@@ -226,7 +226,7 @@ class PRPortPrototype(PortPrototype):
 
         self.providedComSpecs = []                          # type: List[PPortComSpec]
         self.requiredComSpecs = []                          # type: List[RPortComSpec]
-        self.providedRequiredInterface = None               # type: TRefType
+        self.providedRequiredInterface: Union[TRefType, None] = None
 
     def getProvidedComSpecs(self):
         return self.providedComSpecs

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/Composition/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/Composition/__init__.py
@@ -25,7 +25,7 @@ class SwComponentPrototype(AtpPrototype):
     def __init__(self, parent: ARObject, short_name: str) -> None:
         super().__init__(parent, short_name)
 
-        self.typeTRef = None                       # type: RefType
+        self.typeTRef: Union[RefType, None] = None
 
     def getTypeTRef(self) -> RefType:
         return self.typeTRef

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/EndToEndProtection/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/EndToEndProtection/__init__.py
@@ -42,7 +42,7 @@ class EndToEndDescription(ARObject):
         self.dataIdNibbleOffset: Union[Union[PositiveInteger, None] , None] = None
         self.dataLength: Union[Union[PositiveInteger, None] , None] = None
         self.maxDeltaCounterInit: Union[Union[PositiveInteger, None] , None] = None
-        self.maxNoNewOrRepeatedData: int = None
+        self.maxNoNewOrRepeatedData: Union[int, None] = None
         self.syncCounterInit: Union[Union[PositiveInteger, None] , None] = None
 
     def getCategory(self):
@@ -128,7 +128,7 @@ class EndToEndProtectionVariablePrototype(ARObject):
 
         self._receiverIRefs: List[VariableDataPrototypeInSystemInstanceRef] = []
         self.senderIRef: Union[Union[VariableDataPrototypeInSystemInstanceRef, None] , None] = None
-        self.shortLabel: str = None
+        self.shortLabel: Union[str, None] = None
 
     def addReceiverIref(self, iref: VariableDataPrototypeInSystemInstanceRef):
         self._receiverIRefs.append(iref)

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/IncludedDataTypes.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/IncludedDataTypes.py
@@ -24,7 +24,7 @@ class IncludedDataTypeSet(ARObject):
         super().__init__()
 
         self.data_type_refs = []            # type: List[RefType]
-        self.literal_prefix = None          # type: ARLiteral
+        self.literal_prefix: Union[ARLiteral, None] = None
 
     def addDataTypeRef(self, ref_type: RefType):
         self.data_type_refs.append(ref_type)

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ServerCall.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ServerCall.py
@@ -24,7 +24,7 @@ class ServerCallPoint(AbstractAccessPoint, ABC):
         super().__init__(parent, short_name)
 
         self.operationIRef: 'ROperationInAtomicSwcInstanceRef' = None
-        self.timeout: float = None
+        self.timeout: Union[float, None] = None
 
     def getOperationIRef(self):
         return self.operationIRef
@@ -51,7 +51,7 @@ class SynchronousServerCallPoint(ServerCallPoint):
         super().__init__(parent, short_name)
 
         self.calledFromWithinExclusiveAreaRef = None
-        self.timeout: float = None
+        self.timeout: Union[float, None] = None
 
     def getCalledFromWithinExclusiveAreaRef(self):
         return self.calledFromWithinExclusiveAreaRef

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/__init__.py
@@ -80,7 +80,7 @@ class SwcInternalBehavior(InternalBehavior):
         self.events = []                                            # type: List[RTEEvent]
         self.exclusiveAreaPolicies = []                             # type: List[SwcExclusiveAreaPolicy]
         self.explicitInterRunnableVariables = []                    # type: List[VariableDataPrototype]
-        self.handleTerminationAndRestart = None                     # type: str
+        self.handleTerminationAndRestart: Union[str, None] = None
         self.implicitInterRunnableVariables = []                    # type: List[VariableDataPrototype]
         self.includedDataTypeSets = []                              # type: List[IncludedDataTypeSet]
         self.includedModeDeclarationGroupSets = []                  # type: List[IncludedModeDeclarationGroupSet]
@@ -91,7 +91,7 @@ class SwcInternalBehavior(InternalBehavior):
         self.runnables = []                                         # type: List[RunnableEntity]
         self.serviceDependencies = []                               # type: List[SwcServiceDependency]
         self.sharedParameters = []                                  # type: List[ParameterDataPrototype]
-        self.supportsMultipleInstantiation = None                   # type: Boolean
+        self.supportsMultipleInstantiation: Union[Boolean, None] = None
         self.variationPointProxies = []                             # type: List[VariationPointProxy]
 
     def getArTypedPerInstanceMemories(self) -> List[VariableDataPrototype]:

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/ECUResourceMapping.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/ECUResourceMapping.py
@@ -13,8 +13,8 @@ class ECUMapping(Identifiable):
         super().__init__(parent, short_name)
 
         self.commControllerMappings = []                                # type: List[CommunicationControllerMapping]
-        self.ecuRef = None                                              # type: RefType
-        self.ecuInstanceRef = None                                      # type: RefType
+        self.ecuRef: Union[RefType, None] = None
+        self.ecuInstanceRef: Union[RefType, None] = None
         self.hwPortMappings = []                                        # type: List[HwPortMapping]
 
     def getCommControllerMappings(self):

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetCommunication.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetCommunication.py
@@ -216,7 +216,7 @@ class SocketConnectionBundle(Referrable):
         self.pathMtuDiscoveryEnabled: Union[Union[Boolean, None] , None] = None
         self.pdus: List[SocketConnectionIpduIdentifier] = []
         self.serverPortRef: Union[Union[RefType, None] , None] = None
-        self.udpChecksumHandling = None                                                           # type: UdpChecksumCalculationEnum
+        self.udpChecksumHandling: Union[UdpChecksumCalculationEnum, None] = None
 
     def getBundledConnections(self):
         return self.bundledConnections
@@ -276,7 +276,7 @@ class SoAdRoutingGroup(FibexElement):
     def __init__(self, parent: ARObject, short_name: str) -> None:
         super().__init__(parent, short_name)
 
-        self.eventGroupControlType = None     # type: EventGroupControlTypeEnum
+        self.eventGroupControlType: Union[EventGroupControlTypeEnum, None] = None
 
     def getEventGroupControlType(self):
         return self.eventGroupControlType

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology.py
@@ -23,7 +23,7 @@ class MacMulticastGroup(Identifiable):
     def __init__(self, parent, short_name) -> None:
         super().__init__(parent, short_name)
 
-        self.macMulticastAddress = None                                     # type: MacAddressString
+        self.macMulticastAddress: Union[MacAddressString, None] = None
 
     def getMacMulticastAddress(self):
         return self.macMulticastAddress
@@ -44,8 +44,8 @@ class EthernetCluster(CommunicationCluster):
         super().__init__(parent, short_name)
 
         self.couplingPorts = []                                             # type: List[CouplingPortConnection]
-        self.couplingPortStartupActiveTime = None                           # type: TimeValue
-        self.couplingPortSwitchoffDelay = None                              # type: TimeValue
+        self.couplingPortStartupActiveTime: Union[TimeValue, None] = None
+        self.couplingPortSwitchoffDelay: Union[TimeValue, None] = None
         self.macMulticastGroups = []                                        # type: List[MacMulticastGroup]
 
     def getCouplingPorts(self):
@@ -106,9 +106,9 @@ class CouplingPortFifo(CouplingPortStructuralElement):
         super().__init__(parent, short_name)
 
         self.assignedTrafficClasses = []                            # type: List[PositiveInteger]
-        self.minimumFifoLength = None                               # type: PositiveInteger
-        self.shaper = None                                          # type: CouplingPortAbstractShaper
-        self.trafficClassPreemptionSupport = None                   # type: EthernetCouplingPortPreemptionEnum
+        self.minimumFifoLength: Union[PositiveInteger, None] = None
+        self.shaper: Union[CouplingPortAbstractShaper, None] = None
+        self.trafficClassPreemptionSupport: Union[EthernetCouplingPortPreemptionEnum, None] = None
 
     def getAssignedTrafficClasses(self):
         return self.assignedTrafficClasses
@@ -152,7 +152,7 @@ class CouplingPortScheduler(CouplingPortStructuralElement):
     def __init__(self, parent, short_name) -> None:
         super().__init__(parent, short_name)
 
-        self.portScheduler = None                                   # type: EthernetCouplingPortSchedulerEnum
+        self.portScheduler: Union[EthernetCouplingPortSchedulerEnum, None] = None
         self.predecessorRefs = []                                   # type: List[RefType]
 
     def getPortScheduler(self):
@@ -181,8 +181,8 @@ class EthernetPriorityRegeneration(Referrable):
     def __init__(self, parent, short_name) -> None:
         super().__init__(parent, short_name)
 
-        self.ingressPriority = None                                 # type: PositiveInteger
-        self.regeneratedPriority = None                             # type: PositiveInteger
+        self.ingressPriority: Union[PositiveInteger, None] = None
+        self.regeneratedPriority: Union[PositiveInteger, None] = None
 
     def getIngressPriority(self):
         return self.ingressPriority
@@ -216,12 +216,12 @@ class CouplingPortDetails(ARObject):
         super().__init__()
 
         self.couplingPortStructuralElements = []                    # type: List[CouplingPortStructuralElement]
-        self.defaultTrafficClass = None                             # type: PositiveInteger
+        self.defaultTrafficClass: Union[PositiveInteger, None] = None
         self.ethernetPriorityRegenerations = []                     # type: List[EthernetPriorityRegeneration]
         self.ethernetTrafficClassAssignments = []                   # type: List[CouplingPortTrafficClassAssignment]
-        self.framePreemptionSupport = None                          # type: Boolean
-        self.globalTimeProps = None                                 # type: GlobalTimeCouplingPortProps
-        self.lastEgressSchedulerRef = None                          # type: RefType
+        self.framePreemptionSupport: Union[Boolean, None] = None
+        self.globalTimeProps: Union[GlobalTimeCouplingPortProps, None] = None
+        self.lastEgressSchedulerRef: Union[RefType, None] = None
         self.ratePolicies = []                                      # type: List[CouplingPortRatePolicy]
         self.vlanTranslationTables = []                             # type: List[EthernetVlanTranslationTable]
 
@@ -322,10 +322,10 @@ class VlanMembership(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.defaultPriority = None                                 # type: PositiveInteger
-        self.dhcpAddressAssignment = None                           # type: DhcpServerConfiguration
-        self.sendActivity = None                                    # type: EthernetSwitchVlanEgressTaggingEnum
-        self.vlanRef = None                                         # type: RefType
+        self.defaultPriority: Union[PositiveInteger, None] = None
+        self.dhcpAddressAssignment: Union[DhcpServerConfiguration, None] = None
+        self.sendActivity: Union[EthernetSwitchVlanEgressTaggingEnum, None] = None
+        self.vlanRef: Union[RefType, None] = None
 
     def getDefaultPriority(self):
         return self.defaultPriority
@@ -369,20 +369,20 @@ class CouplingPort(Identifiable):
     def __init__(self, parent, short_name) -> None:
         super().__init__(parent, short_name)
 
-        self.connectionNegotiationBehavior = None                   # type: EthernetConnectionNegotiationEnum
-        self.couplingPortDetails = None                             # type: CouplingPortDetails
-        self.couplingPortRole = None                                # type: CouplingPortRoleEnum
-        self.defaultVlanRef = None                                  # type: RefType
+        self.connectionNegotiationBehavior: Union[EthernetConnectionNegotiationEnum, None] = None
+        self.couplingPortDetails: Union[CouplingPortDetails, None] = None
+        self.couplingPortRole: Union[CouplingPortRoleEnum, None] = None
+        self.defaultVlanRef: Union[RefType, None] = None
         self.macAddressVlanAssignments = []                         # type: List[MacAddressVlanMembership]
-        self.macLayerType = None                                    # type: EthernetMacLayerTypeEnum
+        self.macLayerType: Union[EthernetMacLayerTypeEnum, None] = None
         self.macMulticastAddressRefs = []                           # type: List[RefType]
         self.macSecProps = []                                       # type: List[MacSecProps]
-        self.physicalLayerType = None                               # type: EthernetPhysicalLayerTypeEnum
-        self.plcaProps = None                                       # type: PlcaProps
+        self.physicalLayerType: Union[EthernetPhysicalLayerTypeEnum, None] = None
+        self.plcaProps: Union[PlcaProps, None] = None
         self.pncMappingRefs = []                                    # type: List[RefType]
-        self.receiveActivity = None                                 # type: EthernetSwitchVlanIngressTagEnum
+        self.receiveActivity: Union[EthernetSwitchVlanIngressTagEnum, None] = None
         self.vlanMemberships = []                                   # type: List[VlanMembership]
-        self.wakeupSleepOnDatalineConfigRef = None                  # type: RefType
+        self.wakeupSleepOnDatalineConfigRef: Union[RefType, None] = None
 
     def getConnectionNegotiationBehavior(self):
         return self.connectionNegotiationBehavior
@@ -506,14 +506,14 @@ class EthernetCommunicationController(CommunicationController):
     def __init__(self, parent: ARObject, short_name: str) -> None:
         super().__init__(parent, short_name)
 
-        self.canXlConfigRef = None                          # type: RefType
+        self.canXlConfigRef: Union[RefType, None] = None
         self.couplingPorts = []                             # type: List[CouplingPort]
-        self.macLayerType = None                            # type: EthernetMacLayerTypeEnum
-        self.macUnicastAddress = None                       # type: MacAddressString
-        self.maximumReceiveBufferLength = None              # type: Integer
-        self.maximumTransmitBufferLength = None             # type: Integer
-        self.slaveActAsPassiveCommunicationSlave = None     # type: Boolean
-        self.slaveQualifiedUnexpectedLinkDownTime = None    # type: TimeValue
+        self.macLayerType: Union[EthernetMacLayerTypeEnum, None] = None
+        self.macUnicastAddress: Union[MacAddressString, None] = None
+        self.maximumReceiveBufferLength: Union[Integer, None] = None
+        self.maximumTransmitBufferLength: Union[Integer, None] = None
+        self.slaveActAsPassiveCommunicationSlave: Union[Boolean, None] = None
+        self.slaveQualifiedUnexpectedLinkDownTime: Union[TimeValue, None] = None
 
     def getCanXlConfigRef(self):
         return self.canXlConfigRef
@@ -584,12 +584,12 @@ class EthernetCommunicationConnector(CommunicationConnector):
     def __init__(self, parent: ARObject, short_name: str) -> None:
         super().__init__(parent, short_name)
 
-        self.ethIpPropsRef = None                               # type: RefType
-        self.maximumTransmissionUnit = None                     # type: PositiveInteger
-        self.neighborCacheSize = None                           # type: PositiveInteger
+        self.ethIpPropsRef: Union[RefType, None] = None
+        self.maximumTransmissionUnit: Union[PositiveInteger, None] = None
+        self.neighborCacheSize: Union[PositiveInteger, None] = None
         self.networkEndpointRefs = []                           # type: List[RefType]       ## 4.3.1 Version
-        self.pathMtuEnabled = None                              # type: Boolean
-        self.pathMtuTimeout = None                              # type: TimeValue
+        self.pathMtuEnabled: Union[Boolean, None] = None
+        self.pathMtuTimeout: Union[TimeValue, None] = None
 
     def getEthIpPropsRef(self):
         return self.ethIpPropsRef
@@ -649,8 +649,8 @@ class RequestResponseDelay(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.maxValue = None                                        # type: TimeValue
-        self.minValue = None                                        # type: TimeValue
+        self.maxValue: Union[TimeValue, None] = None
+        self.minValue: Union[TimeValue, None] = None
 
     def getMaxValue(self):
         return self.maxValue
@@ -683,10 +683,10 @@ class InitialSdDelayConfig(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.initialDelayMaxValue = None                            # type: TimeValue
-        self.initialDelayMinValue = None                            # type: TimeValue
-        self.initialRepetitionsBaseDelay = None                     # type: TimeValue
-        self.initialRepetitionsMax = None                           # type: PositiveInteger
+        self.initialDelayMaxValue: Union[TimeValue, None] = None
+        self.initialDelayMinValue: Union[TimeValue, None] = None
+        self.initialRepetitionsBaseDelay: Union[TimeValue, None] = None
+        self.initialRepetitionsMax: Union[PositiveInteger, None] = None
 
     def getInitialDelayMaxValue(self):
         return self.initialDelayMaxValue
@@ -735,12 +735,12 @@ class SdClientConfig(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.capabilityRecord = None                                # type: TagWithOptionalValue
-        self.clientServiceMajorVersion = None                       # type: PositiveInteger
-        self.clientServiceMinorVersion = None                       # type: PositiveInteger
-        self.initialFindBehavior = None                             # type: InitialSdDelayConfig
-        self.requestResponseDelay = None                            # type: RequestResponseDelay
-        self.ttl = None                                             # type: PositiveInteger
+        self.capabilityRecord: Union[TagWithOptionalValue, None] = None
+        self.clientServiceMajorVersion: Union[PositiveInteger, None] = None
+        self.clientServiceMinorVersion: Union[PositiveInteger, None] = None
+        self.initialFindBehavior: Union[InitialSdDelayConfig, None] = None
+        self.requestResponseDelay: Union[RequestResponseDelay, None] = None
+        self.ttl: Union[PositiveInteger, None] = None
 
     def getClientServiceMajorVersion(self):
         return self.clientServiceMajorVersion

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/NetworkEndpoint.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/NetworkEndpoint.py
@@ -203,7 +203,7 @@ class DoIpEntity(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.doIpEntityRole = None                                  # type: DoIpEntityRoleEnum
+        self.doIpEntityRole: Union[DoIpEntityRoleEnum, None] = None
 
     def getDoIpEntityRole(self):
         return self.doIpEntityRole
@@ -228,7 +228,7 @@ class TimeSyncClientConfiguration(ARObject):
         super().__init__()
 
         self.orderedMasters = []
-        self.timeSyncTechnology = None                              # type: TimeSyncTechnologyEnum
+        self.timeSyncTechnology: Union[TimeSyncTechnologyEnum, None] = None
 
     def getOrderedMasters(self):
         return self.orderedMasters
@@ -259,7 +259,7 @@ class TimeSyncServerConfiguration(Referrable):
         self.priority: Union[Union[PositiveInteger, None] , None] = None
         self.syncInterval: Union[Union[TimeValue, None] , None] = None
         self.timeSyncServerIdentifier: Union[Union[String, None] , None] = None
-        self.timeSyncTechnology = None                              # type: TimeSyncTechnologyEnum
+        self.timeSyncTechnology: Union[TimeSyncTechnologyEnum, None] = None
 
     def getPriority(self):
         return self.priority

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances.py
@@ -212,8 +212,8 @@ class AbstractServiceInstance(Identifiable, ABC):
         super().__init__(parent, short_name)
 
         self.capabilityRecords = []                                     # type: List[TagWithOptionalValue]
-        self.majorVersion = None                                        # type: PositiveInteger
-        self.methodActivationRoutingGroup = None                        # type: PduActivationRoutingGroup
+        self.majorVersion: Union[PositiveInteger, None] = None
+        self.methodActivationRoutingGroup: Union[PduActivationRoutingGroup, None] = None
         self.routingGroupRefs = []                                      # type: List[RefType]
 
     def getCapabilityRecords(self):
@@ -545,12 +545,12 @@ class SdServerConfig(ARObject):
         super().__init__()
 
         self.capabilityRecords = []                                     # type: List[TagWithOptionalValue]
-        self.initialOfferBehavior = None                                # type: InitialSdDelayConfig
-        self.offerCyclicDelay = None                                    # type: TimeValue
-        self.requestResponseDelay = None                                # type: RequestResponseDelay
-        self.serverServiceMajorVersion = None                           # type: PositiveInteger
-        self.serverServiceMinorVersion = None                           # type: PositiveInteger
-        self.ttl = None                                                 # type: PositiveInteger
+        self.initialOfferBehavior: Union[InitialSdDelayConfig, None] = None
+        self.offerCyclicDelay: Union[TimeValue, None] = None
+        self.requestResponseDelay: Union[RequestResponseDelay, None] = None
+        self.serverServiceMajorVersion: Union[PositiveInteger, None] = None
+        self.serverServiceMinorVersion: Union[PositiveInteger, None] = None
+        self.ttl: Union[PositiveInteger, None] = None
 
     def getCapabilityRecords(self):
         return self.capabilityRecords

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Flexray/FlexrayTopology.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Flexray/FlexrayTopology.py
@@ -382,41 +382,41 @@ class FlexrayCluster(CommunicationCluster):
     def __init__(self, parent: ARObject, short_name: str) -> None:
         super().__init__(parent, short_name)
 
-        self.actionPointOffset = None                       # type: Integer
-        self.bit = None                                     # type: TimeValue
-        self.casRxLowMax = None                             # type: Integer
-        self.coldStartAttempts = None                       # type: Integer
-        self.cycle = None                                   # type: TimeValue
-        self.cycleCountMax = None                           # type: Integer
-        self.detectNitError = None                          # type: Boolean
-        self.dynamicSlotIdlePhase = None                    # type: Integer
-        self.ignoreAfterTx = None                           # type: Integer
-        self.listenNoise = None                             # type: Integer
-        self.macroPerCycle = None                           # type: Integer
-        self.macrotickDuration = None                       # type: TimeValue
-        self.maxWithoutClockCorrectionFatal = None          # type: Integer
-        self.maxWithoutClockCorrectionPassive = None        # type: Integer
-        self.minislotActionPointOffset = None               # type: Integer
-        self.minislotDuration = None                        # type: Integer
-        self.networkIdleTime = None                         # type: Integer
-        self.networkManagementVectorLength = None           # type: Integer
-        self.numberOfMinislots = None                       # type: Integer
-        self.numberOfStaticSlots = None                     # type: Integer
-        self.offsetCorrectionStart = None                   # type: Integer
-        self.payloadLengthStatic = None                     # type: Integer
-        self.safetyMargin = None                            # type: Integer
-        self.sampleClockPeriod = None                       # type: TimeValue
-        self.staticSlotDuration = None                      # type: Integer
-        self.symbolWindow = None                            # type: Integer
-        self.symbolWindowActionPointOffset = None           # type: Integer
-        self.syncFrameIdCountMax = None                     # type: Integer
-        self.tranceiverStandbyDelay = None                  # type: Float
-        self.transmissionStartSequenceDuration = None       # type: Integer
-        self.wakeupRxIdle = None                            # type: Integer
-        self.wakeupRxLow = None                             # type: Integer
-        self.wakeupRxWindow = None                          # type: Integer
-        self.wakeupTxActive = None                          # type: Integer
-        self.wakeupTxIdle = None                            # type: Integer
+        self.actionPointOffset: Union[Integer, None] = None
+        self.bit: Union[TimeValue, None] = None
+        self.casRxLowMax: Union[Integer, None] = None
+        self.coldStartAttempts: Union[Integer, None] = None
+        self.cycle: Union[TimeValue, None] = None
+        self.cycleCountMax: Union[Integer, None] = None
+        self.detectNitError: Union[Boolean, None] = None
+        self.dynamicSlotIdlePhase: Union[Integer, None] = None
+        self.ignoreAfterTx: Union[Integer, None] = None
+        self.listenNoise: Union[Integer, None] = None
+        self.macroPerCycle: Union[Integer, None] = None
+        self.macrotickDuration: Union[TimeValue, None] = None
+        self.maxWithoutClockCorrectionFatal: Union[Integer, None] = None
+        self.maxWithoutClockCorrectionPassive: Union[Integer, None] = None
+        self.minislotActionPointOffset: Union[Integer, None] = None
+        self.minislotDuration: Union[Integer, None] = None
+        self.networkIdleTime: Union[Integer, None] = None
+        self.networkManagementVectorLength: Union[Integer, None] = None
+        self.numberOfMinislots: Union[Integer, None] = None
+        self.numberOfStaticSlots: Union[Integer, None] = None
+        self.offsetCorrectionStart: Union[Integer, None] = None
+        self.payloadLengthStatic: Union[Integer, None] = None
+        self.safetyMargin: Union[Integer, None] = None
+        self.sampleClockPeriod: Union[TimeValue, None] = None
+        self.staticSlotDuration: Union[Integer, None] = None
+        self.symbolWindow: Union[Integer, None] = None
+        self.symbolWindowActionPointOffset: Union[Integer, None] = None
+        self.syncFrameIdCountMax: Union[Integer, None] = None
+        self.tranceiverStandbyDelay: Union[Float, None] = None
+        self.transmissionStartSequenceDuration: Union[Integer, None] = None
+        self.wakeupRxIdle: Union[Integer, None] = None
+        self.wakeupRxLow: Union[Integer, None] = None
+        self.wakeupRxWindow: Union[Integer, None] = None
+        self.wakeupTxActive: Union[Integer, None] = None
+        self.wakeupTxIdle: Union[Integer, None] = None
 
     def getActionPointOffset(self):
         return self.actionPointOffset

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Lin/LinCommunication.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Lin/LinCommunication.py
@@ -98,7 +98,7 @@ class ScheduleTableEntry(ARObject, ABC):
         super().__init__()
 
         self.delay: Union[Union[TimeValue, None] , None] = None
-        self.introduction = None                                # type: DocumentationBlock
+        self.introduction: Union[DocumentationBlock, None] = None
         self.positionInTable: Union[Union[Integer, None] , None] = None
 
     def getDelay(self):
@@ -178,8 +178,8 @@ class LinScheduleTable(Identifiable):
     def __init__(self, parent, short_name) -> None:
         super().__init__(parent, short_name)
 
-        self.resumePosition = None                              # type: ResumePosition
-        self.runMode = None                                     # type: RunMode
+        self.resumePosition: Union[ResumePosition, None] = None
+        self.runMode: Union[RunMode, None] = None
         self.tableEntries: List[ScheduleTableEntry] = []
 
     def getResumePosition(self):

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/__init__.py
@@ -1128,7 +1128,7 @@ class StaticPart(MultiplexedPart):
     def __init__(self) -> None:
         super().__init__()
 
-        self.iPduRef = None                                         # type: RefType
+        self.iPduRef: Union[RefType, None] = None
 
     def getIPduRef(self):
         return self.iPduRef
@@ -1153,9 +1153,9 @@ class DynamicPartAlternative(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.initialDynamicPart = None                              # type: Boolean
-        self.iPduRef = None                                         # type: RefType
-        self.selectorFieldCode = None                               # type: Integer
+        self.initialDynamicPart: Union[Boolean, None] = None
+        self.iPduRef: Union[RefType, None] = None
+        self.selectorFieldCode: Union[Integer, None] = None
 
     def getInitialDynamicPart(self):
         return self.initialDynamicPart
@@ -1211,13 +1211,13 @@ class MultiplexedIPdu(IPdu):
     def __init__(self, parent, short_name) -> None:
         super().__init__(parent, short_name)
 
-        self.dynamicPart = None                                     # type: DynamicPart
-        self.selectorFieldByteOrder = None                          # type: ByteOrderEnum
-        self.selectorFieldLength = None                             # type: Integer
-        self.selectorFieldStartPosition = None                      # type: Integer
-        self.staticPart = None                                      # type: StaticPart
-        self.triggerMode = None                                     # type: TriggerMode
-        self.unusedBitPattern = None                                # type: Integer
+        self.dynamicPart: Union[DynamicPart, None] = None
+        self.selectorFieldByteOrder: Union[ByteOrderEnum, None] = None
+        self.selectorFieldLength: Union[Integer, None] = None
+        self.selectorFieldStartPosition: Union[Integer, None] = None
+        self.staticPart: Union[StaticPart, None] = None
+        self.triggerMode: Union[TriggerMode, None] = None
+        self.unusedBitPattern: Union[Integer, None] = None
 
     def getDynamicPart(self):
         return self.dynamicPart

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
@@ -309,7 +309,7 @@ class FlexrayPhysicalChannel(PhysicalChannel):
     def __init__(self, parent: ARObject, short_name: str) -> None:
         super().__init__(parent, short_name)
 
-        self.channelName = None                                     # type: "FlexrayChannelName"
+        self.channelName: Union["FlexrayChannelName", None] = None
 
     def getChannelName(self):
         return self.channelName
@@ -333,10 +333,10 @@ class CommunicationCluster(FibexElement, ABC):
 
         super().__init__(parent, short_name)
 
-        self.baudrate = None                    # type: ARFloat
+        self.baudrate: Union[ARFloat, None] = None
         self.physicalChannel: List[PhysicalChannel] = []
-        self.protocolName = None                # type: ARLiteral
-        self.protocolVersion = None             # type: ARLiteral
+        self.protocolName: Union[ARLiteral, None] = None
+        self.protocolVersion: Union[ARLiteral, None] = None
 
     def getBaudrate(self):
         return self.baudrate

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
@@ -525,7 +525,7 @@ class NmCluster(Identifiable, ABC):
             raise TypeError("NmCluster is an abstract class.")
         super().__init__(parent, short_name)
 
-        self.communicationClusterRef = None                              # type: RefType
+        self.communicationClusterRef: Union[RefType, None] = None
         self.nmChannelId = None
         self.nmChannelSleepMaster = None
         self.nmNodes = []                                                 # type: List[NmNode]

--- a/src/armodel/v2/models/M2/MSR/AsamHdo/BaseTypes.py
+++ b/src/armodel/v2/models/M2/MSR/AsamHdo/BaseTypes.py
@@ -34,11 +34,11 @@ class BaseTypeDirectDefinition(BaseTypeDefinition):
     def __init__(self) -> None:
         super().__init__()
 
-        self.baseTypeEncoding: str = None
+        self.baseTypeEncoding: Union[str, None] = None
         self.baseTypeSize: Union[Union[ARNumerical, None] , None] = None
         self.byteOrder: Union[Union[ByteOrderEnum, None] , None] = None
         self.memAlignment: Union[Union[ARNumerical, None] , None] = None
-        self.nativeDeclaration: str = None
+        self.nativeDeclaration: Union[str, None] = None
 
     def getBaseTypeEncoding(self):
         return self.baseTypeEncoding

--- a/src/armodel/v2/models/M2/MSR/AsamHdo/ComputationMethod.py
+++ b/src/armodel/v2/models/M2/MSR/AsamHdo/ComputationMethod.py
@@ -109,7 +109,7 @@ class CompuConstTextContent(CompuConstContent):
     def __init__(self) -> None:
         super().__init__()
 
-        self.vt: str = None
+        self.vt: Union[str, None] = None
 
     def getVt(self) -> str:
         return self.vt
@@ -126,7 +126,7 @@ class CompuConstNumericContent(CompuConstContent):
     def __init__(self) -> None:
         super().__init__()
 
-        self.v: float = None
+        self.v: Union[float, None] = None
 
     def getV(self) -> float:
         return self.v
@@ -143,7 +143,7 @@ class CompuConstFormulaContent(CompuConstContent):
     def __init__(self) -> None:
         super().__init__()
 
-        self.vf: str = None
+        self.vf: Union[str, None] = None
 
     def getVf(self) -> str:
         return self.vf
@@ -371,7 +371,7 @@ class CompuMethod(AtpBlueprintable):
 
         self.compuInternalToPhys: Union[Union[Compu, None] , None] = None
         self.compuPhysToInternal: Union[Union[Compu, None] , None] = None
-        self.displayFormat: str = None
+        self.displayFormat: Union[str, None] = None
         self.unitRef: Union[Union[RefType, None] , None] = None
 
     def getCompuInternalToPhys(self) -> Compu:

--- a/src/armodel/v2/models/M2/MSR/CalibrationData/CalibrationValue.py
+++ b/src/armodel/v2/models/M2/MSR/CalibrationData/CalibrationValue.py
@@ -18,7 +18,7 @@ class SwValues(ARObject):
         super().__init__()
 
         self._v = []                    # type: List[ARNumerical]
-        self.vt = None                  # type: float
+        self.vt: Union[float, None] = None
 
     def addV(self, v: ARNumerical):
         self._v.append(v)
@@ -36,10 +36,10 @@ class SwValueCont(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.swArraysize = None             # type: ValueList
-        self.swValuesPhys = None            # type: SwValues
-        self.unitRef = None                 # type: RefType
-        self.unitDisplayName = None         # type: SingleLanguageUnitNames
+        self.swArraysize: Union[ValueList, None] = None
+        self.swValuesPhys: Union[SwValues, None] = None
+        self.unitRef: Union[RefType, None] = None
+        self.unitDisplayName: Union[SingleLanguageUnitNames, None] = None
 
     def getSwArraysize(self):
         return self.swArraysize

--- a/src/armodel/v2/models/M2/MSR/DataDictionary/AuxillaryObjects.py
+++ b/src/armodel/v2/models/M2/MSR/DataDictionary/AuxillaryObjects.py
@@ -10,10 +10,10 @@ class SwAddrMethod(AtpBlueprintable):
     def __init__(self, parent: ARObject, short_name: str) -> None:
         super().__init__(parent, short_name)
 
-        self.memoryAllocationKeywordPolicy = None   # type: ARLiteral
+        self.memoryAllocationKeywordPolicy: Union[ARLiteral, None] = None
         self.options = []                            # type: List[ARLiteral]
-        self.sectionInitializationPolicy = None     # type: ARLiteral
-        self.sectionType = None                     # type: ARLiteral
+        self.sectionInitializationPolicy: Union[ARLiteral, None] = None
+        self.sectionType: Union[ARLiteral, None] = None
 
     def getMemoryAllocationKeywordPolicy(self):
         return self.memoryAllocationKeywordPolicy

--- a/src/armodel/v2/models/M2/MSR/DataDictionary/Axis.py
+++ b/src/armodel/v2/models/M2/MSR/DataDictionary/Axis.py
@@ -15,7 +15,7 @@ class SwGenericAxisParam(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.swGenericAxisParamTypeRef = None           # type: RefType
+        self.swGenericAxisParamTypeRef: Union[RefType, None] = None
         self.vfs = []                                   # type: List[ARFloat]
 
     def getSwGenericAxisParamTypeRef(self):
@@ -41,7 +41,7 @@ class SwAxisGeneric(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.swAxisTypeRef = None                   # type: RefType
+        self.swAxisTypeRef: Union[RefType, None] = None
         self.swGenericAxisParams = []               # type: List[SwGenericAxisParam]
 
     def getSwAxisTypeRef(self):
@@ -62,14 +62,14 @@ class SwAxisIndividual(SwCalprmAxisTypeProps):
     def __init__(self) -> None:
         super().__init__()
 
-        self.compuMethodRef = None              # type: RefType
-        self.dataConstrRef = None               # type: RefType
-        self.inputVariableTypeRef = None        # type: RefType
-        self.swAxisGeneric = None               # type: SwAxisGeneric
-        self.swMaxAxisPoints = None             # type: ARNumerical
-        self.swMinAxisPoints = None             # type: ARNumerical
+        self.compuMethodRef: Union[RefType, None] = None
+        self.dataConstrRef: Union[RefType, None] = None
+        self.inputVariableTypeRef: Union[RefType, None] = None
+        self.swAxisGeneric: Union[SwAxisGeneric, None] = None
+        self.swMaxAxisPoints: Union[ARNumerical, None] = None
+        self.swMinAxisPoints: Union[ARNumerical, None] = None
         self.swVariableRefs = []                # type: List
-        self.unitRef = None                     # type: RefType
+        self.unitRef: Union[RefType, None] = None
 
     def getCompuMethodRef(self):
         return self.compuMethodRef
@@ -132,9 +132,9 @@ class SwAxisGrouped(SwCalprmAxisTypeProps):
     def __init__(self) -> None:
         super().__init__()
 
-        self.sharedAxisTypeRef = None           # type: RefType
-        self.swAxisIndex = None                 # type: ARNumerical
-        self.swCalprmRef = None                 # type: RefType
+        self.sharedAxisTypeRef: Union[RefType, None] = None
+        self.swAxisIndex: Union[ARNumerical, None] = None
+        self.swCalprmRef: Union[RefType, None] = None
 
     def getSharedAxisTypeRef(self):
         return self.sharedAxisTypeRef

--- a/src/armodel/v2/models/M2/MSR/DataDictionary/CalibrationParameter.py
+++ b/src/armodel/v2/models/M2/MSR/DataDictionary/CalibrationParameter.py
@@ -13,8 +13,8 @@ class SwCalprmAxisTypeProps(ARObject, ABC):
 
         super().__init__()
 
-        self.maxGradient = None         # type: ARFloat
-        self.monotony = None            # type: MonotonyEnum
+        self.maxGradient: Union[ARFloat, None] = None
+        self.monotony: Union[MonotonyEnum, None] = None
 
 
 class SwCalprmAxis(ARObject):
@@ -26,11 +26,11 @@ class SwCalprmAxis(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.category = None                        # type: CalprmAxisCategoryEnum
-        self.displayFormat = None                   # type: DisplayFormatString
-        self.sw_axis_index = None                   # type: AxisIndexType
-        self.swCalibrationAccess = None             # type: SwCalibrationAccessEnum
-        self.sw_calprm_axis_type_props = None       # type: SwCalprmAxisTypeProps
+        self.category: Union[CalprmAxisCategoryEnum, None] = None
+        self.displayFormat: Union[DisplayFormatString, None] = None
+        self.sw_axis_index: Union[AxisIndexType, None] = None
+        self.swCalibrationAccess: Union[SwCalibrationAccessEnum, None] = None
+        self.sw_calprm_axis_type_props: Union[SwCalprmAxisTypeProps, None] = None
 
 class SwCalprmAxisSet(ARObject):
 

--- a/src/armodel/v2/models/M2/MSR/DataDictionary/DataDefProperties.py
+++ b/src/armodel/v2/models/M2/MSR/DataDictionary/DataDefProperties.py
@@ -72,34 +72,34 @@ class SwDataDefProps(ARObject):
 
         self.additionalNativeTypeQualifier = None
         self.annotations = []                               # type: List[Annotation]
-        self.baseTypeRef = None                             # type: RefType
-        self.compuMethodRef = None                          # type: RefType
-        self.dataConstrRef = None                           # type: RefType
-        self.displayFormat = None                           # type: ARLiteral
-        self.displayPresentation = None                     # type: ARLiteral
-        self.implementationDataTypeRef = None               # type: RefType
-        self.invalidValue = None                            # type: ValueSpecification
-        self.stepSize = None                                # type: ARFloat
-        self.swAddrMethodRef = None                         # type: RefType
-        self.swAlignment = None                             # type: ARLiteral
-        self.swBitRepresentation = None                     # type: ARLiteral
-        self.swCalibrationAccess = None                     # type: ARLiteral
-        self.swCalprmAxisSet = None                         # type: SwCalprmAxisSet
+        self.baseTypeRef: Union[RefType, None] = None
+        self.compuMethodRef: Union[RefType, None] = None
+        self.dataConstrRef: Union[RefType, None] = None
+        self.displayFormat: Union[ARLiteral, None] = None
+        self.displayPresentation: Union[ARLiteral, None] = None
+        self.implementationDataTypeRef: Union[RefType, None] = None
+        self.invalidValue: Union[ValueSpecification, None] = None
+        self.stepSize: Union[ARFloat, None] = None
+        self.swAddrMethodRef: Union[RefType, None] = None
+        self.swAlignment: Union[ARLiteral, None] = None
+        self.swBitRepresentation: Union[ARLiteral, None] = None
+        self.swCalibrationAccess: Union[ARLiteral, None] = None
+        self.swCalprmAxisSet: Union[SwCalprmAxisSet, None] = None
         self.swComparisonVariables = []
         self.swDataDependency = None
         self.swHostVariable = None
-        self.swImplPolicy = None                            # type: ARLiteral
+        self.swImplPolicy: Union[ARLiteral, None] = None
         self.swIntendedResolution = None
         self.swInterpolationMethod = None
         self.swIsVirtual = None
-        self.swPointerTargetProps = None                    # type: SwPointerTargetProps
-        self.swRecordLayoutRef = None                       # type: RefType
+        self.swPointerTargetProps: Union[SwPointerTargetProps, None] = None
+        self.swRecordLayoutRef: Union[RefType, None] = None
         self.swRefreshTiming = None
         self.swTextProps = None
         self.swValueBlockSize = None
         self.swValueBlockSizeMults = []
-        self.unitRef = None                                 # type: RefType
-        self.valueAxisDataTypeRef = None                    # type: RefType
+        self.unitRef: Union[RefType, None] = None
+        self.valueAxisDataTypeRef: Union[RefType, None] = None
 
         self.conditional = SwDataDefPropsConditional()      # type: SwDataDefPropsConditional
 
@@ -323,9 +323,9 @@ class SwPointerTargetProps(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.functionPointerSignatureRef = None             # type: RefType
-        self.swDataDefProps = None                          # type: SwDataDefProps
-        self.targetCategory = None                          # type: ARLiteral
+        self.functionPointerSignatureRef: Union[RefType, None] = None
+        self.swDataDefProps: Union[SwDataDefProps, None] = None
+        self.targetCategory: Union[ARLiteral, None] = None
 
     def getFunctionPointerSignatureRef(self):
         return self.functionPointerSignatureRef
@@ -358,7 +358,7 @@ class ValueList(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.v = None                                       # type: ARFloat
+        self.v: Union[ARFloat, None] = None
         self._vf = []                                       # type: List[ARLiteral]
 
     def getV(self):

--- a/src/armodel/v2/models/M2/MSR/DataDictionary/RecordLayout.py
+++ b/src/armodel/v2/models/M2/MSR/DataDictionary/RecordLayout.py
@@ -15,14 +15,14 @@ class SwRecordLayoutV(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.baseTypeRef = None                         # type: RefType
-        self.desc = None                                # type: MultiLanguageOverviewParagraph
-        self.shortLabel = None                          # type: ARLiteral
-        self.swGenericAxisParamTypeRef = None           # type: RefType
-        self.swRecordLayoutVAxis = None                 # type: ARNumerical
-        self.swRecordLayoutVFixValue = None             # type: ARNumerical
-        self.swRecordLayoutVIndex = None                # type: ARLiteral
-        self.swRecordLayoutVProp = None                 # type: ARLiteral
+        self.baseTypeRef: Union[RefType, None] = None
+        self.desc: Union[MultiLanguageOverviewParagraph, None] = None
+        self.shortLabel: Union[ARLiteral, None] = None
+        self.swGenericAxisParamTypeRef: Union[RefType, None] = None
+        self.swRecordLayoutVAxis: Union[ARNumerical, None] = None
+        self.swRecordLayoutVFixValue: Union[ARNumerical, None] = None
+        self.swRecordLayoutVIndex: Union[ARLiteral, None] = None
+        self.swRecordLayoutVProp: Union[ARLiteral, None] = None
 
     def getBaseTypeRef(self):
         return self.baseTypeRef
@@ -89,9 +89,9 @@ class SwRecordLayoutGroupContent(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.swRecordLayoutRef = None                   # type: RefType
-        self.swRecordLayoutGroup = None                 # type: SwRecordLayoutGroup
-        self.swRecordLayoutV = None                     # type: SwRecordLayoutV
+        self.swRecordLayoutRef: Union[RefType, None] = None
+        self.swRecordLayoutGroup: Union[SwRecordLayoutGroup, None] = None
+        self.swRecordLayoutV: Union[SwRecordLayoutV, None] = None
 
     def getSwRecordLayoutRef(self):
         return self.swRecordLayoutRef
@@ -124,17 +124,17 @@ class SwRecordLayoutGroup(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.category = None                            # type: ARLiteral
-        self.desc = None                                # type: MultiLanguageOverviewParagraph
-        self.shortLabel = None                          # type: ARLiteral
-        self.swGenericAxisParamTypeRef = None           # type: RefType
-        self.swRecordLayoutComponent = None             # type: ARLiteral
-        self.swRecordLayoutGroupAxis = None             # type: AxisIndexType
-        self.swRecordLayoutGroupContentType = None      # type: SwRecordLayoutGroupContent
-        self.swRecordLayoutGroupFrom = None             # type: ARLiteral
-        self.swRecordLayoutGroupIndex = None            # type: ARLiteral
-        self.swRecordLayoutGroupStep = None             # type: Integer
-        self.swRecordLayoutGroupTo = None               # type: ARLiteral
+        self.category: Union[ARLiteral, None] = None
+        self.desc: Union[MultiLanguageOverviewParagraph, None] = None
+        self.shortLabel: Union[ARLiteral, None] = None
+        self.swGenericAxisParamTypeRef: Union[RefType, None] = None
+        self.swRecordLayoutComponent: Union[ARLiteral, None] = None
+        self.swRecordLayoutGroupAxis: Union[AxisIndexType, None] = None
+        self.swRecordLayoutGroupContentType: Union[SwRecordLayoutGroupContent, None] = None
+        self.swRecordLayoutGroupFrom: Union[ARLiteral, None] = None
+        self.swRecordLayoutGroupIndex: Union[ARLiteral, None] = None
+        self.swRecordLayoutGroupStep: Union[Integer, None] = None
+        self.swRecordLayoutGroupTo: Union[ARLiteral, None] = None
 
     def getCategory(self):
         return self.category
@@ -217,7 +217,7 @@ class SwRecordLayout(ARElement):
     def __init__(self, parent: ARObject, short_name: str) -> None:
         super().__init__(parent, short_name)
 
-        self.swRecordLayoutGroup = None                 # type: SwRecordLayoutGroup
+        self.swRecordLayoutGroup: Union[SwRecordLayoutGroup, None] = None
 
     def getSwRecordLayoutGroup(self):
         return self.swRecordLayoutGroup

--- a/src/armodel/v2/models/M2/MSR/DataDictionary/ServiceProcessTask.py
+++ b/src/armodel/v2/models/M2/MSR/DataDictionary/ServiceProcessTask.py
@@ -13,9 +13,9 @@ class SwServiceArg(Identifiable):
     def __init__(self, parent: ARObject, short_name: str) -> None:
         super().__init__(parent, short_name)
 
-        self.direction = None                   # type: ArgumentDirectionEnum
-        self.swArraysize = None                 # type: ValueList
-        self.swDataDefProps = None              # type: SwDataDefProps
+        self.direction: Union[ArgumentDirectionEnum, None] = None
+        self.swArraysize: Union[ValueList, None] = None
+        self.swDataDefProps: Union[SwDataDefProps, None] = None
 
     def getDirection(self):
         return self.direction

--- a/src/armodel/v2/models/M2/MSR/Documentation/Annotation.py
+++ b/src/armodel/v2/models/M2/MSR/Documentation/Annotation.py
@@ -20,9 +20,9 @@ class GeneralAnnotation(ARObject, ABC):
             raise TypeError("GeneralAnnotation is an abstract class.")
 
         super().__init__()
-        self.annotationOrigin = None        # type: ARLiteral
-        self.annotationText = None          # type: DocumentationBlock
-        self.label = None                   # type: MultilanguageLongName
+        self.annotationOrigin: Union[ARLiteral, None] = None
+        self.annotationText: Union[DocumentationBlock, None] = None
+        self.label: Union[MultilanguageLongName, None] = None
 
     def getAnnotationOrigin(self) -> ARLiteral:
         return self.annotationOrigin

--- a/src/armodel/v2/models/M2/MSR/Documentation/BlockElements/Figure.py
+++ b/src/armodel/v2/models/M2/MSR/Documentation/BlockElements/Figure.py
@@ -27,12 +27,12 @@ class Graphic(EngineeringObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.editfit = None                                     # type: GraphicFitEnum
-        self.editHeight = None                                  # type: String
-        self.editscale = None                                   # type: String
-        self.editWidth = None                                   # type: String
-        self.filename = None                                    # type: String
-        self.fit = None                                         # type: GraphicFitEnum
+        self.editfit: Union[GraphicFitEnum, None] = None
+        self.editHeight: Union[String, None] = None
+        self.editscale: Union[String, None] = None
+        self.editWidth: Union[String, None] = None
+        self.filename: Union[String, None] = None
+        self.fit: Union[GraphicFitEnum, None] = None
 
     def getEditfit(self):
         return self.editfit
@@ -97,9 +97,9 @@ class LGraphic(LanguageSpecific):
     def __init__(self) -> None:
         super().__init__()
 
-        self.l = None                                           # type: str                         # noqa E741
-        self.graphic = None                                     # type: Graphic
-        self.map = None                                         # type: Map
+        self.l: Union[str, None] = None                         # noqa E741
+        self.graphic: Union[Graphic, None] = None
+        self.map: Union[Map, None] = None
 
     def getL(self):
         return self.l
@@ -130,11 +130,11 @@ class MlFigure(Paginateable):
     def __init__(self) -> None:
         super().__init__()
 
-        self.figureCaption = None                               # type: Caption
-        self.helpEntry = None                                   # type: String
+        self.figureCaption: Union[Caption, None] = None
+        self.helpEntry: Union[String, None] = None
         self.lGraphics = []                                     # type: List[LGraphic]
-        self.pgwide = None                                      # type: PgwideEnum
-        self.verbatim = None                                    # type: MultiLanguageVerbatim
+        self.pgwide: Union[PgwideEnum, None] = None
+        self.verbatim: Union[MultiLanguageVerbatim, None] = None
 
     def getFigureCaption(self):
         return self.figureCaption

--- a/src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/ListElements.py
+++ b/src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/ListElements.py
@@ -42,7 +42,7 @@ class ARList(Paginateable):
         super().__init__()
 
         self.items = []                         # type: List[Item]
-        self.type = None                        # type: ListEnum
+        self.type: Union[ListEnum, None] = None
 
     def getItems(self):
         return self.items

--- a/src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/PaginationAndView.py
+++ b/src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/PaginationAndView.py
@@ -18,8 +18,8 @@ class Paginateable(DocumentViewSelectable, ABC):
             raise TypeError("Paginateable is an abstract class.")
         super().__init__()
 
-        self.chapterBreak = None                                # type: ChapterEnumBreak
-        self.keepWithPrevious = None                            # type: KeepWithPreviousEnum
+        self.chapterBreak: Union[ChapterEnumBreak, None] = None
+        self.keepWithPrevious: Union[KeepWithPreviousEnum, None] = None
 
     def getBreak(self):
         return self.chapterBreak

--- a/src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/__init__.py
+++ b/src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/__init__.py
@@ -31,17 +31,17 @@ class DocumentationBlock(ARObject):
     def __init__(self) -> None:
         super().__init__()
 
-        self.defList = None                         # type: DefList
+        self.defList: Union[DefList, None] = None
         self.figures = []                           # type: List[MlFigure]
         self.formula = None                         # type：MlFormula
-        self.labeledList = None                     # type: LabeledList
+        self.labeledList: Union[LabeledList, None] = None
         self.lists = []                             # type: List[ARList]
-        self.msrQueryP2 = None                      # type: MsrQueryP2
-        self.note = None                            # type: Note
+        self.msrQueryP2: Union[MsrQueryP2, None] = None
+        self.note: Union[Note, None] = None
         self.ps = []                                # type: List[MultiLanguageParagraph]
-        self.structuredReq = None                   # type: StructuredReq
-        self.trace = None                           # type: TraceableText
-        self.verbatim = None                        # type: MultiLanguageVerbatim
+        self.structuredReq: Union[StructuredReq, None] = None
+        self.trace: Union[TraceableText, None] = None
+        self.verbatim: Union[MultiLanguageVerbatim, None] = None
 
     def getDefList(self):
         return self.defList


### PR DESCRIPTION
## Summary

Add Union type imports to V2 model typing statements for improved type safety and mypy compliance.

## Changes

This PR adds Union type imports to V2 model files to improve type annotations for nullable attributes.

### Type Annotation Updates
- Pattern:  → 
- Ensures proper type hints for nullable attributes
- Improves mypy compliance and type safety

### Examples
-  → 
-  → 
-  → 

## Files Modified

- 60 files in `src/armodel/v2/models/` directory
- Across AUTOSARTemplates and MSR modules
- Total: 315 insertions, 315 deletions

### Affected Areas
- AUTOSARTemplates/AdaptivePlatform
- AUTOSARTemplates/AutosarTopLevelStructure
- AUTOSARTemplates/BswModuleTemplate
- AUTOSARTemplates/CommonStructure
- AUTOSARTemplates/ECUCDescriptionTemplate
- AUTOSARTemplates/SWComponentTemplate
- AUTOSARTemplates/SystemTemplate
- MSR/AsamHdo
- MSR/CalibrationData
- MSR/DataDictionary
- MSR/Documentation

## Test Coverage

- Existing tests continue to pass
- Type checking improved with Union annotations
- No functional changes to behavior
- Quality checks: Ruff and mypy may have known issues (user requested to continue)

## Requirements

- N/A

## Notes

This is part of ongoing V2 model development and mypy type annotation improvements. The changes follow the V2 coding rules for strict type hints (CODING_RULE_V2_00001).

Closes #402