### PR TITLE
test: add writer Ethernet/CAN controllers and EcuInstance tests (N12)

### DIFF
--- a/tests/test_armodel/writer/test_writer_arpackage_dispatch.py
+++ b/tests/test_armodel/writer/test_writer_arpackage_dispatch.py
@@ -1,0 +1,647 @@
+"""Tests for writer ARPackage dispatch and top-level methods."""
+import xml.etree.cElementTree as ET
+import pytest
+import tempfile
+import os
+
+from armodel.writer.arxml_writer import ARXMLWriter
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import (
+    ARPackage,
+    ReferenceBase,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import (
+    ApplicationSwComponentType,
+    ComplexDeviceDriverSwComponentType,
+    EcuAbstractionSwComponentType,
+    ServiceSwComponentType,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition import (
+    CompositionSwComponentType,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import (
+    ApplicationPrimitiveDataType,
+    ApplicationRecordDataType,
+    ApplicationArrayDataType,
+    DataTypeMappingSet,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import (
+    SenderReceiverInterface,
+    ClientServerInterface,
+    ModeSwitchInterface,
+    TriggerInterface,
+    ParameterInterface,
+    NvDataInterface,
+    PortInterfaceMappingSet,
+    ModeDeclarationMappingSet,
+)
+from armodel.models.M2.MSR.AsamHdo.BaseTypes import SwBaseType
+from armodel.models.M2.MSR.AsamHdo.ComputationMethod import CompuMethod
+from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import DataConstr
+from armodel.models.M2.MSR.AsamHdo.Units import Unit, PhysicalDimension
+from armodel.models.M2.AUTOSARTemplates.CommonStructure import (
+    ConstantSpecification,
+)
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes import (
+    ImplementationDataType,
+)
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping import SwcBswMapping
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import (
+    ModeDeclarationGroup,
+)
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingConstraint.TimingExtensions import (
+    SwcTiming,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection import (
+    EndToEndProtectionSet,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation import (
+    SwcImplementation,
+)
+from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod
+from armodel.models.M2.MSR.DataDictionary.RecordLayout import SwRecordLayout
+from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import (
+    BswModuleDescription,
+)
+from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import (
+    BswModuleEntry,
+)
+from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import (
+    BswImplementation,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate import System
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommunication import (
+    LinUnconditionalFrame,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import (
+    NmConfig,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (
+    NmPdu,
+    NPdu,
+    DcmIPdu,
+    SecuredIPdu,
+    ISignal,
+    SystemSignal,
+    ISignalIPdu,
+    ISignalGroup,
+    SystemSignalGroup,
+    ISignalIPduGroup,
+    MultiplexedIPdu,
+    UserDefinedIPdu,
+    UserDefinedPdu,
+    GeneralPurposePdu,
+    GeneralPurposeIPdu,
+    SecureCommunicationPropsSet,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import (
+    LinCluster,
+    CanCluster,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
+    CanFrame,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform import (
+    Gateway,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.EcuInstance import (
+    EcuInstance,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetFrame import (
+    GenericEthernetFrame,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import (
+    LifeCycleInfoSet,
+)
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.FlatMap import FlatMap
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetTopology import (
+    EthernetCluster,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import (
+    DiagnosticConnection,
+)
+from armodel.models.M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticContribution import (
+    DiagnosticServiceTable,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetCommunication import (
+    SoAdRoutingGroup,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import (
+    CanTpConfig,
+    LinTpConfig,
+    DoIpTpConfig,
+)
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwElement
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import (
+    HwCategory,
+    HwType,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import (
+    DataTransformationSet,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import (
+    FlexrayFrame,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology import (
+    FlexrayCluster,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import (
+    Collection,
+)
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword import (
+    KeywordSet,
+)
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint import (
+    PortPrototypeBlueprint,
+)
+from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucModuleDef
+from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import (
+    EcucModuleConfigurationValues,
+)
+from armodel.models.M2.MSR.DataDictionary.SystemConstant import SwSystemconst
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
+    SwSystemconstantValueSet,
+    PredefinedVariant,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    ARLiteral,
+    RevisionLabelString,
+    ARBoolean,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+def _parent():
+    return ET.Element("ELEMENTS")
+
+
+def _pkg():
+    return AUTOSAR.getInstance().createARPackage("Pkg")
+
+
+def _literal(text):
+    lit = ARLiteral()
+    lit.setValue(text)
+    return lit
+
+
+def _boolean(val):
+    b = ARBoolean()
+    b.setValue(val)
+    return b
+
+
+ELEMENT_TYPES_AND_TAGS = [
+    ("ComplexDeviceDriverSwComponentType", "COMPLEX-DEVICE-DRIVER-SW-COMPONENT-TYPE"),
+    ("CompositionSwComponentType", "COMPOSITION-SW-COMPONENT-TYPE"),
+    ("ApplicationPrimitiveDataType", "APPLICATION-PRIMITIVE-DATA-TYPE"),
+    ("ApplicationRecordDataType", "APPLICATION-RECORD-DATA-TYPE"),
+    ("SwBaseType", "SW-BASE-TYPE"),
+    ("CompuMethod", "COMPU-METHOD"),
+    ("ConstantSpecification", "CONSTANT-SPECIFICATION"),
+    ("DataConstr", "DATA-CONSTR"),
+    ("EndToEndProtectionSet", "END-TO-END-PROTECTION-SET"),
+    ("SenderReceiverInterface", "SENDER-RECEIVER-INTERFACE"),
+    ("Unit", "UNIT"),
+    ("BswModuleDescription", "BSW-MODULE-DESCRIPTION"),
+    ("BswModuleEntry", "BSW-MODULE-ENTRY"),
+    ("SwcBswMapping", "SWC-BSW-MAPPING"),
+    ("ImplementationDataType", "IMPLEMENTATION-DATA-TYPE"),
+    ("ClientServerInterface", "CLIENT-SERVER-INTERFACE"),
+    ("ApplicationSwComponentType", "APPLICATION-SW-COMPONENT-TYPE"),
+    ("EcuAbstractionSwComponentType", "ECU-ABSTRACTION-SW-COMPONENT-TYPE"),
+    ("ApplicationArrayDataType", "APPLICATION-ARRAY-DATA-TYPE"),
+    ("SwRecordLayout", "SW-RECORD-LAYOUT"),
+    ("SwAddrMethod", "SW-ADDR-METHOD"),
+    ("ServiceSwComponentType", "SERVICE-SW-COMPONENT-TYPE"),
+    ("DataTypeMappingSet", "DATA-TYPE-MAPPING-SET"),
+    ("ModeDeclarationGroup", "MODE-DECLARATION-GROUP"),
+    ("ModeSwitchInterface", "MODE-SWITCH-INTERFACE"),
+    ("SwcTiming", "SWC-TIMING"),
+    ("LinUnconditionalFrame", "LIN-UNCONDITIONAL-FRAME"),
+    ("NmConfig", "NM-CONFIG"),
+    ("NmPdu", "NM-PDU"),
+    ("NPdu", "N-PDU"),
+    ("DcmIPdu", "DCM-I-PDU"),
+    ("SecuredIPdu", "SECURED-I-PDU"),
+    ("CanTpConfig", "CAN-TP-CONFIG"),
+    ("LinTpConfig", "LIN-TP-CONFIG"),
+    ("LinCluster", "LIN-CLUSTER"),
+    ("CanCluster", "CAN-CLUSTER"),
+    ("CanFrame", "CAN-FRAME"),
+    ("Gateway", "GATEWAY"),
+    ("ISignal", "I-SIGNAL"),
+    ("System", "SYSTEM"),
+    ("EcuInstance", "ECU-INSTANCE"),
+    ("ISignalIPdu", "I-SIGNAL-I-PDU"),
+    ("SystemSignal", "SYSTEM-SIGNAL"),
+    ("ParameterInterface", "PARAMETER-INTERFACE"),
+    ("NvDataInterface", "NV-DATA-INTERFACE"),
+    ("GenericEthernetFrame", "ETHERNET-FRAME"),
+    ("LifeCycleInfoSet", "LIFE-CYCLE-INFO-SET"),
+    ("PhysicalDimension", "PHYSICAL-DIMENSION"),
+    ("FlatMap", "FLAT-MAP"),
+    ("PortInterfaceMappingSet", "PORT-INTERFACE-MAPPING-SET"),
+    ("EthernetCluster", "ETHERNET-CLUSTER"),
+    ("ISignalIPduGroup", "I-SIGNAL-I-PDU-GROUP"),
+    ("DiagnosticConnection", "DIAGNOSTIC-CONNECTION"),
+    ("DiagnosticServiceTable", "DIAGNOSTIC-SERVICE-TABLE"),
+    ("MultiplexedIPdu", "MULTIPLEXED-I-PDU"),
+    ("UserDefinedIPdu", "USER-DEFINED-I-PDU"),
+    ("UserDefinedPdu", "USER-DEFINED-PDU"),
+    ("GeneralPurposePdu", "GENERAL-PURPOSE-PDU"),
+    ("GeneralPurposeIPdu", "GENERAL-PURPOSE-I-PDU"),
+    ("SoAdRoutingGroup", "SO-AD-ROUTING-GROUP"),
+    ("DoIpTpConfig", "DO-IP-TP-CONFIG"),
+    ("HwElement", "HW-ELEMENT"),
+    ("HwCategory", "HW-CATEGORY"),
+    ("HwType", "HW-TYPE"),
+    ("DataTransformationSet", "DATA-TRANSFORMATION-SET"),
+    ("FlexrayFrame", "FLEXRAY-FRAME"),
+    ("ISignalGroup", "I-SIGNAL-GROUP"),
+    ("SystemSignalGroup", "SYSTEM-SIGNAL-GROUP"),
+    ("FlexrayCluster", "FLEXRAY-CLUSTER"),
+    ("Collection", "COLLECTION"),
+    ("KeywordSet", "KEYWORD-SET"),
+    ("PortPrototypeBlueprint", "PORT-PROTOTYPE-BLUEPRINT"),
+    ("ModeDeclarationMappingSet", "MODE-DECLARATION-MAPPING-SET"),
+    ("EcucModuleDef", "ECUC-MODULE-DEF"),
+    ("EcucModuleConfigurationValues", "ECUC-MODULE-CONFIGURATION-VALUES"),
+    ("SwSystemConst", "SW-SYSTEMCONST"),
+    ("SwSystemconstantValueSet", "SW-SYSTEMCONSTANT-VALUE-SET"),
+    ("PredefinedVariant", "PREDEFINED-VARIANT"),
+]
+
+ELEMENTS_WITH_SPECIAL_SETUP = {
+    "SwcImplementation": lambda elem: (
+        setattr(elem, "swVersion", None),
+        setattr(elem, "vendorId", None),
+    ),
+    "BswImplementation": lambda elem: (
+        setattr(elem, "swVersion", None),
+        setattr(elem, "vendorId", None),
+    ),
+}
+
+
+class TestWriteARPackageElementDispatch:
+    @pytest.mark.parametrize(
+        "element_type,expected_tag", ELEMENT_TYPES_AND_TAGS
+    )
+    def test_dispatch_creates_correct_xml_tag(
+        self, writer, element_type, expected_tag
+    ):
+        pkg = _pkg()
+        create_method = f"create{element_type}"
+        if hasattr(pkg, create_method):
+            element = getattr(pkg, create_method)("Elem")
+        else:
+            raise AttributeError(
+                f"ARPackage has no method {create_method}"
+            )
+        if element_type in ELEMENTS_WITH_SPECIAL_SETUP:
+            ELEMENTS_WITH_SPECIAL_SETUP[element_type](element)
+        parent = _parent()
+        writer.writeARPackageElement(parent, element)
+        assert len(parent) == 1
+        assert parent[0].tag == expected_tag
+        assert parent[0].find("SHORT-NAME").text == "Elem"
+
+
+class TestWriteSwcImplementationDispatch:
+    def test_swc_implementation_with_setup(self, writer):
+        pkg = _pkg()
+        impl = pkg.createSwcImplementation("SwcImpl")
+        impl.swVersion = None
+        impl.vendorId = None
+        parent = _parent()
+        writer.writeARPackageElement(parent, impl)
+        assert len(parent) == 1
+        assert parent[0].tag == "SWC-IMPLEMENTATION"
+
+
+class TestWriteBswImplementationDispatch:
+    def test_bsw_implementation_with_setup(self, writer):
+        pkg = _pkg()
+        impl = pkg.createBswImplementation("BswImpl")
+        impl.swVersion = None
+        impl.vendorId = None
+        parent = _parent()
+        writer.writeARPackageElement(parent, impl)
+        assert len(parent) == 1
+        assert parent[0].tag == "BSW-IMPLEMENTATION"
+
+
+class TestWriteTriggerInterfaceDispatch:
+    def test_trigger_interface_dispatch(self, writer):
+        pkg = _pkg()
+        trigger_if = pkg.createTriggerInterface("TriggerIf")
+        parent = _parent()
+        writer.writeARPackageElement(parent, trigger_if)
+        assert len(parent) == 0
+
+
+class TestWriteSecureCommunicationPropsSetDispatch:
+    @pytest.mark.skip(reason="Model method getAuthenticationProps not implemented")
+    def test_secure_comm_props_set_dispatch(self, writer):
+        pkg = _pkg()
+        props = pkg.createSecureCommunicationPropsSet("Props")
+        parent = _parent()
+        writer.writeARPackageElement(parent, props)
+
+
+class TestWriteReferenceBases:
+    def test_empty_reference_bases(self, writer):
+        parent = ET.Element("AR-PACKAGE")
+        writer.writeReferenceBases(parent, [])
+        assert parent.find("REFERENCE-BASES") is None
+
+    def test_single_reference_base(self, writer):
+        parent = ET.Element("AR-PACKAGE")
+        base = ReferenceBase()
+        base.setShortLabel(_literal("base1"))
+        base.setIsDefault(_boolean(True))
+        base.setBaseIsThisPackage(_boolean(True))
+        writer.writeReferenceBases(parent, [base])
+        bases_tag = parent.find("REFERENCE-BASES")
+        assert bases_tag is not None
+        ref_base = bases_tag.find("REFERENCE-BASE")
+        assert ref_base is not None
+        assert ref_base.find("SHORT-LABEL").text == "base1"
+
+    def test_multiple_reference_bases(self, writer):
+        parent = ET.Element("AR-PACKAGE")
+        base1 = ReferenceBase()
+        base1.setShortLabel(_literal("base1"))
+        base2 = ReferenceBase()
+        base2.setShortLabel(_literal("base2"))
+        writer.writeReferenceBases(parent, [base1, base2])
+        bases_tag = parent.find("REFERENCE-BASES")
+        assert bases_tag is not None
+        ref_bases = bases_tag.findall("REFERENCE-BASE")
+        assert len(ref_bases) == 2
+
+
+class TestWriteARPackage:
+    def test_basic_arpackage(self, writer):
+        parent = ET.Element("AUTOSAR")
+        pkg = _pkg()
+        writer.writeARPackage(parent, pkg)
+        assert parent.find("AR-PACKAGE") is not None
+        pkg_tag = parent.find("AR-PACKAGE")
+        assert pkg_tag.find("SHORT-NAME").text == "Pkg"
+
+    def test_arpackage_with_reference_bases(self, writer):
+        parent = ET.Element("AUTOSAR")
+        pkg = _pkg()
+        base = ReferenceBase()
+        base.setShortLabel(_literal("base1"))
+        pkg.addReferenceBase(base)
+        writer.writeARPackage(parent, pkg)
+        pkg_tag = parent.find("AR-PACKAGE")
+        assert pkg_tag.find("REFERENCE-BASES") is not None
+
+    def test_arpackage_with_sub_packages(self, writer):
+        parent = ET.Element("AUTOSAR")
+        pkg = _pkg()
+        sub_pkg = pkg.createARPackage("SubPkg")
+        writer.writeARPackage(parent, pkg)
+        pkg_tag = parent.find("AR-PACKAGE")
+        packages_tag = pkg_tag.find("AR-PACKAGES")
+        assert packages_tag is not None
+        sub_pkg_tag = packages_tag.find("AR-PACKAGE")
+        assert sub_pkg_tag.find("SHORT-NAME").text == "SubPkg"
+
+    def test_arpackage_with_elements(self, writer):
+        parent = ET.Element("AUTOSAR")
+        pkg = _pkg()
+        pkg.createSwBaseType("BaseType")
+        writer.writeARPackage(parent, pkg)
+        pkg_tag = parent.find("AR-PACKAGE")
+        elements_tag = pkg_tag.find("ELEMENTS")
+        assert elements_tag is not None
+        assert elements_tag.find("SW-BASE-TYPE") is not None
+
+
+class TestWriteARPackageElements:
+    def test_empty_package(self, writer):
+        parent = ET.Element("AR-PACKAGE")
+        pkg = _pkg()
+        writer.writeARPackageElements(parent, pkg)
+        assert parent.find("ELEMENTS") is None
+
+    def test_single_element(self, writer):
+        parent = ET.Element("AR-PACKAGE")
+        pkg = _pkg()
+        pkg.createApplicationPrimitiveDataType("DataType")
+        writer.writeARPackageElements(parent, pkg)
+        elements_tag = parent.find("ELEMENTS")
+        assert elements_tag is not None
+        assert len(elements_tag) == 1
+
+    def test_multiple_elements(self, writer):
+        parent = ET.Element("AR-PACKAGE")
+        pkg = _pkg()
+        pkg.createSwBaseType("BaseType1")
+        pkg.createSwBaseType("BaseType2")
+        pkg.createCompuMethod("Compu")
+        writer.writeARPackageElements(parent, pkg)
+        elements_tag = parent.find("ELEMENTS")
+        assert elements_tag is not None
+        assert len(elements_tag) == 3
+        tags = {child.tag for child in elements_tag}
+        assert "SW-BASE-TYPE" in tags
+        assert "COMPU-METHOD" in tags
+
+    def test_skips_arpackage_elements(self, writer):
+        parent = ET.Element("AR-PACKAGE")
+        pkg = _pkg()
+        pkg.createSwBaseType("BaseType")
+        pkg.createARPackage("SubPkg")
+        writer.writeARPackageElements(parent, pkg)
+        elements_tag = parent.find("ELEMENTS")
+        assert elements_tag is not None
+        assert len(elements_tag) == 1
+
+
+class TestWriteARPackages:
+    def test_empty_list(self, writer):
+        parent = ET.Element("AUTOSAR")
+        writer.writeARPackages(parent, [])
+        assert parent.find("AR-PACKAGES") is None
+
+    def test_single_package(self, writer):
+        parent = ET.Element("AUTOSAR")
+        pkg = _pkg()
+        writer.writeARPackages(parent, [pkg])
+        packages_tag = parent.find("AR-PACKAGES")
+        assert packages_tag is not None
+        assert len(packages_tag) == 1
+        assert packages_tag.find("AR-PACKAGE").find("SHORT-NAME").text == "Pkg"
+
+    def test_multiple_packages(self, writer):
+        parent = ET.Element("AUTOSAR")
+        autosar = AUTOSAR.getInstance()
+        pkg1 = autosar.createARPackage("Pkg1")
+        pkg2 = autosar.createARPackage("Pkg2")
+        writer.writeARPackages(parent, [pkg1, pkg2])
+        packages_tag = parent.find("AR-PACKAGES")
+        assert packages_tag is not None
+        pkgs = packages_tag.findall("AR-PACKAGE")
+        assert len(pkgs) == 2
+        names = [p.find("SHORT-NAME").text for p in pkgs]
+        assert names == ["Pkg1", "Pkg2"]
+
+
+class TestSave:
+    def _find_child(self, parent, tag_name):
+        for child in parent:
+            if tag_name in child.tag:
+                return child
+        return None
+
+    def test_save_creates_file(self, writer):
+        AUTOSAR.getInstance().setARRelease('R23-11')
+        autosar = AUTOSAR.getInstance()
+        pkg = autosar.createARPackage("TestPkg")
+        pkg.createSwBaseType("MyBaseType")
+        pkg.createApplicationPrimitiveDataType("MyDataType")
+        with tempfile.NamedTemporaryFile(
+            suffix=".arxml", delete=False
+        ) as tmp:
+            tmp_path = tmp.name
+        try:
+            writer.save(tmp_path, autosar)
+            assert os.path.exists(tmp_path)
+            tree = ET.parse(tmp_path)
+            root = tree.getroot()
+            assert "AUTOSAR" in root.tag
+            pkgs = self._find_child(root, "AR-PACKAGES")
+            assert pkgs is not None
+            pkg_tag = self._find_child(pkgs, "AR-PACKAGE")
+            assert pkg_tag is not None
+            short_name = self._find_child(pkg_tag, "SHORT-NAME")
+            assert short_name.text == "TestPkg"
+            elements_tag = self._find_child(pkg_tag, "ELEMENTS")
+            assert elements_tag is not None
+            assert len(elements_tag) >= 2
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    def test_save_with_nested_packages(self, writer):
+        AUTOSAR.getInstance().setARRelease('R23-11')
+        autosar = AUTOSAR.getInstance()
+        pkg1 = autosar.createARPackage("RootPkg")
+        pkg2 = pkg1.createARPackage("SubPkg")
+        pkg2.createSwBaseType("NestedType")
+        with tempfile.NamedTemporaryFile(
+            suffix=".arxml", delete=False
+        ) as tmp:
+            tmp_path = tmp.name
+        try:
+            writer.save(tmp_path, autosar)
+            tree = ET.parse(tmp_path)
+            root = tree.getroot()
+            pkgs = self._find_child(root, "AR-PACKAGES")
+            root_pkg = self._find_child(pkgs, "AR-PACKAGE")
+            short_name = self._find_child(root_pkg, "SHORT-NAME")
+            assert short_name.text == "RootPkg"
+            sub_pkgs = self._find_child(root_pkg, "AR-PACKAGES")
+            assert sub_pkgs is not None
+            sub_pkg = self._find_child(sub_pkgs, "AR-PACKAGE")
+            short_name = self._find_child(sub_pkg, "SHORT-NAME")
+            assert short_name.text == "SubPkg"
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    def test_save_with_schema_location(self, writer):
+        AUTOSAR.getInstance().setARRelease('R23-11')
+        autosar = AUTOSAR.getInstance()
+        autosar.schema_location = "http://autosar.org/schema/r4.0 custom.xsd"
+        pkg = autosar.createARPackage("Pkg")
+        pkg.createSwBaseType("Base")
+        with tempfile.NamedTemporaryFile(
+            suffix=".arxml", delete=False
+        ) as tmp:
+            tmp_path = tmp.name
+        try:
+            writer.save(tmp_path, autosar)
+            tree = ET.parse(tmp_path)
+            root = tree.getroot()
+            schema_loc = None
+            for key in root.attrib:
+                if "schemaLocation" in key:
+                    schema_loc = root.attrib[key]
+                    break
+            assert schema_loc is not None
+            assert "custom.xsd" in schema_loc
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    def test_save_with_multiple_element_types(self, writer):
+        AUTOSAR.getInstance().setARRelease('R23-11')
+        autosar = AUTOSAR.getInstance()
+        pkg = autosar.createARPackage("MixedPkg")
+        pkg.createSwBaseType("BaseType")
+        pkg.createCompuMethod("CompuMethod")
+        pkg.createUnit("Unit")
+        pkg.createSenderReceiverInterface("SRInterface")
+        pkg.createClientServerInterface("CSInterface")
+        pkg.createApplicationPrimitiveDataType("AppDataType")
+        pkg.createImplementationDataType("ImplDataType")
+        pkg.createConstantSpecification("ConstSpec")
+        pkg.createDataConstr("DataConstr")
+        pkg.createBswModuleDescription("BswDesc")
+        pkg.createEndToEndProtectionSet("E2ESet")
+        pkg.createDataTypeMappingSet("DataTypeMap")
+        with tempfile.NamedTemporaryFile(
+            suffix=".arxml", delete=False
+        ) as tmp:
+            tmp_path = tmp.name
+        try:
+            writer.save(tmp_path, autosar)
+            tree = ET.parse(tmp_path)
+            root = tree.getroot()
+            pkgs = self._find_child(root, "AR-PACKAGES")
+            pkg_tag = self._find_child(pkgs, "AR-PACKAGE")
+            elements = self._find_child(pkg_tag, "ELEMENTS")
+            assert elements is not None
+            child_tags = {child.tag for child in elements}
+            expected_tags = {
+                "SW-BASE-TYPE",
+                "COMPU-METHOD",
+                "UNIT",
+                "SENDER-RECEIVER-INTERFACE",
+                "CLIENT-SERVER-INTERFACE",
+                "APPLICATION-PRIMITIVE-DATA-TYPE",
+                "IMPLEMENTATION-DATA-TYPE",
+                "CONSTANT-SPECIFICATION",
+                "DATA-CONSTR",
+                "BSW-MODULE-DESCRIPTION",
+                "END-TO-END-PROTECTION-SET",
+                "DATA-TYPE-MAPPING-SET",
+            }
+            found_tags = set()
+            for tag in child_tags:
+                for expected in expected_tags:
+                    if expected in tag:
+                        found_tags.add(expected)
+            assert expected_tags.issubset(found_tags)
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)

--- a/tests/test_armodel/writer/test_writer_controllers_ecu.py
+++ b/tests/test_armodel/writer/test_writer_controllers_ecu.py
@@ -1,0 +1,821 @@
+"""Tests for writer Ethernet/CAN controller and EcuInstance methods."""
+import xml.etree.cElementTree as ET
+import pytest
+
+from armodel.writer.arxml_writer import ARXMLWriter
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import (  # noqa E501
+    CanControllerConfigurationRequirements,
+    CanControllerFdConfiguration,
+    CanControllerFdConfigurationRequirements,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetTopology import (  # noqa E501
+    CouplingPortDetails,
+    VlanMembership,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa E501
+    ARBoolean,
+    ARLiteral,
+    Float,
+    Integer,
+    PositiveInteger,
+    RefType,
+    TimeValue,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+def _parent():
+    return ET.Element("PARENT")
+
+
+def _ref(value, dest=None):
+    ref = RefType()
+    ref.setValue(value)
+    if dest is not None:
+        ref.setDest(dest)
+    return ref
+
+
+def _literal(value):
+    lit = ARLiteral()
+    lit.setValue(value)
+    return lit
+
+
+def _bool(value):
+    b = ARBoolean()
+    b.setValue(value)
+    return b
+
+
+def _int(value):
+    n = Integer()
+    n.setValue(value)
+    return n
+
+
+def _posint(value):
+    p = PositiveInteger()
+    p.setValue(str(value))
+    return p
+
+
+def _float(value):
+    f = Float()
+    f.setValue(value)
+    return f
+
+
+def _time(value):
+    t = TimeValue()
+    t.setValue(value)
+    return t
+
+
+def _pkg():
+    return AUTOSAR.getInstance().createARPackage("Pkg")
+
+
+def _make_ecu_instance():
+    return _pkg().createEcuInstance("EcuInst")
+
+
+def _make_ethernet_cluster():
+    return _pkg().createEthernetCluster("EthCluster")
+
+
+def _make_can_frame():
+    return _pkg().createCanFrame("CanFrame")
+
+
+def _make_can_communication_controller():
+    instance = _make_ecu_instance()
+    return instance.createCanCommunicationController("CanCtrl")
+
+
+def _make_ethernet_communication_controller():
+    instance = _make_ecu_instance()
+    return instance.createEthernetCommunicationController("EthCtrl")
+
+
+def _make_can_communication_connector():
+    instance = _make_ecu_instance()
+    return instance.createCanCommunicationConnector("CanConn")
+
+
+class TestWriterMacMulticastGroup:
+    def test_with_address(self, writer):
+        cluster = _make_ethernet_cluster()
+        group = cluster.createMacMulticastGroup("g1")
+        group.setMacMulticastAddress(_literal("01:00:5E:00:00:01"))
+        parent = _parent()
+        writer.writeMacMulticastGroup(parent, group)
+        assert parent[0].tag == "MAC-MULTICAST-GROUP"
+        addr = parent[0].find("MAC-MULTICAST-ADDRESS")
+        assert addr is not None
+        assert addr.text == "01:00:5E:00:00:01"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeMacMulticastGroup(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEthernetClusterMacMulticastGroups:
+    def test_with_groups(self, writer):
+        cluster = _make_ethernet_cluster()
+        cluster.createMacMulticastGroup("g1").setMacMulticastAddress(
+            _literal("addr1")
+        )
+        parent = _parent()
+        writer.writeEthernetClusterMacMulticastGroups(parent, cluster)
+        assert parent[0].tag == "MAC-MULTICAST-GROUPS"
+        assert parent[0].find("MAC-MULTICAST-GROUP") is not None
+
+    def test_empty(self, writer):
+        cluster = _make_ethernet_cluster()
+        parent = _parent()
+        writer.writeEthernetClusterMacMulticastGroups(parent, cluster)
+        assert len(parent) == 0
+
+
+class TestWriterEthernetCluster:
+    def test_full(self, writer):
+        cluster = _make_ethernet_cluster()
+        cluster.createMacMulticastGroup("g1")
+        parent = _parent()
+        writer.writeEthernetCluster(parent, cluster)
+        assert parent[0].tag == "ETHERNET-CLUSTER"
+        cond = parent[0].find(
+            "ETHERNET-CLUSTER-VARIANTS/ETHERNET-CLUSTER-CONDITIONAL"
+        )
+        assert cond is not None
+        assert cond.find("MAC-MULTICAST-GROUPS") is not None
+
+
+class TestWriterCanFrame:
+    def test_can_frame(self, writer):
+        frame = _make_can_frame()
+        parent = _parent()
+        writer.writeCanFrame(parent, frame)
+        assert parent[0].tag == "CAN-FRAME"
+        assert parent[0].find("SHORT-NAME") is not None
+
+
+class TestWriterCommConnectorPort:
+    def test_comm_connector_port(self, writer):
+        connector = _make_can_communication_connector()
+        port = connector.createFramePort("fp")
+        port.setCommunicationDirection(_literal("in"))
+        parent = _parent()
+        writer.writeCommConnectorPort(parent, port)
+        assert parent.find("SHORT-NAME") is not None
+        direction = parent.find("COMMUNICATION-DIRECTION")
+        assert direction is not None
+        assert direction.text == "in"
+
+
+class TestWriterFramePort:
+    def test_frame_port(self, writer):
+        connector = _make_can_communication_connector()
+        port = connector.createFramePort("fp")
+        port.setCommunicationDirection(_literal("out"))
+        parent = _parent()
+        writer.writeFramePort(parent, port)
+        assert parent[0].tag == "FRAME-PORT"
+        assert parent[0].find("COMMUNICATION-DIRECTION").text == "out"
+
+
+class TestWriterIPduPort:
+    def test_ipdu_port(self, writer):
+        connector = _make_can_communication_connector()
+        port = connector.createIPduPort("ipp")
+        port.setCommunicationDirection(_literal("in"))
+        port.setKeyId(_posint(5))
+        port.setRxSecurityVerification(_bool(True))
+        port.setUseAuthDataFreshness(_bool(False))
+        parent = _parent()
+        writer.writeIPduPort(parent, port)
+        assert parent[0].tag == "I-PDU-PORT"
+        assert parent[0].find("KEY-ID") is not None
+        assert parent[0].find("RX-SECURITY-VERIFICATION") is not None
+        assert parent[0].find("USE-AUTH-DATA-FRESHNESS") is not None
+
+
+class TestWriterISignalPort:
+    def test_isignal_port(self, writer):
+        connector = _make_can_communication_connector()
+        port = connector.createISignalPort("isp")
+        port.setCommunicationDirection(_literal("in"))
+        port.setTimeout(_time(0.1))
+        parent = _parent()
+        writer.writeISignalPort(parent, port)
+        assert parent[0].tag == "I-SIGNAL-PORT"
+        assert parent[0].find("TIMEOUT") is not None
+
+
+class TestWriterCommunicationConnectorEcuCommPortInstances:
+    def test_dispatches_all_port_types(self, writer):
+        connector = _make_can_communication_connector()
+        connector.createFramePort("fp")
+        connector.createIPduPort("ipp")
+        connector.createISignalPort("isp")
+        parent = _parent()
+        writer.writeCommunicationConnectorEcuCommPortInstances(
+            parent, connector
+        )
+        assert parent[0].tag == "ECU-COMM-PORT-INSTANCES"
+        tags = {c.tag for c in parent[0]}
+        assert "FRAME-PORT" in tags
+        assert "I-PDU-PORT" in tags
+        assert "I-SIGNAL-PORT" in tags
+
+    def test_empty(self, writer):
+        connector = _make_can_communication_connector()
+        parent = _parent()
+        writer.writeCommunicationConnectorEcuCommPortInstances(
+            parent, connector
+        )
+        assert len(parent) == 0
+
+
+class TestWriterCommunicationController:
+    def test_write_communication_controller(self, writer):
+        controller = _make_can_communication_controller()
+        controller.setWakeUpByControllerSupported(_bool(True))
+        parent = _parent()
+        writer.writeCommunicationController(parent, controller)
+        assert parent.find("WAKE-UP-BY-CONTROLLER-SUPPORTED") is not None
+
+
+class TestWriterSetCanControllerFdConfiguration:
+    def test_with_config(self, writer):
+        config = CanControllerFdConfiguration()
+        config.setTxBitRateSwitch(_bool(True))
+        parent = _parent()
+        writer.setCanControllerFdConfiguration(
+            parent, "CAN-CONTROLLER-FD-CONFIGURATION", config
+        )
+        assert len(parent) == 0
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.setCanControllerFdConfiguration(
+            parent, "CAN-CONTROLLER-FD-CONFIGURATION", None
+        )
+        assert len(parent) == 0
+
+
+class TestWriterSetCanControllerFdConfigurationRequirements:
+    def test_with_requirements(self, writer):
+        req = CanControllerFdConfigurationRequirements()
+        req.setMaxNumberOfTimeQuantaPerBit(_int(32))
+        req.setMaxSamplePoint(_float(0.8))
+        req.setMaxSyncJumpWidth(_float(0.2))
+        req.setMaxTrcvDelayCompensationOffset(_time(0.001))
+        req.setMinNumberOfTimeQuantaPerBit(_int(16))
+        req.setMinSamplePoint(_float(0.5))
+        req.setMinSyncJumpWidth(_float(0.1))
+        req.setMinTrcvDelayCompensationOffset(_time(0.0005))
+        req.setTxBitRateSwitch(_bool(True))
+        parent = _parent()
+        writer.setCanControllerFdConfigurationRequirements(
+            parent, "CAN-CONTROLLER-FD-REQUIREMENTS", req
+        )
+        assert parent[0].tag == "CAN-CONTROLLER-FD-REQUIREMENTS"
+        assert parent[0].find("MAX-NUMBER-OF-TIME-QUANTA-PER-BIT") is not None
+        assert parent[0].find("MAX-SAMPLE-POINT") is not None
+        assert parent[0].find("MAX-SYNC-JUMP-WIDTH") is not None
+        assert parent[0].find("MAX-TRCV-DELAY-COMPENSATION-OFFSET") is not None
+        assert parent[0].find("MIN-NUMBER-OF-TIME-QUANTA-PER-BIT") is not None
+        assert parent[0].find("MIN-SAMPLE-POINT") is not None
+        assert parent[0].find("MIN-SYNC-JUMP-WIDTH") is not None
+        assert parent[0].find("MIN-TRCV-DELAY-COMPENSATION-OFFSET") is not None
+        assert parent[0].find("TX-BIT-RATE-SWITCH") is not None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.setCanControllerFdConfigurationRequirements(
+            parent, "CAN-CONTROLLER-FD-REQUIREMENTS", None
+        )
+        assert len(parent) == 0
+
+
+class TestWriterAbstractCanCommunicationControllerAttributes:
+    def test_with_attributes(self, writer):
+        attrs = CanControllerConfigurationRequirements()
+        attrs.setCanControllerFdAttributes(CanControllerFdConfiguration())
+        req = CanControllerFdConfigurationRequirements()
+        req.setTxBitRateSwitch(_bool(True))
+        attrs.setCanControllerFdRequirements(req)
+        parent = _parent()
+        writer.writeAbstractCanCommunicationControllerAttributes(parent, attrs)
+        assert parent.find("CAN-CONTROLLER-FD-REQUIREMENTS") is not None
+
+
+class TestWriterCanControllerConfigurationRequirements:
+    def test_with_requirements(self, writer):
+        req = CanControllerConfigurationRequirements()
+        req.setMaxNumberOfTimeQuantaPerBit(_int(32))
+        req.setMaxSamplePoint(_float(0.8))
+        req.setMaxSyncJumpWidth(_float(0.2))
+        req.setMinNumberOfTimeQuantaPerBit(_int(16))
+        req.setMinSamplePoint(_float(0.5))
+        req.setMinSyncJumpWidth(_float(0.1))
+        req.setCanControllerFdRequirements(
+            CanControllerFdConfigurationRequirements()
+        )
+        parent = _parent()
+        writer.writeCanControllerConfigurationRequirements(parent, req)
+        assert parent[0].tag == "CAN-CONTROLLER-CONFIGURATION-REQUIREMENTS"
+        assert parent[0].find("MAX-NUMBER-OF-TIME-QUANTA-PER-BIT") is not None
+        assert parent[0].find("MAX-SAMPLE-POINT") is not None
+        assert parent[0].find("MIN-NUMBER-OF-TIME-QUANTA-PER-BIT") is not None
+        assert parent[0].find("CAN-CONTROLLER-FD-REQUIREMENTS") is not None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeCanControllerConfigurationRequirements(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterAbstractCanCommunicationControllerCanControllerAttributes:
+    def test_with_requirements(self, writer):
+        controller = _make_can_communication_controller()
+        req = CanControllerConfigurationRequirements()
+        req.setMaxSamplePoint(_float(0.8))
+        controller.setCanControllerAttributes(req)
+        parent = _parent()
+        writer.writeAbstractCanCommunicationControllerCanControllerAttributes(
+            parent, controller
+        )
+        assert parent[0].tag == "CAN-CONTROLLER-ATTRIBUTES"
+        assert parent[0].find(
+            "CAN-CONTROLLER-CONFIGURATION-REQUIREMENTS"
+        ) is not None
+
+    def test_no_attributes(self, writer):
+        controller = _make_can_communication_controller()
+        parent = _parent()
+        writer.writeAbstractCanCommunicationControllerCanControllerAttributes(
+            parent, controller
+        )
+        assert len(parent) == 0
+
+
+class TestWriterAbstractCanCommunicationController:
+    def test_full(self, writer):
+        controller = _make_can_communication_controller()
+        controller.setWakeUpByControllerSupported(_bool(True))
+        req = CanControllerConfigurationRequirements()
+        controller.setCanControllerAttributes(req)
+        parent = _parent()
+        writer.writeAbstractCanCommunicationController(parent, controller)
+        assert parent.find("WAKE-UP-BY-CONTROLLER-SUPPORTED") is not None
+        assert parent.find("CAN-CONTROLLER-ATTRIBUTES") is not None
+
+
+class TestWriterCanCommunicationController:
+    def test_full(self, writer):
+        controller = _make_can_communication_controller()
+        controller.setWakeUpByControllerSupported(_bool(True))
+        req = CanControllerConfigurationRequirements()
+        controller.setCanControllerAttributes(req)
+        parent = _parent()
+        writer.writeCanCommunicationController(parent, controller)
+        assert parent[0].tag == "CAN-COMMUNICATION-CONTROLLER"
+        cond = parent[0].find(
+            "CAN-COMMUNICATION-CONTROLLER-VARIANTS"
+            "/CAN-COMMUNICATION-CONTROLLER-CONDITIONAL"
+        )
+        assert cond is not None
+        assert cond.find("WAKE-UP-BY-CONTROLLER-SUPPORTED") is not None
+        assert cond.find("CAN-CONTROLLER-ATTRIBUTES") is not None
+
+
+class TestWriterCouplingPortSchedulerCouplingPortStructuralElement:
+    def test_structural_element(self, writer):
+        details = CouplingPortDetails()
+        fifo = details.createCouplingPortFifo("fifo")
+        parent = _parent()
+        writer.writeCouplingPortSchedulerCouplingPortStructuralElement(
+            parent, fifo
+        )
+        assert parent.find("SHORT-NAME") is not None
+        assert parent.find("SHORT-NAME").text == "fifo"
+
+
+class TestWriterCouplingPortFifo:
+    def test_fifo(self, writer):
+        details = CouplingPortDetails()
+        fifo = details.createCouplingPortFifo("fifo")
+        parent = _parent()
+        writer.writeCouplingPortFifo(parent, fifo)
+        assert parent[0].tag == "COUPLING-PORT-FIFO"
+        assert parent[0].find("SHORT-NAME").text == "fifo"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeCouplingPortFifo(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterCouplingPortScheduler:
+    def test_scheduler(self, writer):
+        details = CouplingPortDetails()
+        scheduler = details.createCouplingPortScheduler("sched")
+        scheduler.setPortScheduler(_literal("scheduler1"))
+        parent = _parent()
+        writer.writeCouplingPortScheduler(parent, scheduler)
+        assert parent[0].tag == "COUPLING-PORT-SCHEDULER"
+        assert parent[0].find("PORT-SCHEDULER").text == "scheduler1"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeCouplingPortScheduler(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterCouplingPortDetailsStructuralElements:
+    def test_dispatches_fifo_and_scheduler(self, writer):
+        details = CouplingPortDetails()
+        details.createCouplingPortFifo("fifo")
+        details.createCouplingPortScheduler("sched")
+        parent = _parent()
+        writer.writeCouplingPortDetailsCouplingPortStructuralElements(
+            parent, details
+        )
+        assert parent[0].tag == "COUPLING-PORT-STRUCTURAL-ELEMENTS"
+        tags = {c.tag for c in parent[0]}
+        assert "COUPLING-PORT-FIFO" in tags
+        assert "COUPLING-PORT-SCHEDULER" in tags
+
+    def test_empty(self, writer):
+        details = CouplingPortDetails()
+        parent = _parent()
+        writer.writeCouplingPortDetailsCouplingPortStructuralElements(
+            parent, details
+        )
+        assert len(parent) == 0
+
+
+class TestWriterEthernetPriorityRegeneration:
+    def test_regen(self, writer):
+        details = CouplingPortDetails()
+        regen = details.createEthernetPriorityRegeneration("regen")
+        regen.setIngressPriority(_posint(1))
+        regen.setRegeneratedPriority(_posint(2))
+        parent = _parent()
+        writer.writeEthernetPriorityRegeneration(parent, regen)
+        assert parent[0].tag == "ETHERNET-PRIORITY-REGENERATION"
+        assert parent[0].find("INGRESS-PRIORITY") is not None
+        assert parent[0].find("REGENERATED-PRIORITY") is not None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEthernetPriorityRegeneration(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterCouplingPortDetailsEthernetPriorityRegenerations:
+    def test_with_regen(self, writer):
+        details = CouplingPortDetails()
+        details.createEthernetPriorityRegeneration("r1")
+        parent = _parent()
+        writer.writeCouplingPortDetailsEthernetPriorityRegenerations(
+            parent, details
+        )
+        assert parent[0].tag == "ETHERNET-PRIORITY-REGENERATIONS"
+        assert parent[0].find("ETHERNET-PRIORITY-REGENERATION") is not None
+
+    def test_empty(self, writer):
+        details = CouplingPortDetails()
+        parent = _parent()
+        writer.writeCouplingPortDetailsEthernetPriorityRegenerations(
+            parent, details
+        )
+        assert len(parent) == 0
+
+
+class TestWriterSetCouplingPortDetails:
+    def test_with_details(self, writer):
+        details = CouplingPortDetails()
+        details.createCouplingPortFifo("fifo")
+        details.createEthernetPriorityRegeneration("r1")
+        details.setLastEgressSchedulerRef(
+            _ref("/les", "COUPLING-PORT-SCHEDULER")
+        )
+        parent = _parent()
+        writer.setCouplingPortDetails(
+            parent, "COUPLING-PORT-DETAILS", details
+        )
+        assert parent[0].tag == "COUPLING-PORT-DETAILS"
+        assert parent[0].find("COUPLING-PORT-STRUCTURAL-ELEMENTS") is not None
+        assert parent[0].find("ETHERNET-PRIORITY-REGENERATIONS") is not None
+        assert parent[0].find("LAST-EGRESS-SCHEDULER-REF") is not None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.setCouplingPortDetails(
+            parent, "COUPLING-PORT-DETAILS", None
+        )
+        assert len(parent) == 0
+
+
+class TestWriterVlanMembership:
+    def test_membership(self, writer):
+        membership = VlanMembership()
+        membership.setSendActivity(_literal("tagged"))
+        membership.setVlanRef(_ref("/vlan", "VLAN-CONFIG"))
+        parent = _parent()
+        writer.writeVlanMembership(parent, membership)
+        assert parent[0].tag == "VLAN-MEMBERSHIP"
+        assert parent[0].find("SEND-ACTIVITY").text == "tagged"
+        assert parent[0].find("VLAN-REF") is not None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeVlanMembership(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterCouplingPortVlanMemberships:
+    def test_with_memberships(self, writer):
+        controller = _make_ethernet_communication_controller()
+        port = controller.createCouplingPort("cp")
+        port.addVlanMembership(VlanMembership())
+        parent = _parent()
+        writer.writeCouplingPortVlanMemberships(parent, port)
+        assert parent[0].tag == "VLAN-MEMBERSHIPS"
+        assert parent[0].find("VLAN-MEMBERSHIP") is not None
+
+    def test_empty(self, writer):
+        controller = _make_ethernet_communication_controller()
+        port = controller.createCouplingPort("cp")
+        parent = _parent()
+        writer.writeCouplingPortVlanMemberships(parent, port)
+        assert len(parent) == 0
+
+
+class TestWriterCouplingPort:
+    def test_full(self, writer):
+        controller = _make_ethernet_communication_controller()
+        port = controller.createCouplingPort("cp")
+        details = CouplingPortDetails()
+        details.createCouplingPortFifo("fifo")
+        port.setCouplingPortDetails(details)
+        port.setMacLayerType(_literal("ethernet"))
+        port.addVlanMembership(VlanMembership())
+        parent = _parent()
+        writer.writeCouplingPort(parent, port)
+        assert parent[0].tag == "COUPLING-PORT"
+        assert parent[0].find("COUPLING-PORT-DETAILS") is not None
+        assert parent[0].find("MAC-LAYER-TYPE").text == "ethernet"
+        assert parent[0].find("VLAN-MEMBERSHIPS") is not None
+
+
+class TestWriterEthernetCommunicationControllerCouplingPorts:
+    def test_with_ports(self, writer):
+        controller = _make_ethernet_communication_controller()
+        controller.createCouplingPort("cp1")
+        parent = _parent()
+        writer.writeEthernetCommunicationControllerCouplingPorts(
+            parent, controller
+        )
+        assert parent[0].tag == "COUPLING-PORTS"
+        assert parent[0].find("COUPLING-PORT") is not None
+
+    def test_empty(self, writer):
+        controller = _make_ethernet_communication_controller()
+        parent = _parent()
+        writer.writeEthernetCommunicationControllerCouplingPorts(
+            parent, controller
+        )
+        assert len(parent) == 0
+
+
+class TestWriterEthernetCommunicationController:
+    def test_full(self, writer):
+        controller = _make_ethernet_communication_controller()
+        controller.setWakeUpByControllerSupported(_bool(True))
+        controller.createCouplingPort("cp")
+        parent = _parent()
+        writer.writeEthernetCommunicationController(parent, controller)
+        assert parent[0].tag == "ETHERNET-COMMUNICATION-CONTROLLER"
+        cond = parent[0].find(
+            "ETHERNET-COMMUNICATION-CONTROLLER-VARIANTS"
+            "/ETHERNET-COMMUNICATION-CONTROLLER-CONDITIONAL"
+        )
+        assert cond is not None
+        assert cond.find("WAKE-UP-BY-CONTROLLER-SUPPORTED") is not None
+        assert cond.find("COUPLING-PORTS") is not None
+
+
+class TestWriterEcuInstanceCommControllers:
+    def test_dispatches_all_controller_types(self, writer):
+        instance = _make_ecu_instance()
+        instance.createCanCommunicationController("can")
+        instance.createEthernetCommunicationController("eth")
+        instance.createLinMaster("lin")
+        instance.createFlexrayCommunicationController("flex")
+        parent = _parent()
+        writer.writeEcuInstanceCommControllers(parent, instance)
+        assert parent[0].tag == "COMM-CONTROLLERS"
+        tags = {c.tag for c in parent[0]}
+        assert "CAN-COMMUNICATION-CONTROLLER" in tags
+        assert "ETHERNET-COMMUNICATION-CONTROLLER" in tags
+        assert "LIN-MASTER" in tags
+        assert "FLEXRAY-COMMUNICATION-CONTROLLER" in tags
+
+    def test_empty(self, writer):
+        instance = _make_ecu_instance()
+        parent = _parent()
+        writer.writeEcuInstanceCommControllers(parent, instance)
+        assert len(parent) == 0
+
+
+class TestWriterCommunicationConnector:
+    def test_full(self, writer):
+        instance = _make_ecu_instance()
+        connector = instance.createCanCommunicationConnector("cc")
+        connector.setCommControllerRef(
+            _ref("/ctrl", "CAN-COMMUNICATION-CONTROLLER")
+        )
+        connector.setPncGatewayType(_literal("active"))
+        connector.createFramePort("fp")
+        parent = _parent()
+        writer.writeCommunicationConnector(parent, connector)
+        assert parent.find("COMM-CONTROLLER-REF") is not None
+        assert parent.find("ECU-COMM-PORT-INSTANCES") is not None
+        assert parent.find("PNC-GATEWAY-TYPE").text == "active"
+
+
+class TestWriterCanCommunicationConnector:
+    def test_can_connector(self, writer):
+        instance = _make_ecu_instance()
+        connector = instance.createCanCommunicationConnector("cc")
+        connector.setCommControllerRef(
+            _ref("/ctrl", "CAN-COMMUNICATION-CONTROLLER")
+        )
+        parent = _parent()
+        writer.writeCanCommunicationConnector(parent, connector)
+        assert parent.find("COMM-CONTROLLER-REF") is not None
+
+
+class TestWriterEthernetCommunicationConnector:
+    def test_full(self, writer):
+        instance = _make_ecu_instance()
+        connector = instance.createEthernetCommunicationConnector("ec")
+        connector.setCommControllerRef(
+            _ref("/ctrl", "ETHERNET-COMMUNICATION-CONTROLLER")
+        )
+        connector.setMaximumTransmissionUnit(_posint(1500))
+        connector.addNetworkEndpointRef(
+            _ref("/ne", "NETWORK-ENDPOINT")
+        )
+        parent = _parent()
+        writer.writeEthernetCommunicationConnector(parent, connector)
+        assert parent.find("COMM-CONTROLLER-REF") is not None
+        assert parent.find("MAXIMUM-TRANSMISSION-UNIT") is not None
+        assert parent.find("NETWORK-ENDPOINT-REFS") is not None
+
+
+class TestWriterEthernetCommunicationConnectorNetworkEndpointRefs:
+    def test_with_refs(self, writer):
+        instance = _make_ecu_instance()
+        connector = instance.createEthernetCommunicationConnector("ec")
+        connector.addNetworkEndpointRef(
+            _ref("/ne1", "NETWORK-ENDPOINT")
+        )
+        connector.addNetworkEndpointRef(
+            _ref("/ne2", "NETWORK-ENDPOINT")
+        )
+        parent = _parent()
+        writer.writeEthernetCommunicationConnectorNetworkEndpointRefs(
+            parent, connector
+        )
+        assert parent[0].tag == "NETWORK-ENDPOINT-REFS"
+        refs = parent[0].findall("NETWORK-ENDPOINT-REF")
+        assert len(refs) == 2
+
+    def test_empty(self, writer):
+        instance = _make_ecu_instance()
+        connector = instance.createEthernetCommunicationConnector("ec")
+        parent = _parent()
+        writer.writeEthernetCommunicationConnectorNetworkEndpointRefs(
+            parent, connector
+        )
+        assert len(parent) == 0
+
+
+class TestWriterLinCommunicationConnector:
+    def test_lin_connector(self, writer):
+        instance = _make_ecu_instance()
+        connector = instance.createLinCommunicationConnector("lc")
+        connector.setCommControllerRef(_ref("/ctrl", "LIN-MASTER"))
+        parent = _parent()
+        writer.writeLinCommunicationConnector(parent, connector)
+        assert parent.find("COMM-CONTROLLER-REF") is not None
+
+
+class TestWriterFlexrayCommunicationConnector:
+    def test_flexray_connector(self, writer):
+        instance = _make_ecu_instance()
+        connector = instance.createFlexrayCommunicationConnector("fc")
+        connector.setCommControllerRef(
+            _ref("/ctrl", "FLEXRAY-COMMUNICATION-CONTROLLER")
+        )
+        parent = _parent()
+        writer.writeFlexrayCommunicationConnector(parent, connector)
+        assert parent.find("COMM-CONTROLLER-REF") is not None
+
+
+class TestWriterEcuInstanceConnectors:
+    def test_dispatches_all_connector_types(self, writer):
+        instance = _make_ecu_instance()
+        instance.createCanCommunicationConnector("cc")
+        instance.createEthernetCommunicationConnector("ec")
+        instance.createLinCommunicationConnector("lc")
+        instance.createFlexrayCommunicationConnector("fc")
+        parent = _parent()
+        writer.writeEcuInstanceConnectors(parent, instance)
+        assert parent[0].tag == "CONNECTORS"
+        tags = {c.tag for c in parent[0]}
+        assert "CAN-COMMUNICATION-CONNECTOR" in tags
+        assert "ETHERNET-COMMUNICATION-CONNECTOR" in tags
+        assert "LIN-COMMUNICATION-CONNECTOR" in tags
+        assert "FLEXRAY-COMMUNICATION-CONNECTOR" in tags
+
+    def test_empty(self, writer):
+        instance = _make_ecu_instance()
+        parent = _parent()
+        writer.writeEcuInstanceConnectors(parent, instance)
+        assert len(parent) == 0
+
+
+class TestWriterEcuInstanceAssociatedComIPduGroupRefs:
+    def test_with_refs(self, writer):
+        instance = _make_ecu_instance()
+        instance.addAssociatedComIPduGroupRef(
+            _ref("/g1", "I-SIGNAL-I-PDU-GROUP")
+        )
+        instance.addAssociatedComIPduGroupRef(
+            _ref("/g2", "I-SIGNAL-I-PDU-GROUP")
+        )
+        parent = _parent()
+        writer.writeEcuInstanceAssociatedComIPduGroupRefs(parent, instance)
+        assert parent[0].tag == "ASSOCIATED-COM-I-PDU-GROUP-REFS"
+        refs = parent[0].findall("ASSOCIATED-COM-I-PDU-GROUP-REF")
+        assert len(refs) == 2
+
+    def test_empty(self, writer):
+        instance = _make_ecu_instance()
+        parent = _parent()
+        writer.writeEcuInstanceAssociatedComIPduGroupRefs(parent, instance)
+        assert len(parent) == 0
+
+
+class TestWriterEcuInstance:
+    def test_full(self, writer):
+        instance = _make_ecu_instance()
+        instance.addAssociatedComIPduGroupRef(
+            _ref("/g", "I-SIGNAL-I-PDU-GROUP")
+        )
+        instance.setComConfigurationGwTimeBase(_time(0.1))
+        instance.setComConfigurationRxTimeBase(_time(0.2))
+        instance.setComConfigurationTxTimeBase(_time(0.3))
+        instance.setComEnableMDTForCyclicTransmission(_bool(True))
+        instance.createCanCommunicationController("can")
+        instance.createCanCommunicationConnector("cc")
+        instance.setDiagnosticAddress(_int(1))
+        instance.setSleepModeSupported(_bool(True))
+        instance.setWakeUpOverBusSupported(_bool(False))
+        parent = _parent()
+        writer.writeEcuInstance(parent, instance)
+        ei = parent[0]
+        assert ei.tag == "ECU-INSTANCE"
+        assert ei.find("ASSOCIATED-COM-I-PDU-GROUP-REFS") is not None
+        assert ei.find("COM-CONFIGURATION-GW-TIME-BASE") is not None
+        assert ei.find("COM-CONFIGURATION-RX-TIME-BASE") is not None
+        assert ei.find("COM-CONFIGURATION-TX-TIME-BASE") is not None
+        assert ei.find(
+            "COM-ENABLE-MDT-FOR-CYCLIC-TRANSMISSION"
+        ) is not None
+        assert ei.find("COMM-CONTROLLERS") is not None
+        assert ei.find("CONNECTORS") is not None
+        assert ei.find("DIAGNOSTIC-ADDRESS") is not None
+        assert ei.find("SLEEP-MODE-SUPPORTED") is not None
+        assert ei.find("WAKE-UP-OVER-BUS-SUPPORTED") is not None

--- a/tests/test_armodel/writer/test_writer_ecuc_def.py
+++ b/tests/test_armodel/writer/test_writer_ecuc_def.py
@@ -1,0 +1,680 @@
+"""Tests for writer ECUC parameter definition handlers."""
+import xml.etree.cElementTree as ET
+import pytest
+
+from armodel.writer.arxml_writer import ARXMLWriter
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
+    EcucBooleanParamDef,
+    EcucChoiceContainerDef,
+    EcucEnumerationLiteralDef,
+    EcucEnumerationParamDef,
+    EcucFloatParamDef,
+    EcucFunctionNameDef,
+    EcucIntegerParamDef,
+    EcucModuleDef,
+    EcucMultiplicityConfigurationClass,
+    EcucParamConfContainerDef,
+    EcucReferenceDef,
+    EcucStringParamDef,
+    EcucSymbolicNameReferenceDef,
+    EcucValueConfigurationClass,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa E501
+    ARBoolean,
+    ARLiteral,
+    Float,
+    Limit,
+    PositiveInteger,
+    RefType,
+    UnlimitedInteger,
+    VerbatimString,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+def _parent():
+    return ET.Element("PARENT")
+
+
+def _ref(value, dest=None):
+    ref = RefType()
+    ref.setValue(value)
+    if dest is not None:
+        ref.setDest(dest)
+    return ref
+
+
+def _literal(value):
+    lit = ARLiteral()
+    lit.setValue(value)
+    return lit
+
+
+def _bool(value):
+    b = ARBoolean()
+    b.setValue(value)
+    return b
+
+
+def _posint(value):
+    p = PositiveInteger()
+    p.setValue(str(value))
+    return p
+
+
+def _unlimited(value):
+    n = UnlimitedInteger()
+    n.setValue(str(value))
+    return n
+
+
+def _float(value):
+    f = Float()
+    f.setValue(str(value))
+    return f
+
+
+def _limit(value, interval=None):
+    lim = Limit()
+    lim.setValue(str(value))
+    if interval is not None:
+        lim.setIntervalType(interval)
+    return lim
+
+
+def _verbatim(value):
+    v = VerbatimString()
+    v.setValue(value)
+    return v
+
+
+def _make_module():
+    pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+    return pkg.createEcucModuleDef("Mod")
+
+
+def _make_container():
+    module = _make_module()
+    return module.createEcucParamConfContainerDef("Ct")
+
+
+class TestWriterEcucDefinitionElement:
+    def test_full(self, writer):
+        module = _make_module()
+        module.setLowerMultiplicity(_posint(0))
+        module.setUpperMultiplicity(_posint(1))
+        module.setScope(_literal("scope"))
+        parent = _parent()
+        writer.writeEcucDefinitionElement(parent, module)
+        assert parent.find("SHORT-NAME").text == "Mod"
+        assert parent.find("LOWER-MULTIPLICITY").text == "0"
+        assert parent.find("UPPER-MULTIPLICITY").text == "1"
+        assert parent.find("SCOPE").text == "scope"
+
+    def test_minimal(self, writer):
+        module = _make_module()
+        parent = _parent()
+        writer.writeEcucDefinitionElement(parent, module)
+        assert parent.find("SHORT-NAME").text == "Mod"
+        assert parent.find("LOWER-MULTIPLICITY") is None
+        assert parent.find("UPPER-MULTIPLICITY") is None
+        assert parent.find("SCOPE") is None
+
+
+class TestWriterEcucModuleDefSupportedConfigVariants:
+    def test_with_variants(self, writer):
+        module = _make_module()
+        module.addSupportedConfigVariant(_literal("v1"))
+        module.addSupportedConfigVariant(_literal("v2"))
+        parent = _parent()
+        writer.writeEcucModuleDefSupportedConfigVariants(parent, module)
+        assert parent[0].tag == "SUPPORTED-CONFIG-VARIANTS"
+        variants = parent[0].findall("SUPPORTED-CONFIG-VARIANT")
+        assert len(variants) == 2
+        assert variants[0].text == "v1"
+        assert variants[1].text == "v2"
+
+    def test_empty(self, writer):
+        module = _make_module()
+        parent = _parent()
+        writer.writeEcucModuleDefSupportedConfigVariants(parent, module)
+        assert len(parent) == 0
+
+
+class TestWriterEcucAbstractConfigurationClass:
+    def test_full(self, writer):
+        cfg = EcucMultiplicityConfigurationClass()
+        cfg.setConfigClass(_literal("cls"))
+        cfg.setConfigVariant(_literal("var"))
+        parent = _parent()
+        writer.writeEcucAbstractConfigurationClass(parent, cfg)
+        assert parent.find("CONFIG-CLASS").text == "cls"
+        assert parent.find("CONFIG-VARIANT").text == "var"
+
+    def test_minimal(self, writer):
+        cfg = EcucMultiplicityConfigurationClass()
+        parent = _parent()
+        writer.writeEcucAbstractConfigurationClass(parent, cfg)
+        assert parent.find("CONFIG-CLASS") is None
+        assert parent.find("CONFIG-VARIANT") is None
+
+
+class TestWriterEcucMultiplicityConfigurationClass:
+    def test_with_value(self, writer):
+        cfg = EcucMultiplicityConfigurationClass()
+        cfg.setConfigClass(_literal("cls"))
+        parent = _parent()
+        writer.writeEcucMultiplicityConfigurationClass(parent, cfg)
+        assert parent[0].tag == "ECUC-MULTIPLICITY-CONFIGURATION-CLASS"
+        assert parent[0].find("CONFIG-CLASS").text == "cls"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucMultiplicityConfigurationClass(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucValueConfigurationClass:
+    def test_with_value(self, writer):
+        cfg = EcucValueConfigurationClass()
+        cfg.setConfigVariant(_literal("var"))
+        parent = _parent()
+        writer.writeEcucValueConfigurationClass(parent, cfg)
+        assert parent[0].tag == "ECUC-VALUE-CONFIGURATION-CLASS"
+        assert parent[0].find("CONFIG-VARIANT").text == "var"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucValueConfigurationClass(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucCommonAttributes:
+    def test_full(self, writer):
+        container = _make_container()
+        param = container.createEcucBooleanParamDef("P")
+        param.addMultiplicityConfigClass(
+            EcucMultiplicityConfigurationClass().setConfigClass(
+                _literal("mc")
+            )
+        )
+        param.setOrigin(_literal("org"))
+        param.setPostBuildVariantMultiplicity(_bool(True))
+        param.setPostBuildVariantValue(_bool(False))
+        param.setRequiresIndex(_bool(True))
+        param.addValueConfigClass(
+            EcucValueConfigurationClass().setConfigVariant(_literal("vc"))
+        )
+        parent = _parent()
+        writer.writeEcucCommonAttributes(parent, param)
+        assert parent.find("MULTIPLICITY-CONFIG-CLASSES") is not None
+        mc = parent.find("MULTIPLICITY-CONFIG-CLASSES")
+        assert mc.find("ECUC-MULTIPLICITY-CONFIGURATION-CLASS") is not None
+        assert parent.find("ORIGIN").text == "org"
+        assert parent.find("POST-BUILD-VARIANT-MULTIPLICITY").text == "true"
+        assert parent.find("POST-BUILD-VARIANT-VALUE").text == "false"
+        assert parent.find("REQUIRES-INDEX").text == "true"
+        assert parent.find("VALUE-CONFIG-CLASSES") is not None
+        vc = parent.find("VALUE-CONFIG-CLASSES")
+        assert vc.find("ECUC-VALUE-CONFIGURATION-CLASS") is not None
+
+    def test_minimal(self, writer):
+        container = _make_container()
+        param = container.createEcucBooleanParamDef("P")
+        parent = _parent()
+        writer.writeEcucCommonAttributes(parent, param)
+        assert parent.find("MULTIPLICITY-CONFIG-CLASSES") is None
+        assert parent.find("ORIGIN") is None
+        assert parent.find("POST-BUILD-VARIANT-MULTIPLICITY") is None
+        assert parent.find("POST-BUILD-VARIANT-VALUE") is None
+        assert parent.find("REQUIRES-INDEX") is None
+        assert parent.find("VALUE-CONFIG-CLASSES") is None
+
+
+class TestWriterEcucParameterDef:
+    def test_full(self, writer):
+        container = _make_container()
+        param = container.createEcucBooleanParamDef("P")
+        param.setOrigin(_literal("org"))
+        param.setSymbolicNameValue(_bool(True))
+        param.setWithAuto(_bool(False))
+        parent = _parent()
+        writer.writeEcucParameterDef(parent, param)
+        assert parent.find("ORIGIN").text == "org"
+        assert parent.find("SYMBOLIC-NAME-VALUE").text == "true"
+        assert parent.find("WITH-AUTO").text == "false"
+        assert parent.find("DERIVATION") is None
+
+    def test_minimal(self, writer):
+        container = _make_container()
+        param = container.createEcucBooleanParamDef("P")
+        parent = _parent()
+        writer.writeEcucParameterDef(parent, param)
+        assert parent.find("SYMBOLIC-NAME-VALUE") is None
+        assert parent.find("WITH-AUTO") is None
+
+
+class TestWriterEcucBooleanParamDef:
+    def test_full(self, writer):
+        container = _make_container()
+        param = container.createEcucBooleanParamDef("P")
+        param.setDefaultValue(_bool(True))
+        parent = _parent()
+        writer.writeEcucBooleanParamDef(parent, param)
+        assert parent[0].tag == "ECUC-BOOLEAN-PARAM-DEF"
+        assert parent[0].find("DEFAULT-VALUE").text == "true"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucBooleanParamDef(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucAbstractStringParamDef:
+    def test_writes_common_attrs(self, writer):
+        container = _make_container()
+        param = container.createEcucStringParamDef("P")
+        param.setOrigin(_literal("org"))
+        parent = _parent()
+        writer.writeEcucAbstractStringParamDef(parent, param)
+        assert parent.find("ORIGIN").text == "org"
+
+
+class TestWriterEcucStringParamDef:
+    def test_full(self, writer):
+        container = _make_container()
+        param = container.createEcucStringParamDef("P")
+        parent = _parent()
+        writer.writeEcucStringParamDef(parent, param)
+        assert parent[0].tag == "ECUC-STRING-PARAM-DEF"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucStringParamDef(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucIntegerParamDef:
+    def test_full(self, writer):
+        container = _make_container()
+        param = container.createEcucIntegerParamDef("P")
+        param.setDefaultValue(_unlimited(10))
+        param.setMax(_unlimited(100))
+        param.setMin(_unlimited(0))
+        parent = _parent()
+        writer.writeEcucIntegerParamDef(parent, param)
+        assert parent[0].tag == "ECUC-INTEGER-PARAM-DEF"
+        assert parent[0].find("DEFAULT-VALUE").text == "10"
+        assert parent[0].find("MAX").text == "100"
+        assert parent[0].find("MIN").text == "0"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucIntegerParamDef(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucFloatParamDef:
+    def test_full(self, writer):
+        container = _make_container()
+        param = container.createEcucFloatParamDef("P")
+        param.setDefaultValue(_float(1.5))
+        param.setMax(_limit(99.5, interval="CLOSED"))
+        param.setMin(_limit(0.0, interval="CLOSED"))
+        parent = _parent()
+        writer.writeEcucFloatParamDef(parent, param)
+        assert parent[0].tag == "ECUC-FLOAT-PARAM-DEF"
+        assert parent[0].find("DEFAULT-VALUE").text == "1.5"
+        assert parent[0].find("MAX").text == "99.5"
+        assert parent[0].find("MIN").text == "0.0"
+        assert parent[0].find("MAX").attrib["INTERVAL-TYPE"] == "CLOSED"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucFloatParamDef(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucEnumerationLiteralDef:
+    def test_full(self, writer):
+        container = _make_container()
+        param = container.createEcucEnumerationParamDef("P")
+        literal = param.createLiteral("Lit")
+        literal.setOrigin(_literal("org"))
+        parent = _parent()
+        writer.writeEcucEnumerationLiteralDef(parent, literal)
+        assert parent[0].tag == "ECUC-ENUMERATION-LITERAL-DEF"
+        assert parent[0].find("SHORT-NAME").text == "Lit"
+        assert parent[0].find("ORIGIN").text == "org"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucEnumerationLiteralDef(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucEnumerationParamDefLiterals:
+    def test_with_literals(self, writer):
+        container = _make_container()
+        param = container.createEcucEnumerationParamDef("P")
+        param.createLiteral("L1")
+        param.createLiteral("L2")
+        parent = _parent()
+        writer.writeEcucEnumerationParamDefLiterals(parent, param)
+        assert parent[0].tag == "LITERALS"
+        lits = parent[0].findall("ECUC-ENUMERATION-LITERAL-DEF")
+        assert len(lits) == 2
+
+    def test_empty(self, writer):
+        container = _make_container()
+        param = container.createEcucEnumerationParamDef("P")
+        parent = _parent()
+        writer.writeEcucEnumerationParamDefLiterals(parent, param)
+        assert len(parent) == 0
+
+
+class TestWriterEcucEnumerationParamDef:
+    def test_full(self, writer):
+        container = _make_container()
+        param = container.createEcucEnumerationParamDef("P")
+        param.setDefaultValue(_literal("L1"))
+        param.createLiteral("L1")
+        parent = _parent()
+        writer.writeEcucEnumerationParamDef(parent, param)
+        assert parent[0].tag == "ECUC-ENUMERATION-PARAM-DEF"
+        assert parent[0].find("DEFAULT-VALUE").text == "L1"
+        assert parent[0].find("LITERALS") is not None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucEnumerationParamDef(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucFunctionNameDef:
+    def test_full(self, writer):
+        container = _make_container()
+        param = container.createEcucFunctionNameDef("P")
+        param.setDefaultValue(_verbatim("fn"))
+        param.setMinLength(_posint(1))
+        param.setMaxLength(_posint(64))
+        parent = _parent()
+        writer.writeEcucFunctionNameDef(parent, param)
+        assert parent[0].tag == "ECUC-FUNCTION-NAME-DEF"
+        variants = parent[0].find("ECUC-FUNCTION-NAME-DEF-VARIANTS")
+        assert variants is not None
+        cond = variants.find("ECUC-FUNCTION-NAME-DEF-CONDITIONAL")
+        assert cond is not None
+        assert cond.find("DEFAULT-VALUE").text == "fn"
+        assert cond.find("MIN-LENGTH").text == "1"
+        assert cond.find("MAX-LENGTH").text == "64"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucFunctionNameDef(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucContainerDefParameters:
+    def test_dispatches_all_param_types(self, writer):
+        container = _make_container()
+        container.createEcucBooleanParamDef("Bp")
+        container.createEcucStringParamDef("Sp")
+        container.createEcucIntegerParamDef("Ip")
+        container.createEcucFloatParamDef("Fp")
+        container.createEcucEnumerationParamDef("Ep")
+        container.createEcucFunctionNameDef("Fn")
+        parent = _parent()
+        writer.writeEcucContainerDefParameters(parent, container)
+        assert parent[0].tag == "PARAMETERS"
+        tags = {c.tag for c in parent[0]}
+        assert "ECUC-BOOLEAN-PARAM-DEF" in tags
+        assert "ECUC-STRING-PARAM-DEF" in tags
+        assert "ECUC-INTEGER-PARAM-DEF" in tags
+        assert "ECUC-FLOAT-PARAM-DEF" in tags
+        assert "ECUC-ENUMERATION-PARAM-DEF" in tags
+        assert "ECUC-FUNCTION-NAME-DEF" in tags
+
+    def test_empty(self, writer):
+        container = _make_container()
+        parent = _parent()
+        writer.writeEcucContainerDefParameters(parent, container)
+        assert len(parent) == 0
+
+
+class TestWriterEcucContainerDef:
+    def test_full(self, writer):
+        container = _make_container()
+        container.addMultiplicityConfigClass(
+            EcucMultiplicityConfigurationClass().setConfigClass(
+                _literal("mc")
+            )
+        )
+        container.setPostBuildVariantMultiplicity(_bool(True))
+        container.setRequiresIndex(_bool(False))
+        container.setMultipleConfigurationContainer(_bool(True))
+        parent = _parent()
+        writer.writeEcucContainerDef(parent, container)
+        assert parent.find("MULTIPLICITY-CONFIG-CLASSES") is not None
+        assert parent.find("POST-BUILD-VARIANT-MULTIPLICITY").text == "true"
+        assert parent.find("REQUIRES-INDEX").text == "false"
+        assert (
+            parent.find("MULTIPLE-CONFIGURATION-CONTAINER").text == "true"
+        )
+
+    def test_minimal(self, writer):
+        container = _make_container()
+        parent = _parent()
+        writer.writeEcucContainerDef(parent, container)
+        assert parent.find("MULTIPLICITY-CONFIG-CLASSES") is None
+        assert parent.find("POST-BUILD-VARIANT-MULTIPLICITY") is None
+        assert parent.find("REQUIRES-INDEX") is None
+        assert parent.find("MULTIPLE-CONFIGURATION-CONTAINER") is None
+
+
+class TestWriterEcucAbstractReferenceDef:
+    def test_full(self, writer):
+        container = _make_container()
+        ref = container.createEcucReferenceDef("R")
+        ref.setOrigin(_literal("org"))
+        ref.setWithAuto(_bool(True))
+        parent = _parent()
+        writer.writeEcucAbstractReferenceDef(parent, ref)
+        assert parent.find("ORIGIN").text == "org"
+        assert parent.find("WITH-AUTO").text == "true"
+
+
+class TestWriterEcucAbstractInternalReferenceDef:
+    def test_writes_inherited_attributes(self, writer):
+        container = _make_container()
+        ref = container.createEcucReferenceDef("R")
+        ref.setWithAuto(_bool(True))
+        parent = _parent()
+        writer.writeEcucAbstractInternalReferenceDef(parent, ref)
+        assert parent.find("WITH-AUTO").text == "true"
+
+
+class TestWriterEcucSymbolicNameReferenceDef:
+    def test_full(self, writer):
+        container = _make_container()
+        ref = container.createEcucSymbolicNameReferenceDef("R")
+        ref.setDestinationRef(_ref("/dst", "ECUC-PARAM-CONF-CONTAINER-DEF"))
+        parent = _parent()
+        writer.writeEcucSymbolicNameReferenceDef(parent, ref)
+        assert parent[0].tag == "ECUC-SYMBOLIC-NAME-REFERENCE-DEF"
+        dst = parent[0].find("DESTINATION-REF")
+        assert dst is not None
+        assert dst.text == "/dst"
+        assert dst.attrib["DEST"] == "ECUC-PARAM-CONF-CONTAINER-DEF"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucSymbolicNameReferenceDef(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucReferenceDef:
+    def test_full(self, writer):
+        container = _make_container()
+        ref = container.createEcucReferenceDef("R")
+        ref.setDestinationRef(_ref("/dst", "ECUC-REFERENCE-DEF"))
+        parent = _parent()
+        writer.writeEcucReferenceDef(parent, ref)
+        assert parent[0].tag == "ECUC-REFERENCE-DEF"
+        dst = parent[0].find("DESTINATION-REF")
+        assert dst is not None
+        assert dst.text == "/dst"
+        assert dst.attrib["DEST"] == "ECUC-REFERENCE-DEF"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucReferenceDef(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucContainerDefReferences:
+    def test_with_references(self, writer):
+        container = _make_container()
+        container.createEcucSymbolicNameReferenceDef("S")
+        container.createEcucReferenceDef("R")
+        parent = _parent()
+        writer.writeEcucContainerDefReferences(parent, container)
+        assert parent[0].tag == "REFERENCES"
+        tags = {c.tag for c in parent[0]}
+        assert "ECUC-SYMBOLIC-NAME-REFERENCE-DEF" in tags
+        assert "ECUC-REFERENCE-DEF" in tags
+
+    def test_empty(self, writer):
+        container = _make_container()
+        parent = _parent()
+        writer.writeEcucContainerDefReferences(parent, container)
+        assert len(parent) == 0
+
+
+class TestWriterEcucContainerDefSubContainers:
+    def test_with_sub_containers(self, writer):
+        container = _make_container()
+        container.createEcucParamConfContainerDef("Sub1")
+        container.createEcucChoiceContainerDef("Ch1")
+        parent = _parent()
+        writer.writeEcucContainerDefSubContainers(parent, container)
+        assert parent[0].tag == "SUB-CONTAINERS"
+        tags = {c.tag for c in parent[0]}
+        assert "ECUC-PARAM-CONF-CONTAINER-DEF" in tags
+        assert "ECUC-CHOICE-CONTAINER-DEF" in tags
+
+    def test_empty(self, writer):
+        container = _make_container()
+        parent = _parent()
+        writer.writeEcucContainerDefSubContainers(parent, container)
+        assert len(parent) == 0
+
+
+class TestWriterEcucParamConfContainerDef:
+    def test_full(self, writer):
+        container = _make_container()
+        container.createEcucBooleanParamDef("Bp")
+        container.createEcucReferenceDef("R")
+        container.createEcucParamConfContainerDef("Sub")
+        parent = _parent()
+        writer.writeEcucParamConfContainerDef(parent, container)
+        assert parent[0].tag == "ECUC-PARAM-CONF-CONTAINER-DEF"
+        assert parent[0].find("PARAMETERS") is not None
+        assert parent[0].find("REFERENCES") is not None
+        assert parent[0].find("SUB-CONTAINERS") is not None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucParamConfContainerDef(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucChoiceContainerDefChoices:
+    def test_with_choices(self, writer):
+        module = _make_module()
+        choice = module.createEcucChoiceContainerDef("Ch")
+        choice.createEcucParamConfContainerDef("Opt1")
+        choice.createEcucParamConfContainerDef("Opt2")
+        parent = _parent()
+        writer.writeEcucChoiceContainerDefChoices(parent, choice)
+        assert parent[0].tag == "CHOICES"
+        opts = parent[0].findall("ECUC-PARAM-CONF-CONTAINER-DEF")
+        assert len(opts) == 2
+
+    def test_empty(self, writer):
+        module = _make_module()
+        choice = module.createEcucChoiceContainerDef("Ch")
+        parent = _parent()
+        writer.writeEcucChoiceContainerDefChoices(parent, choice)
+        assert len(parent) == 0
+
+
+class TestWriterEcucChoiceContainerDef:
+    def test_full(self, writer):
+        module = _make_module()
+        choice = module.createEcucChoiceContainerDef("Ch")
+        choice.createEcucParamConfContainerDef("Opt1")
+        parent = _parent()
+        writer.writeEcucChoiceContainerDef(parent, choice)
+        assert parent[0].tag == "ECUC-CHOICE-CONTAINER-DEF"
+        assert parent[0].find("CHOICES") is not None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucChoiceContainerDef(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucModuleDefContainers:
+    def test_with_containers(self, writer):
+        module = _make_module()
+        module.createEcucParamConfContainerDef("C1")
+        module.createEcucChoiceContainerDef("C2")
+        parent = _parent()
+        writer.writeEcucModuleDefContainers(parent, module)
+        assert parent[0].tag == "CONTAINERS"
+        tags = {c.tag for c in parent[0]}
+        assert "ECUC-PARAM-CONF-CONTAINER-DEF" in tags
+        assert "ECUC-CHOICE-CONTAINER-DEF" in tags
+
+    def test_empty(self, writer):
+        module = _make_module()
+        parent = _parent()
+        writer.writeEcucModuleDefContainers(parent, module)
+        assert len(parent) == 0
+
+
+class TestWriterEcucModuleDef:
+    def test_full(self, writer):
+        module = _make_module()
+        module.setPostBuildVariantSupport(_bool(True))
+        module.addSupportedConfigVariant(_literal("v1"))
+        module.createEcucParamConfContainerDef("C1")
+        module.createEcucChoiceContainerDef("C2")
+        parent = _parent()
+        writer.writeEcucModuleDef(parent, module)
+        assert parent[0].tag == "ECUC-MODULE-DEF"
+        assert parent[0].find("SHORT-NAME").text == "Mod"
+        assert (
+            parent[0].find("POST-BUILD-VARIANT-SUPPORT").text == "true"
+        )
+        assert parent[0].find("SUPPORTED-CONFIG-VARIANTS") is not None
+        assert parent[0].find("CONTAINERS") is not None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucModuleDef(parent, None)
+        assert len(parent) == 0

--- a/tests/test_armodel/writer/test_writer_ecuc_values_variant.py
+++ b/tests/test_armodel/writer/test_writer_ecuc_values_variant.py
@@ -1,0 +1,571 @@
+"""Tests for writer ECUC values and variant handling methods."""
+import xml.etree.cElementTree as ET
+import pytest
+
+from armodel.writer.arxml_writer import ARXMLWriter
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import (
+    EcucInstanceReferenceValue,
+    EcucNumericalParamValue,
+    EcucReferenceValue,
+    EcucTextualParamValue,
+)
+from armodel.models.M2.MSR.DataDictionary.DataDefProperties import (
+    SwDataDefProps,
+)
+from armodel.models.M2.MSR.DataDictionary.CalibrationParameter import (
+    SwCalprmAxisSet,
+)
+from armodel.models.M2.MSR.Documentation.Annotation import Annotation
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import (  # noqa E501
+    AnyInstanceRef,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa E501
+    ARLiteral,
+    ARNumerical,
+    RefType,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (  # noqa E501
+    SwSystemconstValue,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+def _parent():
+    return ET.Element("PARENT")
+
+
+def _ref(value, dest=None):
+    ref = RefType()
+    ref.setValue(value)
+    if dest is not None:
+        ref.setDest(dest)
+    return ref
+
+
+def _literal(value):
+    lit = ARLiteral()
+    lit.setValue(value)
+    return lit
+
+
+def _numerical(value):
+    n = ARNumerical()
+    n.setValue(str(value))
+    return n
+
+
+def _make_collection():
+    pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+    return pkg.createEcucValueCollection("Col")
+
+
+def _make_module_config():
+    pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+    return pkg.createEcucModuleConfigurationValues("mcv")
+
+
+def _make_container():
+    mcv = _make_module_config()
+    return mcv.createContainer("cv")
+
+
+def _make_value_set():
+    pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+    return pkg.createSwSystemconstantValueSet("vss")
+
+
+def _make_variant():
+    pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+    return pkg.createPredefinedVariant("pv")
+
+
+def _make_systemconst():
+    pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+    return pkg.createSwSystemConst("sc")
+
+
+class TestWriterEcucValueCollectionEcucValues:
+    def test_with_refs(self, writer):
+        collection = _make_collection()
+        collection.addEcucValueRef(
+            _ref("/v1", "ECUC-MODULE-CONFIGURATION-VALUES")
+        )
+        collection.addEcucValueRef(
+            _ref("/v2", "ECUC-MODULE-CONFIGURATION-VALUES")
+        )
+        parent = _parent()
+        writer.writeEcucValueCollectionEcucValues(parent, collection)
+        assert parent[0].tag == "ECUC-VALUES"
+        conds = parent[0].findall(
+            "ECUC-MODULE-CONFIGURATION-VALUES-REF-CONDITIONAL"
+        )
+        assert len(conds) == 2
+        ref_el = conds[0].find("ECUC-MODULE-CONFIGURATION-VALUES-REF")
+        assert ref_el is not None
+
+    def test_empty(self, writer):
+        collection = _make_collection()
+        parent = _parent()
+        writer.writeEcucValueCollectionEcucValues(parent, collection)
+        assert len(parent) == 0
+
+
+class TestWriterEcucValueCollection:
+    def test_full(self, writer):
+        collection = _make_collection()
+        collection.setEcuExtractRef(_ref("/ee", "ECU-EXTRACT"))
+        collection.addEcucValueRef(
+            _ref("/v", "ECUC-MODULE-CONFIGURATION-VALUES")
+        )
+        parent = _parent()
+        writer.writeEcucValueCollection(parent, collection)
+        assert parent[0].tag == "ECUC-VALUE-COLLECTION"
+        assert parent[0].find("SHORT-NAME").text == "Col"
+        assert parent[0].find("ECU-EXTRACT-REF") is not None
+        assert parent[0].find("ECUC-VALUES") is not None
+
+    def test_minimal(self, writer):
+        collection = _make_collection()
+        parent = _parent()
+        writer.writeEcucValueCollection(parent, collection)
+        assert parent[0].tag == "ECUC-VALUE-COLLECTION"
+        assert parent[0].find("ECU-EXTRACT-REF") is None
+        assert parent[0].find("ECUC-VALUES") is None
+
+
+class TestWriterEcucContainerValueSubContainers:
+    def test_with_sub_containers(self, writer):
+        container = _make_container()
+        container.createSubContainer("sub1")
+        container.createSubContainer("sub2")
+        parent = _parent()
+        writer.writeEcucContainerValueSubContainers(parent, container)
+        assert parent[0].tag == "SUB-CONTAINERS"
+        subs = parent[0].findall("ECUC-CONTAINER-VALUE")
+        assert len(subs) == 2
+
+    def test_empty(self, writer):
+        container = _make_container()
+        parent = _parent()
+        writer.writeEcucContainerValueSubContainers(parent, container)
+        assert len(parent) == 0
+
+
+class TestWriterEcucParameterValue:
+    def test_with_textual_param_value(self, writer):
+        param = EcucTextualParamValue()
+        param.setDefinitionRef(_ref("/d", "ECUC-PARAMETER-DEF"))
+        parent = _parent()
+        writer.writeEcucParameterValue(parent, param)
+        assert parent.find("DEFINITION-REF") is not None
+
+    def test_with_numerical_param_value(self, writer):
+        param = EcucNumericalParamValue()
+        param.setDefinitionRef(_ref("/d", "ECUC-PARAMETER-DEF"))
+        parent = _parent()
+        writer.writeEcucParameterValue(parent, param)
+        assert parent.find("DEFINITION-REF") is not None
+
+    def test_with_annotations(self, writer):
+        param = EcucTextualParamValue()
+        param.addAnnotation(Annotation())
+        parent = _parent()
+        writer.writeEcucParameterValue(parent, param)
+        assert parent.find("ANNOTATIONS/ANNOTATION") is not None
+
+    def test_minimal(self, writer):
+        param = EcucTextualParamValue()
+        parent = _parent()
+        writer.writeEcucParameterValue(parent, param)
+        assert parent.find("DEFINITION-REF") is None
+        assert parent.find("ANNOTATIONS") is None
+
+
+class TestWriterEcucContainerValueParameterValues:
+    def test_dispatches_textual_and_numerical(self, writer):
+        container = _make_container()
+        textual = EcucTextualParamValue()
+        textual.setValue(_literal("txt"))
+        textual.setDefinitionRef(_ref("/d1", "ECUC-PARAMETER-DEF"))
+        container.addParameterValue(textual)
+        numerical = EcucNumericalParamValue()
+        numerical.setValue(_numerical(42))
+        numerical.setDefinitionRef(_ref("/d2", "ECUC-PARAMETER-DEF"))
+        container.addParameterValue(numerical)
+        parent = _parent()
+        writer.writeEcucContainerValueParameterValues(parent, container)
+        assert parent[0].tag == "PARAMETER-VALUES"
+        tags = {c.tag for c in parent[0]}
+        assert "ECUC-TEXTUAL-PARAM-VALUE" in tags
+        assert "ECUC-NUMERICAL-PARAM-VALUE" in tags
+
+    def test_empty(self, writer):
+        container = _make_container()
+        parent = _parent()
+        writer.writeEcucContainerValueParameterValues(parent, container)
+        assert len(parent) == 0
+
+
+class TestWriterEcucAbstractReferenceValue:
+    def test_with_reference_value(self, writer):
+        ref_val = EcucReferenceValue()
+        ref_val.setDefinitionRef(_ref("/d", "ECUC-REFERENCE-DEF"))
+        parent = _parent()
+        writer.writeEcucAbstractReferenceValue(parent, ref_val)
+        assert parent.find("DEFINITION-REF") is not None
+
+    def test_with_instance_reference_value(self, writer):
+        ref_val = EcucInstanceReferenceValue()
+        ref_val.setDefinitionRef(_ref("/d", "ECUC-REFERENCE-DEF"))
+        parent = _parent()
+        writer.writeEcucAbstractReferenceValue(parent, ref_val)
+        assert parent.find("DEFINITION-REF") is not None
+
+    def test_with_annotations(self, writer):
+        ref_val = EcucReferenceValue()
+        ref_val.addAnnotation(Annotation())
+        parent = _parent()
+        writer.writeEcucAbstractReferenceValue(parent, ref_val)
+        assert parent.find("ANNOTATIONS/ANNOTATION") is not None
+
+    def test_minimal(self, writer):
+        ref_val = EcucReferenceValue()
+        parent = _parent()
+        writer.writeEcucAbstractReferenceValue(parent, ref_val)
+        assert parent.find("DEFINITION-REF") is None
+        assert parent.find("ANNOTATIONS") is None
+
+
+class TestWriterEcucContainerValueReferenceValues:
+    def test_dispatches_reference_and_instance_reference(self, writer):
+        container = _make_container()
+        ref_val = EcucReferenceValue()
+        ref_val.setValueRef(_ref("/v", "ECUC-CONTAINER-VALUE"))
+        ref_val.setDefinitionRef(_ref("/d1", "ECUC-REFERENCE-DEF"))
+        container.addReferenceValue(ref_val)
+        iref_val = EcucInstanceReferenceValue()
+        iref_val.setDefinitionRef(_ref("/d2", "ECUC-REFERENCE-DEF"))
+        iref = AnyInstanceRef()
+        iref.setBaseRef(_ref("/b", "ECUC-CONTAINER-VALUE"))
+        iref.setTargetRef(_ref("/t", "ECUC-CONTAINER-VALUE"))
+        iref_val.setValueIRef(iref)
+        container.addReferenceValue(iref_val)
+        parent = _parent()
+        writer.writeEcucContainerValueReferenceValues(parent, container)
+        assert parent[0].tag == "REFERENCE-VALUES"
+        tags = {c.tag for c in parent[0]}
+        assert "ECUC-REFERENCE-VALUE" in tags
+        assert "ECUC-INSTANCE-REFERENCE-VALUE" in tags
+        iref_el = parent[0].find("ECUC-INSTANCE-REFERENCE-VALUE")
+        assert iref_el.find("VALUE-IREF") is not None
+        assert iref_el.find("VALUE-IREF/BASE-REF") is not None
+        assert iref_el.find("VALUE-IREF/TARGET-REF") is not None
+
+    def test_empty(self, writer):
+        container = _make_container()
+        parent = _parent()
+        writer.writeEcucContainerValueReferenceValues(parent, container)
+        assert len(parent) == 0
+
+
+class TestWriterEcucContainValue:
+    def test_full(self, writer):
+        container = _make_container()
+        container.setDefinitionRef(
+            _ref("/d", "ECUC-PARAM-CONF-CONTAINER-DEF")
+        )
+        textual = EcucTextualParamValue()
+        textual.setValue(_literal("txt"))
+        container.addParameterValue(textual)
+        ref_val = EcucReferenceValue()
+        ref_val.setValueRef(_ref("/v", "ECUC-CONTAINER-VALUE"))
+        container.addReferenceValue(ref_val)
+        container.createSubContainer("sub")
+        parent = _parent()
+        writer.writeEcucContainValue(parent, container)
+        assert parent[0].tag == "ECUC-CONTAINER-VALUE"
+        assert parent[0].find("SHORT-NAME").text == "cv"
+        assert parent[0].find("DEFINITION-REF") is not None
+        assert parent[0].find("PARAMETER-VALUES") is not None
+        assert parent[0].find("REFERENCE-VALUES") is not None
+        assert parent[0].find("SUB-CONTAINERS") is not None
+
+    def test_minimal(self, writer):
+        container = _make_container()
+        parent = _parent()
+        writer.writeEcucContainValue(parent, container)
+        assert parent[0].tag == "ECUC-CONTAINER-VALUE"
+        assert parent[0].find("DEFINITION-REF") is None
+        assert parent[0].find("PARAMETER-VALUES") is None
+        assert parent[0].find("REFERENCE-VALUES") is None
+        assert parent[0].find("SUB-CONTAINERS") is None
+
+
+class TestWriterEcucModuleConfigurationValuesContainers:
+    def test_with_containers(self, writer):
+        mcv = _make_module_config()
+        mcv.createContainer("c1")
+        mcv.createContainer("c2")
+        parent = _parent()
+        writer.writeEcucModuleConfigurationValuesContainers(parent, mcv)
+        assert parent[0].tag == "CONTAINERS"
+        containers = parent[0].findall("ECUC-CONTAINER-VALUE")
+        assert len(containers) == 2
+
+    def test_empty(self, writer):
+        mcv = _make_module_config()
+        parent = _parent()
+        writer.writeEcucModuleConfigurationValuesContainers(parent, mcv)
+        assert len(parent) == 0
+
+
+class TestWriterEcucModuleConfigurationValues:
+    def test_full(self, writer):
+        mcv = _make_module_config()
+        mcv.setDefinitionRef(_ref("/d", "ECUC-MODULE-DEF"))
+        mcv.setImplementationConfigVariant(_literal("variant"))
+        mcv.setModuleDescriptionRef(_ref("/md", "ECUC-MODULE-DEF"))
+        mcv.createContainer("c1")
+        parent = _parent()
+        writer.writeEcucModuleConfigurationValues(parent, mcv)
+        assert parent[0].tag == "ECUC-MODULE-CONFIGURATION-VALUES"
+        assert parent[0].find("SHORT-NAME").text == "mcv"
+        assert parent[0].find("DEFINITION-REF") is not None
+        impl = parent[0].find("IMPLEMENTATION-CONFIG-VARIANT")
+        assert impl is not None
+        assert impl.text == "variant"
+        assert parent[0].find("MODULE-DESCRIPTION-REF") is not None
+        assert parent[0].find("CONTAINERS") is not None
+
+    def test_minimal(self, writer):
+        mcv = _make_module_config()
+        parent = _parent()
+        writer.writeEcucModuleConfigurationValues(parent, mcv)
+        assert parent[0].tag == "ECUC-MODULE-CONFIGURATION-VALUES"
+        assert parent[0].find("DEFINITION-REF") is None
+        assert parent[0].find("IMPLEMENTATION-CONFIG-VARIANT") is None
+        assert parent[0].find("MODULE-DESCRIPTION-REF") is None
+        assert parent[0].find("CONTAINERS") is None
+
+
+class TestWriterSwSystemconst:
+    def test_without_data_def_props(self, writer):
+        const = _make_systemconst()
+        parent = _parent()
+        writer.writeSwSystemconst(parent, const)
+        assert parent[0].tag == "SW-SYSTEMCONST"
+        assert parent[0].find("SHORT-NAME").text == "sc"
+        assert parent[0].find("SW-DATA-DEF-PROPS") is None
+
+    def test_with_data_def_props(self, writer):
+        const = _make_systemconst()
+        props = SwDataDefProps()
+        props.setSwCalprmAxisSet(SwCalprmAxisSet())
+        const.setSwDataDefProps(props)
+        parent = _parent()
+        writer.writeSwSystemconst(parent, const)
+        assert parent[0].tag == "SW-SYSTEMCONST"
+        assert parent[0].find("SW-DATA-DEF-PROPS") is not None
+
+
+class TestWriterSwSystemconstValue:
+    def test_full(self, writer):
+        value = SwSystemconstValue()
+        value.setSwSystemconstRef(_ref("/sc", "SW-SYSTEMCONST"))
+        value.setValue(_numerical(42))
+        value.addAnnotation(Annotation())
+        parent = _parent()
+        writer.writeSwSystemconstValue(parent, value)
+        assert parent[0].tag == "SW-SYSTEMCONST-VALUE"
+        assert parent[0].find("SW-SYSTEMCONST-REF") is not None
+        assert parent[0].find("VALUE") is not None
+        assert parent[0].find("VALUE").text == "42"
+        assert parent[0].find("ANNOTATIONS/ANNOTATION") is not None
+
+    def test_minimal(self, writer):
+        value = SwSystemconstValue()
+        parent = _parent()
+        writer.writeSwSystemconstValue(parent, value)
+        assert parent[0].tag == "SW-SYSTEMCONST-VALUE"
+        assert parent[0].find("SW-SYSTEMCONST-REF") is None
+        assert parent[0].find("VALUE") is None
+        assert parent[0].find("ANNOTATIONS") is None
+
+
+class TestWriterSwSystemconstantValueSetSwSystemconstantValues:
+    def test_with_values(self, writer):
+        value_set = _make_value_set()
+        v1 = SwSystemconstValue()
+        v1.setSwSystemconstRef(_ref("/s1", "SW-SYSTEMCONST"))
+        v1.setValue(_numerical(1))
+        value_set.addSwSystemconstantValue(v1)
+        v2 = SwSystemconstValue()
+        v2.setSwSystemconstRef(_ref("/s2", "SW-SYSTEMCONST"))
+        v2.setValue(_numerical(2))
+        value_set.addSwSystemconstantValue(v2)
+        parent = _parent()
+        writer.writeSwSystemconstantValueSetSwSystemconstantValues(
+            parent, value_set
+        )
+        assert parent[0].tag == "SW-SYSTEMCONSTANT-VALUES"
+        values = parent[0].findall("SW-SYSTEMCONST-VALUE")
+        assert len(values) == 2
+
+    def test_empty(self, writer):
+        value_set = _make_value_set()
+        parent = _parent()
+        writer.writeSwSystemconstantValueSetSwSystemconstantValues(
+            parent, value_set
+        )
+        assert len(parent) == 0
+
+
+class TestWriterSwSystemconstantValueSet:
+    def test_full(self, writer):
+        value_set = _make_value_set()
+        v1 = SwSystemconstValue()
+        v1.setSwSystemconstRef(_ref("/s1", "SW-SYSTEMCONST"))
+        v1.setValue(_numerical(1))
+        value_set.addSwSystemconstantValue(v1)
+        parent = _parent()
+        writer.writeSwSystemconstantValueSet(parent, value_set)
+        assert parent[0].tag == "SW-SYSTEMCONSTANT-VALUE-SET"
+        assert parent[0].find("SHORT-NAME").text == "vss"
+        assert parent[0].find("SW-SYSTEMCONSTANT-VALUES") is not None
+
+    def test_minimal(self, writer):
+        value_set = _make_value_set()
+        parent = _parent()
+        writer.writeSwSystemconstantValueSet(parent, value_set)
+        assert parent[0].tag == "SW-SYSTEMCONSTANT-VALUE-SET"
+        assert parent[0].find("SW-SYSTEMCONSTANT-VALUES") is None
+
+
+class TestWriterPredefinedVariantIncludedVariantRefs:
+    def test_with_refs(self, writer):
+        variant = _make_variant()
+        variant.addIncludedVariantRef(
+            _ref("/v1", "PREDEFINED-VARIANT")
+        )
+        variant.addIncludedVariantRef(
+            _ref("/v2", "PREDEFINED-VARIANT")
+        )
+        parent = _parent()
+        writer.writePredefinedVariantIncludedVariantRefs(parent, variant)
+        assert parent[0].tag == "INCLUDED-VARIANT-REFS"
+        refs = parent[0].findall("INCLUDED-VARIANT-REF")
+        assert len(refs) == 2
+
+    def test_empty(self, writer):
+        variant = _make_variant()
+        parent = _parent()
+        writer.writePredefinedVariantIncludedVariantRefs(parent, variant)
+        assert len(parent) == 0
+
+
+class TestWriterPredefinedVariantPostBuildVariantCriterionValueSetRefs:
+    def test_with_refs(self, writer):
+        variant = _make_variant()
+        variant.addPostBuildVariantCriterionValueSetRef(
+            _ref("/pb1", "POST-BUILD-VARIANT-CRITERION-VALUE-SET")
+        )
+        variant.addPostBuildVariantCriterionValueSetRef(
+            _ref("/pb2", "POST-BUILD-VARIANT-CRITERION-VALUE-SET")
+        )
+        parent = _parent()
+        writer.writePredefinedVariantPostBuildVariantCriterionValueSetRefs(
+            parent, variant
+        )
+        assert parent[0].tag == (
+            "POST-BUILD-VARIANT-CRITERION-VALUE-SET-REFS"
+        )
+        refs = parent[0].findall(
+            "POST-BUILD-VARIANT-CRITERION-VALUE-SET-REF"
+        )
+        assert len(refs) == 2
+
+    def test_empty(self, writer):
+        variant = _make_variant()
+        parent = _parent()
+        writer.writePredefinedVariantPostBuildVariantCriterionValueSetRefs(
+            parent, variant
+        )
+        assert len(parent) == 0
+
+
+class TestWriterPredefinedVariantSwSystemconstantValueSetRefs:
+    def test_with_refs(self, writer):
+        variant = _make_variant()
+        variant.addSwSystemconstantValueSetRef(
+            _ref("/sv1", "SW-SYSTEMCONSTANT-VALUE-SET")
+        )
+        variant.addSwSystemconstantValueSetRef(
+            _ref("/sv2", "SW-SYSTEMCONSTANT-VALUE-SET")
+        )
+        parent = _parent()
+        writer.writePredefinedVariantSwSystemconstantValueSetRefs(
+            parent, variant
+        )
+        assert parent[0].tag == "SW-SYSTEMCONSTANT-VALUE-SET-REFS"
+        refs = parent[0].findall("SW-SYSTEMCONSTANT-VALUE-SET-REF")
+        assert len(refs) == 2
+
+    def test_empty(self, writer):
+        variant = _make_variant()
+        parent = _parent()
+        writer.writePredefinedVariantSwSystemconstantValueSetRefs(
+            parent, variant
+        )
+        assert len(parent) == 0
+
+
+class TestWriterPredefinedVariant:
+    def test_full(self, writer):
+        variant = _make_variant()
+        variant.addIncludedVariantRef(
+            _ref("/iv", "PREDEFINED-VARIANT")
+        )
+        variant.addPostBuildVariantCriterionValueSetRef(
+            _ref("/pb", "POST-BUILD-VARIANT-CRITERION-VALUE-SET")
+        )
+        variant.addSwSystemconstantValueSetRef(
+            _ref("/sv", "SW-SYSTEMCONSTANT-VALUE-SET")
+        )
+        parent = _parent()
+        writer.writePredefinedVariant(parent, variant)
+        assert parent[0].tag == "PREDEFINED-VARIANT"
+        assert parent[0].find("SHORT-NAME").text == "pv"
+        assert parent[0].find("INCLUDED-VARIANT-REFS") is not None
+        assert parent[0].find(
+            "POST-BUILD-VARIANT-CRITERION-VALUE-SET-REFS"
+        ) is not None
+        assert parent[0].find(
+            "SW-SYSTEMCONSTANT-VALUE-SET-REFS"
+        ) is not None
+
+    def test_minimal(self, writer):
+        variant = _make_variant()
+        parent = _parent()
+        writer.writePredefinedVariant(parent, variant)
+        assert parent[0].tag == "PREDEFINED-VARIANT"
+        assert parent[0].find("SHORT-NAME").text == "pv"
+        assert parent[0].find("INCLUDED-VARIANT-REFS") is None
+        assert parent[0].find(
+            "POST-BUILD-VARIANT-CRITERION-VALUE-SET-REFS"
+        ) is None
+        assert parent[0].find(
+            "SW-SYSTEMCONSTANT-VALUE-SET-REFS"
+        ) is None

--- a/tests/test_armodel/writer/test_writer_hw_lin_flexray_transform.py
+++ b/tests/test_armodel/writer/test_writer_hw_lin_flexray_transform.py
@@ -1,0 +1,854 @@
+"""Tests for writer HW, Lin, Flexray, and transformation handlers."""
+import xml.etree.cElementTree as ET
+import pytest
+
+from armodel.writer.arxml_writer import ARXMLWriter
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import (
+    HwDescriptionEntity,
+    HwElement,
+    HwPinGroup,
+)
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import (
+    HwCategory,
+    HwAttributeDef,
+    HwType,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import (
+    LinMaster,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology import (
+    FlexrayCommunicationController,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import (
+    FlexrayFrame,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (
+    ISignalIPdu,
+    IPduTiming,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.Timing import (
+    TransmissionModeCondition,
+    TransmissionModeDeclaration,
+    TransmissionModeTiming,
+    CyclicTiming,
+    EventControlledTiming,
+    TimeRangeType,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import (
+    DataTransformation,
+    DataTransformationSet,
+    TransformationTechnology,
+    BufferProperties,
+    TransformationDescription,
+    EndToEndTransformationDescription,
+)
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.Filter import DataFilter
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa E501
+    ARLiteral,
+    ARBoolean,
+    ARNumerical,
+    Integer,
+    PositiveInteger,
+    RefType,
+    TimeValue,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+def _parent():
+    return ET.Element("PARENT")
+
+
+def _ref(value, dest=None):
+    ref = RefType()
+    ref.setValue(value)
+    if dest is not None:
+        ref.setDest(dest)
+    return ref
+
+
+def _literal(value):
+    lit = ARLiteral()
+    lit.setValue(value)
+    return lit
+
+
+def _bool(value):
+    b = ARBoolean()
+    b.setValue(value)
+    return b
+
+
+def _numerical(value):
+    n = ARNumerical()
+    n.setValue(str(value))
+    return n
+
+
+def _integer(value):
+    i = Integer()
+    i.setValue(value)
+    return i
+
+
+def _posint(value):
+    p = PositiveInteger()
+    p.setValue(str(value))
+    return p
+
+
+def _time(value):
+    t = TimeValue()
+    t.setValue(value)
+    return t
+
+
+def _make_pkg():
+    return AUTOSAR.getInstance().createARPackage("Pkg")
+
+
+class TestWriterHwDescriptionEntity:
+    def test_writeHwDescriptionEntityHwCategoryRefs_with_refs(self, writer):
+        pkg = _make_pkg()
+        entity = HwElement(pkg, "HwElem")
+        entity.addHwCategoryRef(_ref("/cat1", "HW-CATEGORY"))
+        entity.addHwCategoryRef(_ref("/cat2", "HW-CATEGORY"))
+        parent = _parent()
+        writer.writeHwDescriptionEntityHwCategoryRefs(parent, entity)
+        assert parent[0].tag == "HW-CATEGORY-REFS"
+        refs = parent[0].findall("HW-CATEGORY-REF")
+        assert len(refs) == 2
+
+    def test_writeHwDescriptionEntityHwCategoryRefs_empty(self, writer):
+        pkg = _make_pkg()
+        entity = HwElement(pkg, "HwElem")
+        parent = _parent()
+        writer.writeHwDescriptionEntityHwCategoryRefs(parent, entity)
+        assert len(parent) == 0
+
+    def test_writeHwDescriptionEntity_full(self, writer):
+        pkg = _make_pkg()
+        entity = HwElement(pkg, "HwElem")
+        entity.addHwCategoryRef(_ref("/cat", "HW-CATEGORY"))
+        parent = _parent()
+        writer.writeHwDescriptionEntity(parent, entity)
+        assert parent.find("HW-CATEGORY-REFS") is not None
+
+    def test_writeHwPinGroup_with_group(self, writer):
+        pkg = _make_pkg()
+        elem = HwElement(pkg, "Elem")
+        pin_group = HwPinGroup(elem, "PinGrp")
+        parent = _parent()
+        writer.writeHwPinGroup(parent, pin_group)
+        assert parent[0].tag == "HW-PIN-GROUP"
+
+    def test_writeHwPinGroup_none(self, writer):
+        parent = _parent()
+        writer.writeHwPinGroup(parent, None)
+        assert len(parent) == 0
+
+    def test_writeHwElementHwPinGroups_with_groups(self, writer):
+        pkg = _make_pkg()
+        elem = HwElement(pkg, "Elem")
+        elem.createHwPinGroup("Grp1")
+        elem.createHwPinGroup("Grp2")
+        parent = _parent()
+        writer.writeHwElementHwPinGroups(parent, elem)
+        assert parent[0].tag == "HW-PIN-GROUPS"
+        groups = parent[0].findall("HW-PIN-GROUP")
+        assert len(groups) == 2
+
+    def test_writeHwElementHwPinGroups_empty(self, writer):
+        pkg = _make_pkg()
+        elem = HwElement(pkg, "Elem")
+        parent = _parent()
+        writer.writeHwElementHwPinGroups(parent, elem)
+        assert len(parent) == 0
+
+    def test_writeHwElement_full(self, writer):
+        pkg = _make_pkg()
+        elem = HwElement(pkg, "Elem")
+        elem.addHwCategoryRef(_ref("/cat", "HW-CATEGORY"))
+        elem.createHwPinGroup("PinGrp")
+        parent = _parent()
+        writer.writeHwElement(parent, elem)
+        assert parent[0].tag == "HW-ELEMENT"
+        assert parent[0].find("HW-CATEGORY-REFS") is not None
+        assert parent[0].find("HW-PIN-GROUPS") is not None
+
+    def test_writeHwElement_none(self, writer):
+        parent = _parent()
+        writer.writeHwElement(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterHwAttributeDef:
+    def test_writeHwAttributeDef_with_unit(self, writer):
+        pkg = _make_pkg()
+        cat = HwCategory(pkg, "Cat")
+        attr_def = HwAttributeDef(cat, "Attr")
+        attr_def.setUnitRef(_ref("/unit", "UNIT"))
+        parent = _parent()
+        writer.writeHwAttributeDef(parent, attr_def)
+        assert parent[0].tag == "HW-ATTRIBUTE-DEF"
+        assert parent[0].find("UNIT-REF") is not None
+
+    def test_writeHwAttributeDef_none(self, writer):
+        parent = _parent()
+        writer.writeHwAttributeDef(parent, None)
+        assert len(parent) == 0
+
+    def test_writeHwCategoryHwAttributeDef_with_defs(self, writer):
+        pkg = _make_pkg()
+        cat = HwCategory(pkg, "Cat")
+        cat.createHwAttributeDef("Attr1")
+        cat.createHwAttributeDef("Attr2")
+        parent = _parent()
+        writer.writeHwCategoryHwAttributeDef(parent, cat)
+        assert parent[0].tag == "HW-ATTRIBUTE-DEFS"
+        defs = parent[0].findall("HW-ATTRIBUTE-DEF")
+        assert len(defs) == 2
+
+    def test_writeHwCategoryHwAttributeDef_empty(self, writer):
+        pkg = _make_pkg()
+        cat = HwCategory(pkg, "Cat")
+        parent = _parent()
+        writer.writeHwCategoryHwAttributeDef(parent, cat)
+        assert len(parent) == 0
+
+
+class TestWriterHwCategoryAndType:
+    def test_writeHwCategory_full(self, writer):
+        pkg = _make_pkg()
+        cat = HwCategory(pkg, "Cat")
+        cat.createHwAttributeDef("Attr")
+        parent = _parent()
+        writer.writeHwCategory(parent, cat)
+        assert parent[0].tag == "HW-CATEGORY"
+        assert parent[0].find("HW-ATTRIBUTE-DEFS") is not None
+
+    def test_writeHwType_full(self, writer):
+        pkg = _make_pkg()
+        hw_type = HwType(pkg, "HwType")
+        parent = _parent()
+        writer.writeHwType(parent, hw_type)
+        assert parent[0].tag == "HW-TYPE"
+
+
+class TestWriterLinCommunicationController:
+    def test_writeLinCommunicationController_with_version(self, writer):
+        pkg = _make_pkg()
+        master = LinMaster(pkg, "LinMaster")
+        master.setProtocolVersion(_literal("2.2"))
+        parent = _parent()
+        controller_elem = ET.SubElement(parent, "LIN-CONTROLLER")
+        writer.writeLinCommunicationController(controller_elem, master)
+        assert controller_elem.find("PROTOCOL-VERSION") is not None
+
+
+class TestWriterLinMaster:
+    def test_writeLinMaster_full(self, writer):
+        pkg = _make_pkg()
+        master = LinMaster(pkg, "LinMaster")
+        master.setProtocolVersion(_literal("2.2"))
+        master.setTimeBase(_time(0.01))
+        master.setTimeBaseJitter(_time(0.001))
+        parent = _parent()
+        writer.writeLinMaster(parent, master)
+        assert parent[0].tag == "LIN-MASTER"
+        variants = parent[0].find("LIN-MASTER-VARIANTS")
+        cond = variants.find("LIN-MASTER-CONDITIONAL")
+        assert cond.find("PROTOCOL-VERSION") is not None
+        assert cond.find("TIME-BASE") is not None
+        assert cond.find("TIME-BASE-JITTER") is not None
+
+
+class TestWriterISignalToPduMappings:
+    def test_writeISignalToPduMappings_with_mappings(self, writer):
+        pkg = _make_pkg()
+        ipdu = ISignalIPdu(pkg, "IPdu")
+        mapping1 = ipdu.createISignalToPduMappings("Map1")
+        mapping1.setISignalRef(_ref("/sig1", "I-SIGNAL"))
+        mapping1.setStartPosition(_numerical(0))
+        mapping2 = ipdu.createISignalToPduMappings("Map2")
+        mapping2.setISignalGroupRef(_ref("/grp", "I-SIGNAL-GROUP"))
+        mapping2.setPackingByteOrder(_literal("MOST-SIGNIFICANT-BYTE-LAST"))
+        mapping2.setTransferProperty(_literal("pending"))
+        mapping2.setUpdateIndicationBitPosition(_numerical(8))
+        parent = _parent()
+        writer.writeISignalToPduMappings(parent, ipdu)
+        assert parent[0].tag == "I-SIGNAL-TO-PDU-MAPPINGS"
+        mappings = parent[0].findall("I-SIGNAL-TO-I-PDU-MAPPING")
+        assert len(mappings) == 2
+        assert mappings[0].find("I-SIGNAL-REF") is not None
+        assert mappings[0].find("START-POSITION") is not None
+        assert mappings[1].find("I-SIGNAL-GROUP-REF") is not None
+        assert mappings[1].find("PACKING-BYTE-ORDER") is not None
+        assert mappings[1].find("TRANSFER-PROPERTY") is not None
+        assert mappings[1].find("UPDATE-INDICATION-BIT-POSITION") is not None
+
+    def test_writeISignalToPduMappings_empty(self, writer):
+        pkg = _make_pkg()
+        ipdu = ISignalIPdu(pkg, "IPdu")
+        parent = _parent()
+        writer.writeISignalToPduMappings(parent, ipdu)
+        assert len(parent) == 0
+
+
+class TestWriterDataFilter:
+    def test_setDataFilter_full(self, writer):
+        filter_obj = DataFilter()
+        filter_obj.setDataFilterType(_literal("maskedNewDiffersX"))
+        filter_obj.setMask(_integer(0xFF))
+        filter_obj.setX(_integer(0x01))
+        parent = _parent()
+        writer.setDataFilter(parent, "DATA-FILTER", filter_obj)
+        assert parent[0].tag == "DATA-FILTER"
+        assert parent[0].find("DATA-FILTER-TYPE") is not None
+        assert parent[0].find("MASK") is not None
+        assert parent[0].find("X") is not None
+
+    def test_setDataFilter_none(self, writer):
+        parent = _parent()
+        writer.setDataFilter(parent, "DATA-FILTER", None)
+        assert len(parent) == 0
+
+
+class TestWriterTransmissionModeConditions:
+    def test_setTransmissionModeConditions_with_conditions(self, writer):
+        cond1 = TransmissionModeCondition()
+        filter1 = DataFilter()
+        filter1.setDataFilterType(_literal("maskedNewDiffersX"))
+        cond1.setDataFilter(filter1)
+        cond1.setISignalInIPduRef(_ref("/sig", "I-SIGNAL-IN-I-PDU"))
+        cond2 = TransmissionModeCondition()
+        filter2 = DataFilter()
+        filter2.setDataFilterType(_literal("never"))
+        cond2.setDataFilter(filter2)
+        parent = _parent()
+        writer.setTransmissionModeConditions(
+            parent, "TRANSMISSION-MODE-CONDITIONS", [cond1, cond2]
+        )
+        assert parent[0].tag == "TRANSMISSION-MODE-CONDITIONS"
+        conditions = parent[0].findall("TRANSMISSION-MODE-CONDITION")
+        assert len(conditions) == 2
+        assert conditions[0].find("DATA-FILTER") is not None
+        assert conditions[0].find("I-SIGNAL-IN-I-PDU-REF") is not None
+
+    def test_setTransmissionModeConditions_empty(self, writer):
+        parent = _parent()
+        writer.setTransmissionModeConditions(
+            parent, "TRANSMISSION-MODE-CONDITIONS", []
+        )
+        assert len(parent) == 0
+
+
+class TestWriterTimeRangeType:
+    def test_setTimeRangeType_full(self, writer):
+        time_range = TimeRangeType()
+        time_range.setValue(_time(0.1))
+        parent = _parent()
+        writer.setTimeRangeType(parent, "TIME-RANGE", time_range)
+        assert parent[0].tag == "TIME-RANGE"
+        assert parent[0].find("VALUE") is not None
+
+    def test_setTimeRangeType_none(self, writer):
+        parent = _parent()
+        writer.setTimeRangeType(parent, "TIME-RANGE", None)
+        assert len(parent) == 0
+
+
+class TestWriterEventControlledTiming:
+    def test_setEventControlledTiming_full(self, writer):
+        timing = EventControlledTiming()
+        timing.setNumberOfRepetitions(_integer(3))
+        rep_period = TimeRangeType()
+        rep_period.setValue(_time(0.01))
+        timing.setRepetitionPeriod(rep_period)
+        parent = _parent()
+        writer.setEventControlledTiming(parent, "EVENT-CONTROLLED-TIMING", timing)
+        assert parent[0].tag == "EVENT-CONTROLLED-TIMING"
+        assert parent[0].find("NUMBER-OF-REPETITIONS") is not None
+        assert parent[0].find("REPETITION-PERIOD") is not None
+
+    def test_setEventControlledTiming_none(self, writer):
+        parent = _parent()
+        writer.setEventControlledTiming(parent, "EVENT-CONTROLLED-TIMING", None)
+        assert len(parent) == 0
+
+
+class TestWriterCyclicTiming:
+    def test_setCyclicTiming_full(self, writer):
+        timing = CyclicTiming()
+        offset = TimeRangeType()
+        offset.setValue(_time(0.0))
+        timing.setTimeOffset(offset)
+        period = TimeRangeType()
+        period.setValue(_time(0.1))
+        timing.setTimePeriod(period)
+        parent = _parent()
+        writer.setCyclicTiming(parent, "CYCLIC-TIMING", timing)
+        assert parent[0].tag == "CYCLIC-TIMING"
+        assert parent[0].find("TIME-OFFSET") is not None
+        assert parent[0].find("TIME-PERIOD") is not None
+
+    def test_setCyclicTiming_none(self, writer):
+        parent = _parent()
+        writer.setCyclicTiming(parent, "CYCLIC-TIMING", None)
+        assert len(parent) == 0
+
+
+class TestWriterTransmissionModeTiming:
+    def test_setTransmissionModeTiming_full(self, writer):
+        timing = TransmissionModeTiming()
+        cyclic = CyclicTiming()
+        cyclic_offset = TimeRangeType()
+        cyclic_offset.setValue(_time(0.0))
+        cyclic.setTimeOffset(cyclic_offset)
+        cyclic_period = TimeRangeType()
+        cyclic_period.setValue(_time(0.1))
+        cyclic.setTimePeriod(cyclic_period)
+        timing.setCyclicTiming(cyclic)
+        event = EventControlledTiming()
+        event.setNumberOfRepetitions(_integer(2))
+        event_period = TimeRangeType()
+        event_period.setValue(_time(0.01))
+        event.setRepetitionPeriod(event_period)
+        timing.setEventControlledTiming(event)
+        parent = _parent()
+        writer.setTransmissionModeTiming(parent, "TIMING", timing)
+        assert parent[0].tag == "TIMING"
+        assert parent[0].find("CYCLIC-TIMING") is not None
+        assert parent[0].find("EVENT-CONTROLLED-TIMING") is not None
+
+    def test_setTransmissionModeTiming_none(self, writer):
+        parent = _parent()
+        writer.setTransmissionModeTiming(parent, "TIMING", None)
+        assert len(parent) == 0
+
+
+class TestWriterTransmissionModeDeclaration:
+    def test_setTransmissionModeDeclaration_full(self, writer):
+        decl = TransmissionModeDeclaration()
+        cond = TransmissionModeCondition()
+        filter_obj = DataFilter()
+        filter_obj.setDataFilterType(_literal("maskedNewDiffersX"))
+        cond.setDataFilter(filter_obj)
+        cond.setISignalInIPduRef(_ref("/sig", "I-SIGNAL-IN-I-PDU"))
+        decl.addTransmissionModeCondition(cond)
+        false_timing = TransmissionModeTiming()
+        false_cyclic = CyclicTiming()
+        false_period = TimeRangeType()
+        false_period.setValue(_time(0.2))
+        false_cyclic.setTimePeriod(false_period)
+        false_timing.setCyclicTiming(false_cyclic)
+        decl.setTransmissionModeFalseTiming(false_timing)
+        true_timing = TransmissionModeTiming()
+        true_cyclic = CyclicTiming()
+        true_period = TimeRangeType()
+        true_period.setValue(_time(0.1))
+        true_cyclic.setTimePeriod(true_period)
+        true_timing.setCyclicTiming(true_cyclic)
+        decl.setTransmissionModeTrueTiming(true_timing)
+        parent = _parent()
+        writer.setTransmissionModeDeclaration(
+            parent, "TRANSMISSION-MODE-DECLARATION", decl
+        )
+        assert parent[0].tag == "TRANSMISSION-MODE-DECLARATION"
+        assert parent[0].find("TRANSMISSION-MODE-CONDITIONS") is not None
+        assert parent[0].find("TRANSMISSION-MODE-FALSE-TIMING") is not None
+        assert parent[0].find("TRANSMISSION-MODE-TRUE-TIMING") is not None
+
+    def test_setTransmissionModeDeclaration_none(self, writer):
+        parent = _parent()
+        writer.setTransmissionModeDeclaration(
+            parent, "TRANSMISSION-MODE-DECLARATION", None
+        )
+        assert len(parent) == 0
+
+
+class TestWriterIPduTiming:
+    def test_setISignalIPduIPduTimingSpecification_full(self, writer):
+        timing = IPduTiming()
+        timing.setMinimumDelay(_time(0.05))
+        decl = TransmissionModeDeclaration()
+        true_timing = TransmissionModeTiming()
+        true_cyclic = CyclicTiming()
+        true_period = TimeRangeType()
+        true_period.setValue(_time(0.1))
+        true_cyclic.setTimePeriod(true_period)
+        true_timing.setCyclicTiming(true_cyclic)
+        decl.setTransmissionModeTrueTiming(true_timing)
+        timing.setTransmissionModeDeclaration(decl)
+        parent = _parent()
+        writer.setISignalIPduIPduTimingSpecification(parent, timing)
+        assert parent[0].tag == "I-PDU-TIMING-SPECIFICATIONS"
+        ipdu_timing = parent[0].find("I-PDU-TIMING")
+        assert ipdu_timing.find("MINIMUM-DELAY") is not None
+        assert ipdu_timing.find("TRANSMISSION-MODE-DECLARATION") is not None
+
+    def test_setISignalIPduIPduTimingSpecification_none(self, writer):
+        parent = _parent()
+        writer.setISignalIPduIPduTimingSpecification(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterISignalIPdu:
+    def test_writeISignalIPdu_full(self, writer):
+        pkg = _make_pkg()
+        ipdu = ISignalIPdu(pkg, "IPdu")
+        ipdu.setLength(_numerical(64))
+        timing = IPduTiming()
+        timing.setMinimumDelay(_time(0.01))
+        ipdu.setIPduTimingSpecification(timing)
+        mapping = ipdu.createISignalToPduMappings("Map")
+        mapping.setISignalRef(_ref("/sig", "I-SIGNAL"))
+        ipdu.setUnusedBitPattern(_integer(0))
+        parent = _parent()
+        writer.writeISignalIPdu(parent, ipdu)
+        assert parent[0].tag == "I-SIGNAL-I-PDU"
+        assert parent[0].find("LENGTH") is not None
+        assert parent[0].find("I-PDU-TIMING-SPECIFICATIONS") is not None
+        assert parent[0].find("I-SIGNAL-TO-PDU-MAPPINGS") is not None
+        assert parent[0].find("UNUSED-BIT-PATTERN") is not None
+
+
+class TestWriterFlexrayFrame:
+    def test_writeFlexrayFrame_full(self, writer):
+        pkg = _make_pkg()
+        frame = FlexrayFrame(pkg, "FrFrame")
+        frame.setFrameLength(_numerical(16))
+        parent = _parent()
+        writer.writeFlexrayFrame(parent, frame)
+        assert parent[0].tag == "FLEXRAY-FRAME"
+
+    def test_writeFlexrayFrame_none(self, writer):
+        parent = _parent()
+        writer.writeFlexrayFrame(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterFlexrayCommunicationController:
+    def test_writeFlexrayCommunicationController_all_attrs(self, writer):
+        pkg = _make_pkg()
+        controller = FlexrayCommunicationController(pkg, "FrCtrl")
+        controller.setAcceptedStartupRange(_integer(10))
+        controller.setAllowHaltDueToClock(_bool(True))
+        controller.setAllowPassiveToActive(_integer(5))
+        controller.setClusterDriftDamping(_integer(2))
+        controller.setDecodingCorrection(_integer(3))
+        controller.setDelayCompensationA(_integer(4))
+        controller.setDelayCompensationB(_integer(5))
+        controller.setKeySlotOnlyEnabled(_bool(False))
+        controller.setKeySlotUsedForStartUp(_bool(True))
+        controller.setKeySlotUsedForSync(_bool(True))
+        controller.setLatestTX(_integer(20))
+        controller.setListenTimeout(_integer(100))
+        controller.setMacroInitialOffsetA(_integer(30))
+        controller.setMacroInitialOffsetB(_integer(31))
+        controller.setMaximumDynamicPayloadLength(_integer(128))
+        controller.setMicroInitialOffsetA(_integer(1))
+        controller.setMicroInitialOffsetB(_integer(2))
+        controller.setMicroPerCycle(_integer(5000))
+        controller.setMicrotickDuration(_time(0.00001))
+        controller.setOffsetCorrectionOut(_integer(50))
+        controller.setRateCorrectionOut(_integer(60))
+        controller.setSamplesPerMicrotick(_integer(2))
+        controller.setWakeUpPattern(_integer(0))
+        parent = _parent()
+        writer.writeFlexrayCommunicationController(parent, controller)
+        assert parent[0].tag == "FLEXRAY-COMMUNICATION-CONTROLLER"
+        cond = parent[0].find("FLEXRAY-COMMUNICATION-CONTROLLER-VARIANTS").find(
+            "FLEXRAY-COMMUNICATION-CONTROLLER-CONDITIONAL"
+        )
+        assert cond.find("ACCEPTED-STARTUP-RANGE") is not None
+        assert cond.find("ALLOW-HALT-DUE-TO-CLOCK") is not None
+        assert cond.find("ALLOW-PASSIVE-TO-ACTIVE") is not None
+        assert cond.find("CLUSTER-DRIFT-DAMPING") is not None
+        assert cond.find("DECODING-CORRECTION") is not None
+        assert cond.find("DELAY-COMPENSATION-A") is not None
+        assert cond.find("DELAY-COMPENSATION-B") is not None
+        assert cond.find("KEY-SLOT-ONLY-ENABLED") is not None
+        assert cond.find("KEY-SLOT-USED-FOR-START-UP") is not None
+        assert cond.find("KEY-SLOT-USED-FOR-SYNC") is not None
+        assert cond.find("LATEST-TX") is not None
+        assert cond.find("LISTEN-TIMEOUT") is not None
+        assert cond.find("MACRO-INITIAL-OFFSET-A") is not None
+        assert cond.find("MACRO-INITIAL-OFFSET-B") is not None
+        assert cond.find("MAXIMUM-DYNAMIC-PAYLOAD-LENGTH") is not None
+        assert cond.find("MICRO-INITIAL-OFFSET-A") is not None
+        assert cond.find("MICRO-INITIAL-OFFSET-B") is not None
+        assert cond.find("MICRO-PER-CYCLE") is not None
+        assert cond.find("MICROTICK-DURATION") is not None
+        assert cond.find("OFFSET-CORRECTION-OUT") is not None
+        assert cond.find("RATE-CORRECTION-OUT") is not None
+        assert cond.find("SAMPLES-PER-MICROTICK") is not None
+        assert cond.find("WAKE-UP-PATTERN") is not None
+
+    def test_writeFlexrayCommunicationController_none(self, writer):
+        parent = _parent()
+        writer.writeFlexrayCommunicationController(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterDataTransformation:
+    def test_writeDataTransformationTransformerChainRefs_with_refs(self, writer):
+        pkg = _make_pkg()
+        dtf_set = DataTransformationSet(pkg, "DtfSet")
+        dtf = dtf_set.createDataTransformation("Dtf")
+        dtf.addTransformerChainRef(_ref("/chain1", "TRANSFORMER-CHAIN"))
+        dtf.addTransformerChainRef(_ref("/chain2", "TRANSFORMER-CHAIN"))
+        parent = _parent()
+        writer.writeDataTransformationTransformerChainRefs(parent, dtf)
+        assert parent[0].tag == "TRANSFORMER-CHAIN-REFS"
+        refs = parent[0].findall("TRANSFORMER-CHAIN-REF")
+        assert len(refs) == 2
+
+    def test_writeDataTransformationTransformerChainRefs_empty(self, writer):
+        pkg = _make_pkg()
+        dtf_set = DataTransformationSet(pkg, "DtfSet")
+        dtf = dtf_set.createDataTransformation("Dtf")
+        parent = _parent()
+        writer.writeDataTransformationTransformerChainRefs(parent, dtf)
+        assert len(parent) == 0
+
+    def test_writeDataTransformation_full(self, writer):
+        pkg = _make_pkg()
+        dtf_set = DataTransformationSet(pkg, "DtfSet")
+        dtf = dtf_set.createDataTransformation("Dtf")
+        dtf.setExecuteDespiteDataUnavailability(_bool(True))
+        dtf.addTransformerChainRef(_ref("/chain", "TRANSFORMER-CHAIN"))
+        parent = _parent()
+        writer.writeDataTransformation(parent, dtf)
+        assert parent[0].tag == "DATA-TRANSFORMATION"
+        assert parent[0].find("EXECUTE-DESPITE-DATA-UNAVAILABILITY") is not None
+        assert parent[0].find("TRANSFORMER-CHAIN-REFS") is not None
+
+    def test_writeDataTransformation_none(self, writer):
+        parent = _parent()
+        writer.writeDataTransformation(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterDataTransformationSet:
+    def test_writeDataTransformationSetDataTransformations_with_dtfs(self, writer):
+        pkg = _make_pkg()
+        dtf_set = DataTransformationSet(pkg, "DtfSet")
+        dtf_set.createDataTransformation("Dtf1")
+        dtf_set.createDataTransformation("Dtf2")
+        parent = _parent()
+        writer.writeDataTransformationSetDataTransformations(parent, dtf_set)
+        assert parent[0].tag == "DATA-TRANSFORMATIONS"
+        dtfs = parent[0].findall("DATA-TRANSFORMATION")
+        assert len(dtfs) == 2
+
+    def test_writeDataTransformationSetDataTransformations_empty(self, writer):
+        pkg = _make_pkg()
+        dtf_set = DataTransformationSet(pkg, "DtfSet")
+        parent = _parent()
+        writer.writeDataTransformationSetDataTransformations(parent, dtf_set)
+        assert len(parent) == 0
+
+    def test_writeDataTransformationSetTransformationTechnologies_with_techs(
+        self, writer
+    ):
+        pkg = _make_pkg()
+        dtf_set = DataTransformationSet(pkg, "DtfSet")
+        dtf_set.createTransformationTechnology("Tech1")
+        dtf_set.createTransformationTechnology("Tech2")
+        parent = _parent()
+        writer.writeDataTransformationSetTransformationTechnologies(parent, dtf_set)
+        assert parent[0].tag == "TRANSFORMATION-TECHNOLOGYS"
+        techs = parent[0].findall("TRANSFORMATION-TECHNOLOGY")
+        assert len(techs) == 2
+
+    def test_writeDataTransformationSetTransformationTechnologies_empty(self, writer):
+        pkg = _make_pkg()
+        dtf_set = DataTransformationSet(pkg, "DtfSet")
+        parent = _parent()
+        writer.writeDataTransformationSetTransformationTechnologies(parent, dtf_set)
+        assert len(parent) == 0
+
+    def test_writeDataTransformationSet_full(self, writer):
+        pkg = _make_pkg()
+        dtf_set = DataTransformationSet(pkg, "DtfSet")
+        dtf_set.createDataTransformation("Dtf")
+        dtf_set.createTransformationTechnology("Tech")
+        parent = _parent()
+        writer.writeDataTransformationSet(parent, dtf_set)
+        assert parent[0].tag == "DATA-TRANSFORMATION-SET"
+        assert parent[0].find("DATA-TRANSFORMATIONS") is not None
+        assert parent[0].find("TRANSFORMATION-TECHNOLOGYS") is not None
+
+    def test_writeDataTransformationSet_none(self, writer):
+        parent = _parent()
+        writer.writeDataTransformationSet(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterBufferProperties:
+    def test_writeBufferPropertiesBufferComputation_with_computation(self, writer):
+        props = BufferProperties()
+        from armodel.models.M2.MSR.AsamHdo.ComputationMethod import (
+            CompuScale,
+            CompuScaleConstantContents,
+            CompuConst,
+            CompuConstTextContent,
+        )
+        computation = CompuScale()
+        computation.setShortLabel(_literal("scale"))
+        contents = CompuScaleConstantContents()
+        const = CompuConst()
+        text_content = CompuConstTextContent()
+        text_content.setVt(_literal("value"))
+        const.setCompuConstContentType(text_content)
+        contents.setCompuConst(const)
+        computation.setCompuScaleContents(contents)
+        props.setBufferComputation(computation)
+        parent = _parent()
+        writer.writeBufferPropertiesBufferComputation(parent, props)
+        assert parent.find("BUFFER-COMPUTATION") is not None
+
+    def test_writeBufferPropertiesBufferComputation_none(self, writer):
+        props = BufferProperties()
+        parent = _parent()
+        writer.writeBufferPropertiesBufferComputation(parent, props)
+        assert len(parent) == 0
+
+    def test_setBufferProperties_full(self, writer):
+        props = BufferProperties()
+        props.setHeaderLength(_integer(4))
+        props.setInPlace(_bool(True))
+        parent = _parent()
+        writer.setBufferProperties(parent, "BUFFER-PROPERTIES", props)
+        assert parent[0].tag == "BUFFER-PROPERTIES"
+        assert parent[0].find("HEADER-LENGTH") is not None
+        assert parent[0].find("IN-PLACE") is not None
+
+    def test_setBufferProperties_none(self, writer):
+        parent = _parent()
+        writer.setBufferProperties(parent, "BUFFER-PROPERTIES", None)
+        assert len(parent) == 0
+
+
+class TestWriterTransformationDescription:
+    def test_writeDescribable(self, writer):
+        desc = EndToEndTransformationDescription()
+        parent = _parent()
+        writer.writeDescribable(parent, desc)
+        assert len(parent) >= 0
+
+    def test_writeTransformationDescription(self, writer):
+        desc = EndToEndTransformationDescription()
+        parent = _parent()
+        writer.writeTransformationDescription(parent, desc)
+        assert len(parent) >= 0
+
+    def test_writeEndToEndTransformationDescription_full(self, writer):
+        desc = EndToEndTransformationDescription()
+        desc.setDataIdMode(_literal("all16Bit"))
+        desc.setMaxDeltaCounter(_posint(2))
+        desc.setMaxErrorStateInit(_posint(1))
+        desc.setMaxErrorStateInvalid(_posint(2))
+        desc.setMaxErrorStateValid(_posint(3))
+        desc.setMaxNoNewOrRepeatedData(_posint(2))
+        desc.setMinOkStateInit(_posint(0))
+        desc.setMinOkStateInvalid(_posint(1))
+        desc.setMinOkStateValid(_posint(2))
+        desc.setProfileBehavior(_literal("R4_2"))
+        desc.setProfileName(_literal("Profile1"))
+        desc.setSyncCounterInit(_posint(0))
+        desc.setUpperHeaderBitsToShift(_posint(0))
+        desc.setWindowSizeInit(_posint(1))
+        desc.setWindowSizeInvalid(_posint(2))
+        desc.setWindowSizeValid(_posint(3))
+        parent = _parent()
+        writer.writeEndToEndTransformationDescription(parent, desc)
+        assert parent[0].tag == "END-TO-END-TRANSFORMATION-DESCRIPTION"
+        assert parent[0].find("DATA-ID-MODE") is not None
+        assert parent[0].find("MAX-DELTA-COUNTER") is not None
+        assert parent[0].find("MAX-ERROR-STATE-INIT") is not None
+        assert parent[0].find("MAX-ERROR-STATE-INVALID") is not None
+        assert parent[0].find("MAX-ERROR-STATE-VALID") is not None
+        assert parent[0].find("MAX-NO-NEW-OR-REPEATED-DATA") is not None
+        assert parent[0].find("MIN-OK-STATE-INIT") is not None
+        assert parent[0].find("MIN-OK-STATE-INVALID") is not None
+        assert parent[0].find("MIN-OK-STATE-VALID") is not None
+        assert parent[0].find("PROFILE-BEHAVIOR") is not None
+        assert parent[0].find("PROFILE-NAME") is not None
+        assert parent[0].find("SYNC-COUNTER-INIT") is not None
+        assert parent[0].find("UPPER-HEADER-BITS-TO-SHIFT") is not None
+        assert parent[0].find("WINDOW-SIZE-INIT") is not None
+        assert parent[0].find("WINDOW-SIZE-INVALID") is not None
+        assert parent[0].find("WINDOW-SIZE-VALID") is not None
+
+    def test_writeEndToEndTransformationDescription_none(self, writer):
+        parent = _parent()
+        writer.writeEndToEndTransformationDescription(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterTransformationTechnology:
+    def test_writeTransformationTechnologyTransformationDescriptions_with_e2e(
+        self, writer
+    ):
+        pkg = _make_pkg()
+        dtf_set = DataTransformationSet(pkg, "DtfSet")
+        tech = dtf_set.createTransformationTechnology("Tech")
+        desc = EndToEndTransformationDescription()
+        desc.setProfileName(_literal("Profile1"))
+        tech.setTransformationDescription(desc)
+        parent = _parent()
+        writer.writeTransformationTechnologyTransformationDescriptions(parent, tech)
+        assert parent[0].tag == "TRANSFORMATION-DESCRIPTIONS"
+        assert parent[0].find("END-TO-END-TRANSFORMATION-DESCRIPTION") is not None
+
+    def test_writeTransformationTechnologyTransformationDescriptions_none(self, writer):
+        pkg = _make_pkg()
+        dtf_set = DataTransformationSet(pkg, "DtfSet")
+        tech = dtf_set.createTransformationTechnology("Tech")
+        parent = _parent()
+        writer.writeTransformationTechnologyTransformationDescriptions(parent, tech)
+        assert len(parent) == 0
+
+    def test_writeTransformationTechnology_full(self, writer):
+        pkg = _make_pkg()
+        dtf_set = DataTransformationSet(pkg, "DtfSet")
+        tech = dtf_set.createTransformationTechnology("Tech")
+        props = BufferProperties()
+        props.setHeaderLength(_integer(4))
+        tech.setBufferProperties(props)
+        tech.setNeedsOriginalData(_bool(True))
+        tech.setProtocol(_literal("E2E"))
+        desc = EndToEndTransformationDescription()
+        desc.setProfileName(_literal("Profile1"))
+        tech.setTransformationDescription(desc)
+        tech.setTransformerClass(_literal("safety"))
+        tech.setVersion(_literal("1.0"))
+        parent = _parent()
+        writer.writeTransformationTechnology(parent, tech)
+        assert parent[0].tag == "TRANSFORMATION-TECHNOLOGY"
+        assert parent[0].find("BUFFER-PROPERTIES") is not None
+        assert parent[0].find("NEEDS-ORIGINAL-DATA") is not None
+        assert parent[0].find("PROTOCOL") is not None
+        assert parent[0].find("TRANSFORMATION-DESCRIPTIONS") is not None
+        assert parent[0].find("TRANSFORMER-CLASS") is not None
+        assert parent[0].find("VERSION") is not None
+
+    def test_writeTransformationTechnology_none(self, writer):
+        parent = _parent()
+        writer.writeTransformationTechnology(parent, None)
+        assert len(parent) == 0

--- a/tests/test_armodel/writer/test_writer_pdu_secure_soad.py
+++ b/tests/test_armodel/writer/test_writer_pdu_secure_soad.py
@@ -1,0 +1,623 @@
+"""Tests for writer PDU, SecureCommunication, SoAd, and DoIp handlers."""
+import xml.etree.cElementTree as ET
+from unittest.mock import MagicMock
+import pytest
+from armodel.writer.arxml_writer import ARXMLWriter
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (
+    SegmentPosition,
+    MultiplexedPart,
+    StaticPart,
+    DynamicPartAlternative,
+    DynamicPart,
+    MultiplexedIPdu,
+    UserDefinedIPdu,
+    UserDefinedPdu,
+    GeneralPurposePdu,
+    GeneralPurposeIPdu,
+    SecureCommunicationPropsSet,
+    SecureCommunicationAuthenticationProps,
+    SecureCommunicationFreshnessProps,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetCommunication import (
+    SoAdRoutingGroup,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import (
+    DoIpLogicAddress,
+    DoIpTpConnection,
+    DoIpTpConfig,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    ARLiteral,
+    ARBoolean,
+    Integer,
+    PositiveInteger,
+    RefType,
+    ARNumerical,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+def _parent():
+    return ET.Element("PARENT")
+
+
+def _pkg():
+    autosar = AUTOSAR.getInstance()
+    return autosar.createARPackage("Pkg")
+
+
+def _literal(text):
+    val = ARLiteral()
+    val.setValue(text)
+    return val
+
+
+def _int(text):
+    val = Integer()
+    val.setValue(text)
+    return val
+
+
+def _pos_int(text):
+    val = PositiveInteger()
+    val.setValue(text)
+    return val
+
+
+def _bool(text):
+    val = ARBoolean()
+    val.setValue(text)
+    return val
+
+
+def _numerical(text):
+    val = ARNumerical()
+    val.setValue(text)
+    return val
+
+
+def _ref(dest, value):
+    ref = RefType()
+    ref.setDest(dest)
+    ref.setValue(value)
+    return ref
+
+
+class TestWritePdu:
+    def test_with_all_attributes(self, writer):
+        pkg = _pkg()
+        pdu = pkg.createGeneralPurposePdu("pdu")
+        pdu.setHasDynamicLength(_bool("true"))
+        pdu.setLength(_int("64"))
+        parent = _parent()
+        child_elem = ET.SubElement(parent, "GENERAL-PURPOSE-PDU")
+        writer.writePdu(child_elem, pdu)
+        assert child_elem.find("SHORT-NAME").text == "pdu"
+        assert child_elem.find("HAS-DYNAMIC-LENGTH").text == "true"
+        assert child_elem.find("LENGTH").text == "64"
+
+    def test_with_optional_attributes(self, writer):
+        pkg = _pkg()
+        pdu = pkg.createGeneralPurposePdu("pdu")
+        parent = _parent()
+        child_elem = ET.SubElement(parent, "GENERAL-PURPOSE-PDU")
+        writer.writePdu(child_elem, pdu)
+        assert child_elem.find("SHORT-NAME").text == "pdu"
+        assert child_elem.find("HAS-DYNAMIC-LENGTH") is None
+        assert child_elem.find("LENGTH") is None
+
+
+class TestWriteIPdu:
+    def test_basic_ipdu(self, writer):
+        pkg = _pkg()
+        ipdu = pkg.createGeneralPurposeIPdu("ipdu")
+        ipdu.setLength(_int("128"))
+        parent = _parent()
+        child_elem = ET.SubElement(parent, "GENERAL-PURPOSE-I-PDU")
+        writer.writeIPdu(child_elem, ipdu)
+        assert child_elem.find("SHORT-NAME").text == "ipdu"
+        assert child_elem.find("LENGTH").text == "128"
+
+
+class TestWriteSegmentPosition:
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeSegmentPosition(parent, None)
+        assert len(parent) == 0
+
+    def test_with_all_attributes(self, writer):
+        position = SegmentPosition()
+        position.setSegmentByteOrder(_literal("OPAQUE"))
+        position.setSegmentLength(_int("8"))
+        position.setSegmentPosition(_int("0"))
+        parent = _parent()
+        writer.writeSegmentPosition(parent, position)
+        child = parent.find("SEGMENT-POSITION")
+        assert child is not None
+        assert child.find("SEGMENT-BYTE-ORDER").text == "OPAQUE"
+        assert child.find("SEGMENT-LENGTH").text == "8"
+        assert child.find("SEGMENT-POSITION").text == "0"
+
+    def test_with_optional_attributes(self, writer):
+        position = SegmentPosition()
+        parent = _parent()
+        writer.writeSegmentPosition(parent, position)
+        child = parent.find("SEGMENT-POSITION")
+        assert child is not None
+        assert child.find("SEGMENT-BYTE-ORDER") is None
+        assert child.find("SEGMENT-LENGTH") is None
+
+
+class TestWriteMultiplexedPartSegmentPositions:
+    def test_empty(self, writer):
+        part = StaticPart()
+        parent = _parent()
+        writer.writeMultiplexedPartSegmentPositions(parent, part)
+        assert len(parent) == 0
+
+    def test_with_positions(self, writer):
+        part = StaticPart()
+        pos1 = SegmentPosition()
+        pos1.setSegmentLength(_int("8"))
+        pos2 = SegmentPosition()
+        pos2.setSegmentLength(_int("16"))
+        part.addSegmentPosition(pos1)
+        part.addSegmentPosition(pos2)
+        parent = _parent()
+        writer.writeMultiplexedPartSegmentPositions(parent, part)
+        positions_elem = parent.find("SEGMENT-POSITIONS")
+        assert positions_elem is not None
+        positions = positions_elem.findall("SEGMENT-POSITION")
+        assert len(positions) == 2
+
+
+class TestWriteMultiplexedPart:
+    def test_with_positions(self, writer):
+        part = StaticPart()
+        pos = SegmentPosition()
+        pos.setSegmentLength(_int("8"))
+        part.addSegmentPosition(pos)
+        parent = _parent()
+        writer.writeMultiplexedPart(parent, part)
+        positions_elem = parent.find("SEGMENT-POSITIONS")
+        assert positions_elem is not None
+
+
+class TestWriteDynamicPartAlternative:
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeDynamicPartAlternative(parent, None)
+        assert len(parent) == 0
+
+    def test_with_all_attributes(self, writer):
+        alt = DynamicPartAlternative()
+        alt.setIPduRef(_ref("I-PDU", "/ipdu"))
+        alt.setInitialDynamicPart(_bool("true"))
+        alt.setSelectorFieldCode(_int("1"))
+        parent = _parent()
+        writer.writeDynamicPartAlternative(parent, alt)
+        child = parent.find("DYNAMIC-PART-ALTERNATIVE")
+        assert child is not None
+        assert child.find("I-PDU-REF") is not None
+        assert child.find("INITIAL-DYNAMIC-PART").text == "true"
+        assert child.find("SELECTOR-FIELD-CODE").text == "1"
+
+
+class TestWriteDynamicPartDynamicPartAlternatives:
+    def test_empty(self, writer):
+        part = DynamicPart()
+        parent = _parent()
+        writer.writeDynamicPartDynamicPartAlternatives(parent, part)
+        assert len(parent) == 0
+
+    def test_with_alternatives(self, writer):
+        part = DynamicPart()
+        alt1 = DynamicPartAlternative()
+        alt1.setSelectorFieldCode(_int("1"))
+        alt2 = DynamicPartAlternative()
+        alt2.setSelectorFieldCode(_int("2"))
+        part.addDynamicPartAlternative(alt1)
+        part.addDynamicPartAlternative(alt2)
+        parent = _parent()
+        writer.writeDynamicPartDynamicPartAlternatives(parent, part)
+        alts_elem = parent.find("DYNAMIC-PART-ALTERNATIVES")
+        assert alts_elem is not None
+        alts = alts_elem.findall("DYNAMIC-PART-ALTERNATIVE")
+        assert len(alts) == 2
+
+
+class TestWriteDynamicPart:
+    def test_full(self, writer):
+        part = DynamicPart()
+        alt = DynamicPartAlternative()
+        alt.setSelectorFieldCode(_int("1"))
+        part.addDynamicPartAlternative(alt)
+        pos = SegmentPosition()
+        pos.setSegmentLength(_int("8"))
+        part.addSegmentPosition(pos)
+        parent = _parent()
+        writer.writeDynamicPart(parent, part)
+        child = parent.find("DYNAMIC-PART")
+        assert child is not None
+        assert child.find("SEGMENT-POSITIONS") is not None
+        assert child.find("DYNAMIC-PART-ALTERNATIVES") is not None
+
+
+class TestWriteMultiplexedIPduDynamicParts:
+    def test_none(self, writer):
+        pkg = _pkg()
+        ipdu = MultiplexedIPdu(pkg, "ipdu")
+        parent = _parent()
+        writer.writeMultiplexedIPduDynamicParts(parent, ipdu)
+        assert len(parent) == 0
+
+    def test_with_dynamic_part(self, writer):
+        pkg = _pkg()
+        ipdu = MultiplexedIPdu(pkg, "ipdu")
+        part = DynamicPart()
+        alt = DynamicPartAlternative()
+        alt.setSelectorFieldCode(_int("1"))
+        part.addDynamicPartAlternative(alt)
+        ipdu.setDynamicPart(part)
+        parent = _parent()
+        writer.writeMultiplexedIPduDynamicParts(parent, ipdu)
+        parts_elem = parent.find("DYNAMIC-PARTS")
+        assert parts_elem is not None
+        assert parts_elem.find("DYNAMIC-PART") is not None
+
+
+class TestWriteStaticPart:
+    def test_full(self, writer):
+        part = StaticPart()
+        part.setIPduRef(_ref("I-PDU", "/ipdu"))
+        pos = SegmentPosition()
+        pos.setSegmentLength(_int("8"))
+        part.addSegmentPosition(pos)
+        parent = _parent()
+        writer.writeStaticPart(parent, part)
+        child = parent.find("STATIC-PART")
+        assert child is not None
+        assert child.find("SEGMENT-POSITIONS") is not None
+        assert child.find("I-PDU-REF") is not None
+
+
+class TestWriteMultiplexedIPduStaticParts:
+    def test_none(self, writer):
+        pkg = _pkg()
+        ipdu = MultiplexedIPdu(pkg, "ipdu")
+        parent = _parent()
+        writer.writeMultiplexedIPduStaticParts(parent, ipdu)
+        assert len(parent) == 0
+
+    def test_with_static_part(self, writer):
+        pkg = _pkg()
+        ipdu = MultiplexedIPdu(pkg, "ipdu")
+        part = StaticPart()
+        part.setIPduRef(_ref("I-PDU", "/ipdu"))
+        ipdu.setStaticPart(part)
+        parent = _parent()
+        writer.writeMultiplexedIPduStaticParts(parent, ipdu)
+        parts_elem = parent.find("STATIC-PARTS")
+        assert parts_elem is not None
+        assert parts_elem.find("STATIC-PART") is not None
+
+
+class TestWriteMultiplexedIPdu:
+    def test_full(self, writer):
+        pkg = _pkg()
+        ipdu = MultiplexedIPdu(pkg, "muxIpdu")
+        ipdu.setLength(_int("64"))
+        ipdu.setSelectorFieldByteOrder(_literal("OPAQUE"))
+        ipdu.setSelectorFieldLength(_int("4"))
+        ipdu.setSelectorFieldStartPosition(_int("0"))
+        ipdu.setTriggerMode(_literal("TRIGGERED"))
+        ipdu.setUnusedBitPattern(_int("0"))
+        dyn_part = DynamicPart()
+        alt = DynamicPartAlternative()
+        alt.setSelectorFieldCode(_int("1"))
+        dyn_part.addDynamicPartAlternative(alt)
+        ipdu.setDynamicPart(dyn_part)
+        static_part = StaticPart()
+        static_part.setIPduRef(_ref("I-PDU", "/static"))
+        ipdu.setStaticPart(static_part)
+        parent = _parent()
+        writer.writeMultiplexedIPdu(parent, ipdu)
+        child = parent.find("MULTIPLEXED-I-PDU")
+        assert child is not None
+        assert child.find("SHORT-NAME").text == "muxIpdu"
+        assert child.find("LENGTH").text == "64"
+        assert child.find("SELECTOR-FIELD-BYTE-ORDER").text == "OPAQUE"
+        assert child.find("SELECTOR-FIELD-LENGTH").text == "4"
+        assert child.find("SELECTOR-FIELD-START-POSITION").text == "0"
+        assert child.find("TRIGGER-MODE").text == "TRIGGERED"
+        assert child.find("UNUSED-BIT-PATTERN").text == "0"
+        assert child.find("DYNAMIC-PARTS") is not None
+        assert child.find("STATIC-PARTS") is not None
+
+
+class TestWriteUserDefinedIPdu:
+    def test_full(self, writer):
+        pkg = _pkg()
+        ipdu = UserDefinedIPdu(pkg, "userIpdu")
+        ipdu.setLength(_int("32"))
+        ipdu.setCddType(_literal("MyCDD"))
+        parent = _parent()
+        writer.writeUserDefinedIPdu(parent, ipdu)
+        child = parent.find("USER-DEFINED-I-PDU")
+        assert child is not None
+        assert child.find("SHORT-NAME").text == "userIpdu"
+        assert child.find("LENGTH").text == "32"
+        assert child.find("CDD-TYPE").text == "MyCDD"
+
+
+class TestWriteUserDefinedPdu:
+    def test_full(self, writer):
+        pkg = _pkg()
+        pdu = UserDefinedPdu(pkg, "userPdu")
+        pdu.setLength(_int("32"))
+        pdu.setCddType(_literal("MyCDD"))
+        parent = _parent()
+        writer.writeUserDefinedPdu(parent, pdu)
+        child = parent.find("USER-DEFINED-PDU")
+        assert child is not None
+        assert child.find("SHORT-NAME").text == "userPdu"
+        assert child.find("LENGTH").text == "32"
+        assert child.find("CDD-TYPE").text == "MyCDD"
+
+
+class TestWriteGeneralPurposePdu:
+    def test_full(self, writer):
+        pkg = _pkg()
+        pdu = GeneralPurposePdu(pkg, "gpPdu")
+        pdu.setLength(_int("64"))
+        parent = _parent()
+        writer.writeGeneralPurposePdu(parent, pdu)
+        child = parent.find("GENERAL-PURPOSE-PDU")
+        assert child is not None
+        assert child.find("SHORT-NAME").text == "gpPdu"
+        assert child.find("LENGTH").text == "64"
+
+
+class TestWriteGeneralPurposeIPdu:
+    def test_full(self, writer):
+        pkg = _pkg()
+        ipdu = GeneralPurposeIPdu(pkg, "gpIpdu")
+        ipdu.setLength(_int("128"))
+        parent = _parent()
+        writer.writeGeneralPurposeIPdu(parent, ipdu)
+        child = parent.find("GENERAL-PURPOSE-I-PDU")
+        assert child is not None
+        assert child.find("SHORT-NAME").text == "gpIpdu"
+        assert child.find("LENGTH").text == "128"
+
+
+class TestWriteSecureCommunicationAuthenticationProps:
+    def test_with_mock(self, writer):
+        props = MagicMock()
+        auth_algo = MagicMock()
+        auth_algo.setValue.return_value = None
+        props.getAuthAlgorithm.return_value = auth_algo
+        tx_len = MagicMock()
+        tx_len.setValue.return_value = None
+        props.getAuthInfoTxLength.return_value = tx_len
+        parent = _parent()
+        writer.writeSecureCommunicationAuthenticationProps(parent, props)
+        child = parent.find("SECURE-COMMUNICATION-AUTHENTICATION-PROPS")
+        assert child is not None
+
+
+class TestWriteSecureCommunicationPropsSetAuthenticationProps:
+    def test_empty(self, writer):
+        props_set = MagicMock()
+        props_set.getAuthenticationProps.return_value = []
+        parent = _parent()
+        writer.writeSecureCommunicationPropsSetAuthenticationProps(
+            parent, props_set
+        )
+        assert len(parent) == 0
+
+    def test_with_props(self, writer):
+        props_set = MagicMock()
+        pkg = _pkg()
+        props = SecureCommunicationAuthenticationProps(pkg, "authProps")
+        auth_algo = MagicMock()
+        props.getAuthAlgorithm = MagicMock(return_value=auth_algo)
+        tx_len = MagicMock()
+        props.getAuthInfoTxLength = MagicMock(return_value=tx_len)
+        props_set.getAuthenticationProps.return_value = [props]
+        parent = _parent()
+        writer.writeSecureCommunicationPropsSetAuthenticationProps(
+            parent, props_set
+        )
+        props_elem = parent.find("AUTHENTICATION-PROPSS")
+        assert props_elem is not None
+        auth_props = props_elem.find("SECURE-COMMUNICATION-AUTHENTICATION-PROPS")
+        assert auth_props is not None
+        assert auth_props.find("SHORT-NAME").text == "authProps"
+
+
+class TestWriteSecureCommunicationFreshnessProps:
+    def test_with_real_props(self, writer):
+        pkg = _pkg()
+        props = SecureCommunicationFreshnessProps(pkg, "freshProps")
+        props.setFreshnessValueLength(_pos_int("16"))
+        props.setFreshnessValueTxLength(_pos_int("8"))
+        parent = _parent()
+        writer.writeSecureCommunicationFreshnessProps(parent, props)
+        child = parent.find("SECURE-COMMUNICATION-FRESHNESS-PROPS")
+        assert child is not None
+        assert child.find("SHORT-NAME").text == "freshProps"
+        assert child.find("FRESHNESS-VALUE-LENGTH") is not None
+        assert child.find("FRESHNESS-VALUE-TX-LENGTH") is not None
+
+
+class TestWriteSecureCommunicationPropsSetFreshnessProps:
+    def test_empty(self, writer):
+        props_set = MagicMock()
+        props_set.getFreshnessProps.return_value = []
+        parent = _parent()
+        writer.writeSecureCommunicationPropsSetFreshnessProps(parent, props_set)
+        assert len(parent) == 0
+
+    def test_with_props(self, writer):
+        props_set = MagicMock()
+        pkg = _pkg()
+        props = SecureCommunicationFreshnessProps(pkg, "freshProps")
+        props.setFreshnessValueLength(_pos_int("16"))
+        props_set.getFreshnessProps.return_value = [props]
+        parent = _parent()
+        writer.writeSecureCommunicationPropsSetFreshnessProps(parent, props_set)
+        props_elem = parent.find("FRESHNESS-PROPSS")
+        assert props_elem is not None
+        assert props_elem.find("SECURE-COMMUNICATION-FRESHNESS-PROPS") is not None
+
+
+class TestWriteSecureCommunicationPropsSet:
+    def test_full(self, writer):
+        pkg = _pkg()
+        props_set = SecureCommunicationPropsSet(pkg, "secureSet")
+        props_set.getAuthenticationProps = MagicMock(return_value=[])
+        props_set.getFreshnessProps = MagicMock(return_value=[])
+        parent = _parent()
+        writer.writeSecureCommunicationPropsSet(parent, props_set)
+        child = parent.find("SECURE-COMMUNICATION-PROPS-SET")
+        assert child is not None
+        assert child.find("SHORT-NAME").text == "secureSet"
+
+
+class TestWriteSoAdRoutingGroup:
+    def test_full(self, writer):
+        pkg = _pkg()
+        group = SoAdRoutingGroup(pkg, "soadGroup")
+        group.setEventGroupControlType(_literal("ENABLED"))
+        parent = _parent()
+        writer.writeSoAdRoutingGroup(parent, group)
+        child = parent.find("SO-AD-ROUTING-GROUP")
+        assert child is not None
+        assert child.find("SHORT-NAME").text == "soadGroup"
+        assert child.find("EVENT-GROUP-CONTROL-TYPE").text == "ENABLED"
+
+
+class TestWriteDoIpLogicAddress:
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeDoIpLogicAddress(parent, None)
+        assert len(parent) == 0
+
+    def test_full(self, writer):
+        pkg = _pkg()
+        config = DoIpTpConfig(pkg, "doipConfig")
+        address = config.createDoIpLogicAddress("logicAddr")
+        address.setAddress(_int("0xE00"))
+        parent = _parent()
+        writer.writeDoIpLogicAddress(parent, address)
+        child = parent.find("DO-IP-LOGIC-ADDRESS")
+        assert child is not None
+        assert child.find("SHORT-NAME").text == "logicAddr"
+        assert child.find("ADDRESS").text == "0xE00"
+
+
+class TestWriteDoIpTpConfigDoIpLogicAddresses:
+    def test_empty(self, writer):
+        pkg = _pkg()
+        config = DoIpTpConfig(pkg, "doipConfig")
+        parent = _parent()
+        writer.writeDoIpTpConfigDoIpLogicAddresses(parent, config)
+        assert len(parent) == 0
+
+    def test_with_addresses(self, writer):
+        pkg = _pkg()
+        config = DoIpTpConfig(pkg, "doipConfig")
+        addr1 = config.createDoIpLogicAddress("addr1")
+        addr1.setAddress(_int("0xE00"))
+        addr2 = config.createDoIpLogicAddress("addr2")
+        addr2.setAddress(_int("0xE01"))
+        parent = _parent()
+        writer.writeDoIpTpConfigDoIpLogicAddresses(parent, config)
+        addresses_elem = parent.find("DO-IP-LOGIC-ADDRESSS")
+        assert addresses_elem is not None
+        addresses = addresses_elem.findall("DO-IP-LOGIC-ADDRESS")
+        assert len(addresses) == 2
+
+
+class TestWriteDoIpTpConnection:
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeDoIpTpConnection(parent, None)
+        assert len(parent) == 0
+
+    def test_full(self, writer):
+        conn = DoIpTpConnection()
+        conn.createTpConnectionIdent("connIdent")
+        conn.setDoIpSourceAddressRef(_ref("DO-IP-LOGIC-ADDRESS", "/src"))
+        conn.setDoIpTargetAddressRef(_ref("DO-IP-LOGIC-ADDRESS", "/tgt"))
+        conn.setTpSduRef(_ref("I-PDU", "/sdu"))
+        parent = _parent()
+        writer.writeDoIpTpConnection(parent, conn)
+        child = parent.find("DO-IP-TP-CONNECTION")
+        assert child is not None
+        assert child.find("DO-IP-SOURCE-ADDRESS-REF") is not None
+        assert child.find("DO-IP-TARGET-ADDRESS-REF") is not None
+        assert child.find("TP-SDU-REF") is not None
+
+
+class TestWriteDoIpTpConfigTpConnections:
+    def test_empty(self, writer):
+        pkg = _pkg()
+        config = DoIpTpConfig(pkg, "doipConfig")
+        parent = _parent()
+        writer.writeDoIpTpConfigTpConnections(parent, config)
+        assert len(parent) == 0
+
+    def test_with_connections(self, writer):
+        pkg = _pkg()
+        config = DoIpTpConfig(pkg, "doipConfig")
+        conn1 = DoIpTpConnection()
+        conn1.createTpConnectionIdent("conn1")
+        conn1.setDoIpSourceAddressRef(_ref("DO-IP-LOGIC-ADDRESS", "/src1"))
+        config.addTpConnection(conn1)
+        conn2 = DoIpTpConnection()
+        conn2.createTpConnectionIdent("conn2")
+        conn2.setDoIpSourceAddressRef(_ref("DO-IP-LOGIC-ADDRESS", "/src2"))
+        config.addTpConnection(conn2)
+        parent = _parent()
+        writer.writeDoIpTpConfigTpConnections(parent, config)
+        conns_elem = parent.find("TP-CONNECTIONS")
+        assert conns_elem is not None
+        conns = conns_elem.findall("DO-IP-TP-CONNECTION")
+        assert len(conns) == 2
+
+
+class TestWriteDoIpTpConfig:
+    def test_full(self, writer):
+        pkg = _pkg()
+        config = DoIpTpConfig(pkg, "doipConfig")
+        config.setCommunicationClusterRef(
+            _ref("ETHERNET-CLUSTER", "/cluster")
+        )
+        addr = config.createDoIpLogicAddress("addr")
+        addr.setAddress(_int("0xE00"))
+        conn = DoIpTpConnection()
+        conn.createTpConnectionIdent("conn")
+        config.addTpConnection(conn)
+        parent = _parent()
+        writer.writeDoIpTpConfig(parent, config)
+        child = parent.find("DO-IP-TP-CONFIG")
+        assert child is not None
+        assert child.find("SHORT-NAME").text == "doipConfig"
+        assert child.find("COMMUNICATION-CLUSTER-REF") is not None
+        assert child.find("DO-IP-LOGIC-ADDRESSS") is not None
+        assert child.find("TP-CONNECTIONS") is not None

--- a/tests/test_armodel/writer/test_writer_remaining_gaps.py
+++ b/tests/test_armodel/writer/test_writer_remaining_gaps.py
@@ -1,0 +1,459 @@
+"""Tests for writer remaining coverage gaps - dispatch else branches."""
+import xml.etree.ElementTree as ET
+import pytest
+from unittest.mock import MagicMock
+
+from armodel.writer.arxml_writer import ARXMLWriter
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+
+
+class TestWriterDispatchElseBranches:
+    """Test all dispatch else branches with warning option enabled."""
+
+    def setup_method(self):
+        AUTOSAR.getInstance().new()
+        self.writer = ARXMLWriter(options={'warning': True})
+
+    def test_timing_event_disabled_mode_irefs_empty(self):
+        pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+        swc = pkg.createApplicationSwComponentType("Swc")
+        behavior = swc.createSwcInternalBehavior("Behavior")
+        event = behavior.createTimingEvent("TimingEvent1")
+        event.disabledModeIRefs = []
+        element = ET.Element("TIMING-EVENT")
+        self.writer.writeTimingEvent(element, event)
+        assert element.find("DISABLED-MODE-IREFS") is None
+
+    def test_server_call_points_unsupported_type(self):
+        entity = MagicMock()
+        entity.getServerCallPoints.return_value = [MagicMock(spec=object)]
+        element = ET.Element("RUNNABLE-ENTITY")
+        self.writer.writeRunnableEntityServerCallPoints(element, entity)
+        assert True
+
+    def test_ar_typed_per_instance_memories_unsupported_type(self):
+        behavior = MagicMock()
+        behavior.getArTypedPerInstanceMemories.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SWC-INTERNAL-BEHAVIOR")
+        self.writer.writeSwcInternalBehaviorArTypedPerInstanceMemories(element, behavior)
+        assert True
+
+    def test_explicit_inter_runnable_variables_unsupported_type(self):
+        behavior = MagicMock()
+        behavior.getExplicitInterRunnableVariables.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SWC-INTERNAL-BEHAVIOR")
+        self.writer.writeSwcInternalBehaviorExplicitInterRunnableVariables(element, behavior)
+        assert True
+
+    def test_service_dependency_assigned_data_unsupported_type(self):
+        dependency = MagicMock()
+        dependency.getAssignedData.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SERVICE-DEPENDENCY")
+        self.writer.writeServiceDependencyAssignedDataType(element, dependency)
+        assert True
+
+    def test_swc_service_dependency_assigned_data_unsupported_type(self):
+        dependency = MagicMock()
+        dependency.getAssignedData.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SWC-SERVICE-DEPENDENCY")
+        self.writer.writeSwcServiceDependencyAssignedData(element, dependency)
+        assert True
+
+    def test_swc_service_dependency_assigned_ports_unsupported_type(self):
+        dependency = MagicMock()
+        dependency.getAssignedPorts.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SWC-SERVICE-DEPENDENCY")
+        self.writer.writeSwcServiceDependencyAssignedPorts(element, dependency)
+        assert True
+
+    def test_diag_event_debounce_algorithm_unsupported_type(self):
+        needs = MagicMock()
+        needs.getDiagEventDebounceAlgorithm.return_value = MagicMock(spec=object)
+        element = ET.Element("DIAGNOSTIC-EVENT-NEEDS")
+        self.writer.writeDiagEventDebounceAlgorithm(element, needs)
+        assert True
+
+    def test_swc_internal_behavior_service_dependencies_unsupported_type(self):
+        behavior = MagicMock()
+        behavior.getServiceDependencies.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SWC-INTERNAL-BEHAVIOR")
+        self.writer.writeSwcInternalBehaviorServiceDependencies(element, behavior)
+        assert True
+
+    def test_swc_internal_behavior_included_mode_declaration_group_sets_unsupported_type(self):
+        behavior = MagicMock()
+        behavior.getIncludedModeDeclarationGroupSets.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SWC-INTERNAL-BEHAVIOR")
+        self.writer.writeSwcInternalBehaviorIncludedModeDeclarationGroupSets(element, behavior)
+        assert True
+
+    def test_atomic_sw_component_type_internal_behaviors_unsupported_type(self):
+        component = MagicMock()
+        component.getInternalBehavior.return_value = MagicMock(spec=object)
+        element = ET.Element("APPLICATION-SW-COMPONENT-TYPE")
+        self.writer.writeAtomicSwComponentTypeInternalBehaviors(element, component)
+        assert True
+
+    def test_bsw_module_description_provided_mode_groups_unsupported_type(self):
+        desc = MagicMock()
+        desc.getProvidedModeGroups.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-MODULE-DESCRIPTION")
+        self.writer.writeBswModuleDescriptionProvidedModeGroups(element, desc)
+        assert True
+
+    def test_bsw_module_description_required_mode_groups_unsupported_type(self):
+        desc = MagicMock()
+        desc.getRequiredModeGroups.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-MODULE-DESCRIPTION")
+        self.writer.writeBswModuleDescriptionRequiredModeGroups(element, desc)
+        assert True
+
+    def test_bsw_module_entity_data_send_points_unsupported_type(self):
+        entity = MagicMock()
+        entity.getDataSendPoints.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-MODULE-ENTITY")
+        self.writer.writeBswModuleEntityDataSendPoints(element, entity)
+        assert True
+
+    def test_bsw_module_entity_data_receive_points_unsupported_type(self):
+        entity = MagicMock()
+        entity.getDataReceivePoints.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-MODULE-ENTITY")
+        self.writer.writeBswModuleEntityDataReceivePoints(element, entity)
+        assert True
+
+    def test_bsw_module_entity_call_points_unsupported_type(self):
+        entity = MagicMock()
+        entity.getCallPoints.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-MODULE-ENTITY")
+        self.writer.writeBswModuleEntityCallPoints(element, entity)
+        assert True
+
+    def test_bsw_internal_behavior_entities_unsupported_type(self):
+        behavior = MagicMock()
+        behavior.getEntities.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-INTERNAL-BEHAVIOR")
+        self.writer.writeBswInternalBehaviorEntities(element, behavior)
+        assert True
+
+    def test_bsw_internal_behavior_events_unsupported_type(self):
+        behavior = MagicMock()
+        behavior.getBswEvents.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-INTERNAL-BEHAVIOR")
+        self.writer.writeBswInternalBehaviorEvents(element, behavior)
+        assert True
+
+    def test_bsw_internal_behavior_reception_policies_unsupported_type(self):
+        behavior = MagicMock()
+        behavior.getReceptionPolicies.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-INTERNAL-BEHAVIOR")
+        self.writer.writeBswInternalBehaviorReceptionPolicies(element, behavior)
+        assert True
+
+    def test_bsw_internal_behavior_internal_triggering_points_unsupported_type(self):
+        behavior = MagicMock()
+        behavior.getInternalTriggeringPoints.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-INTERNAL-BEHAVIOR")
+        self.writer.writeBswInternalBehaviorInternalTriggeringPoints(element, behavior)
+        assert True
+
+    def test_bsw_module_description_internal_behaviors_unsupported_type(self):
+        desc = MagicMock()
+        desc.getInternalBehavior.return_value = MagicMock(spec=object)
+        element = ET.Element("BSW-MODULE-DESCRIPTION")
+        self.writer.writeBswModuleDescriptionInternalBehaviors(element, desc)
+        assert True
+
+    def test_bsw_module_description_released_triggers_unsupported_type(self):
+        desc = MagicMock()
+        desc.getReleasedTriggers.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-MODULE-DESCRIPTION")
+        self.writer.writeBswModuleDescriptionReleasedTriggers(element, desc)
+        assert True
+
+    def test_bsw_module_description_required_triggers_unsupported_type(self):
+        desc = MagicMock()
+        desc.getRequiredTriggers.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-MODULE-DESCRIPTION")
+        self.writer.writeBswModuleDescriptionRequiredTriggers(element, desc)
+        assert True
+
+    def test_bsw_module_description_provided_datas_unsupported_type(self):
+        desc = MagicMock()
+        desc.getProvidedDatas.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-MODULE-DESCRIPTION")
+        self.writer.writeBswModuleDescriptionProvidedDatas(element, desc)
+        assert True
+
+    def test_bsw_module_description_required_datas_unsupported_type(self):
+        desc = MagicMock()
+        desc.getRequiredDatas.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-MODULE-DESCRIPTION")
+        self.writer.writeBswModuleDescriptionRequiredDatas(element, desc)
+        assert True
+
+    def test_bsw_module_description_provided_client_server_entries_unsupported_type(self):
+        desc = MagicMock()
+        desc.getProvidedClientServerEntries.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-MODULE-DESCRIPTION")
+        self.writer.writeBswModuleDescriptionProvidedClientServerEntries(element, desc)
+        assert True
+
+    def test_bsw_module_description_required_client_server_entries_unsupported_type(self):
+        desc = MagicMock()
+        desc.getRequiredClientServerEntries.return_value = [MagicMock(spec=object)]
+        element = ET.Element("BSW-MODULE-DESCRIPTION")
+        self.writer.writeBswModuleDescriptionRequiredClientServerEntries(element, desc)
+        assert True
+
+    def test_bus_dependent_nm_ecus_unsupported_type(self):
+        nm_ecu = MagicMock()
+        nm_ecu.getBusDependentNmEcus.return_value = [MagicMock(spec=object)]
+        element = ET.Element("NM-ECU")
+        self.writer.writeBusDependentNmEcus(element, nm_ecu)
+        assert True
+
+    def test_nm_config_nm_if_ecus_unsupported_type(self):
+        config = MagicMock()
+        config.getNmIfEcus.return_value = [MagicMock(spec=object)]
+        element = ET.Element("NM-CONFIG")
+        self.writer.writeNmConfigNmIfEcus(element, config)
+        assert True
+
+    def test_multiplicity_config_classes_unsupported_type(self):
+        common_attrs = MagicMock()
+        common_attrs.getMultiplicityConfigClasses.return_value = [MagicMock(spec=object)]
+        element = ET.Element("ECUC-COMMON-ATTRIBUTES")
+        self.writer.setEcucMultiplicityConfigClasses(element, common_attrs.getMultiplicityConfigClasses())
+        assert True
+
+    def test_enumeration_literal_def_unsupported_type(self):
+        param_def = MagicMock()
+        param_def.getLiterals.return_value = [MagicMock(spec=object)]
+        element = ET.Element("ECUC-ENUMERATION-PARAM-DEF")
+        self.writer.writeEcucEnumerationParamDefLiterals(element, param_def)
+        assert True
+
+    def test_container_def_parameters_unsupported_type(self):
+        container_def = MagicMock()
+        container_def.getParameters.return_value = [MagicMock(spec=object)]
+        element = ET.Element("ECUC-PARAM-CONF-CONTAINER-DEF")
+        self.writer.writeEcucContainerDefParameters(element, container_def)
+        assert True
+
+    def test_container_def_references_unsupported_type(self):
+        container_def = MagicMock()
+        container_def.getReferences.return_value = [MagicMock(spec=object)]
+        element = ET.Element("ECUC-PARAM-CONF-CONTAINER-DEF")
+        self.writer.writeEcucContainerDefReferences(element, container_def)
+        assert True
+
+    def test_container_def_sub_containers_unsupported_type(self):
+        container_def = MagicMock()
+        container_def.getSubContainers.return_value = [MagicMock(spec=object)]
+        element = ET.Element("ECUC-PARAM-CONF-CONTAINER-DEF")
+        self.writer.writeEcucContainerDefSubContainers(element, container_def)
+        assert True
+
+    def test_choice_container_def_choices_unsupported_type(self):
+        container_def = MagicMock()
+        container_def.getChoices.return_value = [MagicMock(spec=object)]
+        element = ET.Element("ECUC-CHOICE-CONTAINER-DEF")
+        self.writer.writeEcucChoiceContainerDefChoices(element, container_def)
+        assert True
+
+    def test_module_def_containers_unsupported_type(self):
+        module_def = MagicMock()
+        module_def.getContainers.return_value = [MagicMock(spec=object)]
+        element = ET.Element("ECUC-MODULE-DEF")
+        self.writer.writeEcucModuleDefContainers(element, module_def)
+        assert True
+
+    def test_comm_connector_port_instances_unsupported_type(self):
+        connector = MagicMock()
+        connector.getEcuCommPortInstances.return_value = [MagicMock(spec=object)]
+        element = ET.Element("COMMUNICATION-CONNECTOR")
+        self.writer.writeCommunicationConnectorEcuCommPortInstances(element, connector)
+        assert True
+
+    def test_can_controller_attributes_unsupported_type(self):
+        controller = MagicMock()
+        controller.getCanControllerAttributes.return_value = MagicMock(spec=object)
+        element = ET.Element("CAN-COMMUNICATION-CONTROLLER")
+        self.writer.writeAbstractCanCommunicationControllerCanControllerAttributes(element, controller)
+        assert True
+
+    def test_coupling_port_structural_elements_unsupported_type(self):
+        details = MagicMock()
+        details.getCouplingPortStructuralElements.return_value = [MagicMock(spec=object)]
+        element = ET.Element("COUPLING-PORT-DETAILS")
+        self.writer.writeCouplingPortDetailsCouplingPortStructuralElements(element, details)
+        assert True
+
+    def test_ethernet_priority_regenerations_unsupported_type(self):
+        details = MagicMock()
+        details.getEthernetPriorityRegenerations.return_value = [MagicMock(spec=object)]
+        element = ET.Element("COUPLING-PORT-DETAILS")
+        self.writer.writeCouplingPortDetailsEthernetPriorityRegenerations(element, details)
+        assert True
+
+    def test_sender_rec_array_type_mapping_record_element_mapping_unsupported_type(self):
+        mapping = MagicMock()
+        mapping.getRecordElementMappings.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SENDER-REC-RECORD-TYPE-MAPPING")
+        self.writer.writeSenderRecArrayTypeMappingRecordElementMapping(element, mapping)
+        assert True
+
+    def test_system_mapping_data_mappings_unsupported_type(self):
+        mapping = MagicMock()
+        mapping.getDataMappings.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SYSTEM-MAPPING")
+        self.writer.writeSystemMappingDataMappings(element, mapping)
+        assert True
+
+    def test_system_mapping_sw_mappings_unsupported_type(self):
+        mapping = MagicMock()
+        mapping.getSwMappings.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SYSTEM-MAPPING")
+        self.writer.writeSystemMappingSwMappings(element, mapping)
+        assert True
+
+    def test_system_mapping_ecu_resource_mappings_unsupported_type(self):
+        mapping = MagicMock()
+        mapping.getEcuResourceMappings.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SYSTEM-MAPPING")
+        self.writer.writeSystemMappingEcuResourceMappings(element, mapping)
+        assert True
+
+    def test_system_mapping_sw_impl_mappings_unsupported_type(self):
+        mapping = MagicMock()
+        mapping.getSwImplMappings.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SYSTEM-MAPPING")
+        self.writer.writeSystemMappingSwImplMappings(element, mapping)
+        assert True
+
+    def test_system_mappings_unsupported_type(self):
+        system = MagicMock()
+        system.getSystemMappings.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SYSTEM")
+        self.writer.writeSystemMappings(element, system)
+        assert True
+
+    def test_flat_map_instances_unsupported_type(self):
+        map = MagicMock()
+        map.getInstances.return_value = [MagicMock(spec=object)]
+        element = ET.Element("FLAT-MAP")
+        self.writer.writeFlatMapInstances(element, map)
+        assert True
+
+    def test_port_interface_mappings_unsupported_type(self):
+        mapping_set = MagicMock()
+        mapping_set.getPortInterfaceMappings.return_value = [MagicMock(spec=object)]
+        element = ET.Element("PORT-INTERFACE-MAPPING-SET")
+        self.writer.writePortInterfaceMappings(element, mapping_set)
+        assert True
+
+    def test_ecuc_container_value_sub_containers_unsupported_type(self):
+        container_value = MagicMock()
+        container_value.getSubContainers.return_value = [MagicMock(spec=object)]
+        element = ET.Element("ECUC-CONTAINER-VALUE")
+        self.writer.writeEcucContainerValueSubContainers(element, container_value)
+        assert True
+
+    def test_ecuc_container_value_parameter_values_unsupported_type(self):
+        container_value = MagicMock()
+        container_value.getParameterValues.return_value = [MagicMock(spec=object)]
+        element = ET.Element("ECUC-CONTAINER-VALUE")
+        self.writer.writeEcucContainerValueParameterValues(element, container_value)
+        assert True
+
+    def test_ecuc_container_value_reference_values_unsupported_type(self):
+        container_value = MagicMock()
+        container_value.getReferenceValues.return_value = [MagicMock(spec=object)]
+        element = ET.Element("ECUC-CONTAINER-VALUE")
+        self.writer.writeEcucContainerValueReferenceValues(element, container_value)
+        assert True
+
+    def test_ecuc_module_configuration_values_containers_unsupported_type(self):
+        values = MagicMock()
+        values.getContainers.return_value = [MagicMock(spec=object)]
+        element = ET.Element("ECUC-MODULE-CONFIGURATION-VALUES")
+        self.writer.writeEcucModuleConfigurationValuesContainers(element, values)
+        assert True
+
+    def test_life_cycle_info_set_life_cycle_infos_unsupported_type(self):
+        info_set = MagicMock()
+        info_set.getLifeCycleInfos.return_value = [MagicMock(spec=object)]
+        element = ET.Element("LIFE-CYCLE-INFO-SET")
+        self.writer.writeLifeCycleInfoSetLifeCycleInfos(element, info_set)
+        assert True
+
+    def test_multiplexed_i_pdu_dynamic_parts_unsupported_type(self):
+        ipdu = MagicMock()
+        ipdu.getDynamicParts.return_value = [MagicMock(spec=object)]
+        element = ET.Element("MULTIPLEXED-I-PDU")
+        self.writer.writeMultiplexedIPduDynamicParts(element, ipdu)
+        assert True
+
+    def test_dynamic_part_dynamic_part_alternatives_unsupported_type(self):
+        part = MagicMock()
+        part.getDynamicPartAlternatives.return_value = [MagicMock(spec=object)]
+        element = ET.Element("DYNAMIC-PART")
+        self.writer.writeDynamicPartDynamicPartAlternatives(element, part)
+        assert True
+
+    def test_multiplexed_i_pdu_static_parts_unsupported_type(self):
+        ipdu = MagicMock()
+        ipdu.getStaticParts.return_value = [MagicMock(spec=object)]
+        element = ET.Element("MULTIPLEXED-I-PDU")
+        self.writer.writeMultiplexedIPduStaticParts(element, ipdu)
+        assert True
+
+    def test_secure_communication_props_set_authentication_props_unsupported_type(self):
+        set = MagicMock()
+        set.getAuthenticationProps.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SECURE-COMMUNICATION-PROPS-SET")
+        self.writer.writeSecureCommunicationPropsSetAuthenticationProps(element, set)
+        assert True
+
+    def test_secure_communication_props_set_freshness_props_unsupported_type(self):
+        set = MagicMock()
+        set.getFreshnessProps.return_value = [MagicMock(spec=object)]
+        element = ET.Element("SECURE-COMMUNICATION-PROPS-SET")
+        self.writer.writeSecureCommunicationPropsSetFreshnessProps(element, set)
+        assert True
+
+    def test_do_ip_tp_config_do_ip_logic_addresses_unsupported_type(self):
+        config = MagicMock()
+        config.getDoIpLogicAddresses.return_value = [MagicMock(spec=object)]
+        element = ET.Element("DO-IP-TP-CONFIG")
+        self.writer.writeDoIpTpConfigDoIpLogicAddresses(element, config)
+        assert True
+
+    def test_hw_category_hw_attribute_def_unsupported_type(self):
+        hw_category = MagicMock()
+        hw_category.getHwAttributeDefs.return_value = [MagicMock(spec=object)]
+        element = ET.Element("HW-CATEGORY")
+        self.writer.writeHwCategoryHwAttributeDef(element, hw_category)
+        assert True
+
+    def test_data_transformation_set_data_transformations_unsupported_type(self):
+        dtf_set = MagicMock()
+        dtf_set.getDataTransformations.return_value = [MagicMock(spec=object)]
+        element = ET.Element("DATA-TRANSFORMATION-SET")
+        self.writer.writeDataTransformationSetDataTransformations(element, dtf_set)
+        assert True
+
+    def test_data_transformation_set_transformation_technologies_unsupported_type(self):
+        dtf_set = MagicMock()
+        dtf_set.getTransformationTechnologies.return_value = [MagicMock(spec=object)]
+        element = ET.Element("DATA-TRANSFORMATION-SET")
+        self.writer.writeDataTransformationSetTransformationTechnologies(element, dtf_set)
+        assert True
+
+    def test_transformation_technology_transformation_descriptions_unsupported_type(self):
+        tech = MagicMock()
+        tech.getTransformationDescriptions.return_value = [MagicMock(spec=object)]
+        element = ET.Element("TRANSFORMATION-TECHNOLOGY")
+        self.writer.writeTransformationTechnologyTransformationDescriptions(element, tech)
+        assert True

--- a/tests/test_armodel/writer/test_writer_signals_diagnostic.py
+++ b/tests/test_armodel/writer/test_writer_signals_diagnostic.py
@@ -1,0 +1,528 @@
+"""Tests for writer signal, lifecycle and diagnostic handlers."""
+import xml.etree.cElementTree as ET
+import pytest
+
+from armodel.writer.arxml_writer import ARXMLWriter
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (  # noqa: E501
+    ISignalGroup,
+    ISignalIPduGroup,
+    SystemSignal,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetFrame import (  # noqa: E501
+    GenericEthernetFrame,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import (
+    EndToEndTransformationISignalProps,
+    TransformationISignalProps,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import (
+    LifeCycleInfo,
+    LifeCycleInfoSet,
+    LifeCyclePeriod,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import (  # noqa: E501
+    DiagnosticConnection,
+)
+from armodel.models.M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticContribution import (  # noqa: E501
+    DiagnosticServiceTable,
+)
+from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import (
+    DocumentationBlock,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa: E501
+    ARBoolean,
+    ARLiteral,
+    PositiveInteger,
+    RefType,
+    RevisionLabelString,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+def _parent():
+    return ET.Element("PARENT")
+
+
+def _pkg():
+    return AUTOSAR.getInstance().createARPackage("Pkg")
+
+
+def _ref(value, dest=None):
+    ref = RefType()
+    ref.setValue(value)
+    if dest is not None:
+        ref.setDest(dest)
+    return ref
+
+
+def _literal(value):
+    lit = ARLiteral()
+    lit.setValue(value)
+    return lit
+
+
+def _bool(value):
+    b = ARBoolean()
+    b.setValue(value)
+    return b
+
+
+def _posint(value):
+    p = PositiveInteger()
+    p.setValue(str(value))
+    return p
+
+
+def _revision_label(value):
+    r = RevisionLabelString()
+    r.setValue(value)
+    return r
+
+
+def _make_isignal_group():
+    return _pkg().createISignalGroup("ISigGrp")
+
+
+def _make_isignal_ipdu_group():
+    return _pkg().createISignalIPduGroup("ISigIPduGrp")
+
+
+def _make_system_signal():
+    return _pkg().createSystemSignal("SysSig")
+
+
+def _make_ethernet_frame():
+    return _pkg().createGenericEthernetFrame("EthFrame")
+
+
+def _make_life_cycle_info_set():
+    return _pkg().createLifeCycleInfoSet("LcSet")
+
+
+def _make_diagnostic_connection():
+    return _pkg().createDiagnosticConnection("DiagConn")
+
+
+def _make_diagnostic_service_table():
+    return _pkg().createDiagnosticServiceTable("DiagTable")
+
+
+class TestWriterISignalGroupISignalRef:
+    def test_with_refs(self, writer):
+        group = _make_isignal_group()
+        group.addISignalRef(_ref("/s1", "I-SIGNAL"))
+        group.addISignalRef(_ref("/s2", "I-SIGNAL"))
+        parent = _parent()
+        writer.writeISignalGroupISignalRef(parent, group)
+        assert parent[0].tag == "I-SIGNAL-REFS"
+        refs = parent[0].findall("I-SIGNAL-REF")
+        assert len(refs) == 2
+
+    def test_empty(self, writer):
+        group = _make_isignal_group()
+        parent = _parent()
+        writer.writeISignalGroupISignalRef(parent, group)
+        assert len(parent) == 0
+
+
+class TestWriterISignalGroupComBasedSignalGroupTransformation:
+    def test_with_refs(self, writer):
+        group = _make_isignal_group()
+        group.addComBasedSignalGroupTransformationRef(
+            _ref("/dt1", "DATA-TRANSFORMATION")
+        )
+        group.addComBasedSignalGroupTransformationRef(
+            _ref("/dt2", "DATA-TRANSFORMATION")
+        )
+        parent = _parent()
+        writer.writeISignalGroupComBasedSignalGroupTransformation(
+            parent, group
+        )
+        assert parent[0].tag == "COM-BASED-SIGNAL-GROUP-TRANSFORMATIONS"
+        cond = parent[0].find("DATA-TRANSFORMATION-REF-CONDITIONAL")
+        assert cond is not None
+        refs = cond.findall("DATA-TRANSFORMATION-REF")
+        assert len(refs) == 2
+
+    def test_empty(self, writer):
+        group = _make_isignal_group()
+        parent = _parent()
+        writer.writeISignalGroupComBasedSignalGroupTransformation(
+            parent, group
+        )
+        assert len(parent) == 0
+
+
+class TestWriterTransformationISignalProps:
+    def test_dispatch_writes_describable(self, writer):
+        props = EndToEndTransformationISignalProps()
+        parent = _parent()
+        writer.writeTransformationISignalProps(parent, props)
+        assert len(parent) == 0
+
+
+class TestWriterEndToEndTransformationISignalPropsDataIds:
+    def test_with_ids(self, writer):
+        props = EndToEndTransformationISignalProps()
+        props.addDataId(_posint(1))
+        props.addDataId(_posint(2))
+        parent = _parent()
+        writer.writeEndToEndTransformationISignalPropsDataIds(parent, props)
+        assert parent[0].tag == "DATA-IDS"
+        ids = parent[0].findall("DATA-ID")
+        assert len(ids) == 2
+
+    def test_empty(self, writer):
+        props = EndToEndTransformationISignalProps()
+        parent = _parent()
+        writer.writeEndToEndTransformationISignalPropsDataIds(parent, props)
+        assert len(parent) == 0
+
+
+class TestWriterEndToEndTransformationISignalProps:
+    def test_full(self, writer):
+        props = EndToEndTransformationISignalProps()
+        props.setTransformerRef(_ref("/tr", "TRANSFORMATION-PROPS"))
+        props.addDataId(_posint(10))
+        props.setDataLength(_posint(64))
+        parent = _parent()
+        writer.writeEndToEndTransformationISignalProps(parent, props)
+        assert parent[0].tag == "END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS"
+        variants = parent[0].find(
+            "END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-VARIANTS"
+        )
+        assert variants is not None
+        cond = variants.find(
+            "END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-CONDITIONAL"
+        )
+        assert cond is not None
+        assert cond.find("TRANSFORMER-REF") is not None
+        assert cond.find("DATA-IDS") is not None
+        assert cond.find("DATA-LENGTH") is not None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEndToEndTransformationISignalProps(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterISignalGroupTransformationISignalProps:
+    def test_with_end_to_end_props(self, writer):
+        group = _make_isignal_group()
+        props = EndToEndTransformationISignalProps()
+        props.setTransformerRef(_ref("/tr", "TRANSFORMATION-PROPS"))
+        group.setTransformationISignalProps(props)
+        parent = _parent()
+        writer.writeISignalGroupTransformationISignalProps(parent, group)
+        assert parent[0].tag == "TRANSFORMATION-I-SIGNAL-PROPSS"
+        assert parent[0].find(
+            "END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS"
+        ) is not None
+
+    def test_none(self, writer):
+        group = _make_isignal_group()
+        parent = _parent()
+        writer.writeISignalGroupTransformationISignalProps(parent, group)
+        assert len(parent) == 0
+
+    def test_unsupported_props_warns(self, caplog):
+        warn_writer = ARXMLWriter(options={"warning": True})
+
+        class _OtherProps(TransformationISignalProps):
+            def __init__(self):
+                super().__init__()
+
+        group = _make_isignal_group()
+        group.setTransformationISignalProps(_OtherProps())
+        parent = _parent()
+        warn_writer.writeISignalGroupTransformationISignalProps(parent, group)
+        assert parent[0].tag == "TRANSFORMATION-I-SIGNAL-PROPSS"
+        assert parent[0].find(
+            "END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS"
+        ) is None
+        assert "Unsupported TransformationISignalProps" in caplog.text
+
+
+class TestWriterISignalGroup:
+    def test_full(self, writer):
+        group = _make_isignal_group()
+        group.addISignalRef(_ref("/s1", "I-SIGNAL"))
+        group.addComBasedSignalGroupTransformationRef(
+            _ref("/dt", "DATA-TRANSFORMATION")
+        )
+        group.setSystemSignalGroupRef(
+            _ref("/ssg", "SYSTEM-SIGNAL-GROUP")
+        )
+        props = EndToEndTransformationISignalProps()
+        props.setTransformerRef(_ref("/tr", "TRANSFORMATION-PROPS"))
+        props.addDataId(_posint(5))
+        props.setDataLength(_posint(32))
+        group.setTransformationISignalProps(props)
+        parent = _parent()
+        writer.writeISignalGroup(parent, group)
+        elem = parent.find("I-SIGNAL-GROUP")
+        assert elem is not None
+        assert elem.find("SHORT-NAME") is not None
+        assert elem.find("I-SIGNAL-REFS") is not None
+        assert elem.find("COM-BASED-SIGNAL-GROUP-TRANSFORMATIONS") is not None
+        assert elem.find("SYSTEM-SIGNAL-GROUP-REF") is not None
+        assert elem.find("TRANSFORMATION-I-SIGNAL-PROPSS") is not None
+
+
+class TestWriterISignalIPduGroup:
+    def test_full(self, writer):
+        group = _make_isignal_ipdu_group()
+        group.setCommunicationDirection(_literal("OUT"))
+        group.setCommunicationMode(_literal("PERIODIC"))
+        group.addContainedISignalIPduGroupRef(
+            _ref("/g", "I-SIGNAL-I-PDU-GROUP")
+        )
+        group.addISignalIPduRef(_ref("/p", "I-SIGNAL-I-PDU"))
+        parent = _parent()
+        writer.writeISignalIPduGroup(parent, group)
+        elem = parent.find("I-SIGNAL-I-PDU-GROUP")
+        assert elem is not None
+        assert elem.find("SHORT-NAME") is not None
+        assert elem.find("COMMUNICATION-DIRECTION").text == "OUT"
+        assert elem.find("COMMUNICATION-MODE").text == "PERIODIC"
+        assert elem.find("CONTAINED-I-SIGNAL-I-PDU-GROUP-REFS") is not None
+        assert elem.find("I-SIGNAL-I-PDUS") is not None
+        cond = elem.find("I-SIGNAL-I-PDUS/I-SIGNAL-I-PDU-REF-CONDITIONAL")
+        assert cond is not None
+
+    def test_empty(self, writer):
+        group = _make_isignal_ipdu_group()
+        parent = _parent()
+        writer.writeISignalIPduGroup(parent, group)
+        elem = parent.find("I-SIGNAL-I-PDU-GROUP")
+        assert elem is not None
+        assert elem.find("COMMUNICATION-DIRECTION") is None
+        assert elem.find("COMMUNICATION-MODE") is None
+        assert elem.find("CONTAINED-I-SIGNAL-I-PDU-GROUP-REFS") is None
+        assert elem.find("I-SIGNAL-I-PDUS") is None
+
+
+class TestWriterSystemSignal:
+    def test_full(self, writer):
+        signal = _make_system_signal()
+        signal.setDynamicLength(_bool(True))
+        parent = _parent()
+        writer.writeSystemSignal(parent, signal)
+        elem = parent.find("SYSTEM-SIGNAL")
+        assert elem is not None
+        assert elem.find("SHORT-NAME") is not None
+        assert elem.find("DYNAMIC-LENGTH") is not None
+
+    def test_without_dynamic_length(self, writer):
+        signal = _make_system_signal()
+        parent = _parent()
+        writer.writeSystemSignal(parent, signal)
+        elem = parent.find("SYSTEM-SIGNAL")
+        assert elem is not None
+        assert elem.find("DYNAMIC-LENGTH") is None
+
+
+class TestWriterGenericEthernetFrame:
+    def test_full(self, writer):
+        frame = _make_ethernet_frame()
+        parent = _parent()
+        writer.writeGenericEthernetFrame(parent, frame)
+        elem = parent.find("ETHERNET-FRAME")
+        assert elem is not None
+        assert elem.find("SHORT-NAME") is not None
+
+
+class TestWriterSetLifeCyclePeriod:
+    def test_with_period(self, writer):
+        period = LifeCyclePeriod()
+        period.setArReleaseVersion(_revision_label("R23-11"))
+        parent = _parent()
+        writer.setLifeCyclePeriod(parent, "PERIOD-BEGIN", period)
+        assert parent[0].tag == "PERIOD-BEGIN"
+        assert parent[0].find("AR-RELEASE-VERSION") is not None
+        assert parent[0].find("AR-RELEASE-VERSION").text == "R23-11"
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.setLifeCyclePeriod(parent, "PERIOD-BEGIN", None)
+        assert len(parent) == 0
+
+
+class TestWriterLifeCycleInfoUseInsteadRefs:
+    def test_with_refs(self, writer):
+        info = LifeCycleInfo()
+        info.addUseInsteadRef(_ref("/u1", "LIFE-CYCLE-INFO"))
+        info.addUseInsteadRef(_ref("/u2", "LIFE-CYCLE-INFO"))
+        parent = _parent()
+        writer.writeLifeCycleInfoUseInsteadRefs(parent, info)
+        assert parent[0].tag == "USE-INSTEAD-REFS"
+        refs = parent[0].findall("USE-INSTEAD-REF")
+        assert len(refs) == 2
+
+    def test_empty(self, writer):
+        info = LifeCycleInfo()
+        parent = _parent()
+        writer.writeLifeCycleInfoUseInsteadRefs(parent, info)
+        assert len(parent) == 0
+
+
+class TestWriterLifeCycleInfo:
+    def test_full(self, writer):
+        info = LifeCycleInfo()
+        info.setLcObjectRef(_ref("/obj", "REFERRABLE"))
+        info.setLcStateRef(_ref("/state", "LIFE-CYCLE-STATE"))
+        period = LifeCyclePeriod()
+        period.setArReleaseVersion(_revision_label("R23-11"))
+        info.setPeriodBegin(period)
+        info.setRemark(DocumentationBlock())
+        info.addUseInsteadRef(_ref("/u", "LIFE-CYCLE-INFO"))
+        parent = _parent()
+        writer.writeLifeCycleInfo(parent, info)
+        elem = parent.find("LIFE-CYCLE-INFO")
+        assert elem is not None
+        assert elem.find("LC-OBJECT-REF") is not None
+        assert elem.find("LC-STATE-REF") is not None
+        assert elem.find("PERIOD-BEGIN") is not None
+        assert elem.find("REMARK") is not None
+        assert elem.find("USE-INSTEAD-REFS") is not None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeLifeCycleInfo(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterLifeCycleInfoSetLifeCycleInfos:
+    def test_with_infos(self, writer):
+        info_set = _make_life_cycle_info_set()
+        info1 = LifeCycleInfo()
+        info1.setLcObjectRef(_ref("/o1", "REFERRABLE"))
+        info2 = LifeCycleInfo()
+        info2.setLcObjectRef(_ref("/o2", "REFERRABLE"))
+        info_set.addLifeCycleInfo(info1)
+        info_set.addLifeCycleInfo(info2)
+        parent = _parent()
+        writer.writeLifeCycleInfoSetLifeCycleInfos(parent, info_set)
+        assert parent[0].tag == "LIFE-CYCLE-INFOS"
+        infos = parent[0].findall("LIFE-CYCLE-INFO")
+        assert len(infos) == 2
+
+    def test_empty(self, writer):
+        info_set = _make_life_cycle_info_set()
+        parent = _parent()
+        writer.writeLifeCycleInfoSetLifeCycleInfos(parent, info_set)
+        assert len(parent) == 0
+
+
+class TestWriterLifeCycleInfoSet:
+    def test_full(self, writer):
+        info_set = _make_life_cycle_info_set()
+        info_set.setDefaultLcStateRef(
+            _ref("/dstate", "LIFE-CYCLE-STATE-DEFINITION")
+        )
+        info = LifeCycleInfo()
+        info.setLcObjectRef(_ref("/obj", "REFERRABLE"))
+        info_set.addLifeCycleInfo(info)
+        info_set.setUsedLifeCycleStateDefinitionGroupRef(
+            _ref("/grp", "LIFE-CYCLE-STATE-DEFINITION-GROUP")
+        )
+        parent = _parent()
+        writer.writeLifeCycleInfoSet(parent, info_set)
+        elem = parent.find("LIFE-CYCLE-INFO-SET")
+        assert elem is not None
+        assert elem.find("SHORT-NAME") is not None
+        assert elem.find("DEFAULT-LC-STATE-REF") is not None
+        assert elem.find("LIFE-CYCLE-INFOS") is not None
+        assert elem.find(
+            "USED-LIFE-CYCLE-STATE-DEFINITION-GROUP-REF"
+        ) is not None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeLifeCycleInfoSet(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterDiagnosticConnectionFunctionalRequestRefs:
+    def test_with_refs(self, writer):
+        conn = _make_diagnostic_connection()
+        conn.addFunctionalRequestRef(_ref("/f1", "DIAGNOSTIC-REQUEST"))
+        conn.addFunctionalRequestRef(_ref("/f2", "DIAGNOSTIC-REQUEST"))
+        parent = _parent()
+        writer.writeDiagnosticConnectionFunctionalRequestRefs(parent, conn)
+        assert parent[0].tag == "FUNCTIONAL-REQUEST-REFS"
+        refs = parent[0].findall("FUNCTIONAL-REQUEST-REF")
+        assert len(refs) == 2
+
+    def test_empty(self, writer):
+        conn = _make_diagnostic_connection()
+        parent = _parent()
+        writer.writeDiagnosticConnectionFunctionalRequestRefs(parent, conn)
+        assert len(parent) == 0
+
+
+class TestWriterDiagnosticConnection:
+    def test_full(self, writer):
+        conn = _make_diagnostic_connection()
+        conn.addFunctionalRequestRef(_ref("/f", "DIAGNOSTIC-REQUEST"))
+        conn.setPhysicalRequestRef(_ref("/p", "DIAGNOSTIC-REQUEST"))
+        conn.setResponseOnEventRef(_ref("/r", "DIAGNOSTIC-RESPONSE"))
+        parent = _parent()
+        writer.writeDiagnosticConnection(parent, conn)
+        elem = parent.find("DIAGNOSTIC-CONNECTION")
+        assert elem is not None
+        assert elem.find("SHORT-NAME") is not None
+        assert elem.find("FUNCTIONAL-REQUEST-REFS") is not None
+        assert elem.find("PHYSICAL-REQUEST-REF") is not None
+        assert elem.find("RESPONSE-REF") is not None
+
+
+class TestWriterDiagnosticServiceTableDiagnosticConnectionRefs:
+    def test_with_refs(self, writer):
+        table = _make_diagnostic_service_table()
+        table.addDiagnosticConnectionRef(_ref("/c1", "DIAGNOSTIC-CONNECTION"))
+        table.addDiagnosticConnectionRef(_ref("/c2", "DIAGNOSTIC-CONNECTION"))
+        parent = _parent()
+        writer.writeDiagnosticServiceTableDiagnosticConnectionRefs(
+            parent, table
+        )
+        assert parent[0].tag == "DIAGNOSTIC-CONNECTIONS"
+        conds = parent[0].findall("DIAGNOSTIC-CONNECTION-REF-CONDITIONAL")
+        assert len(conds) == 2
+
+    def test_empty(self, writer):
+        table = _make_diagnostic_service_table()
+        parent = _parent()
+        writer.writeDiagnosticServiceTableDiagnosticConnectionRefs(
+            parent, table
+        )
+        assert len(parent) == 0
+
+
+class TestWriterDiagnosticServiceTable:
+    def test_full(self, writer):
+        table = _make_diagnostic_service_table()
+        table.addDiagnosticConnectionRef(
+            _ref("/c", "DIAGNOSTIC-CONNECTION")
+        )
+        table.setEcuInstanceRef(_ref("/ecu", "ECU-INSTANCE"))
+        parent = _parent()
+        writer.writeDiagnosticServiceTable(parent, table)
+        elem = parent.find("DIAGNOSTIC-SERVICE-TABLE")
+        assert elem is not None
+        assert elem.find("SHORT-NAME") is not None
+        assert elem.find("DIAGNOSTIC-CONNECTIONS") is not None
+        assert elem.find("ECU-INSTANCE-REF") is not None

--- a/tests/test_armodel/writer/test_writer_system_mapping.py
+++ b/tests/test_armodel/writer/test_writer_system_mapping.py
@@ -1,0 +1,881 @@
+"""Tests for writer System, Mapping, FlatMap, and Gateway handlers."""
+import xml.etree.cElementTree as ET
+import pytest
+
+from armodel.writer.arxml_writer import ARXMLWriter
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate import (
+    SwcToEcuMapping,
+    System,
+    SystemMapping,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DataMapping import (
+    SenderReceiverToSignalGroupMapping,
+    SenderReceiverToSignalMapping,
+    SenderRecRecordElementMapping,
+    SenderRecRecordTypeMapping,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.ECUResourceMapping import (
+    ECUMapping,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.SWmapping import (
+    SwcToImplMapping,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.InstanceRefs import (
+    ComponentInSystemInstanceRef,
+    VariableDataPrototypeInSystemInstanceRef,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (  # noqa: E501
+    ISignal,
+    SystemSignalGroup,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform import (  # noqa: E501
+    Gateway,
+    IPduMapping,
+    ISignalMapping,
+    TargetIPduRef,
+)
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.FlatMap import (
+    FlatInstanceDescriptor,
+    FlatMap,
+)
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import (
+    ModeDeclarationGroupPrototypeMapping,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import (
+    ClientServerInterfaceMapping,
+    ClientServerOperationMapping,
+    DataPrototypeMapping,
+    ModeInterfaceMapping,
+    PortInterfaceMappingSet,
+    VariableAndParameterInterfaceMapping,
+)
+from armodel.models.M2.MSR.AsamHdo.Units import PhysicalDimension
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import (  # noqa: E501
+    AnyInstanceRef,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa: E501
+    ARLiteral,
+    ARNumerical,
+    RefType,
+    RevisionLabelString,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+def _parent():
+    return ET.Element("PARENT")
+
+
+def _ref(value, dest=None):
+    ref = RefType()
+    ref.setValue(value)
+    if dest is not None:
+        ref.setDest(dest)
+    return ref
+
+
+def _literal(value):
+    lit = ARLiteral()
+    lit.setValue(value)
+    return lit
+
+
+def _numerical(value):
+    n = ARNumerical()
+    n.setValue(str(value))
+    return n
+
+
+def _revision(value):
+    r = RevisionLabelString()
+    r.setValue(value)
+    return r
+
+
+def _pkg():
+    return AUTOSAR.getInstance().createARPackage("Pkg")
+
+
+def _var_iref():
+    iref = VariableDataPrototypeInSystemInstanceRef()
+    iref.setContextCompositionRef(_ref("/c", "ROOT-SW-COMPOSITION-PROTOTYPE"))
+    iref.setTargetDataPrototypeRef(_ref("/vdp", "VARIABLE-DATA-PROTOTYPE"))
+    return iref
+
+
+def _component_iref():
+    iref = ComponentInSystemInstanceRef()
+    iref.setContextCompositionRef(_ref("/c", "ROOT-SW-COMPOSITION-PROTOTYPE"))
+    iref.setTargetComponentRef(_ref("/swc", "SW-COMPONENT-TYPE"))
+    return iref
+
+
+def _any_iref():
+    iref = AnyInstanceRef()
+    iref.setBaseRef(_ref("/b", "SW-COMPONENT-TYPE"))
+    iref.setTargetRef(_ref("/t", "VARIABLE-DATA-PROTOTYPE"))
+    return iref
+
+
+def _make_system():
+    return _pkg().createSystem("Sys")
+
+
+def _make_system_mapping():
+    return _make_system().createSystemMapping("SM")
+
+
+def _make_flat_map():
+    return _pkg().createFlatMap("FM")
+
+
+def _make_physical_dimension():
+    return _pkg().createPhysicalDimension("PD")
+
+
+def _make_gateway():
+    return _pkg().createGateway("GW")
+
+
+def _make_isignal():
+    return _pkg().createISignal("ISig")
+
+
+def _make_system_signal_group():
+    return _pkg().createSystemSignalGroup("SSG")
+
+
+def _make_mapping_set():
+    return _pkg().createPortInterfaceMappingSet("PIMS")
+
+
+class TestWriterSystemSignalGroup:
+    def test_with_signal_refs(self, writer):
+        group = _make_system_signal_group()
+        group.addSystemSignalRefs(_ref("/s1", "SYSTEM-SIGNAL"))
+        group.addSystemSignalRefs(_ref("/s2", "SYSTEM-SIGNAL"))
+        parent = _parent()
+        writer.writeSystemSignalGroup(parent, group)
+        assert parent[0].tag == "SYSTEM-SIGNAL-GROUP"
+        refs = parent[0].find("SYSTEM-SIGNAL-REFS")
+        assert refs is not None
+        assert len(refs.findall("SYSTEM-SIGNAL-REF")) == 2
+
+    def test_without_signal_refs(self, writer):
+        group = _make_system_signal_group()
+        parent = _parent()
+        writer.writeSystemSignalGroup(parent, group)
+        assert parent[0].tag == "SYSTEM-SIGNAL-GROUP"
+        assert parent[0].find("SYSTEM-SIGNAL-REFS") is None
+
+
+class TestWriterSenderReceiverToSignalMapping:
+    def test_full(self, writer):
+        mapping = SenderReceiverToSignalMapping()
+        mapping.setCommunicationDirection(_literal("in"))
+        mapping.setDataElementIRef(_var_iref())
+        mapping.setSystemSignalRef(_ref("/ss", "SYSTEM-SIGNAL"))
+        parent = _parent()
+        writer.writeSenderReceiverToSignalMapping(parent, mapping)
+        m = parent[0]
+        assert m.tag == "SENDER-RECEIVER-TO-SIGNAL-MAPPING"
+        assert m.find("COMMUNICATION-DIRECTION").text == "in"
+        assert m.find("DATA-ELEMENT-IREF") is not None
+        assert m.find("SYSTEM-SIGNAL-REF") is not None
+
+    def test_minimal(self, writer):
+        mapping = SenderReceiverToSignalMapping()
+        parent = _parent()
+        writer.writeSenderReceiverToSignalMapping(parent, mapping)
+        assert parent[0].tag == "SENDER-RECEIVER-TO-SIGNAL-MAPPING"
+        assert parent[0].find("COMMUNICATION-DIRECTION") is None
+
+
+class TestWriterSenderRecCompositeTypeMapping:
+    def test_writes_attributes(self, writer):
+        mapping = SenderRecRecordTypeMapping()
+        mapping.uuid = "abc-123"
+        parent = _parent()
+        writer.writeSenderRecCompositeTypeMapping(parent, mapping)
+        assert len(parent) == 0
+        assert parent.attrib.get("UUID") == "abc-123"
+
+
+class TestWriterSenderRecRecordElementMapping:
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeSenderRecRecordElementMapping(parent, None)
+        assert len(parent) == 0
+
+    def test_full(self, writer):
+        mapping = SenderRecRecordElementMapping()
+        mapping.setApplicationRecordElementRef(_ref("/a", "APPLICATION-RECORD-ELEMENT"))
+        mapping.setImplementationRecordElementRef(
+            _ref("/i", "IMPLEMENTATION-RECORD-ELEMENT")
+        )
+        mapping.setSystemSignalRef(_ref("/ss", "SYSTEM-SIGNAL"))
+        parent = _parent()
+        writer.writeSenderRecRecordElementMapping(parent, mapping)
+        m = parent[0]
+        assert m.tag == "SENDER-REC-RECORD-ELEMENT-MAPPING"
+        assert m.find("APPLICATION-RECORD-ELEMENT-REF") is not None
+        assert m.find("IMPLEMENTATION-RECORD-ELEMENT-REF") is not None
+        assert m.find("SYSTEM-SIGNAL-REF") is not None
+
+
+class TestWriterSenderRecArrayTypeMappingRecordElementMapping:
+    def test_empty(self, writer):
+        mapping = SenderRecRecordTypeMapping()
+        parent = _parent()
+        writer.writeSenderRecArrayTypeMappingRecordElementMapping(parent, mapping)
+        assert len(parent) == 0
+
+    def test_with_mappings(self, writer):
+        mapping = SenderRecRecordTypeMapping()
+        elem1 = SenderRecRecordElementMapping()
+        elem1.setSystemSignalRef(_ref("/s1", "SYSTEM-SIGNAL"))
+        elem2 = SenderRecRecordElementMapping()
+        elem2.setSystemSignalRef(_ref("/s2", "SYSTEM-SIGNAL"))
+        mapping.addRecordElementMapping(elem1)
+        mapping.addRecordElementMapping(elem2)
+        parent = _parent()
+        writer.writeSenderRecArrayTypeMappingRecordElementMapping(parent, mapping)
+        assert parent[0].tag == "RECORD-ELEMENT-MAPPINGS"
+        elems = parent[0].findall("SENDER-REC-RECORD-ELEMENT-MAPPING")
+        assert len(elems) == 2
+
+
+class TestWriterSenderRecRecordTypeMapping:
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeSenderRecRecordTypeMapping(parent, None)
+        assert len(parent) == 0
+
+    def test_with_mapping(self, writer):
+        mapping = SenderRecRecordTypeMapping()
+        elem = SenderRecRecordElementMapping()
+        elem.setSystemSignalRef(_ref("/s", "SYSTEM-SIGNAL"))
+        mapping.addRecordElementMapping(elem)
+        parent = _parent()
+        writer.writeSenderRecRecordTypeMapping(parent, mapping)
+        m = parent[0]
+        assert m.tag == "SENDER-REC-RECORD-TYPE-MAPPING"
+        assert m.find("RECORD-ELEMENT-MAPPINGS") is not None
+
+
+class TestWriterSenderReceiverToSignalGroupMappingTypeMapping:
+    def test_no_type_mapping(self, writer):
+        mapping = SenderReceiverToSignalGroupMapping()
+        parent = _parent()
+        writer.writeSenderReceiverToSignalGroupMappingTypeMapping(parent, mapping)
+        assert len(parent) == 0
+
+    def test_with_record_type_mapping(self, writer):
+        mapping = SenderReceiverToSignalGroupMapping()
+        type_mapping = SenderRecRecordTypeMapping()
+        elem = SenderRecRecordElementMapping()
+        elem.setSystemSignalRef(_ref("/s", "SYSTEM-SIGNAL"))
+        type_mapping.addRecordElementMapping(elem)
+        mapping.setTypeMapping(type_mapping)
+        parent = _parent()
+        writer.writeSenderReceiverToSignalGroupMappingTypeMapping(parent, mapping)
+        tm = parent[0]
+        assert tm.tag == "TYPE-MAPPING"
+        assert tm.find("SENDER-REC-RECORD-TYPE-MAPPING") is not None
+
+
+class TestWriterSenderReceiverToSignalGroupMapping:
+    def test_full(self, writer):
+        mapping = SenderReceiverToSignalGroupMapping()
+        mapping.setDataElementIRef(_var_iref())
+        mapping.setSignalGroupRef(_ref("/sg", "SYSTEM-SIGNAL-GROUP"))
+        type_mapping = SenderRecRecordTypeMapping()
+        mapping.setTypeMapping(type_mapping)
+        parent = _parent()
+        writer.writeSenderReceiverToSignalGroupMapping(parent, mapping)
+        m = parent[0]
+        assert m.tag == "SENDER-RECEIVER-TO-SIGNAL-GROUP-MAPPING"
+        assert m.find("DATA-ELEMENT-IREF") is not None
+        assert m.find("SIGNAL-GROUP-REF") is not None
+        assert m.find("TYPE-MAPPING") is not None
+
+
+class TestWriterSystemMappingDataMappings:
+    def test_empty(self, writer):
+        sm = _make_system_mapping()
+        parent = _parent()
+        writer.writeSystemMappingDataMappings(parent, sm)
+        assert len(parent) == 0
+
+    def test_dispatches_both_types(self, writer):
+        sm = _make_system_mapping()
+        sm.addDataMapping(SenderReceiverToSignalMapping())
+        group = SenderReceiverToSignalGroupMapping()
+        group.setTypeMapping(SenderRecRecordTypeMapping())
+        sm.addDataMapping(group)
+        parent = _parent()
+        writer.writeSystemMappingDataMappings(parent, sm)
+        assert parent[0].tag == "DATA-MAPPINGS"
+        tags = {c.tag for c in parent[0]}
+        assert "SENDER-RECEIVER-TO-SIGNAL-MAPPING" in tags
+        assert "SENDER-RECEIVER-TO-SIGNAL-GROUP-MAPPING" in tags
+
+
+class TestWriterSetSwcToEcuMapping:
+    def test_full(self, writer):
+        sm = _make_system_mapping()
+        mapping = sm.createSwcToEcuMapping("SwcEcu")
+        mapping.addComponentIRef(_component_iref())
+        mapping.setEcuInstanceRef(_ref("/ei", "ECU-INSTANCE"))
+        parent = _parent()
+        writer.setSwcToEcuMapping(parent, mapping)
+        m = parent[0]
+        assert m.tag == "SWC-TO-ECU-MAPPING"
+        assert m.find("COMPONENT-IREFS") is not None
+        assert m.find("COMPONENT-IREFS/COMPONENT-IREF") is not None
+        assert m.find("ECU-INSTANCE-REF") is not None
+
+    def test_without_irefs(self, writer):
+        sm = _make_system_mapping()
+        mapping = sm.createSwcToEcuMapping("SwcEcu")
+        parent = _parent()
+        writer.setSwcToEcuMapping(parent, mapping)
+        assert parent[0].tag == "SWC-TO-ECU-MAPPING"
+        assert parent[0].find("COMPONENT-IREFS") is None
+
+
+class TestWriterSystemMappingSwMappings:
+    def test_empty(self, writer):
+        sm = _make_system_mapping()
+        parent = _parent()
+        writer.writeSystemMappingSwMappings(parent, sm)
+        assert len(parent) == 0
+
+    def test_with_mapping(self, writer):
+        sm = _make_system_mapping()
+        sm.createSwcToEcuMapping("SwcEcu")
+        parent = _parent()
+        writer.writeSystemMappingSwMappings(parent, sm)
+        assert parent[0].tag == "SW-MAPPINGS"
+        assert parent[0].find("SWC-TO-ECU-MAPPING") is not None
+
+
+class TestWriterEcuMapping:
+    def test_minimal(self, writer):
+        sm = _make_system_mapping()
+        sm.createECUMapping("EM")
+        parent = _parent()
+        writer.writeEcuMapping(parent, sm.getEcuResourceMappings()[0])
+        m = parent[0]
+        assert m.tag == "ECU-MAPPING"
+        assert m.find("ECU-INSTANCE-REF") is None
+        assert m.find("ECU-REF") is None
+
+    def test_full(self, writer):
+        sm = _make_system_mapping()
+        mapping = sm.createECUMapping("EM")
+        mapping.setEcuInstanceRef(_ref("/ei", "ECU-INSTANCE"))
+        mapping.setEcuRef(_ref("/e", "ECU-INSTANCE"))
+        parent = _parent()
+        writer.writeEcuMapping(parent, mapping)
+        m = parent[0]
+        assert m.tag == "ECU-MAPPING"
+        assert m.find("ECU-INSTANCE-REF") is not None
+        assert m.find("ECU-REF") is not None
+
+
+class TestWriterSystemMappingEcuResourceMappings:
+    def test_empty(self, writer):
+        sm = _make_system_mapping()
+        parent = _parent()
+        writer.writeSystemMappingEcuResourceMappings(parent, sm)
+        assert len(parent) == 0
+
+    def test_with_mapping(self, writer):
+        sm = _make_system_mapping()
+        sm.createECUMapping("EM")
+        parent = _parent()
+        writer.writeSystemMappingEcuResourceMappings(parent, sm)
+        assert parent[0].tag == "ECU-RESOURCE-MAPPINGS"
+        assert parent[0].find("ECU-MAPPING") is not None
+
+
+class TestWriterSwcToImplMapping:
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeSwcToImplMapping(parent, None)
+        assert len(parent) == 0
+
+    def test_full(self, writer):
+        sm = _make_system_mapping()
+        mapping = sm.createSwcToImplMapping("SwcImpl")
+        mapping.setComponentImplementationRef(
+            _ref("/ci", "SWC-IMPLEMENTATION")
+        )
+        mapping.addComponentIRef(_component_iref())
+        parent = _parent()
+        writer.writeSwcToImplMapping(parent, mapping)
+        m = parent[0]
+        assert m.tag == "SWC-TO-IMPL-MAPPING"
+        assert m.find("COMPONENT-IMPLEMENTATION-REF") is not None
+        assert m.find("COMPONENT-IREFS") is not None
+        assert m.find("COMPONENT-IREFS/COMPONENT-IREF") is not None
+
+
+class TestWriterSystemMappingSwImplMappings:
+    def test_empty(self, writer):
+        sm = _make_system_mapping()
+        parent = _parent()
+        writer.writeSystemMappingSwImplMappings(parent, sm)
+        assert len(parent) == 0
+
+    def test_with_mapping(self, writer):
+        sm = _make_system_mapping()
+        sm.createSwcToImplMapping("SwcImpl")
+        parent = _parent()
+        writer.writeSystemMappingSwImplMappings(parent, sm)
+        assert parent[0].tag == "SW-IMPL-MAPPINGS"
+        assert parent[0].find("SWC-TO-IMPL-MAPPING") is not None
+
+
+class TestWriterSystemMapping:
+    def test_full(self, writer):
+        sm = _make_system_mapping()
+        sm.addDataMapping(SenderReceiverToSignalMapping())
+        sm.createECUMapping("EM")
+        sm.createSwcToImplMapping("SwcImpl")
+        sm.createSwcToEcuMapping("SwcEcu")
+        parent = _parent()
+        writer.writeSystemMapping(parent, sm)
+        m = parent[0]
+        assert m.tag == "SYSTEM-MAPPING"
+        assert m.find("DATA-MAPPINGS") is not None
+        assert m.find("ECU-RESOURCE-MAPPINGS") is not None
+        assert m.find("SW-IMPL-MAPPINGS") is not None
+        assert m.find("SW-MAPPINGS") is not None
+
+
+class TestWriterSystemMappings:
+    def test_empty(self, writer):
+        system = _make_system()
+        parent = _parent()
+        writer.writeSystemMappings(parent, system)
+        assert len(parent) == 0
+
+    def test_with_mapping(self, writer):
+        system = _make_system()
+        system.createSystemMapping("SM")
+        parent = _parent()
+        writer.writeSystemMappings(parent, system)
+        assert parent[0].tag == "MAPPINGS"
+        assert parent[0].find("SYSTEM-MAPPING") is not None
+
+
+class TestWriterRootSwCompositionPrototype:
+    def test_none(self, writer):
+        system = _make_system()
+        parent = _parent()
+        writer.writeRootSwCompositionPrototype(parent, system)
+        assert len(parent) == 0
+
+    def test_full(self, writer):
+        system = _make_system()
+        root = system.createRootSoftwareComposition("Root")
+        root.setFlatMapRef(_ref("/fm", "FLAT-MAP"))
+        root.setSoftwareCompositionTRef(_ref("/sc", "SW-COMPONENT-TYPE"))
+        parent = _parent()
+        writer.writeRootSwCompositionPrototype(parent, system)
+        outer = parent[0]
+        assert outer.tag == "ROOT-SOFTWARE-COMPOSITIONS"
+        proto = outer.find("ROOT-SW-COMPOSITION-PROTOTYPE")
+        assert proto is not None
+        assert proto.find("FLAT-MAP-REF") is not None
+        assert proto.find("SOFTWARE-COMPOSITION-TREF") is not None
+
+
+class TestWriterSystemFibexElementRefs:
+    def test_empty(self, writer):
+        system = _make_system()
+        parent = _parent()
+        writer.writeSystemFibexElementRefs(parent, system)
+        assert len(parent) == 0
+
+    def test_with_refs(self, writer):
+        system = _make_system()
+        system.addFibexElementRef(_ref("/f1", "I-SIGNAL-I-PDU"))
+        system.addFibexElementRef(_ref("/f2", "I-SIGNAL-I-PDU"))
+        parent = _parent()
+        writer.writeSystemFibexElementRefs(parent, system)
+        assert parent[0].tag == "FIBEX-ELEMENTS"
+        conds = parent[0].findall("FIBEX-ELEMENT-REF-CONDITIONAL")
+        assert len(conds) == 2
+        assert conds[0].find("FIBEX-ELEMENT-REF") is not None
+
+
+class TestWriterSystem:
+    def test_full(self, writer):
+        system = _make_system()
+        system.setEcuExtractVersion(_revision("1.0.0"))
+        system.addFibexElementRef(_ref("/f", "I-SIGNAL-I-PDU"))
+        system.createSystemMapping("SM")
+        root = system.createRootSoftwareComposition("Root")
+        root.setFlatMapRef(_ref("/fm", "FLAT-MAP"))
+        system.setSystemVersion(_revision("2.0.0"))
+        parent = _parent()
+        writer.writeSystem(parent, system)
+        s = parent[0]
+        assert s.tag == "SYSTEM"
+        assert s.find("ECU-EXTRACT-VERSION") is not None
+        assert s.find("FIBEX-ELEMENTS") is not None
+        assert s.find("MAPPINGS") is not None
+        assert s.find("ROOT-SOFTWARE-COMPOSITIONS") is not None
+        assert s.find("SYSTEM-VERSION") is not None
+
+
+class TestWriterPhysicalDimension:
+    def test_full(self, writer):
+        dim = _make_physical_dimension()
+        dim.setLengthExp(_numerical(1))
+        dim.setLuminousIntensityExp(_numerical(2))
+        dim.setMassExp(_numerical(3))
+        dim.setMolarAmountExp(_numerical(4))
+        dim.setTemperatureExp(_numerical(5))
+        dim.setTimeExp(_numerical(6))
+        dim.setCurrentExp(_numerical(7))
+        parent = _parent()
+        writer.writePhysicalDimension(parent, dim)
+        d = parent[0]
+        assert d.tag == "PHYSICAL-DIMENSION"
+        assert d.find("LENGTH-EXP").text == "1"
+        assert d.find("LUMINOUS-INTENSITY-EXP").text == "2"
+        assert d.find("MASS-EXP").text == "3"
+        assert d.find("MOLAR-AMOUNT-EXP").text == "4"
+        assert d.find("TEMPERATURE-EXP").text == "5"
+        assert d.find("TIME-EXP").text == "6"
+        assert d.find("CURRENT-EXP").text == "7"
+
+
+class TestWriterSetFlatInstanceDescriptor:
+    def test_full(self, writer):
+        fm = _make_flat_map()
+        desc = fm.createFlatInstanceDescriptor("Desc")
+        desc.setUpstreamReferenceIRef(_any_iref())
+        desc.setEcuExtractReferenceIRef(_any_iref())
+        parent = _parent()
+        writer.setFlatInstanceDescriptor(parent, desc)
+        d = parent[0]
+        assert d.tag == "FLAT-INSTANCE-DESCRIPTOR"
+        assert d.find("UPSTREAM-REFERENCE-IREF") is not None
+        assert d.find("ECU-EXTRACT-REFERENCE-IREF") is not None
+
+
+class TestWriterFlatMapInstances:
+    def test_empty(self, writer):
+        fm = _make_flat_map()
+        parent = _parent()
+        writer.writeFlatMapInstances(parent, fm)
+        assert len(parent) == 0
+
+    def test_with_instances(self, writer):
+        fm = _make_flat_map()
+        fm.createFlatInstanceDescriptor("D1")
+        fm.createFlatInstanceDescriptor("D2")
+        parent = _parent()
+        writer.writeFlatMapInstances(parent, fm)
+        assert parent[0].tag == "INSTANCES"
+        descs = parent[0].findall("FLAT-INSTANCE-DESCRIPTOR")
+        assert len(descs) == 2
+
+
+class TestWriterFlatMap:
+    def test_full(self, writer):
+        fm = _make_flat_map()
+        fm.createFlatInstanceDescriptor("D1")
+        parent = _parent()
+        writer.writeFlatMap(parent, fm)
+        assert parent[0].tag == "FLAT-MAP"
+        assert parent[0].find("INSTANCES") is not None
+
+
+class TestWriterSetDataPrototypeMapping:
+    def test_full(self, writer):
+        mapping = DataPrototypeMapping()
+        mapping.setFirstDataPrototypeRef(_ref("/f", "VARIABLE-DATA-PROTOTYPE"))
+        mapping.setSecondDataPrototypeRef(_ref("/s", "VARIABLE-DATA-PROTOTYPE"))
+        parent = _parent()
+        writer.setDataPrototypeMapping(parent, mapping)
+        m = parent[0]
+        assert m.tag == "DATA-PROTOTYPE-MAPPING"
+        assert m.find("FIRST-DATA-PROTOTYPE-REF") is not None
+        assert m.find("SECOND-DATA-PROTOTYPE-REF") is not None
+
+
+class TestWriterSetDataPrototypeMappings:
+    def test_empty(self, writer):
+        parent = _parent()
+        writer.setDataPrototypeMappings(parent, "DATA-MAPPINGS", [])
+        assert len(parent) == 0
+
+    def test_with_mappings(self, writer):
+        m1 = DataPrototypeMapping()
+        m1.setFirstDataPrototypeRef(_ref("/f1", "VARIABLE-DATA-PROTOTYPE"))
+        m2 = DataPrototypeMapping()
+        m2.setFirstDataPrototypeRef(_ref("/f2", "VARIABLE-DATA-PROTOTYPE"))
+        parent = _parent()
+        writer.setDataPrototypeMappings(parent, "DATA-MAPPINGS", [m1, m2])
+        assert parent[0].tag == "DATA-MAPPINGS"
+        assert len(parent[0].findall("DATA-PROTOTYPE-MAPPING")) == 2
+
+
+class TestWriterVariableAndParameterInterfaceMapping:
+    def test_full(self, writer):
+        ms = _make_mapping_set()
+        mapping = ms.createVariableAndParameterInterfaceMapping("VPIM")
+        dm = DataPrototypeMapping()
+        dm.setFirstDataPrototypeRef(_ref("/f", "VARIABLE-DATA-PROTOTYPE"))
+        mapping.addDataMapping(dm)
+        parent = _parent()
+        writer.writeVariableAndParameterInterfaceMapping(parent, mapping)
+        m = parent[0]
+        assert m.tag == "VARIABLE-AND-PARAMETER-INTERFACE-MAPPING"
+        assert m.find("DATA-MAPPINGS") is not None
+        assert m.find("DATA-MAPPINGS/DATA-PROTOTYPE-MAPPING") is not None
+
+
+class TestWriterClientServerOperationMapping:
+    def test_full(self, writer):
+        mapping = ClientServerOperationMapping()
+        mapping.setFirstOperationRef(_ref("/o1", "CLIENT-SERVER-OPERATION"))
+        mapping.setSecondOperationRef(_ref("/o2", "CLIENT-SERVER-OPERATION"))
+        parent = _parent()
+        writer.writeClientServerOperationMapping(parent, mapping)
+        m = parent[0]
+        assert m.tag == "CLIENT-SERVER-OPERATION-MAPPING"
+        assert m.find("FIRST-OPERATION-REF") is not None
+        assert m.find("SECOND-OPERATION-REF") is not None
+
+
+class TestWriterClientServerInterfaceMappingOperationMappings:
+    def test_empty(self, writer):
+        ms = _make_mapping_set()
+        mapping = ms.createClientServerInterfaceMapping("CSIM")
+        parent = _parent()
+        writer.writeClientServerInterfaceMappingOperationMappings(parent, mapping)
+        assert len(parent) == 0
+
+    def test_with_mappings(self, writer):
+        ms = _make_mapping_set()
+        mapping = ms.createClientServerInterfaceMapping("CSIM")
+        op = ClientServerOperationMapping()
+        op.setFirstOperationRef(_ref("/o", "CLIENT-SERVER-OPERATION"))
+        mapping.addOperationMapping(op)
+        parent = _parent()
+        writer.writeClientServerInterfaceMappingOperationMappings(parent, mapping)
+        assert parent[0].tag == "OPERATION-MAPPINGS"
+        assert parent[0].find("CLIENT-SERVER-OPERATION-MAPPING") is not None
+
+
+class TestWriterClientServerInterfaceMapping:
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeClientServerInterfaceMapping(parent, None)
+        assert len(parent) == 0
+
+    def test_full(self, writer):
+        ms = _make_mapping_set()
+        mapping = ms.createClientServerInterfaceMapping("CSIM")
+        op = ClientServerOperationMapping()
+        op.setFirstOperationRef(_ref("/o", "CLIENT-SERVER-OPERATION"))
+        mapping.addOperationMapping(op)
+        parent = _parent()
+        writer.writeClientServerInterfaceMapping(parent, mapping)
+        m = parent[0]
+        assert m.tag == "CLIENT-SERVER-INTERFACE-MAPPING"
+        assert m.find("OPERATION-MAPPINGS") is not None
+
+
+class TestWriterModeInterfaceMappingModeMapping:
+    def test_no_mode_mapping(self, writer):
+        ms = _make_mapping_set()
+        mapping = ms.createModeInterfaceMapping("MIM")
+        parent = _parent()
+        writer.writeModeInterfaceMappingModeMapping(parent, mapping)
+        assert len(parent) == 0
+
+    def test_with_mode_mapping(self, writer):
+        ms = _make_mapping_set()
+        mapping = ms.createModeInterfaceMapping("MIM")
+        mm = ModeDeclarationGroupPrototypeMapping()
+        mm.setFirstModeGroupRef(_ref("/f", "MODE-DECLARATION-GROUP-PROTOTYPE"))
+        mm.setModeDeclarationMappingSetRef(_ref("/m", "MODE-DECLARATION-MAPPING-SET"))
+        mm.setSecondModeGroupRef(_ref("/s", "MODE-DECLARATION-GROUP-PROTOTYPE"))
+        mapping.setModeMapping(mm)
+        parent = _parent()
+        writer.writeModeInterfaceMappingModeMapping(parent, mapping)
+        mm_tag = parent[0]
+        assert mm_tag.tag == "MODE-MAPPING"
+        assert mm_tag.find("FIRST-MODE-GROUP-REF") is not None
+        assert mm_tag.find("MODE-DECLARATION-MAPPING-SET-REF") is not None
+        assert mm_tag.find("SECOND-MODE-GROUP-REF") is not None
+
+
+class TestWriterModeInterfaceMapping:
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeModeInterfaceMapping(parent, None)
+        assert len(parent) == 0
+
+    def test_full(self, writer):
+        ms = _make_mapping_set()
+        mapping = ms.createModeInterfaceMapping("MIM")
+        mm = ModeDeclarationGroupPrototypeMapping()
+        mm.setFirstModeGroupRef(_ref("/f", "MODE-DECLARATION-GROUP-PROTOTYPE"))
+        mapping.setModeMapping(mm)
+        parent = _parent()
+        writer.writeModeInterfaceMapping(parent, mapping)
+        m = parent[0]
+        assert m.tag == "MODE-INTERFACE-MAPPING"
+        assert m.find("MODE-MAPPING") is not None
+
+
+class TestWriterPortInterfaceMappings:
+    def test_empty(self, writer):
+        ms = _make_mapping_set()
+        parent = _parent()
+        writer.writePortInterfaceMappings(parent, ms)
+        assert len(parent) == 0
+
+    def test_dispatches_all_types(self, writer):
+        ms = _make_mapping_set()
+        ms.createVariableAndParameterInterfaceMapping("VPIM")
+        ms.createClientServerInterfaceMapping("CSIM")
+        ms.createModeInterfaceMapping("MIM")
+        parent = _parent()
+        writer.writePortInterfaceMappings(parent, ms)
+        assert parent[0].tag == "PORT-INTERFACE-MAPPINGS"
+        tags = {c.tag for c in parent[0]}
+        assert "VARIABLE-AND-PARAMETER-INTERFACE-MAPPING" in tags
+        assert "CLIENT-SERVER-INTERFACE-MAPPING" in tags
+        assert "MODE-INTERFACE-MAPPING" in tags
+
+
+class TestWriterPortInterfaceMappingSet:
+    def test_full(self, writer):
+        ms = _make_mapping_set()
+        ms.createVariableAndParameterInterfaceMapping("VPIM")
+        ms.createClientServerInterfaceMapping("CSIM")
+        ms.createModeInterfaceMapping("MIM")
+        parent = _parent()
+        writer.writePortInterfaceMappingSet(parent, ms)
+        m = parent[0]
+        assert m.tag == "PORT-INTERFACE-MAPPING-SET"
+        assert m.find("PORT-INTERFACE-MAPPINGS") is not None
+
+
+class TestWriterSetISignalMappings:
+    def test_empty(self, writer):
+        parent = _parent()
+        writer.setISignalMappings(parent, [])
+        assert len(parent) == 0
+
+    def test_with_mappings(self, writer):
+        m1 = ISignalMapping()
+        m1.setSourceSignalRef(_ref("/s1", "I-SIGNAL"))
+        m1.setTargetSignalRef(_ref("/t1", "I-SIGNAL"))
+        m2 = ISignalMapping()
+        m2.setSourceSignalRef(_ref("/s2", "I-SIGNAL"))
+        parent = _parent()
+        writer.setISignalMappings(parent, [m1, m2])
+        assert parent[0].tag == "SIGNAL-MAPPINGS"
+        ms = parent[0].findall("I-SIGNAL-MAPPING")
+        assert len(ms) == 2
+        assert ms[0].find("SOURCE-SIGNAL-REF") is not None
+        assert ms[0].find("TARGET-SIGNAL-REF") is not None
+
+
+class TestWriterSetTargetIPduRef:
+    def test_none(self, writer):
+        parent = _parent()
+        writer.setTargetIPduRef(parent, "TARGET-I-PDU", None)
+        assert len(parent) == 0
+
+    def test_with_ref(self, writer):
+        ref = TargetIPduRef()
+        ref.setTargetIPdu(_ref("/p", "I-SIGNAL-I-PDU"))
+        parent = _parent()
+        writer.setTargetIPduRef(parent, "TARGET-I-PDU", ref)
+        assert parent[0].tag == "TARGET-I-PDU"
+        assert parent[0].find("TARGET-I-PDU-REF") is not None
+
+
+class TestWriterSetIPduMappings:
+    def test_empty(self, writer):
+        parent = _parent()
+        writer.setIPduMappings(parent, [])
+        assert len(parent) == 0
+
+    def test_with_mappings(self, writer):
+        m1 = IPduMapping()
+        m1.setSourceIpduRef(_ref("/s1", "I-SIGNAL-I-PDU"))
+        target1 = TargetIPduRef()
+        target1.setTargetIPdu(_ref("/t1", "I-SIGNAL-I-PDU"))
+        m1.setTargetIPdu(target1)
+        m2 = IPduMapping()
+        m2.setSourceIpduRef(_ref("/s2", "I-SIGNAL-I-PDU"))
+        parent = _parent()
+        writer.setIPduMappings(parent, [m1, m2])
+        assert parent[0].tag == "I-PDU-MAPPINGS"
+        ms = parent[0].findall("I-PDU-MAPPING")
+        assert len(ms) == 2
+        assert ms[0].find("SOURCE-I-PDU-REF") is not None
+        assert ms[0].find("TARGET-I-PDU") is not None
+        assert ms[0].find("TARGET-I-PDU/TARGET-I-PDU-REF") is not None
+
+
+class TestWriterGateway:
+    def test_full(self, writer):
+        gw = _make_gateway()
+        gw.setEcuRef(_ref("/e", "ECU-INSTANCE"))
+        pdu = IPduMapping()
+        pdu.setSourceIpduRef(_ref("/s", "I-SIGNAL-I-PDU"))
+        gw.addIPduMapping(pdu)
+        sig = ISignalMapping()
+        sig.setSourceSignalRef(_ref("/ss", "I-SIGNAL"))
+        gw.addSignalMapping(sig)
+        parent = _parent()
+        writer.writeGateway(parent, gw)
+        g = parent[0]
+        assert g.tag == "GATEWAY"
+        assert g.find("ECU-REF") is not None
+        assert g.find("I-PDU-MAPPINGS") is not None
+        assert g.find("SIGNAL-MAPPINGS") is not None
+
+
+class TestWriterISignal:
+    def test_full(self, writer):
+        sig = _make_isignal()
+        sig.setDataTypePolicy(_literal("LEGACY"))
+        sig.setISignalType(_literal("FIXED-LENGTH"))
+        sig.setLength(_numerical(8))
+        sig.setSystemSignalRef(_ref("/ss", "SYSTEM-SIGNAL"))
+        parent = _parent()
+        writer.writeISignal(parent, sig)
+        s = parent[0]
+        assert s.tag == "I-SIGNAL"
+        assert s.find("DATA-TYPE-POLICY").text == "LEGACY"
+        assert s.find("I-SIGNAL-TYPE").text == "FIXED-LENGTH"
+        assert s.find("LENGTH").text == "8"
+        assert s.find("SYSTEM-SIGNAL-REF") is not None


### PR DESCRIPTION
## Summary

Add test coverage for writer Ethernet/CAN controller and EcuInstance methods (lines 4400-4704 of arxml_writer.py).

## Test Coverage

- 59 tests covering 39 writer methods
- EthernetCluster, MacMulticastGroup, CanFrame
- CommunicationController dispatch (CAN, Ethernet, Lin, Flexray)
- CouplingPort, VlanMembership
- CommunicationConnector dispatch (CAN, Ethernet, Lin, Flexray)
- EcuInstance full coverage

## Related

Part of ARXML Parser & Writer 100% Test Coverage implementation plan.