### PR TITLE
fix: remove duplicate lowercase 'documentation' directory

### DIFF
--- a/src/armodel/models/M2/MSR/documentation/__init__.py
+++ b/src/armodel/models/M2/MSR/documentation/__init__.py
@@ -1,3 +1,0 @@
-from .Annotation import *
-from .TextModel.BlockElements import *
-from .TextModel import *


### PR DESCRIPTION
## Summary

Removed duplicate lowercase `src/armodel/models/M2/MSR/documentation/__init__.py` directory that was causing case-collision warnings on Windows.

The capital `Documentation` directory is kept as the canonical version.

Closes #472