### PR TITLE
refactor: fix type() comparison style

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/HeapUsage.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/HeapUsage.py
@@ -22,7 +22,7 @@ class HeapUsage(Identifiable, ABC):
             parent: The parent ARObject that contains this heap usage
             short_name: The unique short name of this heap usage
         """
-        if type(self) == HeapUsage:
+        if type(self) is HeapUsage:
             raise TypeError("HeapUsage is an abstract class.")
         
         super().__init__(parent, short_name)

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/StackUsage.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/StackUsage.py
@@ -25,7 +25,7 @@ class StackUsage(Identifiable, ABC):
             parent: The parent ARObject that contains this stack usage
             short_name: The unique short name of this stack usage
         """
-        if type(self) == StackUsage:
+        if type(self) is StackUsage:
             raise TypeError("StackUsage is an abstract class.")
         
         super().__init__(parent, short_name)

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/TimingExtensions.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/TimingExtensions.py
@@ -27,7 +27,7 @@ class TimingExtension(ARElement):
     __metaclass__ = ABC
 
     def __init__(self, parent: ARObject, short_name: str):
-        if type(self) == TimingExtension:
+        if type(self) is TimingExtension:
             raise TypeError("TimingExtension is an abstract class.")
 
         super().__init__(parent, short_name)

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/AbstractStructure.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/AbstractStructure.py
@@ -18,7 +18,7 @@ class AtpInstanceRef(ARObject, ABC):
     """
     
     def __init__(self):
-        if type(self) == AtpInstanceRef:
+        if type(self) is AtpInstanceRef:
             raise TypeError("AtpInstanceRef is an abstract class.")
 
         super().__init__()

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/EngineeringObject.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/EngineeringObject.py
@@ -16,7 +16,7 @@ class EngineeringObject(ARObject, ABC):
     """
     
     def __init__(self):
-        if type(self) == EngineeringObject:
+        if type(self) is EngineeringObject:
             raise TypeError("EngineeringObject is an abstract class.")
 
         super().__init__()

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/InstanceRefs.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/InstanceRefs.py
@@ -17,7 +17,7 @@ class ModeGroupInAtomicSwcInstanceRef(AtpInstanceRef, ABC):
 
     def __init__(self):
         
-        if type(self) == ModeGroupInAtomicSwcInstanceRef:
+        if type(self) is ModeGroupInAtomicSwcInstanceRef:
             raise TypeError("ModeGroupInAtomicSwcInstanceRef is an abstract class.")
         
         super().__init__()
@@ -150,7 +150,7 @@ class VariableInAtomicSwcInstanceRef(AtpInstanceRef, ABC):
     """
 
     def __init__(self):
-        if type(self) == VariableInAtomicSwcInstanceRef:
+        if type(self) is VariableInAtomicSwcInstanceRef:
             raise TypeError("VariableInAtomicSwcInstanceRef is an abstract class.")
 
         super().__init__()

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Composition/InstanceRefs.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Composition/InstanceRefs.py
@@ -15,7 +15,7 @@ class PortInCompositionTypeInstanceRef(AtpInstanceRef, ABC):
     """
 
     def __init__(self):
-        if type(self) == PortInCompositionTypeInstanceRef:
+        if type(self) is PortInCompositionTypeInstanceRef:
             raise TypeError("PortInCompositionTypeInstanceRef is an abstract class.")
         
         super().__init__()
@@ -106,7 +106,7 @@ class OperationInAtomicSwcInstanceRef(AtpInstanceRef, ABC):
     """
 
     def __init__(self):
-        if type(self) == OperationInAtomicSwcInstanceRef:
+        if type(self) is OperationInAtomicSwcInstanceRef:
             raise TypeError("OperationInAtomicSwcInstanceRef is an abstract class.")
         
         super().__init__()

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Datatype/DataPrototypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Datatype/DataPrototypes.py
@@ -20,7 +20,7 @@ class DataPrototype(AtpPrototype, ABC):
     """
 
     def __init__(self, parent:ARObject, short_name: str):
-        if type(self) == DataPrototype:
+        if type(self) is DataPrototype:
             raise TypeError("DataPrototype is an abstract class.")
 
         super().__init__(parent, short_name)
