### PR TITLE
fix: resolve Python keyword property names and malformed imports

### DIFF
--- a/src/armodel/v2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py
@@ -1100,33 +1100,33 @@ class BswEntryRelationship(ARObject):
             )
         self._bswEntry = value
         # this case the bswEntry be set to drivedFrom.
-        self._from: Optional["BswModuleEntry"] = None
+        self._from_module: Optional["BswModuleEntry"] = None
 
     @property
-    def from(self) -> Optional["BswModuleEntry"]:
-        """Get from (Pythonic accessor)."""
-        return self._from
+    def from_module(self) -> Optional["BswModuleEntry"]:
+        """Get from_module (Pythonic accessor)."""
+        return self._from_module
 
-    @from.setter
-    def from(self, value: Optional["BswModuleEntry"]) -> None:
+    @from_module.setter
+    def from_module(self, value: Optional["BswModuleEntry"]) -> None:
         """
-        Set from with validation.
+        Set from_module with validation.
         
         Args:
-            value: The from to set
+            value: The from_module to set
         
         Raises:
             TypeError: If value type is incorrect
         """
         if value is None:
-            self._from = None
+            self._from_module = None
             return
 
         if not isinstance(value, BswModuleEntry):
             raise TypeError(
-                f"from must be BswModuleEntry or None, got {type(value).__name__}"
+                f"from_module must be BswModuleEntry or None, got {type(value).__name__}"
             )
-        self._from = value
+        self._from_module = value
         self._to: Optional["BswModuleEntry"] = None
 
     @property
@@ -1187,30 +1187,30 @@ class BswEntryRelationship(ARObject):
 
     def getFrom(self) -> "BswModuleEntry":
         """
-        AUTOSAR-compliant getter for from.
-        
+        AUTOSAR-compliant getter for from_module.
+
         Returns:
-            The from value
-        
+            The from_module value
+
         Note:
-            Delegates to from property (CODING_RULE_V2_00017)
+            Delegates to from_module property (CODING_RULE_V2_00017)
         """
-        return self.from  # Delegates to property
+        return self.from_module  # Delegates to property
 
     def setFrom(self, value: "BswModuleEntry") -> "BswEntryRelationship":
         """
-        AUTOSAR-compliant setter for from with method chaining.
-        
+        AUTOSAR-compliant setter for from_module with method chaining.
+
         Args:
-            value: The from to set
-        
+            value: The from_module to set
+
         Returns:
             self for method chaining
-        
+
         Note:
-            Delegates to from property setter (gets validation automatically)
+            Delegates to from_module property setter (gets validation automatically)
         """
-        self.from = value  # Delegates to property setter
+        self.from_module = value  # Delegates to property setter
         return self
 
     def getTo(self) -> "BswModuleEntry":
@@ -1259,20 +1259,20 @@ class BswEntryRelationship(ARObject):
         self.bsw_entry = value  # Use property setter (gets validation)
         return self
 
-    def with_from(self, value: Optional["BswModuleEntry"]) -> "BswEntryRelationship":
+    def with_from_module(self, value: Optional["BswModuleEntry"]) -> "BswEntryRelationship":
         """
-        Set from and return self for chaining.
-        
+        Set from_module and return self for chaining.
+
         Args:
-            value: The from to set
-        
+            value: The from_module to set
+
         Returns:
             self for method chaining
-        
+
         Example:
-            >>> obj.with_from("value")
+            >>> obj.with_from_module("value")
         """
-        self.from = value  # Use property setter (gets validation)
+        self.from_module = value  # Use property setter (gets validation)
         return self
 
     def with_to(self, value: Optional["BswModuleEntry"]) -> "BswEntryRelationship":

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/EcucParamConfContainerDef.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/EcucParamConfContainerDef.py
@@ -1,10 +1,9 @@
 from typing import List
 
-from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
 from armodel.v2.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucContainerDef,
 )
