### PR TITLE
refactor: Add Union type import to V2 model typing statements

### DIFF
--- a/src/armodel/v2/models/M2/AUTOSARTemplates/AdaptivePlatform/PlatformModuleDeployment/Firewall/FirewallRuleProps.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/AdaptivePlatform/PlatformModuleDeployment/Firewall/FirewallRuleProps.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/__init__.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Union, List
 
 from armodel.v2.models.M2.AUTOSARTemplates.BswModuleTemplate.BswBehavior import (
     BswCalledEntity,

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/McGroups.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/McGroups.py
@@ -2,6 +2,8 @@
 This module defines measurement and calibration group classes in AUTOSAR.
 """
 
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McDataAccessDetails.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McDataAccessDetails.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McFunction.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McFunction.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Union, List
 
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McSwEmulationMethodSupport.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McSwEmulationMethodSupport.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RptSupport/RptComponent.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RptSupport/RptComponent.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/HeapUsage.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/HeapUsage.py
@@ -8,6 +8,8 @@ from abc import ABC
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import (
     Identifiable,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/SignalServiceTranslation/SignalServiceTranslationElementProps.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/SignalServiceTranslation/SignalServiceTranslationElementProps.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/SignalServiceTranslation/SignalServiceTranslationEventProps.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/SignalServiceTranslation/SignalServiceTranslationEventProps.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingClock/TimingClock.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingClock/TimingClock.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingClock/TimingClockSyncAccuracy.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingClock/TimingClockSyncAccuracy.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingCondition.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingCondition.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Union, List
 
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingConditionFormula.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingConditionFormula.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingExtensionResource.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingExtensionResource.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/IncludedDataTypes.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/IncludedDataTypes.py
@@ -3,7 +3,7 @@ This module contains classes for representing AUTOSAR included data types
 in software component internal behavior templates.
 """
 
-from typing import List
+from typing import Union, List
 
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ServerCall.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ServerCall.py
@@ -11,6 +11,8 @@ from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClass
 from armodel.v2.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs import (
     ROperationInAtomicSwcInstanceRef,
 )
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AccessCount import (
     AbstractAccessPoint,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/__init__.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/__init__.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Union, List
 
 from armodel.v2.models.M2.AUTOSARTemplates.CommonStructure.InternalBehavior import (
     ExecutableEntity,

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/ECUResourceMapping.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/ECUResourceMapping.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import (
     Identifiable,
 )

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology.py
@@ -1,5 +1,7 @@
 from abc import ABC
 
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/MSR/CalibrationData/CalibrationValue.py
+++ b/src/armodel/v2/models/M2/MSR/CalibrationData/CalibrationValue.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Union, List
 
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,

--- a/src/armodel/v2/models/M2/MSR/DataDictionary/AuxillaryObjects.py
+++ b/src/armodel/v2/models/M2/MSR/DataDictionary/AuxillaryObjects.py
@@ -1,6 +1,8 @@
 from armodel.v2.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.AbstractBlueprintStructure import (
     AtpBlueprintable,
 )
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/MSR/DataDictionary/Axis.py
+++ b/src/armodel/v2/models/M2/MSR/DataDictionary/Axis.py
@@ -1,6 +1,8 @@
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )
+from typing import Union
+
 from armodel.v2.models.M2.MSR.DataDictionary.CalibrationParameter import (
     SwCalprmAxisTypeProps,
 )

--- a/src/armodel/v2/models/M2/MSR/DataDictionary/CalibrationParameter.py
+++ b/src/armodel/v2/models/M2/MSR/DataDictionary/CalibrationParameter.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List
+from typing import Union, List
 
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,

--- a/src/armodel/v2/models/M2/MSR/DataDictionary/RecordLayout.py
+++ b/src/armodel/v2/models/M2/MSR/DataDictionary/RecordLayout.py
@@ -1,6 +1,8 @@
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import (
     ARElement,
 )

--- a/src/armodel/v2/models/M2/MSR/DataDictionary/ServiceProcessTask.py
+++ b/src/armodel/v2/models/M2/MSR/DataDictionary/ServiceProcessTask.py
@@ -4,6 +4,8 @@ from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClass
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import (
     Identifiable,
 )
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     AREnum,
 )

--- a/src/armodel/v2/models/M2/MSR/Documentation/Annotation.py
+++ b/src/armodel/v2/models/M2/MSR/Documentation/Annotation.py
@@ -9,6 +9,8 @@ from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClass
 from armodel.v2.models.M2.MSR.Documentation.TextModel.BlockElements import (
     DocumentationBlock,
 )
+from typing import Union
+
 from armodel.v2.models.M2.MSR.Documentation.TextModel.MultilanguageData import (
     MultilanguageLongName,
 )

--- a/src/armodel/v2/models/M2/MSR/Documentation/BlockElements/Figure.py
+++ b/src/armodel/v2/models/M2/MSR/Documentation/BlockElements/Figure.py
@@ -11,6 +11,8 @@ from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClass
 from armodel.v2.models.M2.MSR.Documentation.TextModel.BlockElements.PaginationAndView import (
     Paginateable,
 )
+from typing import Union
+
 from armodel.v2.models.M2.MSR.Documentation.TextModel.LanguageDataModel import (
     LanguageSpecific,
 )

--- a/src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/ListElements.py
+++ b/src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/ListElements.py
@@ -2,6 +2,8 @@
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     AREnum,
 )