@@ -56,7 +56,7 @@ class AutosarDataPrototype(DataPrototype, ABC):
     """
 
     def __init__(self, parent:ARObject, short_name: str):
-        if type(self) == AutosarDataPrototype:
+        if type(self) is AutosarDataPrototype:
             raise TypeError("AutosarDataPrototype is an abstract class.")
 
         super().__init__(parent, short_name)
@@ -125,7 +125,7 @@ class ApplicationCompositeElementDataPrototype(DataPrototype, ABC):
     """
 
     def __init__(self, parent:ARObject, short_name: str):
-        if type(self) == ApplicationCompositeElementDataPrototype:
+        if type(self) is ApplicationCompositeElementDataPrototype:
             raise TypeError("ApplicationCompositeElementDataPrototype is an abstract class.")
 
         super().__init__(parent, short_name)

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/AccessCount.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/AccessCount.py
@@ -14,7 +14,7 @@ class AbstractAccessPoint(AtpStructureElement, ABC):
     """
 
     def __init__(self, parent: ARObject, short_name: str):
-        if type(self) == AbstractAccessPoint:
+        if type(self) is AbstractAccessPoint:
             raise TypeError("ARObject is an abstract class.")
 
         super().__init__(parent, short_name)

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DoIp.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DoIp.py
@@ -14,7 +14,7 @@ class AbstractDoIpLogicAddressProps(Identifiable, ABC):
     serving as the foundation for specific DoIP address types in the system.
     """
     def __init__(self, parent: ARObject, short_name: str):
-        if type(self) == AbstractDoIpLogicAddressProps:
+        if type(self) is AbstractDoIpLogicAddressProps:
             raise TypeError("AbstractDoIpLogicAddressProps is an abstract class.")
         
         super().__init__(parent, short_name)

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/NetworkEndpoint.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/NetworkEndpoint.py
@@ -14,7 +14,7 @@ class NetworkEndpointAddress(ARObject, ABC):
     addresses (IPv4, IPv6, etc.) used in AUTOSAR communication.
     """
     def __init__(self):
-        if type(self) == NetworkEndpointAddress:
+        if type(self) is NetworkEndpointAddress:
             raise TypeError("NetworkEndpointAddress is an abstract class.")
         
         super().__init__()

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances.py
@@ -17,7 +17,7 @@ class TransportProtocolConfiguration(ARObject, ABC):
     communication.
     """
     def __init__(self):
-        if type(self) == TransportProtocolConfiguration:
+        if type(self) is TransportProtocolConfiguration:
             raise TypeError("TransportProtocolConfiguration is an abstract class.")
         
         super().__init__()
@@ -56,7 +56,7 @@ class TcpUdpConfig(TransportProtocolConfiguration, ABC):
     connectionless transport protocols.
     """
     def __init__(self):
-        if type(self) == TcpUdpConfig:
+        if type(self) is TcpUdpConfig:
             raise TypeError("TcpUdpConfig is an abstract class.")
         
         super().__init__()
@@ -188,7 +188,7 @@ class AbstractServiceInstance(Identifiable, ABC):
     architecture.
     """
     def __init__(self, parent: ARObject, short_name: str):
-        if type(self) == AbstractServiceInstance:
+        if type(self) is AbstractServiceInstance:
             raise TypeError("AbstractServiceInstance is an abstract class.")
 
         super().__init__(parent, short_name)

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Lin/LinCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Lin/LinCommunication.py
@@ -14,7 +14,7 @@ class LinFrame(Frame, ABC):
     foundation for concrete LIN frame implementations.
     """
     def __init__(self, parent: ARObject, short_name: str):
-        if type(self) == LinFrame:
+        if type(self) is LinFrame:
             raise TypeError("LinFrame is an abstract class.")
         
         super().__init__(parent, short_name)
@@ -78,7 +78,7 @@ class ScheduleTableEntry(ARObject, ABC):
     """
     def __init__(self):
         
-        if type(self) == ScheduleTableEntry:
+        if type(self) is ScheduleTableEntry:
             raise TypeError("ScheduleTableEntry is an abstract class.")
         
         super().__init__()
@@ -149,7 +149,7 @@ class LinConfigurationEntry(ScheduleTableEntry, ABC):
     """
     def __init__(self):
 
-        if type(self) == LinConfigurationEntry:
+        if type(self) is LinConfigurationEntry:
             raise TypeError("LinConfigurationEntry is an abstract class.")
         
         super().__init__()

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
@@ -16,7 +16,7 @@ class NmClusterCoupling(ARObject, ABC):
     network management clusters for coordinated network management.
     """
     def __init__(self):
