### PR TITLE
docs: Sync Sphinx docs for 1.9.1-1.9.3 releases

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,10 +1,31 @@
 Changelog
 =========
 
-Version 1.9.0 (Current)
+Version 1.9.3 (Current)
 ------------------------
 
-* Current stable version
+* Added parse/write support for ``NvDataInterface`` (PR #485)
+* Added ``--unescape-entities`` parameter to ``arxml-format`` CLI to normalize
+  ``&quot;`` / ``&apos;`` entities in attribute values (PR #495)
+* Bumped project version metadata to 1.9.3
+
+Version 1.9.2
+-------------
+
+* Added parse/write support for ``PREDEFINED-VARIANT`` and related reference
+  lists under variant handling (PR #481)
+* Added ``PredefinedVariant`` model reference and suffix APIs
+
+Version 1.9.1
+-------------
+
+* Added ``SW-SYSTEMCONSTANT-VALUE-SET`` ARXML input/output support (PR #479)
+* Added ``ARPackage`` APIs and tests for system constant value sets
+
+Version 1.9.0
+-------------
+
+* Established baseline of the 1.9.x series
 
 Version 1.8.7
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,8 @@ Welcome to py-armodel's Documentation
 
 py-armodel is a Python library for parsing and generating AUTOSAR ARXML files. It provides comprehensive support for AUTOSAR models including software components, data types, communication patterns, and system configurations.
 
-**Current Version**: 1.9.0  
-**Python Requirements**: >= 3.5  
+**Current Version**: 1.9.3
+**Python Requirements**: >= 3.5
 **License**: MIT
 
 .. image:: https://badge.fury.io/py/armodel.svg

--- a/docs/user_guide/cli_tools.rst
+++ b/docs/user_guide/cli_tools.rst
@@ -48,13 +48,21 @@ Format ARXML files for better readability.
 
 .. code-block:: bash
 
-   arxml-format <input.arxml> <output.arxml>
+   arxml-format [OPTIONS] <input.arxml> <output.arxml>
 
-**Example:**
+**Options:**
+
+* ``--unescape-entities`` - Unescape XML quote entities (``&quot;`` and
+  ``&apos;``) in the formatted output. Useful for attribute values where the
+  XML serializer keeps them escaped. Disabled by default.
+* ``-h, --help`` - Show help message
+
+**Examples:**
 
 .. code-block:: bash
 
    arxml-format input.arxml formatted_output.arxml
+   arxml-format --unescape-entities input.arxml unescaped_output.arxml
 
 armodel-component
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

The Sphinx documentation had fallen behind the latest three feature releases (1.9.1, 1.9.2, 1.9.3). The version metadata on `docs/index.rst` still reported 1.9.0, the changelog had no entries for recent feature work, and the new `arxml-format --unescape-entities` CLI flag (added in #495) was missing from the CLI user guide.

## Changes

- **`docs/index.rst`** — Bump "Current Version" from `1.9.0` to `1.9.3`.
- **`docs/changelog.rst`** — Add entries for:
  - **1.9.1** — `SW-SYSTEMCONSTANT-VALUE-SET` ARXML I/O (#479)
  - **1.9.2** — `PREDEFINED-VARIANT` parse/write support (#481)
  - **1.9.3** — `NvDataInterface` parse/write support (#485) + `--unescape-entities` CLI flag (#495)
  - Convert old 1.9.0 entry into a historical baseline.
- **`docs/user_guide/cli_tools.rst`** — Add an Options block and second example to the `arxml-format` section, documenting `--unescape-entities` and `-h, --help`.

## Files Modified

- `docs/changelog.rst`
- `docs/index.rst`
- `docs/user_guide/cli_tools.rst`

## Test Coverage

Documentation-only change. Verified via:
- `flake8 src tests scripts --select=E9,F63,F7,F82` — 0 errors
- `pytest` — 2346 passed
- `python -m sphinx -b html -q docs docs/_build` — exit 0, no new warnings introduced by these edits (confirmed by stashing edits and re-running — the one residual `cli_tools.rst` "Title underline too short" warning pre-exists on the unrelated `connector-update` heading).

## Requirements Traceability

- Closes #499