-
+from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     RefType,
 )
 

--- a/src/armodel/v2/models/M2/AUTOSARTemplates/EcucReferenceValue.py
+++ b/src/armodel/v2/models/M2/AUTOSARTemplates/EcucReferenceValue.py
@@ -1,10 +1,9 @@
 from typing import Optional
 
-from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
 from armodel.v2.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import (
     EcucAbstractReferenceValue,
 )
-
+from armodel.v2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     RefType,
 )
 

--- a/src/armodel/v2/models/M2/MSR/Documentation/BlockElements/Figure.py
+++ b/src/armodel/v2/models/M2/MSR/Documentation/BlockElements/Figure.py
@@ -107,33 +107,33 @@ class Area(ARObject):
                 f"alt must be String or str or None, got {type(value).__name__}"
             )
         self._alt = value
-        self._class: Optional["String"] = None
+        self._class_name: Optional["String"] = None
 
     @property
-    def class(self) -> Optional["String"]:
-        """Get class (Pythonic accessor)."""
-        return self._class
+    def class_name(self) -> Optional["String"]:
+        """Get class_name (Pythonic accessor)."""
+        return self._class_name
 
-    @class.setter
-    def class(self, value: Optional["String"]) -> None:
+    @class_name.setter
+    def class_name(self, value: Optional["String"]) -> None:
         """
-        Set class with validation.
+        Set class_name with validation.
         
         Args:
-            value: The class to set
+            value: The class_name to set
         
         Raises:
             TypeError: If value type is incorrect
         """
         if value is None:
-            self._class = None
+            self._class_name = None
             return
 
         if not isinstance(value, (String, str)):
             raise TypeError(
-                f"class must be String or str or None, got {type(value).__name__}"
+                f"class_name must be String or str or None, got {type(value).__name__}"
             )
-        self._class = value
+        self._class_name = value
         # their order depend on figure defined.
         self._coords: Optional["String"] = None
 
@@ -755,24 +755,24 @@ class Area(ARObject):
             The class value
         
         Note:
-            Delegates to class property (CODING_RULE_V2_00017)
+            Delegates to class_name property (CODING_RULE_V2_00017)
         """
-        return self.class  # Delegates to property
+        return self.class_name  # Delegates to property
 
     def setClass(self, value: "String") -> "Area":
         """
-        AUTOSAR-compliant setter for class with method chaining.
-        
+        AUTOSAR-compliant setter for class_name with method chaining.
+
         Args:
-            value: The class to set
-        
+            value: The class_name to set
+
         Returns:
             self for method chaining
-        
+
         Note:
-            Delegates to class property setter (gets validation automatically)
+            Delegates to class_name property setter (gets validation automatically)
         """
-        self.class = value  # Delegates to property setter
+        self.class_name = value  # Delegates to property setter
         return self
 
     def getCoords(self) -> "String":
@@ -1341,20 +1341,20 @@ class Area(ARObject):
         self.alt = value  # Use property setter (gets validation)
         return self
 
-    def with_class(self, value: Optional["String"]) -> "Area":
+    def with_class_name(self, value: Optional["String"]) -> "Area":
         """
-        Set class and return self for chaining.
+        Set class_name and return self for chaining.
         
         Args:
-            value: The class to set
+            value: The class_name to set
         
         Returns:
             self for method chaining
         
         Example:
-            >>> obj.with_class("value")
+            >>> obj.with_class_name("value")
         """
-        self.class = value  # Use property setter (gets validation)
+        self.class_name = value  # Use property setter (gets validation)
         return self
 
     def with_coords(self, value: Optional["String"]) -> "Area":
@@ -2827,33 +2827,33 @@ class Map(ARObject):
         # Any number of elements may be assigned class name or set of class names.
         # Multiple shall be separated by white space names are typically used to apply
                 # CSS to an element.
-        self._class: Optional["String"] = None
+        self._class_name: Optional["String"] = None
 
     @property
-    def class(self) -> Optional["String"]:
-        """Get class (Pythonic accessor)."""
-        return self._class
+    def class_name(self) -> Optional["String"]:
+        """Get class_name (Pythonic accessor)."""
+        return self._class_name
 
-    @class.setter
-    def class(self, value: Optional["String"]) -> None:
+    @class_name.setter
+    def class_name(self, value: Optional["String"]) -> None:
         """