-        if type(self) == NmClusterCoupling:
+        if type(self) is NmClusterCoupling:
             raise TypeError("NmClusterCoupling is an abstract class.")
         
         super().__init__()
@@ -89,7 +89,7 @@ class NmNode(Identifiable, ABC):
     controller references, node IDs, and communication properties.
     """
     def __init__(self, parent: ARObject, short_name: str):
-        if type(self) == NmNode:
+        if type(self) is NmNode:
             raise TypeError("NmNode is an abstract class.")
         
         super().__init__(parent, short_name)

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -17,7 +17,7 @@ class TpConfig(FibexElement, ABC):
     protocol implementations including communication cluster references.
     """
     def __init__(self, parent: ARObject, short_name: str):
-        if type(self) == TpConfig:
+        if type(self) is TpConfig:
             raise TypeError("TpConfig is an abstract class.")
         
         super().__init__(parent, short_name)
@@ -103,7 +103,7 @@ class TpConnection(ARObject, ABC):
     protocol connections including connection identification.
     """
     def __init__(self):
-        if type(self) == TpConnection:
+        if type(self) is TpConnection:
             raise TypeError("TpConnection is an abstract class.")
         
         super().__init__()

--- a/src/armodel/models/M2/MSR/AsamHdo/BaseTypes.py
+++ b/src/armodel/models/M2/MSR/AsamHdo/BaseTypes.py
@@ -72,7 +72,7 @@ class BaseType(ARElement, ABC):
     Base: ARElement
     """
     def __init__(self, parent: ARObject, short_name: str):
-        if type(self) == BaseType:
+        if type(self) is BaseType:
             raise TypeError("BaseType is an abstract class.")
 
         super().__init__(parent, short_name)

--- a/src/armodel/models/M2/MSR/AsamHdo/ComputationMethod.py
+++ b/src/armodel/models/M2/MSR/AsamHdo/ComputationMethod.py
@@ -14,7 +14,7 @@ class CompuContent(ARObject, ABC):
     Base: ARObject
     """
     def __init__(self):
-        if type(self) == CompuContent:
+        if type(self) is CompuContent:
             raise TypeError("CompuContent is an abstract class.")
 
         super().__init__()
@@ -72,7 +72,7 @@ class CompuConstContent(ARObject, ABC):
     Aggregated by   : CompuConst.compuConstContentType
     """
     def __init__(self):
-        if type(self) == CompuConstContent:
+        if type(self) is CompuConstContent:
             raise TypeError("CompuConstContent is an abstract class.")
 
         super().__init__()
@@ -139,7 +139,7 @@ class CompuScaleContents(ARObject, ABC):
     Base: ARObject
     """
     def __init__(self):
-        if type(self) == CompuScaleContents:
+        if type(self) is CompuScaleContents:
             raise TypeError("CompuScaleContents is an abstract class.")
 
         super().__init__()

--- a/src/armodel/models/M2/MSR/DataDictionary/CalibrationParameter.py
+++ b/src/armodel/models/M2/MSR/DataDictionary/CalibrationParameter.py
@@ -8,7 +8,7 @@ class SwCalprmAxisTypeProps(ARObject, ABC):
     gradient and monotony constraints.
     """
     def __init__(self):
-        if type(self) == SwCalprmAxisTypeProps:
+        if type(self) is SwCalprmAxisTypeProps:
             raise TypeError("SwCalprmAxisTypeProps is an abstract class.")
 
         super().__init__()

--- a/src/armodel/report/excel_report.py
+++ b/src/armodel/report/excel_report.py
@@ -36,7 +36,7 @@ class ExcelReporter:
     def write_cell(self, sheet, row, column, value, format = None):
         cell = sheet.cell(row = row, column=column) 
         cell.value = value
-        if (format != None):
+        if format is not None:
             if ('alignment' in format):
                 cell.alignment = format['alignment']
             if ('number_format' in format):


### PR DESCRIPTION
## Summary

Replace `type(self) == Class` with `type(self) is Class` for identity comparison per PEP 8.

## Changes
- 19 files updated  
- Abstract class type checks use identity operator

Closes #486