### PR TITLE
fix: remove invalid python.install method key from RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,9 +13,5 @@ sphinx:
 
 python:
   install:
-    - method: pip
-      path: .
-      extra_requirements: []
-    - method: pip
-      path: docs
-      requirements: requirements.txt
+    - path: .
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary
- Remove invalid `method` key from `python.install` in RTD config
- RTD v2 does not support `method: pip` — it auto-detects install method
- Use `path` for package install and `requirements` for requirements files

## Test plan
- [ ] Verify RTD build passes with updated config
- [ ] Check no "Invalid configuration key: python.install.*.method" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)