### PR TITLE
test: improve ARXML parser test coverage with targeted handler tests

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py
@@ -295,8 +295,9 @@ class BswModuleEntry(AtpBlueprintable):
         Raises:
             ValueError: If the execution context is not valid
         """
-        if value.upper() not in ("HOOK", "INTERRUPT-CAT-1", "INTERRUPT-CAT-2", "TASK", "UNSPECIFIED"):
-            raise ValueError("Invalid execution context <%s> of BswModuleEntry <%s>" % (value, self.short_name))
+        if value is not None:
+            if value.upper() not in ("HOOK", "INTERRUPT-CAT-1", "INTERRUPT-CAT-2", "TASK", "UNSPECIFIED"):
+                raise ValueError("Invalid execution context <%s> of BswModuleEntry <%s>" % (value, self.short_name))
         self.executionContext = value
         return self
 
@@ -458,6 +459,9 @@ class BswModuleEntry(AtpBlueprintable):
         Raises:
             ValueError: If the implementation policy is not valid
         """
+        if value is None:
+            self.swServiceImplPolicy = None
+            return self
         if value.upper() not in ("INLINE", "INLINE-CONDITIONAL", "MACRO", "STANDARD"):
             raise ValueError("Invalid SwServiceImplPolicy <%s> of BswModuleEntry <%s>" % (value, self.short_name))
         self.swServiceImplPolicy = value

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
@@ -3,7 +3,7 @@ from typing import List
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Identifiable, Describable, PackageableElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, ARPositiveInteger, Boolean, ByteOrderEnum
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer, PositiveInteger, RefType, ARBoolean
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer, PositiveInteger, RefType, ARBoolean, String
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import TimeValue, UnlimitedInteger
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.Timing import TransmissionModeDeclaration
@@ -1239,11 +1239,29 @@ class SecureCommunicationPropsSet(FibexElement):
 
 class UserDefinedPdu(Pdu):
     """
-    Represents a user-defined Protocol Data Unit (PDU) that allows for custom
-    communication patterns defined by the user rather than following standard PDU types.
+    Allows to describe PDU-based communication over Complex Communication Drivers.
+
+    If a new BSW module is added above the BusIf (e.g. a new Nm module) then this
+    Pdu element shall be used to describe the communication.
+
+    Requirements:
+        atp.recommendedPackage=Pdus
+
+    Attributes:
+        cddType: Optional attribute that defines the CDD (Complex Device Driver)
+            that transmits or receives the UserDefinedPdu. If several CDDs are
+            defined this attribute is used to distinguish between them.
     """
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
+        self.cddType: String = None
+
+    def getCddType(self):
+        return self.cddType
+
+    def setCddType(self, value):
+        self.cddType = value
+        return self
 
 
 class UserDefinedIPdu(IPdu):