-        Set class with validation.
+        Set class_name with validation.
         
         Args:
-            value: The class to set
+            value: The class_name to set
         
         Raises:
             TypeError: If value type is incorrect
         """
         if value is None:
-            self._class = None
+            self._class_name = None
             return
 
         if not isinstance(value, (String, str)):
             raise TypeError(
-                f"class must be String or str or None, got {type(value).__name__}"
+                f"class_name must be String or str or None, got {type(value).__name__}"
             )
-        self._class = value
+        self._class_name = value
                 # to be referenced in image through the attribute USEMAP.
         # Although not actually necessary in the MSR model, it was order to support the
                 # MAPs which were created.
@@ -3237,24 +3237,24 @@ class Map(ARObject):
             The class value
         
         Note:
-            Delegates to class property (CODING_RULE_V2_00017)
+            Delegates to class_name property (CODING_RULE_V2_00017)
         """
-        return self.class  # Delegates to property
+        return self.class_name  # Delegates to property
 
     def setClass(self, value: "String") -> "Map":
         """
-        AUTOSAR-compliant setter for class with method chaining.
-        
+        AUTOSAR-compliant setter for class_name with method chaining.
+
         Args:
-            value: The class to set
-        
+            value: The class_name to set
+
         Returns:
             self for method chaining
-        
+
         Note:
-            Delegates to class property setter (gets validation automatically)
+            Delegates to class_name property setter (gets validation automatically)
         """
-        self.class = value  # Delegates to property setter
+        self.class_name = value  # Delegates to property setter
         return self
 
     def getName(self) -> "NameToken":
@@ -3611,20 +3611,20 @@ class Map(ARObject):
         self.area = value  # Use property setter (gets validation)
         return self
 
-    def with_class(self, value: Optional["String"]) -> "Map":
+    def with_class_name(self, value: Optional["String"]) -> "Map":
         """
-        Set class and return self for chaining.
+        Set class_name and return self for chaining.
         
         Args:
-            value: The class to set
+            value: The class_name to set
         
         Returns:
             self for method chaining
         
         Example:
-            >>> obj.with_class("value")
+            >>> obj.with_class_name("value")
         """
-        self.class = value  # Use property setter (gets validation)
+        self.class_name = value  # Use property setter (gets validation)
         return self
 
     def with_name(self, value: Optional["NameToken"]) -> "Map":


### PR DESCRIPTION
## Summary

Fix syntax errors in V2 models caused by:

1. Python keywords used as property names (\rom\, \class\)
2. Malformed import statements in ECUC template files

## Changes

### Property Renames
- \BswInterfaces.py\: Renamed \rom\ property to \rom_module\
  - Updated all references in getter, setter, and fluent methods
- \Figure.py\: Renamed \class\ property to \class_name\
  - Updated in both \Area\ and \Map\ classes
  - Updated all references in getter, setter, and fluent methods

### Import Fixes
- \EcucParamConfContainerDef.py\: Fixed malformed import statement for \RefType\
- \EcucReferenceValue.py\: Fixed malformed import statement for \RefType\

## Impact

- Fixes syntax errors that prevented code from parsing correctly
- All 365 V2 tests pass
- No mypy or ruff errors related to these changes

## Testing

\\\ash
pytest tests/test_armodel/v2/ -v
# 365 passed in 0.87s

mypy src/armodel/v2/reader/ src/armodel/v2/writer/ src/armodel/v2/models/models.py
# Success: no issues found
\\\

Closes #451