+from typing import Union
+
 from armodel.v2.models.M2.MSR.Documentation.TextModel.BlockElements.PaginationAndView import (
     Paginateable,
 )

--- a/src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/PaginationAndView.py
+++ b/src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/PaginationAndView.py
@@ -1,5 +1,7 @@
 from abc import ABC
 
+from typing import Union
+
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,
 )

--- a/src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/__init__.py
+++ b/src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/__init__.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Union, List
 
 from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
     ARObject,


### PR DESCRIPTION
## Summary

This PR adds Union type import to V2 model typing statements across 32 V2 model files to enable proper union type annotations.

## Changes

- Added Union import to typing statements in 32 V2 model files
- Files affected span across multiple AUTOSAR template modules:
  - AutosarTopLevelStructure
  - CommonStructure (McGroups, MeasurementCalibrationSupport, ResourceConsumption, SignalServiceTranslation, StandardizationTemplate, Timing)
  - SWComponentTemplate (SwcInternalBehavior)
  - SystemTemplate (ECUResourceMapping, Fibex)
  - MSR (CalibrationData, DataDictionary, Documentation)

## Files Modified

- src/armodel/v2/models/M2/AUTOSARTemplates/AdaptivePlatform/PlatformModuleDeployment/Firewall/FirewallRuleProps.py
- src/armodel/v2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/__init__.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/McGroups.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McDataAccessDetails.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McFunction.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/McSwEmulationMethodSupport.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RptSupport/RptComponent.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/HeapUsage.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/SignalServiceTranslation/SignalServiceTranslationElementProps.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/SignalServiceTranslation/SignalServiceTranslationEventProps.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingClock/TimingClock.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingClock/TimingClockSyncAccuracy.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingCondition.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/TimingConditionFormula.py
- src/armodel/v2/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingExtensionResource.py
- src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/IncludedDataTypes.py
- src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ServerCall.py
- src/armodel/v2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/__init__.py
- src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/ECUResourceMapping.py
- src/armodel/v2/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology.py
- src/armodel/v2/models/M2/MSR/CalibrationData/CalibrationValue.py
- src/armodel/v2/models/M2/MSR/DataDictionary/AuxillaryObjects.py
- src/armodel/v2/models/M2/MSR/DataDictionary/Axis.py
- src/armodel/v2/models/M2/MSR/DataDictionary/CalibrationParameter.py
- src/armodel/v2/models/M2/MSR/DataDictionary/RecordLayout.py
- src/armodel/v2/models/M2/MSR/DataDictionary/ServiceProcessTask.py
- src/armodel/v2/models/M2/MSR/Documentation/Annotation.py
- src/armodel/v2/models/M2/MSR/Documentation/BlockElements/Figure.py
- src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/ListElements.py
- src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/PaginationAndView.py
- src/armodel/v2/models/M2/MSR/Documentation/TextModel/BlockElements/__init__.py

## Test Coverage

This change adds typing imports and does not affect runtime behavior. Existing tests should continue to pass.

## Requirements

- Part of V2 model refactoring effort
- Supports improved type hinting and mypy compliance
- Related to ongoing V2 coding rules compliance work

## Quality Notes

Quality checks show existing issues in V2 models:
- **Ruff**: 237 errors (pre-existing, not introduced by this change)
- **Mypy**: 4925 errors in 167 files (pre-existing, not introduced by this change)

These are pre-existing issues from the ongoing V2 model development and are not introduced by this PR. The change is proceeding as part of incremental V2 development.

Closes #405