@@ -1253,6 +1271,14 @@ class UserDefinedIPdu(IPdu):
     """
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
+        self.cddType: ARLiteral = None
+
+    def getCddType(self):
+        return self.cddType
+
+    def setCddType(self, value):
+        self.cddType = value
+        return self
 
 
 class SecureCommunicationAuthenticationProps(Identifiable):

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -428,6 +428,7 @@ class ARXMLParser(AbstractARXMLParser):
             short_name = self.getShortName(child_element)
 
             # self.logger.debug("Read VariableAccesses %s" % short_name)
+            supported = True
 
             if (key == "DATA-RECEIVE-POINT-BY-ARGUMENTS"):
                 variable_access = parent.createDataReceivePointByArgument(short_name)
@@ -452,8 +453,10 @@ class ARXMLParser(AbstractARXMLParser):
                 variable_access.setAccessedVariableRef(self.getAutosarVariableRef(child_element, "ACCESSED-VARIABLE"))
             else:
                 self.notImplemented("Unsupported Variable Accesss <%s>" % key)
+                supported = False
 
-            self.readIdentifiable(child_element, variable_access)
+            if supported:
+                self.readIdentifiable(child_element, variable_access)
 
     def readBswModuleDescriptionImplementedEntryRefs(self, element: ET.Element, parent: BswModuleDescription):
         for child_element in self.findall(element, "PROVIDED-ENTRYS/BSW-MODULE-ENTRY-REF-CONDITIONAL"):
@@ -1236,13 +1239,17 @@ class ARXMLParser(AbstractARXMLParser):
             .setBehaviorRef(self.getChildElementOptionalRefType(element, "BEHAVIOR-REF")) \
             .setVendorApiInfix(self.getChildElementOptionalLiteral(element, "VENDOR-API-INFIX"))
         self.readBswImplementationVendorSpecificModuleDefRefs(element, impl)
-        AUTOSAR.getInstance().addImplementationBehaviorMap(impl.getFullName(), impl.getBehaviorRef().getValue())
+        behavior_ref = impl.getBehaviorRef()
+        if behavior_ref is not None:
+            AUTOSAR.getInstance().addImplementationBehaviorMap(impl.getFullName(), behavior_ref.getValue())
 
     def readSwcImplementation(self, element: ET.Element, impl: SwcImplementation):
         self.logger.debug("Read SwcImplementation <%s>" % impl.getShortName())
         self.readImplementation(element, impl)
         impl.setBehaviorRef(self.getChildElementOptionalRefType(element, "BEHAVIOR-REF"))
-        AUTOSAR.getInstance().addImplementationBehaviorMap(impl.getFullName(), impl.getBehaviorRef().getValue())
+        behavior_ref = impl.getBehaviorRef()
+        if behavior_ref is not None:
+            AUTOSAR.getInstance().addImplementationBehaviorMap(impl.getFullName(), behavior_ref.getValue())
 
     def readRunnableEntityDataReceivePointByArguments(self, element, parent: RunnableEntity):
         self._readVariableAccesses(element, parent, "DATA-RECEIVE-POINT-BY-ARGUMENTS")

--- a/tests/test_armodel/parser/test_arxml_parser_dispatch.py
+++ b/tests/test_armodel/parser/test_arxml_parser_dispatch.py
@@ -1,0 +1,607 @@
+"""Tests for the ARPackage element dispatch in ARXMLParser.
+
+Targets `readARPackageElements` (arxml_parser.py:5635-5893) — the 65+ branch
+if/elif chain that routes AUTOSAR top-level element tags to their handler
+methods. Each test feeds a minimal-but-valid XML snippet through the dispatch
+and asserts the resulting object is created on the parent ARPackage via the
+corresponding getter.
+
+Goal: exercise every branch of the dispatch chain, which naturally cascades
+coverage into each handler method (~30–100 lines per handler).
+"""
+
+import pytest
+import xml.etree.ElementTree as ET
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage
+from armodel.parser.arxml_parser import ARXMLParser
+
+NS = "http://autosar.org/schema/r4.0"
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    """Reset AUTOSAR singleton before each test."""
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def parser():
+    """Parser configured in warning mode so missing optional nested elements
+    don't raise — keeps dispatch tests focused on routing, not full parsing."""
+    AUTOSAR.getInstance().new()
+    return ARXMLParser(options={"warning": True})
+
+
+@pytest.fixture
+def strict_parser():
+    """Default parser (raises on errors)."""
+    AUTOSAR.getInstance().new()
+    return ARXMLParser()
+
+
+def _make_parent() -> ARPackage:
+    """Create a fresh ARPackage parent on the AUTOSAR singleton."""
+    autosar = AUTOSAR.getInstance()
+    parent = ARPackage(parent=autosar, short_name="TestPkg")
+    return parent
+
+
+def _dispatch(parser, parent: ARPackage, inner_xml: str) -> None:
+    """Feed <AR-PACKAGE><ELEMENTS>...</ELEMENTS></AR-PACKAGE> to readARPackageElements.
+
+    The parser's dispatch does `findall(element, "ELEMENTS/*")`, so the passed
+    element must be the AR-PACKAGE wrapper, not the ELEMENTS element itself.
+    """
+    xml = f"<AR-PACKAGE xmlns='{NS}'><SHORT-NAME>TestPkg</SHORT-NAME><ELEMENTS>{inner_xml}</ELEMENTS></AR-PACKAGE>"
+    pkg_element = ET.fromstring(xml)
+    parser.readARPackageElements(pkg_element, parent)
+
+
+def _snip(tag: str, short_name: str = "X", body: str = "") -> str:
+    return f"<{tag}><SHORT-NAME>{short_name}</SHORT-NAME>{body}</{tag}>"
+
+
+# ==================== Software components ====================
+
+
+class TestSwComponentDispatch:
+    def test_composition_sw_component_type(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("COMPOSITION-SW-COMPONENT-TYPE", "C1"))
+        assert len(parent.getCompositionSwComponentTypes()) == 1
+
+    def test_complex_device_driver_sw_component_type(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("COMPLEX-DEVICE-DRIVER-SW-COMPONENT-TYPE", "C1"))
+        assert len(parent.getComplexDeviceDriverSwComponentTypes()) == 1
+
+    def test_application_sw_component_type(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("APPLICATION-SW-COMPONENT-TYPE", "A1"))
+        # getAtomicSwComponentTypes includes ApplicationSwComponentType
+        assert len(parent.getAtomicSwComponentTypes()) == 1
+
+    def test_ecu_abstraction_sw_component_type(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("ECU-ABSTRACTION-SW-COMPONENT-TYPE", "E1"))
+        assert len(parent.getSwComponentTypes()) == 1
+
+    def test_service_sw_component_type(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SERVICE-SW-COMPONENT-TYPE", "S1"))
+        assert len(parent.getSwComponentTypes()) == 1
+
+    def test_sensor_actuator_sw_component_type(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SENSOR-ACTUATOR-SW-COMPONENT-TYPE", "SA1"))
+        assert len(parent.getSensorActuatorSwComponentType()) == 1
+
+    def test_swc_implementation(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SWC-IMPLEMENTATION", "I1"))
+        assert len(parent.getSwcImplementations()) == 1
+
+    def test_bsw_implementation(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("BSW-IMPLEMENTATION", "BI1"))
+        assert len(parent.getBswImplementations()) == 1
+
+    def test_swc_bsw_mapping(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SWC-BSW-MAPPING", "M1"))
+        assert len(parent.getSwcBswMappings()) == 1
+
+
+# ==================== Datatypes ====================
+
+
+class TestDataTypeDispatch:
+    def test_application_primitive_data_type(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("APPLICATION-PRIMITIVE-DATA-TYPE", "AP1"))
+        assert len(parent.getApplicationPrimitiveDataTypes()) == 1
+
+    def test_application_record_data_type(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("APPLICATION-RECORD-DATA-TYPE", "AR1"))
+        # ApplicationRecordDataType reuses ApplicationPrimitiveDataType list
+        assert len(parent.getApplicationDataType()) >= 1
+
+    def test_application_array_data_type(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("APPLICATION-ARRAY-DATA-TYPE", "AA1"))
+        assert len(parent.getApplicationArrayDataTypes()) == 1
+
+    def test_implementation_data_type(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("IMPLEMENTATION-DATA-TYPE", "IDT1"))
+        assert len(parent.getImplementationDataTypes()) == 1
+
+    def test_sw_base_type(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SW-BASE-TYPE", "BT1"))
+        assert len(parent.getSwBaseTypes()) == 1
+
+    def test_compu_method(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("COMPU-METHOD", "CM1"))
+        assert len(parent.getCompuMethods()) == 1
+
+    def test_data_constr(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("DATA-CONSTR", "DC1"))
+        assert len(parent.getDataConstrs()) == 1
+
+    def test_unit(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("UNIT", "U1"))
+        assert len(parent.getUnits()) == 1
+
+    def test_constant_specification(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("CONSTANT-SPECIFICATION", "CS1"))
+        assert len(parent.getConstantSpecifications()) == 1
+
+    def test_sw_record_layout(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SW-RECORD-LAYOUT", "RL1"))
+        assert len(parent.getSwRecordLayouts()) == 1
+
+    def test_sw_addr_method(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SW-ADDR-METHOD", "AM1"))
+        assert len(parent.getSwAddrMethods()) == 1
+
+    def test_data_type_mapping_set(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("DATA-TYPE-MAPPING-SET", "DTS1"))
+        assert len(parent.getDataTypeMappingSets()) == 1
+
+
+# ==================== Port interfaces ====================
+
+
+class TestPortInterfaceDispatch:
+    def test_sender_receiver_interface(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SENDER-RECEIVER-INTERFACE", "SR1"))
+        assert len(parent.getSenderReceiverInterfaces()) == 1
+
+    def test_client_server_interface(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("CLIENT-SERVER-INTERFACE", "CS1"))
+        assert len(parent.getClientServerInterfaces()) == 1
+
+    def test_parameter_interface(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("PARAMETER-INTERFACE", "PI1"))
+        assert len(parent.getParameterInterfaces()) == 1
+
+    def test_nv_data_interface(self, parser):
+        # No dedicated getter on ARPackage; assert via getElement.
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("NV-DATA-INTERFACE", "NV1"))
+        # Verify it was added to package (no exception means dispatch succeeded).
+        assert parent.getElement("NV1") is not None
+
+    def test_mode_switch_interface(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("MODE-SWITCH-INTERFACE", "MS1"))
+        assert len(parent.getModeSwitchInterfaces()) == 1
+
+    def test_trigger_interface(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("TRIGGER-INTERFACE", "TI1"))
+        assert len(parent.getTriggerInterfaces()) == 1
+
+
+# ==================== BSW ====================
+
+
+class TestBswDispatch:
+    def test_bsw_module_description(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("BSW-MODULE-DESCRIPTION", "BMD1"))
+        assert len(parent.getBswModuleDescriptions()) == 1
+
+    def test_bsw_module_entry(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("BSW-MODULE-ENTRY", "BME1"))
+        assert len(parent.getBswModuleEntries()) == 1
+
+
+# ==================== Misc structure ====================
+
+
+class TestMiscDispatch:
+    def test_mode_declaration_group(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("MODE-DECLARATION-GROUP", "MDG1"))
+        assert len(parent.getModeDeclarationGroups()) == 1
+
+    def test_swc_timing(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SWC-TIMING", "ST1"))
+        assert len(parent.getSwcTimings()) == 1
+
+    def test_end_to_end_protection_set(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("END-TO-END-PROTECTION-SET", "E2E1"))
+        # No dedicated ARPackage getter for E2E; verify dispatch succeeded.
+        assert parent.getElement("E2E1") is not None
+
+    def test_physical_dimension(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("PHYSICAL-DIMENSION", "PD1"))
+        assert len(parent.getEcucPhysicalDimensions()) == 1
+
+
+# ==================== Network / bus ====================
+
+
+class TestNetworkDispatch:
+    def test_lin_cluster(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("LIN-CLUSTER", "LC1"))
+        assert len(parent.getLinClusters()) == 1
+
+    def test_can_cluster(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("CAN-CLUSTER", "CC1"))
+        assert len(parent.getCanClusters()) == 1
+
+    def test_flexray_cluster(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("FLEXRAY-CLUSTER", "FC1"))
+        # No dedicated getter for FlexrayCluster on ARPackage; verify dispatch.
+        assert parent.getElement("FC1") is not None
+
+    def test_ethernet_cluster(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("ETHERNET-CLUSTER", "EC1"))
+        assert parent.getElement("EC1") is not None
+
+    def test_lin_unconditional_frame(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("LIN-UNCONDITIONAL-FRAME", "LF1"))
+        assert len(parent.getLinUnconditionalFrames()) == 1
+
+    def test_can_frame(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("CAN-FRAME", "CF1"))
+        assert len(parent.getCanFrames()) == 1
+
+    def test_flexray_frame(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("FLEXRAY-FRAME", "FF1"))
+        assert len(parent.getFlexrayFrames()) == 1
+
+    def test_ethernet_frame(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("ETHERNET-FRAME", "EF1"))
+        assert parent.getElement("EF1") is not None
+
+    def test_nm_pdu(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("NM-PDU", "NMP1"))
+        assert len(parent.getNmPdus()) == 1
+
+    def test_n_pdu(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("N-PDU", "NP1"))
+        assert len(parent.getNPdus()) == 1
+
+    def test_dcm_i_pdu(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("DCM-I-PDU", "DIP1"))
+        assert len(parent.getDcmIPdus()) == 1
+
+    def test_secured_i_pdu(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SECURED-I-PDU", "SIP1"))
+        assert len(parent.getSecuredIPdus()) == 1
+
+    def test_i_signal(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("I-SIGNAL", "IS1"))
+        assert len(parent.getISignals()) == 1
+
+    def test_i_signal_group(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("I-SIGNAL-GROUP", "ISG1"))
+        assert len(parent.getISignalGroups()) == 1
+
+    def test_i_signal_i_pdu(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("I-SIGNAL-I-PDU", "IIP1"))
+        assert len(parent.getISignalIPdus()) == 1
+
+    def test_i_signal_i_pdu_group(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("I-SIGNAL-I-PDU-GROUP", "IIPG1"))
+        assert parent.getElement("IIPG1") is not None
+
+    def test_system_signal(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SYSTEM-SIGNAL", "SS1"))
+        assert len(parent.getSystemSignals()) == 1
+
+    def test_system_signal_group(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SYSTEM-SIGNAL-GROUP", "SSG1"))
+        assert len(parent.getSystemSignalGroups()) == 1
+
+    def test_multiplexed_i_pdu(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("MULTIPLEXED-I-PDU", "MIP1"))
+        assert parent.getElement("MIP1") is not None
+
+    def test_user_defined_i_pdu(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("USER-DEFINED-I-PDU", "UDI1"))
+        assert parent.getElement("UDI1") is not None
+
+    def test_user_defined_pdu(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("USER-DEFINED-PDU", "UDP1"))
+        assert parent.getElement("UDP1") is not None
+
+    def test_general_purpose_pdu(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("GENERAL-PURPOSE-PDU", "GPP1"))
+        assert parent.getElement("GPP1") is not None
+
+    def test_general_purpose_i_pdu(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("GENERAL-PURPOSE-I-PDU", "GPI1"))
+        assert parent.getElement("GPI1") is not None
+
+
+# ==================== Network management / TP / comm security ====================
+
+
+class TestNmAndCommDispatch:
+    def test_nm_config(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("NM-CONFIG", "NC1"))
+        assert len(parent.getNmConfigs()) == 1
+
+    def test_can_tp_config(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("CAN-TP-CONFIG", "CTP1"))
+        assert len(parent.getCanTpConfigs()) == 1
+
+    def test_lin_tp_config(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("LIN-TP-CONFIG", "LTP1"))
+        assert parent.getElement("LTP1") is not None
+
+    def test_do_ip_tp_config(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("DO-IP-TP-CONFIG", "DITP1"))
+        assert parent.getElement("DITP1") is not None
+
+    def test_secure_communication_props_set(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SECURE-COMMUNICATION-PROPS-SET", "SC1"))
+        assert parent.getElement("SC1") is not None
+
+    def test_so_ad_routing_group(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SO-AD-ROUTING-GROUP", "SAR1"))
+        assert parent.getElement("SAR1") is not None
+
+    def test_data_transformation_set(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("DATA-TRANSFORMATION-SET", "DT1"))
+        assert len(parent.getDataTransformationSets()) == 1
+
+
+# ==================== System ====================
+
+
+class TestSystemDispatch:
+    def test_system(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SYSTEM", "SYS1"))
+        assert len(parent.getSystems()) == 1
+
+    def test_ecu_instance(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("ECU-INSTANCE", "EI1"))
+        assert len(parent.getEcuInstances()) == 1
+
+    def test_gateway(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("GATEWAY", "GW1"))
+        assert len(parent.getGateways()) == 1
+
+
+# ==================== ECUC ====================
+
+
+class TestEcucDispatch:
+    def test_ecuc_value_collection(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("ECUC-VALUE-COLLECTION", "EVC1"))
+        assert len(parent.getEcucValueCollections()) == 1
+
+    def test_ecuc_module_configuration_values(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("ECUC-MODULE-CONFIGURATION-VALUES", "EMV1"))
+        assert len(parent.getEcucModuleConfigurationValues()) == 1
+
+    def test_ecuc_module_def(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("ECUC-MODULE-DEF", "EMD1"))
+        assert len(parent.getEcucModuleDefs()) == 1
+
+
+# ==================== Diagnostic ====================
+
+
+class TestDiagnosticDispatch:
+    def test_diagnostic_connection(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("DIAGNOSTIC-CONNECTION", "DC1"))
+        assert parent.getElement("DC1") is not None
+
+    def test_diagnostic_service_table(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("DIAGNOSTIC-SERVICE-TABLE", "DST1"))
+        assert parent.getElement("DST1") is not None
+
+
+# ==================== Variant / lifecycle ====================
+
+
+class TestVariantAndLifecycleDispatch:
+    def test_sw_systemconst(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SW-SYSTEMCONST", "SC1"))
+        assert len(parent.getSwSystemConsts()) == 1
+
+    def test_sw_systemconstant_value_set(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("SW-SYSTEMCONSTANT-VALUE-SET", "SVS1"))
+        assert len(parent.getSwSystemconstantValueSets()) == 1
+
+    def test_predefined_variant(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("PREDEFINED-VARIANT", "PV1"))
+        assert len(parent.getPredefinedVariants()) == 1
+
+    def test_life_cycle_info_set(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("LIFE-CYCLE-INFO-SET", "LC1"))
+        assert parent.getElement("LC1") is not None
+
+    def test_collection(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("COLLECTION", "CO1"))
+        assert len(parent.getCollections()) == 1
+
+    def test_keyword_set(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("KEYWORD-SET", "KS1"))
+        assert len(parent.getKeywordSets()) == 1
+
+
+# ==================== Mapping / blueprint ====================
+
+
+class TestMappingDispatch:
+    def test_flat_map(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("FLAT-MAP", "FM1"))
+        assert parent.getElement("FM1") is not None
+
+    def test_port_interface_mapping_set(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("PORT-INTERFACE-MAPPING-SET", "PIM1"))
+        assert parent.getElement("PIM1") is not None
+
+    def test_port_prototype_blueprint(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("PORT-PROTOTYPE-BLUEPRINT", "PPB1"))
+        assert len(parent.getPortPrototypeBlueprints()) == 1
+
+    def test_mode_declaration_mapping_set(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("MODE-DECLARATION-MAPPING-SET", "MDM1"))
+        assert len(parent.getModeDeclarationMappingSets()) == 1
+
+
+# ==================== HW ====================
+
+
+class TestHwDispatch:
+    def test_hw_element(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("HW-ELEMENT", "HE1"))
+        assert len(parent.getHwElements()) == 1
+
+    def test_hw_category(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("HW-CATEGORY", "HC1"))
+        assert len(parent.getHwCategories()) == 1
+
+    def test_hw_type(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("HW-TYPE", "HT1"))
+        assert parent.getElement("HT1") is not None
+
+
+# ==================== Else-branch (unsupported element) ====================
+
+
+class TestUnsupportedElement:
+    def test_unsupported_tag_raises_NotImplementedError_by_default(self, strict_parser):
+        parent = _make_parent()
+        with pytest.raises(NotImplementedError, match="Unsupported Element type"):
+            _dispatch(strict_parser, parent, _snip("TOTALLY-UNKNOWN-TAG", "U1"))
+
+    def test_unsupported_tag_logs_in_warning_mode(self, parser, caplog):
+        import logging
+        parent = _make_parent()
+        with caplog.at_level(logging.ERROR):
+            _dispatch(parser, parent, _snip("TOTALLY-UNKNOWN-TAG", "U1"))
+        assert any("Unsupported Element type" in r.getMessage() for r in caplog.records)
+
+
+# ==================== Top-level load() and readARPackages() edge cases ====================
+
+
+class TestLoadAndReadARPackages:
+    def test_load_invalid_root_tag_raises_ValueError(self, strict_parser, tmp_path):
+        # File contains a non-AUTOSAR root element.
+        bad = tmp_path / "bad.arxml"
+        bad.write_text(f"<NOT-AUTOSAR xmlns='{NS}'></NOT-AUTOSAR>", encoding="utf-8")
+        from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSARDoc
+        document = AUTOSARDoc()
+        with pytest.raises(ValueError, match="Invalid ARXML file"):
+            strict_parser.load(str(bad), document)
+
+    def test_readARPackages_unknown_child_tag_raises(self, strict_parser):
+        # Manually invoke readARPackages with an unexpected child.
+        import xml.etree.ElementTree as ET
+        xml = f"<ROOT xmlns='{NS}'><AR-PACKAGES><TOTALLY-UNKNOWN/></AR-PACKAGES></ROOT>"
+        root = ET.fromstring(xml)
+        parent = _make_parent()
+        with pytest.raises(NotImplementedError, match="Unsupported ARPackage"):
+            strict_parser.readARPackages(root, parent)
+
+    def test_readARPackages_unknown_child_tag_warns(self, parser, caplog):
+        import logging
+        import xml.etree.ElementTree as ET
+        xml = f"<ROOT xmlns='{NS}'><AR-PACKAGES><TOTALLY-UNKNOWN/></AR-PACKAGES></ROOT>"
+        root = ET.fromstring(xml)
+        parent = _make_parent()
+        with caplog.at_level(logging.ERROR):
+            strict_parser_warning = ARXMLParser(options={"warning": True})
+            strict_parser_warning.readARPackages(root, parent)
+        assert any("Unsupported ARPackage" in r.getMessage() for r in caplog.records)

--- a/tests/test_armodel/parser/test_arxml_parser_error_paths.py
+++ b/tests/test_armodel/parser/test_arxml_parser_error_paths.py
@@ -1,0 +1,442 @@
+"""Tests for error/warning paths and converters in AbstractARXMLParser.
+
+Targets the uncovered branches in `src/armodel/parser/abstract_arxml_parser.py`:
+- raiseError / notImplemented / raiseWarning (warning-mode vs raise-mode)
+- _convertStringToBooleanValue / _convertStringToNumberValue
+- Optional-element getters' null and error branches
+- Required-element getters' raise branches
+- Abstract instantiation guard
+"""
+
+import logging
+
+import pytest
+import xml.etree.ElementTree as ET
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.parser.abstract_arxml_parser import AbstractARXMLParser
+from armodel.parser.arxml_parser import ARXMLParser
+
+NS = "http://autosar.org/schema/r4.0"
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    """Reset AUTOSAR singleton before each test."""
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def parser():
+    """Create ARXML parser instance (concrete subclass of AbstractARXMLParser)."""
+    AUTOSAR.getInstance().new()
+    return ARXMLParser()
+
+
+@pytest.fixture
+def warning_parser():
+    """Parser configured in warning mode (logs instead of raising)."""
+    AUTOSAR.getInstance().new()
+    return ARXMLParser(options={"warning": True})
+
+
+def _snip(inner_xml: str) -> ET.Element:
+    return ET.fromstring(f"<ROOT xmlns='{NS}'>{inner_xml}</ROOT>")
+
+
+# ==================== Abstract instantiation guard ====================
+
+
+class TestAbstractInstantiation:
+    def test_AbstractARXMLParser_cannot_be_instantiated(self):
+        with pytest.raises(TypeError, match="abstract class"):
+            AbstractARXMLParser()
+
+
+# ==================== raiseError / notImplemented / raiseWarning ====================
+
+
+class TestErrorAndWarning:
+    def test_raiseError_raises_ValueError_by_default(self, parser):
+        with pytest.raises(ValueError, match="boom"):
+            parser.raiseError("boom")
+
+    def test_raiseError_logs_in_warning_mode(self, warning_parser, caplog):
+        with caplog.at_level(logging.ERROR):
+            warning_parser.raiseError("soft fail")
+        assert any("soft fail" in rec.getMessage() for rec in caplog.records)
+        # Should NOT raise
+        assert warning_parser.options["warning"] is True
+
+    def test_notImplemented_raises_NotImplementedError_by_default(self, parser):
+        with pytest.raises(NotImplementedError, match="not yet"):
+            parser.notImplemented("not yet")
+
+    def test_notImplemented_logs_in_warning_mode(self, warning_parser, caplog):
+        with caplog.at_level(logging.ERROR):
+            warning_parser.notImplemented("skip")
+        assert any("skip" in rec.getMessage() for rec in caplog.records)
+
+    def test_raiseWarning_always_logs(self, parser, caplog):
+        with caplog.at_level(logging.WARNING):
+            parser.raiseWarning("careful")
+        assert any("careful" in rec.getMessage() for rec in caplog.records)
+
+
+# ==================== String converters ====================
+
+
+class TestStringConverters:
+    def test_convertStringToBooleanValue_true(self, parser):
+        assert parser._convertStringToBooleanValue("true") is True
+
+    def test_convertStringToBooleanValue_false_for_non_true(self, parser):
+        # Any value other than literal "true" is interpreted as False.
+        assert parser._convertStringToBooleanValue("false") is False
+        assert parser._convertStringToBooleanValue("False") is False
+        assert parser._convertStringToBooleanValue("0") is False
+        assert parser._convertStringToBooleanValue("") is False
+
+    def test_convertStringToNumberValue_decimal(self, parser):
+        assert parser._convertStringToNumberValue("42") == 42
+        assert parser._convertStringToNumberValue("-7") == -7
+
+    def test_convertStringToNumberValue_hex_lowercase(self, parser):
+        assert parser._convertStringToNumberValue("0xff") == 255
+
+    def test_convertStringToNumberValue_hex_uppercase(self, parser):
+        # re.I is used, so 0X should also match.
+        assert parser._convertStringToNumberValue("0X10") == 16
+
+    def test_convertStringToNumberValue_hex_short_value(self, parser):
+        assert parser._convertStringToNumberValue("0xa") == 10
+
+
+# ==================== Required-element getters (raise on missing) ====================
+
+
+class TestRequiredGetters:
+    def test_getShortName_missing_raises_ValueError(self, parser):
+        element = _snip("<NO-SHORT-NAME>foo</NO-SHORT-NAME>")
+        with pytest.raises(ValueError, match="Short Name is required"):
+            parser.getShortName(element)
+
+    def test_getChildElementLiteral_missing_raises_ValueError(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        with pytest.raises(ValueError, match="has not been defined"):
+            parser.getChildElementLiteral("X", element, "MISSING-KEY")
+
+    def test_getChildElementLiteral_present_returns_literal(self, parser):
+        element = _snip("<NAME>hello</NAME>")
+        literal = parser.getChildElementLiteral("X", element, "NAME")
+        assert literal is not None
+        assert literal.getValue() == "hello"
+
+    def test_getChildElementRefType_missing_raises_ValueError(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        with pytest.raises(ValueError, match="has not been defined"):
+            parser.getChildElementRefType("X", element, "MISSING-REF")
+
+
+# ==================== Optional-element getters (None handling) ====================
+
+
+class TestOptionalGetters:
+    def test_getChildElementOptionalLiteral_missing_returns_None(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildElementOptionalLiteral(element, "ABSENT") is None
+
+    def test_getChildElementOptionalLiteral_empty_text_returns_empty_string(self, parser):
+        # Empty element <X></X> — text is None and gets converted to "".
+        element = _snip("<EMPTY></EMPTY>")
+        literal = parser.getChildElementOptionalLiteral(element, "EMPTY")
+        assert literal is not None
+        assert literal.getText() == ""
+
+    def test_getChildElementOptionalLiteral_with_text(self, parser):
+        element = _snip("<NAME>value</NAME>")
+        literal = parser.getChildElementOptionalLiteral(element, "NAME")
+        assert literal is not None
+        assert literal.getText() == "value"
+
+    def test_getChildElementOptionalFloatValue_missing_returns_None(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildElementOptionalFloatValue(element, "ABSENT") is None
+
+    def test_getChildElementOptionalFloatValue_empty_text_returns_None(self, parser):
+        # Element exists but text is None → returns None (per implementation).
+        element = _snip("<VAL></VAL>")
+        assert parser.getChildElementOptionalFloatValue(element, "VAL") is None
+
+    def test_getChildElementOptionalFloatValue_with_value(self, parser):
+        element = _snip("<VAL>3.14</VAL>")
+        f = parser.getChildElementOptionalFloatValue(element, "VAL")
+        assert f is not None
+        assert float(f.getValue()) == pytest.approx(3.14)
+
+    def test_getChildElementOptionalTimeValue_missing_returns_None(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildElementOptionalTimeValue(element, "ABSENT") is None
+
+    def test_getChildElementOptionalTimeValue_empty_text_returns_None(self, parser):
+        element = _snip("<T></T>")
+        assert parser.getChildElementOptionalTimeValue(element, "T") is None
+
+    def test_getChildElementOptionalIntegerValue_missing_returns_None(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildElementOptionalIntegerValue(element, "ABSENT") is None
+
+    def test_getChildElementOptionalIntegerValue_with_value(self, parser):
+        element = _snip("<V>42</V>")
+        i = parser.getChildElementOptionalIntegerValue(element, "V")
+        assert i is not None
+        assert i.getValue() == 42
+
+    def test_getChildElementOptionalPositiveInteger_missing_returns_None(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildElementOptionalPositiveInteger(element, "ABSENT") is None
+
+    def test_getChildElementOptionalPositiveInteger_empty_text_returns_None(self, parser):
+        element = _snip("<V></V>")
+        assert parser.getChildElementOptionalPositiveInteger(element, "V") is None
+
+    def test_getChildElementOptionalPositiveInteger_negative_raises(self, parser):
+        element = _snip("<V>-5</V>")
+        with pytest.raises(ValueError, match="Invalid PositiveInteger"):
+            parser.getChildElementOptionalPositiveInteger(element, "V")
+
+    def test_getChildElementOptionalPositiveInteger_valid(self, parser):
+        element = _snip("<V>5</V>")
+        v = parser.getChildElementOptionalPositiveInteger(element, "V")
+        assert v is not None
+        assert v.getValue() == 5
+
+
+class TestOptionalBooleanValue:
+    def test_missing_returns_None(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildElementOptionalBooleanValue(element, "ABSENT") is None
+
+    def test_empty_text_returns_None(self, parser):
+        element = _snip("<B></B>")
+        # getChildElementOptionalLiteral returns "" for empty, bool getter returns None.
+        assert parser.getChildElementOptionalBooleanValue(element, "B") is None
+
+    def test_true_returns_Boolean(self, parser):
+        element = _snip("<B>true</B>")
+        b = parser.getChildElementOptionalBooleanValue(element, "B")
+        assert b is not None
+        assert b.getValue() is True
+
+    def test_false_returns_Boolean(self, parser):
+        element = _snip("<B>false</B>")
+        b = parser.getChildElementOptionalBooleanValue(element, "B")
+        assert b is not None
+        assert b.getValue() is False
+
+
+class TestOptionalRevisionLabelString:
+    def test_missing_returns_None(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildElementOptionalRevisionLabelString(element, "ABSENT") is None
+
+    def test_none_text_returns_None(self, parser):
+        element = _snip("<R></R>")
+        assert parser.getChildElementOptionalRevisionLabelString(element, "R") is None
+
+    def test_valid_value(self, parser):
+        element = _snip("<R>1.0.0</R>")
+        v = parser.getChildElementOptionalRevisionLabelString(element, "R")
+        assert v is not None
+        assert v.getValue() == "1.0.0"
+
+    def test_valid_value_with_suffix(self, parser):
+        element = _snip("<R>1.2.3;build5</R>")
+        v = parser.getChildElementOptionalRevisionLabelString(element, "R")
+        assert v is not None
+        assert v.getValue() == "1.2.3;build5"
+
+    def test_invalid_format_raises_ValueError(self, parser):
+        element = _snip("<R>not-a-version</R>")
+        with pytest.raises(ValueError, match="Invalid RevisionLabelString"):
+            parser.getChildElementOptionalRevisionLabelString(element, "R")
+
+
+# ==================== List getters ====================
+
+
+class TestListGetters:
+    def test_getChildElementLiteralValueList_empty(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildElementLiteralValueList(element, "ITEM") == []
+
+    def test_getChildElementLiteralValueList_multiple(self, parser):
+        element = _snip("<ITEMS><ITEM>a</ITEM><ITEM>b</ITEM></ITEMS>")
+        result = parser.getChildElementLiteralValueList(element, "ITEMS/ITEM")
+        assert [r.getValue() for r in result] == ["a", "b"]
+
+    def test_getChildElementFloatValueList_empty(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildElementFloatValueList(element, "ITEM") == []
+
+    def test_getChildElementFloatValueList_multiple(self, parser):
+        element = _snip("<ITEMS><ITEM>1.5</ITEM><ITEM>2.5</ITEM></ITEMS>")
+        result = parser.getChildElementFloatValueList(element, "ITEMS/ITEM")
+        assert [float(r.getValue()) for r in result] == [1.5, 2.5]
+
+    def test_getChildElementNumericalValueList_empty(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildElementNumericalValueList(element, "ITEM") == []
+
+    def test_getChildElementNumericalValueList_multiple(self, parser):
+        element = _snip("<ITEMS><ITEM>1</ITEM><ITEM>2</ITEM></ITEMS>")
+        result = parser.getChildElementNumericalValueList(element, "ITEMS/ITEM")
+        assert [r.getValue() for r in result] == [1, 2]
+
+
+# ==================== Limit element ====================
+
+
+class TestChildLimitElement:
+    def test_missing_returns_None(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildLimitElement(element, "ABSENT") is None
+
+    def test_with_interval_type(self, parser):
+        element = _snip('<L INTERVAL-TYPE="CLOSED">100</L>')
+        limit = parser.getChildLimitElement(element, "L")
+        assert limit is not None
+        assert limit.intervalType == "CLOSED"
+        assert limit.value == "100"
+
+    def test_without_interval_type(self, parser):
+        element = _snip("<L>50</L>")
+        limit = parser.getChildLimitElement(element, "L")
+        assert limit is not None
+        assert limit.intervalType is None
+        assert limit.value == "50"
+
+
+# ==================== RefType getters ====================
+
+
+class TestRefTypeGetters:
+    def test_getChildElementOptionalRefType_missing_returns_None(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildElementOptionalRefType(element, "ABSENT") is None
+
+    def test_getChildElementOptionalRefType_with_base_and_dest(self, parser):
+        element = _snip(
+            '<R BASE="b" DEST="UNIT">/pkg/u</R>'
+        )
+        ref = parser.getChildElementOptionalRefType(element, "R")
+        assert ref is not None
+        assert ref.getBase() == "b"
+        assert ref.getDest() == "UNIT"
+        assert ref.getValue() == "/pkg/u"
+
+    def test_getChildElementOptionalRefType_minimal(self, parser):
+        element = _snip("<R>/pkg/u</R>")
+        ref = parser.getChildElementOptionalRefType(element, "R")
+        assert ref is not None
+        assert ref.getValue() == "/pkg/u"
+
+    def test_getChildElementRefTypeList_empty(self, parser):
+        element = _snip("<SHORT-NAME>X</SHORT-NAME>")
+        assert parser.getChildElementRefTypeList(element, "ITEM") == []
+
+    def test_getChildElementRefTypeList_multiple(self, parser):
+        element = _snip(
+            "<ITEMS>"
+            "<R DEST=\"UNIT\">/a</R>"
+            "<R DEST=\"UNIT\">/b</R>"
+            "</ITEMS>"
+        )
+        result = parser.getChildElementRefTypeList(element, "ITEMS/R")
+        assert len(result) == 2
+        assert [r.getValue() for r in result] == ["/a", "/b"]
+
+
+# ==================== Misc utility methods ====================
+
+
+class TestUtilityMethods:
+    def test_readElementOptionalAttrib_present(self, parser):
+        root = _snip('<X T="t1" UUID="u1"/>')
+        element = parser.find(root, "X")
+        assert parser.readElementOptionalAttrib(element, "T") == "t1"
+        assert parser.readElementOptionalAttrib(element, "UUID") == "u1"
+
+    def test_readElementOptionalAttrib_absent_returns_None(self, parser):
+        element = _snip("<X/>")
+        assert parser.readElementOptionalAttrib(element, "MISSING") is None
+
+    def test_getPureTagName_strips_namespace(self, parser):
+        assert parser.getPureTagName(f"{{{NS}}}SHORT-NAME") == "SHORT-NAME"
+        assert parser.getPureTagName("SHORT-NAME") == "SHORT-NAME"
+
+    def test_convert_find_key_preserves_wildcards(self, parser):
+        # "*" and "." should not be prefixed with xmlns:
+        key = parser.convert_find_key("AR-PACKAGES/*")
+        assert key == "xmlns:AR-PACKAGES/*"
+
+    def test_convert_find_key_preserves_dot(self, parser):
+        key = parser.convert_find_key("./SHORT-NAME")
+        assert key == "./xmlns:SHORT-NAME"
+
+    def test_convert_find_key_plain(self, parser):
+        key = parser.convert_find_key("SHORT-NAME")
+        assert key == "xmlns:SHORT-NAME"
+
+
+# ==================== readARObjectAttributes ====================
+
+
+class TestReadARObjectAttributes:
+    def test_reads_timestamp_and_uuid(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral
+
+        root = _snip('<X T="t1" UUID="u1"/>')
+        element = parser.find(root, "X")
+        obj = ARLiteral()
+        parser.readARObjectAttributes(element, obj)
+        assert obj.timestamp == "t1"
+        assert obj.uuid == "u1"
+
+    def test_handles_missing_attributes(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral
+
+        root = _snip("<X/>")
+        element = parser.find(root, "X")
+        obj = ARLiteral()
+        parser.readARObjectAttributes(element, obj)
+        assert obj.timestamp is None
+        assert obj.uuid is None
+
+
+# ==================== getAUTOSARInfo ====================
+
+
+class TestGetAUTOSARInfo:
+    def test_records_schema_location(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSARDoc
+
+        document = AUTOSARDoc()
+        element = ET.fromstring(
+            f"<AUTOSAR xmlns='{NS}' "
+            f"xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' "
+            f"xsi:schemaLocation='http://autosar.org/schema/r4.0 AUTOSAR.xsd'>"
+            f"</AUTOSAR>"
+        )
+        parser.getAUTOSARInfo(element, document)
+        assert document.schema_location.startswith("http://autosar.org/schema/r4.0")
+
+    def test_no_schema_location(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSARDoc
+
+        document = AUTOSARDoc()
+        element = _snip("<X/>")
+        # Should be a no-op; should not raise.
+        parser.getAUTOSARInfo(element, document)

--- a/tests/test_armodel/parser/test_arxml_parser_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_handlers.py
@@ -1,0 +1,891 @@
+"""Phase E: targeted tests for uncovered handler methods in ARXMLParser.
+
+Each test directly invokes a single handler method on `ARXMLParser` with a
+minimal XML snippet, lifting coverage on specific read*/get* bodies that the
+dispatch tests in test_arxml_parser_dispatch.py only route around.
+
+Coverage focus (from term-missing report on arxml_parser.py):
+    Group A — core element helpers (lines 325-424)
+    Group B — SwComponentType / SwConnector (lines 2095-2384)
+    Group C — DataTypes & ValueSpecs (lines 1903-1997)
+    Group D — Port interfaces & CompuMethod (lines 2522-2581)
+    Group E — BswBehavior orchestrators (lines 815-871)
+"""
+
+import logging
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from armodel.models import AUTOSAR
+from armodel.parser.arxml_parser import ARXMLParser
+
+NS = "http://autosar.org/schema/r4.0"
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    """Reset AUTOSAR singleton before each test."""
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def parser():
+    AUTOSAR.getInstance().new()
+    return ARXMLParser()
+
+
+@pytest.fixture
+def warning_parser():
+    """Parser configured in warning mode (logs instead of raising)."""
+    AUTOSAR.getInstance().new()
+    return ARXMLParser(options={"warning": True})
+
+
+def _snip(inner: str, root_tag: str = "ROOT") -> ET.Element:
+    """Wrap an inner XML fragment in a root element bound to the AUTOSAR NS."""
+    return ET.fromstring(f"<{root_tag} xmlns='{NS}'>{inner}</{root_tag}>")
+
+
+def _autosar_root():
+    """Return the AUTOSAR singleton for use as a parent in model constructors."""
+    return AUTOSAR.getInstance()
+
+
+# ==================== Group D: Port interfaces & CompuMethod ====================
+
+
+class TestPortInterfaceAndCompuHandlers:
+    """Exercise readClientServerInterface and CompuMethod helpers."""
+
+    def test_readClientServerInterface_minimal(self, warning_parser):
+        from armodel.models import ClientServerInterface
+
+        csi = ClientServerInterface(parent=_autosar_root(), short_name="csi")
+        element = _snip(
+            "<SHORT-NAME>csi</SHORT-NAME>",
+            root_tag="CLIENT-SERVER-INTERFACE",
+        )
+        warning_parser.readClientServerInterface(element, csi)
+        assert csi.getShortName() == "csi"
+
+    def test_getCompuConstContent_VF_branch(self, parser):
+        from armodel.models import CompuConstFormulaContent
+
+        element = _snip("<VF>formula</VF>", root_tag="PARENT")
+        content = parser.getCompuConstContent(element)
+        assert isinstance(content, CompuConstFormulaContent)
+        assert content.getVf().getValue() == "formula"
+
+    def test_getCompuConstContent_V_branch(self, parser):
+        from armodel.models import CompuConstNumericContent
+
+        element = _snip("<V>42</V>", root_tag="PARENT")
+        content = parser.getCompuConstContent(element)
+        assert isinstance(content, CompuConstNumericContent)
+        assert content.getV().getValue() == 42
+
+    def test_getCompuConstContent_VT_branch(self, parser):
+        from armodel.models import CompuConstTextContent
+
+        element = _snip("<VT>label</VT>", root_tag="PARENT")
+        content = parser.getCompuConstContent(element)
+        assert isinstance(content, CompuConstTextContent)
+        assert content.getVt().getValue() == "label"
+
+    def test_getCompuConstContent_unsupported_tag_warns(self, warning_parser, caplog):
+        element = _snip("<BAD-TAG>x</BAD-TAG>", root_tag="PARENT")
+        with caplog.at_level(logging.ERROR):
+            content = warning_parser.getCompuConstContent(element)
+        assert content is None
+        assert any("Unsupported CompuConstContent" in r.getMessage() for r in caplog.records)
+
+    def test_getCompuConstContent_empty_returns_None(self, parser):
+        element = _snip("", root_tag="PARENT")
+        assert parser.getCompuConstContent(element) is None
+
+    def test_getCompuConst_wraps_content(self, parser):
+        element = _snip("<CC><VT>hello</VT></CC>", root_tag="PARENT")
+        compu_const = parser.getCompuConst(element, "CC")
+        assert compu_const is not None
+        assert compu_const.getCompuConstContentType() is not None
+
+    def test_getCompuConst_missing_returns_None(self, parser):
+        element = _snip("<X/>")
+        assert parser.getCompuConst(element, "CC") is None
+
+    def test_readCompuConst_VT_branch(self, parser):
+        from armodel.models import CompuScale
+
+        scale = CompuScale()
+        element = _snip(
+            "<COMPU-CONST><VT>label</VT></COMPU-CONST>",
+            root_tag="SCALE",
+        )
+        parser.readCompuConst(element, scale)
+        assert scale.compuScaleContents is not None
+        contents = scale.compuScaleContents
+        assert contents.compuConst is not None
+        assert contents.compuConst.compuConstContentType.vt.getValue() == "label"
+
+    def test_readCompuConst_no_VT_skips(self, parser):
+        from armodel.models import CompuScale
+
+        scale = CompuScale()
+        scale.compuScaleContents = None  # ensure starting state
+        element = _snip("", root_tag="SCALE")
+        parser.readCompuConst(element, scale)
+        # compuScaleContents should remain unset (None).
+        assert scale.compuScaleContents is None
+
+    def test_readCompuNominatorDenominator_adds_V(self, parser):
+        from armodel.models import CompuNominatorDenominator
+
+        cnd = CompuNominatorDenominator()
+        element = _snip(
+            "<COMPU-NUMERATOR><V>1</V><V>2</V><V>3</V></COMPU-NUMERATOR>",
+            root_tag="PARENT",
+        )
+        parser.readCompuNominatorDenominator(
+            element, "COMPU-NUMERATOR", cnd
+        )
+        assert len(cnd.get_vs()) == 3
+
+    def test_readCompuNominatorDenominator_empty(self, parser):
+        from armodel.models import CompuNominatorDenominator
+
+        cnd = CompuNominatorDenominator()
+        element = _snip("<COMPU-NUMERATOR/>", root_tag="PARENT")
+        parser.readCompuNominatorDenominator(element, "COMPU-NUMERATOR", cnd)
+        assert len(cnd.get_vs()) == 0
+
+    def test_readCompuRationCoeffs_populates_contents(self, parser):
+        from armodel.models import CompuScale, CompuScaleRationalFormula
+
+        scale = CompuScale()
+        element = _snip(
+            "<COMPU-RATIONAL-COEFFS>"
+            "<COMPU-DENOMINATOR><V>1</V></COMPU-DENOMINATOR>"
+            "<COMPU-NUMERATOR><V>2</V><V>3</V></COMPU-NUMERATOR>"
+            "</COMPU-RATIONAL-COEFFS>",
+            root_tag="SCALE",
+        )
+        parser.readCompuRationCoeffs(element, scale)
+        assert isinstance(scale.compuScaleContents, CompuScaleRationalFormula)
+        coeffs = scale.compuScaleContents.compuRationalCoeffs
+        assert coeffs is not None
+        assert len(coeffs.compuDenominator.get_vs()) == 1
+        assert len(coeffs.compuNumerator.get_vs()) == 2
+
+    def test_readCompuRationCoeffs_missing_no_op(self, parser):
+        from armodel.models import CompuScale
+
+        scale = CompuScale()
+        scale.compuScaleContents = None
+        element = _snip("", root_tag="SCALE")
+        parser.readCompuRationCoeffs(element, scale)
+        assert scale.compuScaleContents is None
+
+
+# ==================== Group A: AdminData & Referrable helpers ====================
+
+
+class TestAdminDataAndReferrableHandlers:
+    """Exercise getAdminData, readReferrable, readIdentifiable, multilanguage
+    helpers, and InstanceRef builders."""
+
+    def test_getAdminData_full(self, parser):
+        element = _snip(
+            "<ADMIN-DATA>"
+            "<LANGUAGE>EN</LANGUAGE>"
+            "<USED-LANGUAGES><L-4>EN</L-4></USED-LANGUAGES>"
+            "<SDGS><SDG GID='G'><SD>x</SD></SDG></SDGS>"
+            "<DOC-REVISIONS>"
+            "<DOC-REVISION>"
+            "<ISSUED-BY>alice</ISSUED-BY>"
+            "<REVISION-LABEL>1.0.0</REVISION-LABEL>"
+            "</DOC-REVISION>"
+            "</DOC-REVISIONS>"
+            "</ADMIN-DATA>",
+            root_tag="PARENT",
+        )
+        admin = parser.getAdminData(element, "ADMIN-DATA")
+        assert admin is not None
+        assert admin.getLanguage().getValue() == "EN"
+        assert len(admin.getSdgs()) == 1
+        assert len(admin.getDocRevisions()) == 1
+
+    def test_getAdminData_missing_returns_None(self, parser):
+        element = _snip("<X/>")
+        assert parser.getAdminData(element, "ADMIN-DATA") is None
+
+    def test_readReferrable_minimal(self, parser):
+        from armodel.models import BswVariableAccess
+
+        obj = BswVariableAccess(parent=_autosar_root(), short_name="va")
+        element = _snip("", root_tag="ELEM")
+        elem = ET.fromstring(
+            f"<ELEM xmlns='{NS}' UUID='abc' T='2024-01-01T00:00:00'/>"
+        )
+        parser.readReferrable(elem, obj)
+        assert obj.uuid == "abc"
+        assert obj.timestamp == "2024-01-01T00:00:00"
+
+    def test_readMultilanguageReferrable_sets_longName(self, parser):
+        # Use a concrete MultilanguageReferrable subclass (Unit extends ARElement
+        # extends Identifiable extends MultilanguageReferrable).
+        from armodel.models import Unit
+
+        obj = Unit(parent=_autosar_root(), short_name="u")
+        element = _snip(
+            "<LONG-NAME><L-4 L='EN'>MyLong</L-4></LONG-NAME>",
+            root_tag="ELEM",
+        )
+        parser.readMultilanguageReferrable(element, obj)
+        assert obj.getLongName() is not None
+
+    def test_readIdentifiable_populates_category_desc_admin(self, parser):
+        from armodel.models import Unit
+
+        obj = Unit(parent=_autosar_root(), short_name="u")
+        element = _snip(
+            "<CATEGORY>CAT_A</CATEGORY>"
+            "<DESC><L-2 L='EN'>desc</L-2></DESC>"
+            "<INTRODUCTION><L-1>intro</L-1></INTRODUCTION>"
+            "<ADMIN-DATA><LANGUAGE>EN</LANGUAGE></ADMIN-DATA>",
+            root_tag="ELEM",
+        )
+        parser.readIdentifiable(element, obj)
+        assert obj.getCategory().getValue() == "CAT_A"
+        assert obj.getDesc() is not None
+        assert obj.getAdminData() is not None
+        assert obj.getAdminData().getLanguage().getValue() == "EN"
+
+    def test_readIdentifiable_with_annotation(self, parser):
+        from armodel.models import Unit
+
+        obj = Unit(parent=_autosar_root(), short_name="u")
+        element = _snip(
+            "<ANNOTATIONS>"
+            "<ANNOTATION>"
+            "<LABEL><L-4>note</L-4></LABEL>"
+            "<TEXT><L-1>body</L-1></TEXT>"
+            "</ANNOTATION>"
+            "</ANNOTATIONS>",
+            root_tag="ELEM",
+        )
+        parser.readIdentifiable(element, obj)
+        assert len(obj.getAnnotations()) == 1
+
+    def test_readARElement_delegates_to_readIdentifiable(self, parser):
+        from armodel.models import Unit
+
+        obj = Unit(parent=_autosar_root(), short_name="u")
+        element = _snip("<CATEGORY>CAT_A</CATEGORY>", root_tag="ELEM")
+        parser.readARElement(element, obj)
+        assert obj.getCategory().getValue() == "CAT_A"
+
+    def test_getMultilanguageLongName_multiple_L4(self, parser):
+        element = _snip(
+            "<LONG-NAME>"
+            "<L-4 L='EN'>a</L-4>"
+            "<L-4 L='DE'>b</L-4>"
+            "</LONG-NAME>",
+            root_tag="PARENT",
+        )
+        long_name = parser.getMultilanguageLongName(element, "LONG-NAME")
+        assert long_name is not None
+        # readLLongName adds each L-4 via addL4.
+        assert len(long_name.getL4s()) == 2
+
+    def test_getMultilanguageLongName_missing_returns_None(self, parser):
+        element = _snip("<X/>")
+        assert parser.getMultilanguageLongName(element, "LONG-NAME") is None
+
+    def test_getMultiLanguageOverviewParagraph_with_L2(self, parser):
+        element = _snip(
+            "<DESC><L-2 L='EN'>overview</L-2></DESC>",
+            root_tag="PARENT",
+        )
+        paragraph = parser.getMultiLanguageOverviewParagraph(element, "DESC")
+        assert paragraph is not None
+        assert len(paragraph.getL2s()) == 1
+
+    def test_getVariableInAtomicSWCTypeInstanceRef_full(self, parser):
+        element = _snip(
+            "<AUTOSAR-VARIABLE-IREF>"
+            "<PORT-PROTOTYPE-REF DEST='PORT-PROTOTYPE'>/p1</PORT-PROTOTYPE-REF>"
+            "<TARGET-DATA-PROTOTYPE-REF DEST='VARIABLE-DATA-PROTOTYPE'>/td1</TARGET-DATA-PROTOTYPE-REF>"
+            "</AUTOSAR-VARIABLE-IREF>",
+            root_tag="PARENT",
+        )
+        iref = parser.getVariableInAtomicSWCTypeInstanceRef(
+            parser.find(element, "AUTOSAR-VARIABLE-IREF")
+        )
+        assert iref is not None
+        assert iref.getPortPrototypeRef().getValue() == "/p1"
+        assert iref.getTargetDataPrototypeRef().getValue() == "/td1"
+
+    def test_getVariableInAtomicSWCTypeInstanceRef_none_element(self, parser):
+        assert parser.getVariableInAtomicSWCTypeInstanceRef(None) is None
+
+    def test_getComponentInSystemInstanceRef_full(self, parser):
+        element = _snip(
+            "<COMPONENT-IREF>"
+            "<BASE-REF DEST='X'>/b</BASE-REF>"
+            "<CONTEXT-COMPOSITION-REF DEST='COMPOSITION-SW-COMPONENT-TYPE'>/c</CONTEXT-COMPOSITION-REF>"
+            "<TARGET-COMPONENT-REF DEST='SW-COMPONENT-PROTOTYPE'>/t</TARGET-COMPONENT-REF>"
+            "</COMPONENT-IREF>",
+            root_tag="PARENT",
+        )
+        iref = parser.getComponentInSystemInstanceRef(
+            parser.find(element, "COMPONENT-IREF")
+        )
+        assert iref is not None
+        assert iref.getBaseRef().getValue() == "/b"
+        assert iref.getContextCompositionRef().getValue() == "/c"
+        assert iref.getTargetComponentRef().getValue() == "/t"
+
+    def test_getAutosarVariableRef_with_iref(self, parser):
+        element = _snip(
+            "<ACCESSED-VARIABLE>"
+            "<AUTOSAR-VARIABLE-IREF>"
+            "<PORT-PROTOTYPE-REF DEST='PORT-PROTOTYPE'>/p1</PORT-PROTOTYPE-REF>"
+            "<TARGET-DATA-PROTOTYPE-REF DEST='VARIABLE-DATA-PROTOTYPE'>/td1</TARGET-DATA-PROTOTYPE-REF>"
+            "</AUTOSAR-VARIABLE-IREF>"
+            "<LOCAL-VARIABLE-REF DEST='VARIABLE-DATA-PROTOTYPE'>/lv</LOCAL-VARIABLE-REF>"
+            "</ACCESSED-VARIABLE>",
+            root_tag="PARENT",
+        )
+        ref = parser.getAutosarVariableRef(element, "ACCESSED-VARIABLE")
+        assert ref is not None
+        assert ref.getLocalVariableRef().getValue() == "/lv"
+        assert ref.getAutosarVariableIRef() is not None
+
+
+# ==================== Group C: DataTypes & ValueSpecs ====================
+
+
+class TestDataTypeAndValueSpecHandlers:
+    """Exercise readImplementationDataType, readSwBaseType, SwValues,
+    ValueList, SwValueCont, ApplicationValueSpecification, and
+    getChildValueSpecification."""
+
+    def test_readSwBaseType_full(self, parser):
+        from armodel.models import SwBaseType
+
+        bt = SwBaseType(parent=_autosar_root(), short_name="bt")
+        # Per AUTOSAR schema, BASE-TYPE-* children live directly under SW-BASE-TYPE
+        # (no BASE-TYPE-DEFINITION wrapper). See tests/integration_tests/test_files.
+        element = _snip(
+            "<SHORT-NAME>bt</SHORT-NAME>"
+            "<BASE-TYPE-SIZE>32</BASE-TYPE-SIZE>"
+            "<BASE-TYPE-ENCODING>IEEE754</BASE-TYPE-ENCODING>"
+            "<BYTE-ORDER>BIG-ENDIAN</BYTE-ORDER>"
+            "<MEM-ALIGNMENT>4</MEM-ALIGNMENT>"
+            "<NATIVE-DECLARATION>float</NATIVE-DECLARATION>",
+            root_tag="SW-BASE-TYPE",
+        )
+        parser.readSwBaseType(element, bt)
+        definition = bt.getBaseTypeDefinition()
+        assert definition.getBaseTypeSize().getValue() == 32
+        assert definition.getNativeDeclaration().getValue() == "float"
+        assert definition.getByteOrder().getValue() == "BIG-ENDIAN"
+
+    def test_readBaseTypeDirectDefinition_empty(self, parser):
+        from armodel.models import BaseTypeDirectDefinition
+
+        definition = BaseTypeDirectDefinition()
+        element = _snip("<X/>")
+        parser.readBaseTypeDirectDefinition(element, definition)
+        assert definition.getBaseTypeSize() is None
+        assert definition.getBaseTypeEncoding() is None
+        assert definition.getByteOrder() is None
+        assert definition.getMemAlignment() is None
+        assert definition.getNativeDeclaration() is None
+
+    def test_readImplementationDataType_minimal(self, parser):
+        from armodel.models import ImplementationDataType
+
+        idt = ImplementationDataType(parent=_autosar_root(), short_name="idt")
+        element = _snip(
+            "<SHORT-NAME>idt</SHORT-NAME>", root_tag="IMPLEMENTATION-DATA-TYPE"
+        )
+        parser.readImplementationDataType(element, idt)
+        assert idt.getDynamicArraySizeProfile() is None
+        assert idt.getTypeEmitter() is None
+
+    def test_readImplementationDataType_with_typeEmitter_and_profile(self, parser):
+        from armodel.models import ImplementationDataType
+
+        idt = ImplementationDataType(parent=_autosar_root(), short_name="idt")
+        element = _snip(
+            "<SHORT-NAME>idt</SHORT-NAME>"
+            "<DYNAMIC-ARRAY-SIZE-PROFILE>VAR</DYNAMIC-ARRAY-SIZE-PROFILE>"
+            "<TYPE-EMITTER>HAL</TYPE-EMITTER>",
+            root_tag="IMPLEMENTATION-DATA-TYPE",
+        )
+        parser.readImplementationDataType(element, idt)
+        assert idt.getDynamicArraySizeProfile().getValue() == "VAR"
+        assert idt.getTypeEmitter().getValue() == "HAL"
+
+    def test_readImplementationDataType_with_symbol_props(self, parser):
+        from armodel.models import ImplementationDataType
+
+        idt = ImplementationDataType(parent=_autosar_root(), short_name="idt")
+        element = _snip(
+            "<SHORT-NAME>idt</SHORT-NAME>"
+            "<SYMBOL-PROPS>"
+            "<SHORT-NAME>sp</SHORT-NAME>"
+            "</SYMBOL-PROPS>",
+            root_tag="IMPLEMENTATION-DATA-TYPE",
+        )
+        parser.readImplementationDataType(element, idt)
+        # Symbol props are stored on the data type; verify at least no exception.
+        assert idt.getShortName() == "idt"
+
+    def test_readImplementationDataTypeSubElements_unsupported_tag_warns(
+        self, warning_parser, caplog
+    ):
+        from armodel.models import ImplementationDataType
+
+        idt = ImplementationDataType(parent=_autosar_root(), short_name="idt")
+        element = _snip(
+            "<SUB-ELEMENTS><BAD-ELEMENT/></SUB-ELEMENTS>",
+            root_tag="IMPLEMENTATION-DATA-TYPE",
+        )
+        with caplog.at_level(logging.ERROR):
+            warning_parser.readImplementationDataTypeSubElements(element, idt)
+        assert any(
+            "Unsupported ImplementationDataType SubElement" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_getSwValues_with_V_and_VT(self, parser):
+        element = _snip(
+            "<SW-VALUES-PHYS>"
+            "<V>1.0</V>"
+            "<V>2.0</V>"
+            "<VT>label</VT>"
+            "</SW-VALUES-PHYS>",
+            root_tag="PARENT",
+        )
+        sw_values = parser.getSwValues(element, "SW-VALUES-PHYS")
+        assert sw_values is not None
+        assert len(sw_values.getVs()) == 2
+        assert sw_values.vt.getValue() == "label"
+
+    def test_getSwValues_missing_returns_None(self, parser):
+        element = _snip("<X/>")
+        assert parser.getSwValues(element, "SW-VALUES-PHYS") is None
+
+    def test_getValueList_present(self, parser):
+        element = _snip(
+            "<SW-ARRAYSIZE><V>4</V></SW-ARRAYSIZE>", root_tag="PARENT"
+        )
+        value_list = parser.getValueList(element, "SW-ARRAYSIZE")
+        assert value_list is not None
+        # ValueList stores a single V (ARFloat).
+        assert value_list.getV() is not None
+        assert float(value_list.getV().getValue()) == 4.0
+
+    def test_getValueList_missing_returns_None(self, parser):
+        element = _snip("<X/>")
+        assert parser.getValueList(element, "SW-ARRAYSIZE") is None
+
+    def test_getSwValueCont_full(self, parser):
+        element = _snip(
+            "<SW-VALUE-CONT>"
+            "<UNIT-REF DEST='UNIT'>/u</UNIT-REF>"
+            "<SW-ARRAYSIZE><V>2</V></SW-ARRAYSIZE>"
+            "<SW-VALUES-PHYS><V>1.0</V></SW-VALUES-PHYS>"
+            "</SW-VALUE-CONT>",
+            root_tag="PARENT",
+        )
+        cont = parser.getSwValueCont(element)
+        assert cont is not None
+        assert cont.getUnitRef().getValue() == "/u"
+        assert cont.getSwArraysize() is not None
+        assert cont.getSwValuesPhys() is not None
+        assert len(cont.getSwValuesPhys().getVs()) == 1
+
+    def test_getSwValueCont_missing_returns_None(self, parser):
+        element = _snip("<X/>")
+        assert parser.getSwValueCont(element) is None
+
+    def test_readApplicationValueSpecification_populates_fields(self, parser):
+        from armodel.models import ApplicationValueSpecification
+
+        value_spec = ApplicationValueSpecification()
+        value_spec.short_name = "vs"  # required by readValueSpecification path
+        element = _snip(
+            "<SHORT-NAME>vs</SHORT-NAME>"
+            "<CATEGORY>CAT</CATEGORY>"
+            "<SW-VALUE-CONT>"
+            "<UNIT-REF DEST='UNIT'>/u</UNIT-REF>"
+            "</SW-VALUE-CONT>",
+            root_tag="APPLICATION-VALUE-SPECIFICATION",
+        )
+        parser.readApplicationValueSpecification(element, value_spec)
+        assert value_spec.getCategory().getValue() == "CAT"
+        assert value_spec.getSwValueCont() is not None
+        assert value_spec.getSwValueCont().getUnitRef().getValue() == "/u"
+
+    def test_getChildValueSpecification_present(self, parser):
+        from armodel.models import NumericalValueSpecification
+
+        element = _snip(
+            "<INIT-VALUE>"
+            "<NUMERICAL-VALUE-SPECIFICATION>"
+            "<SHORT-NAME>n</SHORT-NAME>"
+            "<VALUE>42</VALUE>"
+            "</NUMERICAL-VALUE-SPECIFICATION>"
+            "</INIT-VALUE>",
+            root_tag="PARENT",
+        )
+        value_spec = parser.getChildValueSpecification(element, "INIT-VALUE")
+        assert value_spec is not None
+        assert isinstance(value_spec, NumericalValueSpecification)
+
+    def test_getChildValueSpecification_missing_returns_None(self, parser):
+        element = _snip("<X/>")
+        assert parser.getChildValueSpecification(element, "INIT-VALUE") is None
+
+
+# ==================== Group B: SwComponentType & Connectors ====================
+
+
+class TestSwComponentAndConnectorHandlers:
+    """Exercise readSwComponentTypePorts, readSwComponentPrototype,
+    readSwConnector family, readCompositionSwComponentTypeDataTypeMappingSet,
+    and readDataTypeMaps."""
+
+    @pytest.fixture
+    def composition(self):
+        from armodel.models import CompositionSwComponentType
+
+        return CompositionSwComponentType(parent=_autosar_root(), short_name="Comp")
+
+    def test_readSwComponentTypePorts_creates_PPort(self, parser, composition):
+        element = _snip(
+            "<PORTS>"
+            "<P-PORT-PROTOTYPE><SHORT-NAME>pp1</SHORT-NAME></P-PORT-PROTOTYPE>"
+            "</PORTS>",
+            root_tag="COMP",
+        )
+        parser.readSwComponentTypePorts(element, composition)
+        assert len(composition.getPPortPrototypes()) == 1
+
+    def test_readSwComponentTypePorts_creates_RPort(self, parser, composition):
+        element = _snip(
+            "<PORTS>"
+            "<R-PORT-PROTOTYPE><SHORT-NAME>rp1</SHORT-NAME></R-PORT-PROTOTYPE>"
+            "</PORTS>",
+            root_tag="COMP",
+        )
+        parser.readSwComponentTypePorts(element, composition)
+        assert len(composition.getRPortPrototypes()) == 1
+
+    def test_readSwComponentTypePorts_creates_PRPort(self, parser, composition):
+        element = _snip(
+            "<PORTS>"
+            "<PR-PORT-PROTOTYPE><SHORT-NAME>prp1</SHORT-NAME></PR-PORT-PROTOTYPE>"
+            "</PORTS>",
+            root_tag="COMP",
+        )
+        parser.readSwComponentTypePorts(element, composition)
+        assert len(composition.getPRPortPrototypes()) == 1
+
+    def test_readSwComponentTypePorts_unsupported_tag_warns(
+        self, warning_parser, composition, caplog
+    ):
+        element = _snip(
+            "<PORTS><BAD-PORT/></PORTS>", root_tag="COMP"
+        )
+        with caplog.at_level(logging.ERROR):
+            warning_parser.readSwComponentTypePorts(element, composition)
+        assert any(
+            "Unsupported Port Prototype" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_readSwComponentPrototype_sets_typeTRef(self, parser, composition):
+        prototype = composition.createSwComponentPrototype("cp1")
+        element = _snip(
+            "<SHORT-NAME>cp1</SHORT-NAME>"
+            "<TYPE-TREF DEST='COMPOSITION-SW-COMPONENT-TYPE'>/t</TYPE-TREF>",
+            root_tag="SW-COMPONENT-PROTOTYPE",
+        )
+        parser.readSwComponentPrototype(element, prototype)
+        assert prototype.getTypeTRef().getValue() == "/t"
+
+    def test_readAssemblySwConnector_with_provider_and_requester(
+        self, parser, composition
+    ):
+        connector = composition.createAssemblySwConnector("a1")
+        element = _snip(
+            "<SHORT-NAME>a1</SHORT-NAME>"
+            "<PROVIDER-IREF>"
+            "<CONTEXT-COMPONENT-REF DEST='SW-COMPONENT-PROTOTYPE'>/c1</CONTEXT-COMPONENT-REF>"
+            "<TARGET-P-PORT-REF DEST='P-PORT-PROTOTYPE'>/pp1</TARGET-P-PORT-REF>"
+            "</PROVIDER-IREF>"
+            "<REQUESTER-IREF>"
+            "<CONTEXT-COMPONENT-REF DEST='SW-COMPONENT-PROTOTYPE'>/c2</CONTEXT-COMPONENT-REF>"
+            "<TARGET-R-PORT-REF DEST='R-PORT-PROTOTYPE'>/rp1</TARGET-R-PORT-REF>"
+            "</REQUESTER-IREF>",
+            root_tag="ASSEMBLY-SW-CONNECTOR",
+        )
+        parser.readAssemblySwConnector(element, connector)
+        assert connector.getProviderIRef() is not None
+        assert connector.getProviderIRef().getTargetPPortRef().getValue() == "/pp1"
+        assert connector.getRequesterIRef() is not None
+        assert connector.getRequesterIRef().getTargetRPortRef().getValue() == "/rp1"
+
+    def test_readAssemblySwConnector_without_IRefs(self, parser, composition):
+        connector = composition.createAssemblySwConnector("a2")
+        element = _snip(
+            "<SHORT-NAME>a2</SHORT-NAME>", root_tag="ASSEMBLY-SW-CONNECTOR"
+        )
+        parser.readAssemblySwConnector(element, connector)
+        assert connector.getProviderIRef() is None
+        assert connector.getRequesterIRef() is None
+
+    def test_readSwConnector_sets_mappingRef(self, parser, composition):
+        connector = composition.createAssemblySwConnector("a3")
+        element = _snip(
+            "<SHORT-NAME>a3</SHORT-NAME>"
+            "<MAPPING-REF DEST='X'>/m</MAPPING-REF>",
+            root_tag="ASSEMBLY-SW-CONNECTOR",
+        )
+        parser.readAssemblySwConnector(element, connector)
+        assert connector.getMappingRef().getValue() == "/m"
+
+    def test_readDelegationSwConnector_inner_RPort_IRef(
+        self, parser, composition
+    ):
+        connector = composition.createDelegationSwConnector("d1")
+        element = _snip(
+            "<SHORT-NAME>d1</SHORT-NAME>"
+            "<INNER-PORT-IREF>"
+            "<R-PORT-IN-COMPOSITION-INSTANCE-REF>"
+            "<CONTEXT-COMPONENT-REF DEST='SW-COMPONENT-PROTOTYPE'>/c</CONTEXT-COMPONENT-REF>"
+            "<TARGET-R-PORT-REF DEST='R-PORT-PROTOTYPE'>/rp</TARGET-R-PORT-REF>"
+            "</R-PORT-IN-COMPOSITION-INSTANCE-REF>"
+            "</INNER-PORT-IREF>"
+            "<OUTER-PORT-REF DEST='PORT-PROTOTYPE'>/op</OUTER-PORT-REF>",
+            root_tag="DELEGATION-SW-CONNECTOR",
+        )
+        parser.readDelegationSwConnector(element, connector)
+        assert connector.getInnerPortIRref() is not None
+        assert connector.getOuterPortRef().getValue() == "/op"
+
+    def test_readDelegationSwConnector_inner_PPort_IRef(
+        self, parser, composition
+    ):
+        connector = composition.createDelegationSwConnector("d2")
+        element = _snip(
+            "<SHORT-NAME>d2</SHORT-NAME>"
+            "<INNER-PORT-IREF>"
+            "<P-PORT-IN-COMPOSITION-INSTANCE-REF>"
+            "<CONTEXT-COMPONENT-REF DEST='SW-COMPONENT-PROTOTYPE'>/c</CONTEXT-COMPONENT-REF>"
+            "<TARGET-P-PORT-REF DEST='P-PORT-PROTOTYPE'>/pp</TARGET-P-PORT-REF>"
+            "</P-PORT-IN-COMPOSITION-INSTANCE-REF>"
+            "</INNER-PORT-IREF>"
+            "<OUTER-PORT-REF DEST='PORT-PROTOTYPE'>/op</OUTER-PORT-REF>",
+            root_tag="DELEGATION-SW-CONNECTOR",
+        )
+        parser.readDelegationSwConnector(element, connector)
+        assert connector.getInnerPortIRref() is not None
+        assert connector.getOuterPortRef().getValue() == "/op"
+
+    def test_readDelegationSwConnector_only_inner_ref(self, parser, composition):
+        # Note: readDelegationSwConnector checks getInnerPortIRref() AND
+        # getOuterPortRef() for None *before* OUTER-PORT-REF is parsed, so the
+        # only way to avoid the raise is to supply an INNER-PORT-IREF.
+        connector = composition.createDelegationSwConnector("d3")
+        element = _snip(
+            "<SHORT-NAME>d3</SHORT-NAME>"
+            "<INNER-PORT-IREF>"
+            "<R-PORT-IN-COMPOSITION-INSTANCE-REF>"
+            "<CONTEXT-COMPONENT-REF DEST='SW-COMPONENT-PROTOTYPE'>/c</CONTEXT-COMPONENT-REF>"
+            "<TARGET-R-PORT-REF DEST='R-PORT-PROTOTYPE'>/rp</TARGET-R-PORT-REF>"
+            "</R-PORT-IN-COMPOSITION-INSTANCE-REF>"
+            "</INNER-PORT-IREF>",
+            root_tag="DELEGATION-SW-CONNECTOR",
+        )
+        parser.readDelegationSwConnector(element, connector)
+        assert connector.getInnerPortIRref() is not None
+        # OUTER-PORT-REF was absent; should remain None.
+        assert connector.getOuterPortRef() is None
+
+    def test_readDelegationSwConnector_both_missing_warns(
+        self, warning_parser, composition, caplog
+    ):
+        connector = composition.createDelegationSwConnector("d4")
+        element = _snip(
+            "<SHORT-NAME>d4</SHORT-NAME>", root_tag="DELEGATION-SW-CONNECTOR"
+        )
+        with caplog.at_level(logging.ERROR):
+            warning_parser.readDelegationSwConnector(element, connector)
+        assert any(
+            "Invalid PortPrototype of DELEGATION-SW-CONNECTOR" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_readCompositionSwComponentTypeDataTypeMappingSet_adds_refs(
+        self, parser, composition
+    ):
+        element = _snip(
+            "<DATA-TYPE-MAPPING-REFS>"
+            "<DATA-TYPE-MAPPING-REF DEST='DATA-TYPE-MAPPING-SET'>/dtm1</DATA-TYPE-MAPPING-REF>"
+            "<DATA-TYPE-MAPPING-REF DEST='DATA-TYPE-MAPPING-SET'>/dtm2</DATA-TYPE-MAPPING-REF>"
+            "</DATA-TYPE-MAPPING-REFS>",
+            root_tag="COMP",
+        )
+        parser.readCompositionSwComponentTypeDataTypeMappingSet(element, composition)
+        assert len(composition.getDataTypeMappings()) == 2
+
+    def test_readCompositionSwComponentTypeDataTypeMappingSet_missing_no_op(
+        self, parser, composition
+    ):
+        element = _snip("<X/>")
+        parser.readCompositionSwComponentTypeDataTypeMappingSet(element, composition)
+        assert len(composition.getDataTypeMappings()) == 0
+
+    def test_readDataTypeMaps_adds_to_parent_and_global(self, parser):
+        from armodel.models import DataTypeMappingSet
+
+        dtms = DataTypeMappingSet(parent=_autosar_root(), short_name="DTMS")
+        element = _snip(
+            "<DATA-TYPE-MAPS>"
+            "<DATA-TYPE-MAP>"
+            "<APPLICATION-DATA-TYPE-REF DEST='APPLICATION-DATA-TYPE'>/adt</APPLICATION-DATA-TYPE-REF>"
+            "<IMPLEMENTATION-DATA-TYPE-REF DEST='IMPLEMENTATION-DATA-TYPE'>/idt</IMPLEMENTATION-DATA-TYPE-REF>"
+            "</DATA-TYPE-MAP>"
+            "</DATA-TYPE-MAPS>",
+            root_tag="DATA-TYPE-MAPPING-SET",
+        )
+        parser.readDataTypeMaps(element, dtms)
+        assert len(dtms.getDataTypeMaps()) == 1
+
+
+# ==================== Group E: BswBehavior orchestrators ====================
+
+
+class TestBswBehaviorOrchestratorHandlers:
+    """Exercise readSwcInternalBehavior (top-level cascade), readBswVariableAccess,
+    and the readBswModuleEntityDataSendPoints/DataReceiverPoints dispatchers."""
+
+    def test_readSwcInternalBehavior_minimal(self, warning_parser):
+        from armodel.models import ApplicationSwComponentType
+
+        app = ApplicationSwComponentType(parent=_autosar_root(), short_name="a")
+        behavior = app.createSwcInternalBehavior("ib")
+        element = _snip(
+            "<SHORT-NAME>ib</SHORT-NAME>", root_tag="SWC-INTERNAL-BEHAVIOR"
+        )
+        warning_parser.readSwcInternalBehavior(element, behavior)
+        # The two end-of-method optional fields should be None with empty body.
+        assert behavior.getHandleTerminationAndRestart() is None
+        assert behavior.getSupportsMultipleInstantiation() is None
+
+    def test_readSwcInternalBehavior_with_optional_literals(self, warning_parser):
+        from armodel.models import ApplicationSwComponentType
+
+        app = ApplicationSwComponentType(parent=_autosar_root(), short_name="a")
+        behavior = app.createSwcInternalBehavior("ib")
+        element = _snip(
+            "<SHORT-NAME>ib</SHORT-NAME>"
+            "<HANDLE-TERMINATION-AND-RESTART>YES</HANDLE-TERMINATION-AND-RESTART>"
+            "<SUPPORTS-MULTIPLE-INSTANTIATION>true</SUPPORTS-MULTIPLE-INSTANTIATION>",
+            root_tag="SWC-INTERNAL-BEHAVIOR",
+        )
+        warning_parser.readSwcInternalBehavior(element, behavior)
+        assert behavior.getHandleTerminationAndRestart().getValue() == "YES"
+        assert behavior.getSupportsMultipleInstantiation() is not None
+
+    def test_readBswVariableAccess_sets_ref(self, parser):
+        from armodel.models import BswVariableAccess
+
+        access = BswVariableAccess(parent=_autosar_root(), short_name="va")
+        element = _snip(
+            "<SHORT-NAME>va</SHORT-NAME>"
+            "<ACCESSED-VARIABLE-REF DEST='VARIABLE-DATA-PROTOTYPE'>/v</ACCESSED-VARIABLE-REF>",
+            root_tag="BSW-VARIABLE-ACCESS",
+        )
+        parser.readBswVariableAccess(element, access)
+        assert access.getAccessedVariableRef().getValue() == "/v"
+
+    def test_readBswVariableAccess_missing_ref_is_None(self, parser):
+        from armodel.models import BswVariableAccess
+
+        access = BswVariableAccess(parent=_autosar_root(), short_name="va")
+        element = _snip(
+            "<SHORT-NAME>va</SHORT-NAME>", root_tag="BSW-VARIABLE-ACCESS"
+        )
+        parser.readBswVariableAccess(element, access)
+        assert access.getAccessedVariableRef() is None
+
+    def test_readBswModuleEntityDataSendPoints_creates_point(self, parser):
+        from armodel.models import BswInternalBehavior
+
+        behavior = BswInternalBehavior(parent=_autosar_root(), short_name="bib")
+        entity = behavior.createBswSchedulableEntity("e1")
+        element = _snip(
+            "<DATA-SEND-POINTS>"
+            "<BSW-VARIABLE-ACCESS><SHORT-NAME>s1</SHORT-NAME></BSW-VARIABLE-ACCESS>"
+            "</DATA-SEND-POINTS>",
+            root_tag="ENTITY",
+        )
+        parser.readBswModuleEntityDataSendPoints(element, entity)
+        assert len(entity.getDataSendPoints()) == 1
+
+    def test_readBswModuleEntityDataSendPoints_unsupported_tag_warns(
+        self, warning_parser, caplog
+    ):
+        from armodel.models import BswInternalBehavior
+
+        behavior = BswInternalBehavior(parent=_autosar_root(), short_name="bib")
+        entity = behavior.createBswSchedulableEntity("e1")
+        element = _snip(
+            "<DATA-SEND-POINTS><BAD/></DATA-SEND-POINTS>", root_tag="ENTITY"
+        )
+        with caplog.at_level(logging.ERROR):
+            warning_parser.readBswModuleEntityDataSendPoints(element, entity)
+        assert any(
+            "Unsupported Data Send Point" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_readBswModuleEntityDataReceiverPoints_creates_point(self, parser):
+        from armodel.models import BswInternalBehavior
+
+        behavior = BswInternalBehavior(parent=_autosar_root(), short_name="bib")
+        entity = behavior.createBswSchedulableEntity("e1")
+        element = _snip(
+            "<DATA-RECEIVE-POINTS>"
+            "<BSW-VARIABLE-ACCESS><SHORT-NAME>r1</SHORT-NAME></BSW-VARIABLE-ACCESS>"
+            "</DATA-RECEIVE-POINTS>",
+            root_tag="ENTITY",
+        )
+        parser.readBswModuleEntityDataReceiverPoints(element, entity)
+        assert len(entity.getDataReceivePoints()) == 1
+
+    def test_readBswModuleEntityDataReceiverPoints_unsupported_tag_warns(
+        self, warning_parser, caplog
+    ):
+        from armodel.models import BswInternalBehavior
+
+        behavior = BswInternalBehavior(parent=_autosar_root(), short_name="bib")
+        entity = behavior.createBswSchedulableEntity("e1")
+        element = _snip(
+            "<DATA-RECEIVE-POINTS><BAD/></DATA-RECEIVE-POINTS>", root_tag="ENTITY"
+        )
+        with caplog.at_level(logging.ERROR):
+            warning_parser.readBswModuleEntityDataReceiverPoints(element, entity)
+        assert any(
+            "Unsupported Data Receive Point" in r.getMessage()
+            for r in caplog.records
+        )

--- a/tests/test_armodel/parser/test_arxml_parser_internals.py
+++ b/tests/test_armodel/parser/test_arxml_parser_internals.py
@@ -1,0 +1,266 @@
+"""Phase D: targeted tests for uncovered internal parser methods.
+
+Each test directly invokes an internal method on ARXMLParser with a minimal
+XML snippet, lifting coverage on specific handler bodies that the dispatch
+tests in test_arxml_parser_dispatch.py only route around.
+
+Focus areas (from coverage report on arxml_parser.py):
+- SDG / Sd / SdgCaption / SdgSdxRefs parsing (lines 250-323)
+- DocRevision / Modification parsing (lines 293-323)
+- _readVariableAccesses branching (lines 426-457)
+"""
+
+import pytest
+import xml.etree.ElementTree as ET
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models import (
+    AdminData,
+    BswModuleDescription,
+    DocRevision,
+    RunnableEntity,
+    Sdg,
+)
+from armodel.parser.arxml_parser import ARXMLParser
+
+NS = "http://autosar.org/schema/r4.0"
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def parser():
+    AUTOSAR.getInstance().new()
+    return ARXMLParser()
+
+
+def _snip(inner: str, root_tag: str = "ROOT") -> ET.Element:
+    return ET.fromstring(f"<{root_tag} xmlns='{NS}'>{inner}</{root_tag}>")
+
+
+# ==================== SDG (Service Data Group) ====================
+
+
+class TestSdgParsing:
+    def test_getSdg_minimal(self, parser):
+        element = _snip(
+            "<SD GID='MyGroup'>value1</SD>",
+            root_tag="SDG",
+        )
+        sdg = parser.getSdg(element)
+        assert isinstance(sdg, Sdg)
+
+    def test_getSdg_with_caption(self, parser):
+        element = _snip(
+            "<SDG-CAPTION><SHORT-NAME>Caption1</SHORT-NAME></SDG-CAPTION>",
+            root_tag="SDG",
+        )
+        sdg = parser.getSdg(element)
+        assert sdg is not None
+
+    def test_getSdg_with_nested_sdg(self, parser):
+        element = _snip(
+            "<SDG GID='Inner'><SD>x</SD></SDG>",
+            root_tag="SDG",
+        )
+        sdg = parser.getSdg(element)
+        assert sdg is not None
+
+    def test_getSdg_with_sdx_refs(self, parser):
+        element = _snip(
+            "<SDX-REF DEST='SOMETHING'>/path/to/ref</SDX-REF>",
+            root_tag="SDG",
+        )
+        sdg = parser.getSdg(element)
+        assert sdg is not None
+
+    def test_readAdminDataSdgs(self, parser):
+        element = _snip(
+            "<SDGS>"
+            "<SDG GID='A'><SD>x</SD></SDG>"
+            "<SDG GID='B'><SD>y</SD></SDG>"
+            "</SDGS>"
+        )
+        admin = AdminData()
+        parser.readAdminDataSdgs(element, admin)
+        # Verify both SDGs added.
+        assert len(admin.getSdgs()) == 2
+
+    def test_readAdminDataSdgs_unsupported_tag_warns(self, caplog):
+        import logging
+        AUTOSAR.getInstance().new()
+        p = ARXMLParser(options={"warning": True})
+        element = _snip("<SDGS><UNKNOWN-SDG/></SDGS>")
+        admin = AdminData()
+        with caplog.at_level(logging.ERROR):
+            p.readAdminDataSdgs(element, admin)
+        assert any("Unsupported SDG" in r.getMessage() for r in caplog.records)
+
+
+# ==================== Modification / DocRevision ====================
+
+
+class TestRevisionParsing:
+    def test_readDocRevision_minimal(self, parser):
+        element = _snip(
+            "<DATE>2024-01-01T00:00:00</DATE>"
+            "<ISSUED-BY>alice</ISSUED-BY>"
+            "<REVISION-LABEL>1.0.0</REVISION-LABEL>"
+            "<STATE>released</STATE>",
+            root_tag="DOC-REVISION",
+        )
+        revision = DocRevision()
+        parser.readDocRevision(element, revision)
+        assert revision.getIssuedBy().getValue() == "alice"
+        assert revision.getState().getValue() == "released"
+
+    def test_readDocRevision_with_modifications(self, parser):
+        element = _snip(
+            "<MODIFICATIONS>"
+            "<MODIFICATION>"
+            "<CHANGE><L-4>L-1</L-4></CHANGE>"
+            "<REASON><L-4>R-1</L-4></REASON>"
+            "</MODIFICATION>"
+            "</MODIFICATIONS>",
+            root_tag="DOC-REVISION",
+        )
+        revision = DocRevision()
+        parser.readDocRevision(element, revision)
+        # modification was added
+        assert len(revision.getModifications()) == 1
+
+    def test_readAdminDataDocRevisions(self, parser):
+        element = _snip(
+            "<DOC-REVISIONS>"
+            "<DOC-REVISION>"
+            "<ISSUED-BY>bob</ISSUED-BY>"
+            "<REVISION-LABEL>2.0.0</REVISION-LABEL>"
+            "</DOC-REVISION>"
+            "</DOC-REVISIONS>"
+        )
+        admin = AdminData()
+        parser.readAdminDataDocRevisions(element, admin)
+        assert len(admin.getDocRevisions()) == 1
+
+    def test_readAdminDataDocRevisions_unsupported_tag_warns(self, caplog):
+        import logging
+        AUTOSAR.getInstance().new()
+        p = ARXMLParser(options={"warning": True})
+        element = _snip("<DOC-REVISIONS><UNKNOWN/></DOC-REVISIONS>")
+        admin = AdminData()
+        with caplog.at_level(logging.ERROR):
+            p.readAdminDataDocRevisions(element, admin)
+        assert any("Unsupported DocRevision" in r.getMessage() for r in caplog.records)
+
+
+# ==================== RxIdentifierRange ====================
+
+
+class TestRxIdentifierRange:
+    def test_getChildElementRxIdentifierRange(self, parser):
+        # The method does find(element, "RX-IDENTIFIER-RANGE"), so element
+        # must be the parent wrapper containing <RX-IDENTIFIER-RANGE>.
+        element = _snip(
+            "<RX-IDENTIFIER-RANGE>"
+            "<LOWER-CAN-ID>0x100</LOWER-CAN-ID>"
+            "<UPPER-CAN-ID>0x1FF</UPPER-CAN-ID>"
+            "</RX-IDENTIFIER-RANGE>",
+            root_tag="PARENT",
+        )
+        rng = parser.getChildElementRxIdentifierRange(element, "RX-IDENTIFIER-RANGE")
+        assert rng is not None
+        assert rng.getLowerCanId().getValue() == 256
+        assert rng.getUpperCanId().getValue() == 511
+
+    def test_getChildElementRxIdentifierRange_missing_returns_None(self, parser):
+        element = _snip("<X/>")
+        assert parser.getChildElementRxIdentifierRange(element, "ABSENT") is None
+
+
+# ==================== _readVariableAccesses branching ====================
+
+
+class TestReadVariableAccessesBranches:
+    """Exercise each branch of _readVariableAccesses (arxml_parser.py:426)."""
+
+    @pytest.fixture
+    def runnable(self):
+        return RunnableEntity(parent=None, short_name="R1")
+
+    @pytest.mark.parametrize("key,creator_attr", [
+        ("DATA-RECEIVE-POINT-BY-ARGUMENTS", "getDataReceivePointByArguments"),
+        ("DATA-RECEIVE-POINT-BY-VALUES", "getDataReceivePointByValues"),
+        ("DATA-READ-ACCESSS", "getDataReadAccesses"),
+        ("DATA-WRITE-ACCESSS", "getDataWriteAccesses"),
+        ("DATA-SEND-POINTS", "getDataSendPoints"),
+        ("WRITTEN-LOCAL-VARIABLES", "getWrittenLocalVariables"),
+        ("READ-LOCAL-VARIABLES", "getReadLocalVariables"),
+    ])
+    def test_branch(self, parser, runnable, key, creator_attr):
+        element = _snip(
+            f"<{key}>"
+            f"<VARIABLE-ACCESS>"
+            f"<SHORT-NAME>va1</SHORT-NAME>"
+            f"</VARIABLE-ACCESS>"
+            f"</{key}>",
+            root_tag=key,
+        )
+        parser._readVariableAccesses(element, runnable, key)
+        # Each branch creates one variable access on the runnable.
+        created = getattr(runnable, creator_attr)()
+        assert len(created) == 1, f"{key} did not produce a variable access"
+
+    def test_unsupported_key_warns(self, runnable, caplog):
+        import logging
+        AUTOSAR.getInstance().new()
+        p = ARXMLParser(options={"warning": True})
+        # Match the double-wrap pattern from test_branch: outer ROOT contains
+        # the <BAD-KEY> parent which itself wraps the VARIABLE-ACCESS.
+        element = _snip(
+            "<BAD-KEY><VARIABLE-ACCESS><SHORT-NAME>va</SHORT-NAME></VARIABLE-ACCESS></BAD-KEY>",
+            root_tag="ROOT",
+        )
+        with caplog.at_level(logging.ERROR):
+            p._readVariableAccesses(element, runnable, "BAD-KEY")
+        assert any("Unsupported Variable Access" in r.getMessage() for r in caplog.records)
+
+
+# ==================== readBswModuleDescriptionImplementedEntryRefs ====================
+
+
+class TestBswModuleDescriptionImplementedEntryRefs:
+    def test_reads_implemented_entry_refs(self, parser):
+        bmd = BswModuleDescription(parent=None, short_name="Bmd1")
+        element = _snip(
+            "<PROVIDED-ENTRYS>"
+            "<BSW-MODULE-ENTRY-REF-CONDITIONAL>"
+            "<BSW-MODULE-ENTRY-REF DEST='BSW-MODULE-ENTRY'>/pkg/Entry1</BSW-MODULE-ENTRY-REF>"
+            "</BSW-MODULE-ENTRY-REF-CONDITIONAL>"
+            "<BSW-MODULE-ENTRY-REF-CONDITIONAL>"
+            "<BSW-MODULE-ENTRY-REF DEST='BSW-MODULE-ENTRY'>/pkg/Entry2</BSW-MODULE-ENTRY-REF>"
+            "</BSW-MODULE-ENTRY-REF-CONDITIONAL>"
+            "</PROVIDED-ENTRYS>",
+            root_tag="ROOT",
+        )
+        parser.readBswModuleDescriptionImplementedEntryRefs(element, bmd)
+        assert len(bmd.getImplementedEntryRefs()) == 2
+
+    def test_skips_entries_without_ref(self, parser):
+        bmd = BswModuleDescription(parent=None, short_name="Bmd1")
+        element = _snip(
+            "<PROVIDED-ENTRYS>"
+            "<BSW-MODULE-ENTRY-REF-CONDITIONAL/>"
+            "<BSW-MODULE-ENTRY-REF-CONDITIONAL>"
+            "<BSW-MODULE-ENTRY-REF DEST='BSW-MODULE-ENTRY'>/pkg/Entry</BSW-MODULE-ENTRY-REF>"
+            "</BSW-MODULE-ENTRY-REF-CONDITIONAL>"
+            "</PROVIDED-ENTRYS>",
+            root_tag="ROOT",
+        )
+        parser.readBswModuleDescriptionImplementedEntryRefs(element, bmd)
+        # Only one had a ref; the empty conditional should be skipped.
+        assert len(bmd.getImplementedEntryRefs()) == 1


### PR DESCRIPTION
## Summary

Closes #503. Adds 240 new targeted unit tests for the ARXML reader, plus minor source fixes exposed while writing them. Drives `abstract_arxml_parser.py` to **99%** coverage and `arxml_parser.py` from **63% → 65%**.

## Changes

### Source fixes (defensive None-handling)

- **`src/armodel/parser/arxml_parser.py`**
  - `_readVariableAccesses`: skip `readIdentifiable` when the variable access key is unsupported
  - `readBswImplementation` / `readSwcImplementation`: guard against `None` behavior ref before registering the implementation-behavior map
- **`src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py`**
  - `BswModuleEntry.setExecutionContext` / `setSwServiceImplPolicy`: accept `None`
- **`src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py`**
  - `UserDefinedPdu` / `UserDefinedIPdu`: add the missing `cddType` attribute with getter/setter

### New test files (240 tests)

| File | Tests | Focus |
|---|---|---|
| `test_arxml_parser_dispatch.py` | 89 | 65-branch `readARPackageElements` dispatch chain |
| `test_arxml_parser_error_paths.py` | 63 | `AbstractARXMLParser` converters, optional/required getters, utility methods |
| `test_arxml_parser_internals.py` | 22 | SDG / DocRevision / `_readVariableAccesses` / `readBswModuleDescriptionImplementedEntryRefs` |
| `test_arxml_parser_handlers.py` | 66 | Phase E: 5 classes covering ~30 specific `read*`/`get*` handlers |

## Files Modified

**Source (3 files, +45/-8):**
- `src/armodel/parser/arxml_parser.py`
- `src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py`
- `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py`

**Tests (4 new files, +2206):**
- `tests/test_armodel/parser/test_arxml_parser_dispatch.py`
- `tests/test_armodel/parser/test_arxml_parser_error_paths.py`
- `tests/test_armodel/parser/test_arxml_parser_internals.py`
- `tests/test_armodel/parser/test_arxml_parser_handlers.py`

## Test Coverage

| File | Before | After |
|---|---|---|
| `src/armodel/parser/abstract_arxml_parser.py` | ~50% | **99%** |
| `src/armodel/parser/arxml_parser.py` | 63% | **65%** |

The line-count gain on `arxml_parser.py` is modest (+2pp) because the file is 4494 lines and minimal XML snippets don't cascade into deeper helpers. However, the directly targeted handler methods are now all covered, which was the goal of this phase. Future phases can target deeper cascades (port com specs, sender/receiver com specs, SwComponentType sub-readers) with richer XML fixtures.

## Test Plan

- [x] All 240 new tests pass in isolation
- [x] Full regression suite (**2599 tests**) passes in 43s
- [x] flake8 (`E9,F63,F7,F82`, max-line-length=127) clean on `src/` and `tests/`
- [x] No new dependencies introduced
- [x] Split into two commits: source fixes first, then tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)