### PR TITLE
fix: correct RTD config build.jobs syntax

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,9 +4,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  commands:
-    - sphinx-apidoc -o docs/api src/armodel --force --separate
-    - sphinx-build docs docs/_build/html
+  jobs:
+    pre_build:
+      - sphinx-apidoc -o docs/api src/armodel --force --separate
 
 python:
   install:


### PR DESCRIPTION
## Summary
- Replace `build.commands` with `build.jobs.pre_build` in `.readthedocs.yaml`
- `build.commands` not valid in RTD v2 config (caused validation error)
- `sphinx-apidoc` now runs in `pre_build` job

## Changes
- `.readthedocs.yaml` — use correct RTD v2 `build.jobs` syntax

## Test Plan
- [ ] RTD "latest" build succeeds
- [ ] Docs at https://py-armodel.readthedocs.io/en/latest/

🤖 Generated with [Claude Code](https://claude.com/claude-code)