### PR TITLE
fix: enable branch coverage in test runner script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,16 @@ where = ["src"]
 
 [tool.setuptools.dynamic]
 version = {attr = "armodel.__version__"}
+
+[tool.coverage.run]
+branch = true
+source = ["armodel"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -167,6 +167,7 @@ def run_unit_tests(
     if run_coverage:
         cmd.extend([
             "--cov=armodel",
+            "--cov-branch",  # Enable branch coverage
             "--cov-report=term-missing",
             "--cov-report=html:htmlcov/unit",
             "--cov-report=xml:coverage_unit.xml",
@@ -242,7 +243,8 @@ def run_integration_tests(
     if run_coverage:
         cmd.extend([
             "--cov=armodel",
-            "--cov-append",
+            "--cov-branch",  # Enable branch coverage
+            # Note: Removed --cov-append to generate independent integration coverage report
             "--cov-report=term-missing",
             "--cov-report=html:htmlcov/integration",
             "--cov-report=xml:coverage_integration.xml",


### PR DESCRIPTION
Fix coverage report showing 0% branch coverage. Added --cov-branch flag and coverage configuration in pyproject.toml.