### PR TITLE
feat: MC/Rpt calibration support model with parser/writer coverage

### DIFF
--- a/docs/development/class_check_rules.md
+++ b/docs/development/class_check_rules.md
@@ -91,6 +91,21 @@ The class must reflect the AUTOSAR PDF specification for its attributes.
       `ARObject, AtpInstanceRef` must inherit `AtpInstanceRef`, matching its
       sibling instance-ref classes). The `Base` column also drives the
       `createXXX` vs `setXXX` choice (see 1.6 below).
+- [ ] **"`InstanceRef`"-named classes are not automatically refs.** A class
+      whose *name* ends in `InstanceRef` and whose attributes are the
+      `context`/`target` ref pair still takes its base from the spec `Base`
+      column — the name and shape do **not** justify a `RefType` or
+      `AtpInstanceRef` base. The spec note may explicitly state that the
+      class "follows the pattern of an InstanceRef but is not implemented
+      based on the abstract classes" (e.g. `ImplementationElementInParameterInstanceRef`,
+      Table 9.7, because `ImplementationDataTypeElement` isn't derived from
+      `AtpPrototype`); such a class inherits plain `ARObject` and its
+      `context`/`target` Kind-`ref` attributes map to `Optional[RefType]`
+      fields with the `Ref` suffix. A wrongly-inherited `RefType` base (a) is
+      flagged by `reports/deviation_class_hierarchy_mismatches.md` (expected
+      `ARObject`, got `RefType`) and (b) forces the parser/writer into the
+      flat-ref serialization shape for what is actually a typed iref
+      (Rule 1.7) — silently dropping the inner refs on round-trip.
 - [ ] Classes that inherit only from `ARObject` (no `Referrable`/`Identifiable`
       in `Base`) take no `parent`/`short_name` parameters: `__init__(self)`
       with all fields defaulted to `None`/`[]`. Check the spec `Base` column
@@ -161,7 +176,42 @@ The class must reflect the AUTOSAR PDF specification for its attributes.
       detect this on its own because it only verifies that listed methods
       exist; it does not verify that each field maps to the spec.
       Cross-check the `__init__` field list against the spec `Attribute` rows
-      and account for every field.
+      and account for every field. Two fabrication shapes recur that the
+      plain "field appears nowhere in the spec" framing under-describes, and
+      both are resolved by **removing** the fabricated field(s) and creating
+      the spec-aligned replacement(s), not by recording a deviation: (a)
+      **N:1 collapse** — a single generic fabricated field stands in for
+      *several* distinct spec attributes (e.g. `AliasNameAssignment.elementRef`
+      of type `AnyInstanceRef` collapsed the two mutually-exclusive spec refs
+      `identifiable` (Ref→Identifiable) and `flatInstance`
+      (Ref→FlatInstanceDescriptor) into one generic instance-ref); the fix is
+      N spec-aligned fields, each with its own concrete type and, for refs,
+      the proper DEST-typed `RefType` + `Ref` suffix — never one generic
+      field. (b) **Shadowing rename** — a field whose *name is invented* but
+      shadows a real spec attribute semantically (e.g. `aliasName` (a bare
+      `str`) shadowed spec `shortLabel` (a `String` primitive), both meaning
+      "the alias name"); there is no spec attribute with the invented name,
+      so this is fabrication, not a naming deviation (Rule 1.5), and the fix
+      is to rename to the spec name **and** re-type to the spec primitive
+      (`str` → `String`) in one step. (c) **Whole-class stub** — *every*
+      field is fabricated, so the class models none of its spec attributes:
+      one or two loosely-typed generic fields (`someName: str`,
+      `someRefs: List[RefType]`) with a complete accessor pair and a
+      plausible-sounding docstring, which together make the class look
+      implemented while the entire spec table is unrepresented. Shapes (a)
+      and (b) still leave *some* spec attribute modeled, so a spot check
+      finds real fields; a stub has none, and reviewing "does this field
+      look right?" per field never fires because each individual field is
+      internally consistent. The fix is a full rewrite from the spec table —
+      remove all fabricated fields, add one field + accessor pair per spec
+      attribute — not an incremental patch.
+      **Cheap detector for shape (c):** a class with **no `# Spec:` line and
+      no `# Spec verified:` marker** (Rules 2, 13.1) has never been through a
+      field-to-spec pass, so treat its *entire* field set as unverified
+      rather than assuming the fields are right and only the marker is
+      missing. A pre-rules checklist whose rows are all `[ ]` is the same
+      signal. Conversely, do not read a fully-`[x]` checklist as evidence of
+      field correctness — the checklist is method-only (Rule 2).
 - [ ] **PDF-table omission vs. fabricated API.** An attribute that is absent
       from the class's PDF `Attribute` column but **present in the XSD with a
       real documentation block** (no `atp.Status="removed"`) is *not*
@@ -285,6 +335,22 @@ The class must reflect the AUTOSAR PDF specification for its attributes.
       → field `measurableSystemConstantValuesRefs` with
       `addMeasurableSystemConstantValuesRef`/`getMeasurableSystemConstantValuesRefs` —
       the doubled trailing `s` is the correct suffix append, not a typo.
+- [ ] **A name mismatch is fixed by renaming, not recorded as a `naming`
+      deviation.** A field/accessor whose base name does not match the spec
+      `Attribute` column (e.g. spec `aliasName` modeled as `alias`/`aliases`,
+      or `targetRef` modeled as `target`) is always fixable — unlike a type
+      or multiplicity deviation that the XML representation can force, a name
+      has no such constraint. Recording such a mismatch as a `naming`
+      deviation row in `docs/method_deviation_by_class.md` and leaving it
+      there indefinitely is an anti-pattern that mirrors the "fabricated
+      attribute recorded instead of removed" smell (Rule 1.3): it documents a
+      bug rather than fixing it. The aligned action is to **rename** the
+      field and its accessors (and the checklist rows) to the spec base name,
+      update every consumer, and **remove** the `naming` deviation row — do
+      not leave a stale `naming` row once the name is corrected. A surviving
+      `naming` row in the tracker is itself a signal that the field-to-spec
+      cross-check has not actually been performed; treat it as a to-fix, not
+      as an accepted gap.
 
 ### 1.6 `createXXX` vs `setXXX`
 
@@ -371,7 +437,21 @@ The class must reflect the AUTOSAR PDF specification for its attributes.
       `MODE-GROUP-IREF`'s `P-MODE-GROUP...`/`R-MODE-GROUP...`, which dispatch
       on the child tag. Mixing the two shapes silently drops the inner refs on
       round-trip, because the reader looks for inner refs directly under the
-      iref element.
+      iref element. A third, sneakier shape is to treat the typed iref as a
+      **plain ref**: because the iref class name ends in `InstanceRef`, it may
+      inherit `RefType` and be serialized with the flat-ref helpers
+      (`getChildElementOptionalRefType`/`setChildElementOptionalRefType`),
+      which read/write the attribute-named element as a ref (its text
+      content) and never touch the inner refs — they vanish on round-trip
+      while the iref element itself survives and the model still carries the
+      iref object, so a unit-level get/set test passes. The parser must
+      construct the iref class and read the inner refs directly under the
+      attribute-named element, and the writer must emit them there
+      (`McDataInstance.instanceInMemory` → `<INSTANCE-IN-MEMORY><CONTEXT-REF>…</CONTEXT-REF><TARGET-REF>…</TARGET-REF></INSTANCE-IN-MEMORY>` —
+      no nested `<IMPLEMENTATION-ELEMENT-IN-PARAMETER-INSTANCE-REF>` wrapper,
+      no flat text). Check the XSD element's `type` attribute to tell a typed
+      iref from a plain `REF` element (which has `simpleContent` + `DEST`
+      instead of a class `type`); the base-class fix is Rule 1.2.
 - [ ] **Exception:** an attribute marked `Stereotypes: atpDerived` is a
       *derived* attribute — it is computed from its context and has **no**
       XML element, so it has no parser/writer element and is exempt from this
@@ -413,8 +493,45 @@ The class must reflect the AUTOSAR PDF specification for its attributes.
       plain `ARObject` children) rather than serializing placeholder fields —
       this keeps the XML schema-valid and the round-trip lossless at the
       aggregator level, and is recorded in the deviation tracker pending the
-      child's own pass (e.g. `McSupportData`'s `McSwEmulationMethodSupport`
-      and `RptSupportData` children).
+      child's own pass.
+- [ ] **Identity-only child serialization is a debt to be repaid by the
+      child's own pass.** The identity-only shape above is deliberately
+      lossy for everything except the item's existence, and for a plain
+      `ARObject` child it degenerates to an **empty element**: the parser
+      constructs a bare instance and ignores the element's contents, and the
+      writer emits an item element with no children. Round-trip tests then
+      pass while asserting only `len(getXxxs()) == n`, so nothing fails when
+      the child's real attributes are dropped. When the child's own alignment
+      pass lands, that placeholder must be replaced **in the same change** by
+      a real `readXxx`/`writeXxx` pair for the child, wired in from the
+      aggregator's loop — an aligned model whose aggregator still emits the
+      empty element is a Rule 1.7 violation, not a completed pass. Verify by
+      grepping the aggregator's loop for a bare `ET.SubElement(wrapper,
+      "ITEM")` with no following `self.writeXxx(...)`, and for a parser loop
+      whose body constructs the child but never reads from `child_element`
+      (a loop variable that is bound and never used is the tell — flake8's
+      `F841`-adjacent smell that the linter does not flag for `for` targets).
+      Extend the aggregator's existing round-trip test to assert the child's
+      *field values*, not just the list length, so the lossy shape cannot
+      return unnoticed.
+- [ ] **Aggregator serialization sequenced after the child's alignment.**
+      The bullet above covers an aggregator that is *already* wired into a
+      parser/writer dispatch and merely emits its not-yet-aligned child by
+      identity. The harder case is an aggregator with **zero existing
+      serialization** — no `readXxx`/`writeXxx`, no dispatch branch — whose
+      *only* aggregated child type is itself not yet aligned (e.g.
+      `AliasNameSet` aggregates a single `aliasName` of type
+      `AliasNameAssignment`, which still carries fabricated attributes and is
+      missing its spec attributes). Fully serializing the aggregator now
+      would persist the child's wrong shape, so the aggregator's parser/writer
+      coverage (and its dispatch wiring into the owning `ARPackage.element`
+      reader/writer) is **sequenced after** the child's own alignment pass
+      (Rule 1.10) and recorded as *pending* in the deviation tracker — not
+      skipped and not implemented against a placeholder child. Align the
+      aggregator's **model** fully in the meantime (base class, field,
+      accessors, tests, docstrings — every rule except 1.7); only the
+      serialization is deferred, and the tracker row names the blocking child
+      so the sequencing is explicit.
 
 ### 1.8 Cross-package types
 
@@ -455,9 +572,22 @@ The class must reflect the AUTOSAR PDF specification for its attributes.
       missing class from its own spec table, mirroring its siblings and its
       abstract parent if the `Base` column lists one, give it a method-parity
       checklist, tests, and parser/writer coverage, and only then type the
-      referencing attribute against it. This applies to **every** kind of
+      referencing attribute against it.       This applies to **every** kind of
       referenced class, not only `<name>InstanceRef` types (see the `iref`
       specifics in Rule 1.5).
+- [ ] **A referenced class that *exists* but is a stub counts as missing.**
+      This rule's trigger is not "the name resolves" but "the class models
+      its spec table". A referenced type that imports cleanly yet carries
+      only fabricated fields (Rule 1.3 shape (c)) gives the referencing
+      attribute a correct *type* and a worthless *shape*, so aligning the
+      referencing class against it produces a class that is aligned on paper
+      and still round-trips nothing. Before typing an attribute against an
+      existing class, check that class for a `# Spec:` line and a
+      `# Spec verified:` marker; if either is absent, align it first in the
+      same pass — the aggregated child's alignment is **in scope**, not a
+      follow-up. This keeps the pass self-contained: aligning a parent whose
+      child is a stub otherwise immediately re-opens as the Rule 1.7
+      identity-only debt above.
 - [ ] A missing **primitive** has its own spec table in the AUTOSAR markdown,
       formatted `Primitive <Name>` (e.g. Table 4.15 `CseCodeType`), **not** a
       `Class`/`Enumeration` table — verify the referenced type's actual kind
@@ -490,16 +620,44 @@ The class must reflect the AUTOSAR PDF specification for its attributes.
 ### 1.11 Member order follows the PDF
 
 - [ ] Members are declared in the **same order as the spec table's attribute
-      rows** — i.e. ascending `xml.sequenceOffset` (the PDF's `Tags:
-      xml.sequenceOffset=NN` value). The order of the `__init__` fields, the
-      order of the getter/setter/adder methods, and the order of the method
-      parity checklist rows (Rule 2) must all follow the spec table row order,
-      **not** alphabetical or file-of-creation order. A class whose accessors
-      are ordered by name or by refactor history rather than by the spec is
-      misaligned. (Example: `EngineeringObject` attributes are
-      `shortLabel`(offset 10), `category`(20), `revisionLabel`(30),
-      `domain`(40), so the accessors and checklist list them in exactly that
-      sequence.)
+      rows are displayed in the PDF** — the order you read top-to-bottom when
+      you open the table. The order of the `__init__` fields, the order of
+      the getter/setter/adder methods, and the order of the method parity
+      checklist rows (Rule 2) must all follow that displayed row order, **not**
+      alphabetical-by-Python-name or file-of-creation order. A class whose
+      accessors are ordered by name or by refactor history rather than by the
+      spec is misaligned.
+      The `Tags: xml.sequenceOffset=NN` value is only a **secondary signal**:
+      it usually *agrees* with the displayed row order (most tables are
+      rendered in ascending-offset order, e.g. `EngineeringObject` shows
+      `shortLabel`(10), `category`(20), `revisionLabel`(30), `domain`(40) and
+      the accessors/checklist follow exactly that sequence). But the two can
+      **diverge**: some PDF tables are rendered alphabetically (or otherwise)
+      so the displayed rows are *not* in ascending-offset order. In that case
+      the **displayed row order wins** — it is literally "the order in the
+      PDF". Do **not** reorder by `sequenceOffset` when the table prints
+      otherwise. (Counter-example: `AliasNameAssignment` Table 9.3 prints its
+      rows `flatInstance`/`identifiable`/`label`/`shortLabel` even though their
+      offsets are 60/50/20/10; the aligned class therefore declares
+      `flatInstanceRef`, `identifiableRef`, `label`, `shortLabel` in that
+      order — the reverse of ascending offset.) Always read the actual
+      PDF/markdown row order; never assume it from the offset values. Note
+      that this is purely a **Python source-ordering** convention (fields,
+      methods, checklist); the parser/writer still emit XML elements in the
+      XSD's `sequenceOffset` order regardless of how the model members are
+      declared.
+      Because the two orders diverge routinely, **write them down separately**
+      when they do: the PDF row order drives the Python member sequence, and
+      the XSD element sequence (`sequenceOffset` ascending, negatives first)
+      drives the order of `setChildElementXxx` / `getChildElementXxx` calls in
+      `writeXxx`/`readXxx`. A common divergence is an alphabetically-rendered
+      table whose `shortLabel`/`category` rows print *last* while their
+      offsets (`-100`/`-90`) put them *first* in the XML — writing the
+      parser/writer in the class's member order then emits elements out of
+      XSD sequence, which a round-trip test through this library will not
+      catch (the reader is order-insensitive) but a schema validator will.
+      Derive the serialization order from the XSD group, never from the PDF
+      table or the Python member order.
 - [ ] Within one attribute, the accessor pair order is `getXxx` then
       `setXxx` (or `addXxx`/`getXxxs` for list attributes) — getter before
       setter for each attribute, mirroring the sibling classes that are already
@@ -1190,6 +1348,18 @@ field-to-spec cross-check is the gate, not the checklist.
    deviation (see Rule 1.3). Otherwise the field is fabricated. **Remove it**
    (unless it's a documented read-only derived convenience property with
    tests, recorded in the deviation tracker — see Rule 1.3).
+5. **Run the cross-check in both directions.** The procedure above walks
+   each *model field* (code → spec) to catch fabricated fields. A deviation
+   tracker that was built only by walking *spec → code* (producing only
+   `missing` rows) is **not** evidence of completeness: fabricated fields
+   can coexist with `missing` rows for the very spec attributes they shadow
+   (e.g. `AliasNameAssignment`'s tracker held three `missing` rows for
+   `flatInstanceRef`/`identifiableRef`/`label` while the fabricated
+   `elementRef`/`aliasName` that masked them had no row at all — the code→spec
+   pass had never been run). Always perform the code → spec pass; when a
+   `missing` spec attribute has a suspiciously-similar fabricated field,
+   that fabricated field is its stand-in and the removal + replacement happen
+   together, clearing the `missing` row.
 
 ---
 
@@ -1243,6 +1413,26 @@ paraphrase.
       overwrite an existing [attribute]."
       This documents the guard behavior so consumers understand that setting
       `None` is safe and intentional, not a bug.
+- [ ] **Verify every docstring against the PDF/XSD note explicitly — this rule
+      has no mechanical check.** The set-based Rule 2/7 script verifies only
+      that the checklist == methods, that every method is tested, and that the
+      `# Spec verified` marker is present; it says nothing about whether the
+      `#` inline comments or the getter/setter docstrings actually match the
+      spec wording. A class can pass Rule 2/7 and the version marker, and even
+      be labeled "fully aligned" in `docs/method_deviation_by_class.md`, yet
+      carry docstrings that are loose paraphrases or — worse — *semantically
+      wrong* rewrites of the PDF note (e.g. `McDataInstance.displayIdentifier`'s
+      PDF note "An optional attribute to be used to set the ASAM ASAP2
+      DISPLAY_IDENTIFIER attribute" had been rewritten as "Optional identifier
+      to be used by an MCD system to identify this data instance", which states
+      a different purpose; 8 of `McDataInstance`'s 12 attributes were paraphrased
+      this way while the class passed every other check). Docstring drift is
+      invisible to every automated check in this document, so for **each**
+      attribute open the PDF/markdown `Note` (or the matching XSD
+      `<xsd:documentation>` block, which carries the same verbatim text) and
+      diff it against the inline comment and the getter/setter docstrings; quote
+      the semantic sentence verbatim. Do not trust the class's prior "aligned"
+      status or the tracker note — re-derive from the PDF.
 
 Example from a spec PDF:
 ```python
@@ -1410,6 +1600,23 @@ Every method on the class must have test coverage in the mirrored test file
       an `ARNumerical`) — such failures surface only in the end-to-end round
       trip, never in the class's own unit tests. A minimal robustness fix in
       the base writer is a legitimate part of aligning the subclass.
+- [ ] A round-trip test asserts the **field values** that came back, not just
+      that an object was reconstructed. `len(getXxxs()) == 1` /
+      `getXxx() is not None` pass unchanged against a writer that emits an
+      empty element and a parser that ignores its contents (the Rule 1.7
+      identity-only shape), so such assertions cannot detect a lossy
+      round trip — assert each attribute's value explicitly, including the
+      attributes of aggregated children one level down.
+- [ ] A class with a **wrapper-element list** (Rule 1.7) needs a second
+      round-trip case for the *empty* list: assert the serialized file
+      contains no wrapper tag at all and that re-parsing yields `[]`. The
+      populated case alone cannot catch a writer that emits an empty
+      `<WRAPPER/>`, because both shapes re-parse to the same model. Assert on
+      the written file's text for the wrapper tag's absence, since the
+      re-parsed model looks identical either way. Pair this with the
+      `None`-valued optional attributes in the same case (they must be absent
+      from the XML and `None` after re-parse) so the "nothing set" shape is
+      covered end-to-end.
 
 Verification (run in the repo root; replace the paths for the class under
 check):

--- a/docs/development/method_deviation_by_class.md
+++ b/docs/development/method_deviation_by_class.md
@@ -464,67 +464,69 @@ No deviations — all Table 9.1 attributes (`emulationSupport` via `addEmulation
 
 Note:
 - `McDataInstance` is fully aligned (Table 9.4 + XSD additions) and serialized with its inner attributes (`readMcDataInstance`/`writeMcDataInstance`).
-- The RptSupport children (`McSwEmulationMethodSupport` excluded) are aligned and serialized recursively under `RPT-SUPPORT-DATA`.
-- `McSwEmulationMethodSupport` is still a placeholder pending its own alignment pass — parser/writer emit the item element without inner content.
+- The RptSupport children are aligned and serialized recursively under `RPT-SUPPORT-DATA`.
+- `McSwEmulationMethodSupport` is aligned and serialized with its inner attributes (`readMcSwEmulationMethodSupport`/`writeMcSwEmulationMethodSupport`), replacing the earlier identity-only placeholder.
 
 ## `AliasNameSet`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 174
 - **Package:** `M2::AUTOSARTemplates::CommonStructure::FlatMap`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/FlatMap.py`
 
+Model aligned: inherits `ARElement` (spec `Base`) with `__init__(self, parent, short_name)`;
+the single spec attribute `aliasName` (`AliasNameAssignment`, `*`, `aggr`) is modeled as
+`aliasNames`/`addAliasName`/`getAliasNames` (the earlier `alias`/`aliases` naming deviation
+has been fixed and this row cleared).
+
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| `alias` | `—` | `aliasName` | `AliasNameAssignment` | — | naming |
+| — *(pending)* | `—` | `aliasName` | `AliasNameAssignment` | aggr | parser/writer coverage pending the aggregated child `AliasNameAssignment`'s own alignment pass (it still carries fabricated `aliasName`/`elementRef` and is missing `shortLabel`/`label`/`identifiableRef`/`flatInstanceRef`); `AliasNameSet` is not yet wired into any `ARPackage.element` dispatch |
 
 ## `AliasNameAssignment`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 175
 - **Package:** `M2::AUTOSARTemplates::CommonStructure::FlatMap`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/FlatMap.py`
 
+Model aligned: the four spec attributes `shortLabel` (String), `label`
+(MultilanguageLongName), `identifiableRef` (Ref → Identifiable) and
+`flatInstanceRef` (Ref → FlatInstanceDescriptor) are implemented in
+sequenceOffset order (10/20/50/60). Two fabricated fields were removed:
+`aliasName` (a `str` shadowing spec `shortLabel`) and `elementRef`
+(an `AnyInstanceRef` collapsing the two mutually-exclusive spec refs
+`identifiable` + `flatInstance` into one) — these had not been tracked as
+fabricated; only the *missing* spec attributes had rows (the code→spec
+direction of the cross-check had not been run).
+
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — *(missing)* | `—` | `flatInstanceRef` | `Ref (FlatInstanceDescriptor)` | Ref | missing |
-| — *(missing)* | `—` | `identifiableRef` | `Ref (Identifiable)` | Ref | missing |
-| — *(missing)* | `—` | `label` | `MultilanguageLongName` | — | missing |
+| — *(pending)* | `—` | `shortLabel`/`label`/`identifiableRef`/`flatInstanceRef` | String / MultilanguageLongName / Ref / Ref | attr/aggr/ref/ref | parser/writer coverage pending `AliasNameSet`'s wiring into the `ARPackage.element` read/write dispatch (`AliasNameAssignment` is never a standalone element; it is serialized only inside `ALIAS-NAME-SET/ALIAS-NAMES`) |
 
 ## `McDataInstance`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 177
 - **Package:** `M2::AUTOSARTemplates::CommonStructure::MeasurementCalibrationSupport`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/__init__.py`
 
-No deviations — all Table 9.4 attributes (`role`, `rptImplPolicy`, `subElement`, `symbol`) plus the XSD-only attributes the PDF table omits (`arraySize`, `displayIdentifier`, `flatMapEntryRef`, `instanceInMemory`, `mcDataAccessDetails`, `mcDataAssignment`, `resultingProperties`, `resultingRptSwPrototypingAccess`) are implemented with parser/writer coverage (`readMcDataInstance`/`writeMcDataInstance`). Note: `instanceInMemory` is typed as the concrete `ImplementationElementInParameterInstanceRef` (a `RefType` subclass) and serialized flat as a ref; the child classes it aggregates (`McDataAccessDetails`, `RoleBasedMcDataAssignment`, `SwDataDefProps`, `RptSwPrototypingAccess`) are carried with their own coverage where aligned and by identity where not.
+No deviations — all Table 9.4 attributes (`role`, `rptImplPolicy`, `subElement`, `symbol`) plus the XSD-only attributes the PDF table omits (`arraySize`, `displayIdentifier`, `flatMapEntryRef`, `instanceInMemory`, `mcDataAccessDetails`, `mcDataAssignment`, `resultingProperties`, `resultingRptSwPrototypingAccess`) are implemented with parser/writer coverage (`readMcDataInstance`/`writeMcDataInstance`). Note: `instanceInMemory` is typed as the concrete `ImplementationElementInParameterInstanceRef` (an `ARObject`, not a `RefType`) and serialized as a typed iref with `CONTEXT-REF`/`TARGET-REF` directly under the `INSTANCE-IN-MEMORY` element; the child classes it aggregates (`McDataAccessDetails`, `RoleBasedMcDataAssignment`, `SwDataDefProps`, `RptSwPrototypingAccess`) are carried with their own coverage where aligned and by identity where not.
 
 ## `McSwEmulationMethodSupport`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 180
 - **Package:** `M2::AUTOSARTemplates::CommonStructure::MeasurementCalibrationSupport`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/__init__.py`
 
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `baseReferenceRef` | `Ref (VariableDataPrototype)` | Ref | missing |
-| — *(missing)* | `—` | `category` | `Identifier` | — | missing |
-| — *(missing)* | `—` | `elementGroup` | `Ref (VariableDataPrototype)` | — | missing |
-| — *(missing)* | `—` | `referenceTableRef` | `Ref (VariableDataPrototype)` | Ref | missing |
+No deviations — all Table 9.5 attributes (`baseReference`, `category`, `elementGroup`, `referenceTable`, `shortLabel`) are implemented with parser/writer coverage (`readMcSwEmulationMethodSupport`/`writeMcSwEmulationMethodSupport`, reached from `readMcSupportData`/`writeMcSupportData`). `elementGroup` is an `aggr` of `McParameterElementGroup` (`*`) serialized through the `ELEMENT-GROUPS`/`MC-PARAMETER-ELEMENT-GROUP` wrapper; the earlier tracker rows mistyped it as a ref and omitted `shortLabel` entirely. The previously fabricated `emulationMethodName` field (no spec basis, PDF or XSD) has been removed.
 
 ## `McParameterElementGroup`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 181
 - **Package:** `M2::AUTOSARTemplates::CommonStructure::MeasurementCalibrationSupport`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/__init__.py`
 
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `ramLocationRef` | `Ref (VariableDataPrototype)` | Ref | missing |
-| — *(missing)* | `—` | `romLocationRef` | `Ref (ParameterDataPrototype)` | Ref | missing |
+No deviations — all Table 9.6 attributes (`ramLocation`, `romLocation`, `shortLabel`) are implemented with parser/writer coverage (`readMcParameterElementGroup`/`writeMcParameterElementGroup`). The previously fabricated `parameterRefs` list (no spec basis, PDF or XSD) has been removed; `shortLabel` was missing from the earlier tracker rows.
 
 ## `ImplementationElementInParameterInstanceRef`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 184
 - **Package:** `M2::AUTOSARTemplates::CommonStructure::MeasurementCalibrationSupport`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/__init__.py`
 
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `contextRef` | `Ref (ParameterDataPrototype)` | Ref | missing |
-| — *(missing)* | `—` | `targetRef` | `Ref (AbstractImplementationDataTypeElement)` | Ref | missing |
+No deviations — all Table 9.7 attributes (`context`, `target`) are implemented with parser/writer coverage (`readImplementationElementInParameterInstanceRef`/`writeMcDataInstance`). The class's base was corrected from `RefType` to `ARObject` (spec `Base` row; the earlier `RefType` base was a hierarchy mismatch flagged by `reports/deviation_class_hierarchy_mismatches.md`); `INSTANCE-IN-MEMORY` is a typed iref and is serialized with `CONTEXT-REF`/`TARGET-REF` directly under the `INSTANCE-IN-MEMORY` element, not as a flat ref. The earlier tracker rows recorded `contextRef`/`targetRef` as missing; they are now implemented.
 
 ## `McFunction`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 186

--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -1,1 +1,1 @@
-Let us update the `McSupportData` class follow @docs\development\class_check_rules.md and collect the change feedback and update @docs\development\class_check_rules.md to make rule more general
+Let us update the `ImplementationElementInParameterInstanceRef` class follow @docs\development\class_check_rules.md and collect the change feedback and update @docs\development\class_check_rules.md to make rule more general

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/FlatMap.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/FlatMap.py
@@ -4,13 +4,14 @@ in the CommonStructure module. Flat maps are used to describe instance
 hierarchies in a flat manner, typically used for code generation purposes.
 """
 
-from typing import List
+from typing import List, Optional
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpBlueprintable
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Identifier
+from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultilanguageLongName
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Identifier, RefType, String
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import AnyInstanceRef
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Identifiable
 
 
 class FlatInstanceDescriptor(Identifiable):
@@ -216,62 +217,188 @@ class FlatMap(AtpBlueprintable):
 
 class AliasNameAssignment(ARObject):
     """
-    Represents an alias name assignment in AUTOSAR.
-    This class defines how aliases are assigned to elements.
+    This meta-class represents the ability to associate an alternative name to a flat representations or an Identifiable. The usage of this name is defined outside of AUTOSAR. For example this name can be used by MCD tools or as a name for component instances in the ECU extract. Note that flatInstance and identifiable are mutually exclusive.
+
+    [constr_10363] Existence of attribute AliasNameAssignment.shortLabel: For each AliasNameAssignment, the attribute shortLabel shall exist at the time when the configuration of the BSW module is finished.
     """
 
     # AliasNameAssignment method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
-    # [ ] getAliasName                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setAliasName                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getElementRef                [x] impl  [ ] docstring  [ ] test
-    # [ ] setElementRef                [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 9.3, p.175
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
+    # [x] getFlatInstanceRef           [x] impl  [x] docstring  [x] test
+    # [x] setFlatInstanceRef           [x] impl  [x] docstring  [x] test
+    # [x] getIdentifiableRef           [x] impl  [x] docstring  [x] test
+    # [x] setIdentifiableRef           [x] impl  [x] docstring  [x] test
+    # [x] getLabel                     [x] impl  [x] docstring  [x] test
+    # [x] setLabel                     [x] impl  [x] docstring  [x] test
+    # [x] getShortLabel                [x] impl  [x] docstring  [x] test
+    # [x] setShortLabel                [x] impl  [x] docstring  [x] test
 
     def __init__(self):
-        """
-        Initializes the AliasNameAssignment with default values.
-        """
         super().__init__()
-        self.aliasName: str = None
-        self.elementRef: AnyInstanceRef = None
 
-    def getAliasName(self):
-        return self.aliasName
+        # Assignment of a unique name to a flat representation.
+        self.flatInstanceRef: Optional[RefType] = None
+        # Assignment of a unique name to an Identifiable.
+        self.identifiableRef: Optional[RefType] = None
+        # This represents an "Alias LongName".
+        self.label: Optional[MultilanguageLongName] = None
+        # This attribute represents the alias name. It is modeled as string because the alias name is used outside of AUTOSAR and therefore no naming conventions can be applied within AUTOSAR.
+        self.shortLabel: Optional[String] = None
 
-    def setAliasName(self, value):
-        self.aliasName = value
+    def getFlatInstanceRef(self) -> Optional[RefType]:
+        """
+        Gets the reference assigning a unique name to a flat representation (DEST: FlatInstanceDescriptor subtypes). Mutually exclusive with identifiableRef.
+
+        Returns:
+            RefType instance, or None if not set
+        """
+        return self.flatInstanceRef
+
+    def setFlatInstanceRef(self, value: Optional[RefType]) -> "AliasNameAssignment":
+        """
+        Sets the reference assigning a unique name to a flat representation (DEST: FlatInstanceDescriptor subtypes). Mutually exclusive with identifiableRef.
+
+        A None value is a no-op and does not overwrite an existing flatInstanceRef.
+
+        Args:
+            value: The RefType instance to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.flatInstanceRef = value
         return self
 
-    def getElementRef(self):
-        return self.elementRef
+    def getIdentifiableRef(self) -> Optional[RefType]:
+        """
+        Gets the reference assigning a unique name to an Identifiable (DEST: Identifiable subtypes). Mutually exclusive with flatInstanceRef.
 
-    def setElementRef(self, value):
-        self.elementRef = value
+        Returns:
+            RefType instance, or None if not set
+        """
+        return self.identifiableRef
+
+    def setIdentifiableRef(self, value: Optional[RefType]) -> "AliasNameAssignment":
+        """
+        Sets the reference assigning a unique name to an Identifiable (DEST: Identifiable subtypes). Mutually exclusive with flatInstanceRef.
+
+        A None value is a no-op and does not overwrite an existing identifiableRef.
+
+        Args:
+            value: The RefType instance to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.identifiableRef = value
+        return self
+
+    def getLabel(self) -> Optional[MultilanguageLongName]:
+        """
+        Gets the "Alias LongName" (multi-language long name).
+
+        Returns:
+            MultilanguageLongName instance, or None if not set
+        """
+        return self.label
+
+    def setLabel(self, value: Optional[MultilanguageLongName]) -> "AliasNameAssignment":
+        """
+        Sets the "Alias LongName" (multi-language long name).
+
+        A None value is a no-op and does not overwrite an existing label.
+
+        Args:
+            value: The MultilanguageLongName instance to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.label = value
+        return self
+
+    def getShortLabel(self) -> Optional[String]:
+        """
+        Gets the alias name (modeled as String because it is used outside of AUTOSAR).
+
+        Returns:
+            String instance holding the alias name, or None if not set
+        """
+        return self.shortLabel
+
+    def setShortLabel(self, value: Optional[String]) -> "AliasNameAssignment":
+        """
+        Sets the alias name (modeled as String because it is used outside of AUTOSAR). [constr_10363] shortLabel shall exist at the time when the configuration of the BSW module is finished.
+
+        A None value is a no-op and does not overwrite an existing shortLabel.
+
+        Args:
+            value: The String instance holding the alias name to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.shortLabel = value
         return self
 
 
-class AliasNameSet(ARObject):
+class AliasNameSet(ARElement):
     """
-    Represents a set of alias name assignments.
+    This meta-class represents a set of AliasNames. The AliasNameSet can for example be an input to the A2L-Generator.
+
+    [constr_10362] Existence of attribute AliasNameSet.aliasName: For each AliasNameSet, the attribute aliasName shall exist at least once at the time when the configuration of the BSW module is finished.
     """
 
     # AliasNameSet method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
-    # [ ] addAlias                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getAliases                   [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 9.2, p.174
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
+    # [x] addAliasName                 [x] impl  [x] docstring  [x] test
+    # [x] getAliasNames                [x] impl  [x] docstring  [x] test
 
-    def __init__(self):
+    def __init__(self, parent: ARObject, short_name: str):
         """
-        Initializes the AliasNameSet with default values.
+        Initializes the AliasNameSet with a parent and short name.
+
+        Args:
+            parent: The parent ARObject that contains this alias name set
+            short_name: The unique short name of this alias name set
         """
-        super().__init__()
-        self.aliases = []
+        super().__init__(parent, short_name)
 
-    def addAlias(self, alias):
-        self.aliases.append(alias)
+        # AliasNames contained in the AliasNameSet.
+        self.aliasNames: List[AliasNameAssignment] = []
 
-    def getAliases(self):
-        return self.aliases
+    def addAliasName(self, value: Optional[AliasNameAssignment]) -> "AliasNameSet":
+        """
+        Appends an AliasNameAssignment to this set.
+
+        A None value is a no-op and does not append to the list.
+
+        Args:
+            value: The AliasNameAssignment to add
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.aliasNames.append(value)
+        return self
+
+    def getAliasNames(self) -> List[AliasNameAssignment]:
+        """
+        Gets the AliasNameAssignments contained in this set.
+
+        Returns:
+            List of AliasNameAssignment instances (empty by default)
+        """
+        return self.aliasNames
 
 
 class RtePluginProps(ARObject):

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/__init__.py
@@ -84,100 +84,347 @@ class McDataAccessDetails(ARObject):
 
 class McParameterElementGroup(ARObject):
     """
-    Represents an MC (Measurement and Calibration) parameter element group in AUTOSAR.
-    Defines a group of parameter elements for measurement and calibration purposes.
+    Denotes a group of calibration parameters which are handled by the RTE as one data structure.
     """
 
     # McParameterElementGroup method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
-    # [ ] addParameterRef              [x] impl  [x] docstring  [ ] test
-    # [ ] getParameterRefs             [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 9.6, p.181
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
+    # [x] getRamLocationRef            [x] impl  [x] docstring  [x] test
+    # [x] setRamLocationRef            [x] impl  [x] docstring  [x] test
+    # [x] getRomLocationRef            [x] impl  [x] docstring  [x] test
+    # [x] setRomLocationRef            [x] impl  [x] docstring  [x] test
+    # [x] getShortLabel                [x] impl  [x] docstring  [x] test
+    # [x] setShortLabel                [x] impl  [x] docstring  [x] test
 
     def __init__(self):
         """
         Initializes the McParameterElementGroup with default values.
         """
         super().__init__()
-        self.parameterRefs: List[RefType] = []
 
-    def addParameterRef(self, ref: RefType):
+        # Refers to the RAM location of this parameter group. To be used for the init-RAM method. [constr_10342] For each McParameterElementGroup, the reference in the role ramLocation shall exist at the time when the configuration of the BSW module is finished.
+        self.ramLocationRef: Optional[RefType] = None
+
+        # Refers to the ROM location of this parameter group. To be used for the init-RAM method. [constr_10343] For each McParameterElementGroup, the reference in the role romLocation shall exist at the time when the configuration of the BSW module is finished.
+        self.romLocationRef: Optional[RefType] = None
+
+        # Assigns a name to this element. [constr_10344] For each McParameterElementGroup, the attribute shortLabel shall exist at the time when the configuration of the BSW module is finished. Tags: xml.sequenceOffset=-100
+        self.shortLabel: Optional[Identifier] = None
+
+    def getRamLocationRef(self) -> Optional[RefType]:
         """
-        Adds a parameter reference to this MC parameter element group.
+        Gets the reference to the RAM location of this parameter group. To be used for the init-RAM method.
+
+        Returns:
+            RefType referencing the VariableDataPrototype holding the RAM location, or None if not set
+        """
+        return self.ramLocationRef
+
+    def setRamLocationRef(self, value: Optional[RefType]) -> "McParameterElementGroup":
+        """
+        Sets the reference to the RAM location of this parameter group. To be used for the init-RAM method.
+        A None value is a no-op and does not overwrite an existing reference.
 
         Args:
-            ref: The parameter reference to add
+            value: The RAM location reference to set
 
         Returns:
             self for method chaining
         """
-        self.parameterRefs.append(ref)
+        if value is not None:
+            self.ramLocationRef = value
         return self
 
-    def getParameterRefs(self) -> List[RefType]:
+    def getRomLocationRef(self) -> Optional[RefType]:
         """
-        Gets the list of parameter references.
+        Gets the reference to the ROM location of this parameter group. To be used for the init-RAM method.
 
         Returns:
-            List of parameter references
+            RefType referencing the ParameterDataPrototype holding the ROM location, or None if not set
         """
-        return self.parameterRefs
+        return self.romLocationRef
+
+    def setRomLocationRef(self, value: Optional[RefType]) -> "McParameterElementGroup":
+        """
+        Sets the reference to the ROM location of this parameter group. To be used for the init-RAM method.
+        A None value is a no-op and does not overwrite an existing reference.
+
+        Args:
+            value: The ROM location reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.romLocationRef = value
+        return self
+
+    def getShortLabel(self) -> Optional[Identifier]:
+        """
+        Gets the name assigned to this element.
+
+        Returns:
+            Identifier representing the short label, or None if not set
+        """
+        return self.shortLabel
+
+    def setShortLabel(self, value: Optional[Identifier]) -> "McParameterElementGroup":
+        """
+        Sets the name assigned to this element.
+        A None value is a no-op and does not overwrite an existing short label.
+
+        Args:
+            value: The short label identifier to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.shortLabel = value
+        return self
 
 
 class McSwEmulationMethodSupport(ARObject):
     """
-    Represents MC (Measurement and Calibration) software emulation method support in AUTOSAR.
-    Defines support for software emulation methods in measurement and calibration.
+    This denotes the method used by the RTE to handle the calibration data. It is published by the RTE generator and can be used e.g. to generate the corresponding emulation method in a Complex Driver. According to the actual method given by the category attribute, not all attributes are always needed: • double pointered method: only baseReference is mandatory • single pointered method: only referenceTable is mandatory • initRam method: only elementGroup(s) are mandatory Note: For single/double pointered method the group locations are implicitly accessed via the reference table and their location can be found from the initial values in the M1 model of the respective pointers. Therefore, the description of elementGroups is not needed in these cases. Likewise, for double pointered method the reference table description can be accessed via the M1 model under baseReference.
     """
 
     # McSwEmulationMethodSupport method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
-    # [ ] getEmulationMethodName       [x] impl  [x] docstring  [ ] test
-    # [ ] setEmulationMethodName       [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 9.5, p.180
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
+    # [x] getBaseReferenceRef          [x] impl  [x] docstring  [x] test
+    # [x] setBaseReferenceRef          [x] impl  [x] docstring  [x] test
+    # [x] getCategory                  [x] impl  [x] docstring  [x] test
+    # [x] setCategory                  [x] impl  [x] docstring  [x] test
+    # [x] addElementGroup              [x] impl  [x] docstring  [x] test
+    # [x] getElementGroups             [x] impl  [x] docstring  [x] test
+    # [x] getReferenceTableRef         [x] impl  [x] docstring  [x] test
+    # [x] setReferenceTableRef         [x] impl  [x] docstring  [x] test
+    # [x] getShortLabel                [x] impl  [x] docstring  [x] test
+    # [x] setShortLabel                [x] impl  [x] docstring  [x] test
 
     def __init__(self):
         """
         Initializes the McSwEmulationMethodSupport with default values.
         """
         super().__init__()
-        self.emulationMethodName: str = None
 
-    def getEmulationMethodName(self) -> str:
+        # Refers to the base pointer in case of the double-pointered method.
+        self.baseReferenceRef: Optional[RefType] = None
+
+        # Identifies the actual method. The possible names shall correspond to the symbols of the ECU configuration parameter for the calibration method of the RTE, and can include vendor specific methods. [constr_10340] For each McSwEmulationMethodSupport, the attribute category shall exist at the time when the configuration of the BSW module is finished. Tags: xml.sequenceOffset=-90
+        self.category: Optional[Identifier] = None
+
+        # Denotes the grouping of calibration parameters in the actual RTE code. Depending on the category, this information maybe required to set up the emulation code.
+        self.elementGroups: List[McParameterElementGroup] = []
+
+        # Refers to the pointer table in case of the single-pointered method.
+        self.referenceTableRef: Optional[RefType] = None
+
+        # Assigns a name to this element. [constr_10341] For each McSwEmulationMethodSupport, the attribute shortLabel shall exist at the time when the configuration of the BSW module is finished. Tags: xml.sequenceOffset=-100
+        self.shortLabel: Optional[Identifier] = None
+
+    def getBaseReferenceRef(self) -> Optional[RefType]:
         """
-        Gets the emulation method name.
+        Gets the reference to the base pointer in case of the double-pointered method.
 
         Returns:
-            String representing the emulation method name
+            RefType referencing the VariableDataPrototype used as base pointer, or None if not set
         """
-        return self.emulationMethodName
+        return self.baseReferenceRef
 
-    def setEmulationMethodName(self, value: str):
+    def setBaseReferenceRef(self, value: Optional[RefType]) -> "McSwEmulationMethodSupport":
         """
-        Sets the emulation method name.
+        Sets the reference to the base pointer in case of the double-pointered method.
+        A None value is a no-op and does not overwrite an existing reference.
 
         Args:
-            value: String value to set
+            value: The base reference to set
 
         Returns:
             self for method chaining
         """
-        self.emulationMethodName = value
+        if value is not None:
+            self.baseReferenceRef = value
+        return self
+
+    def getCategory(self) -> Optional[Identifier]:
+        """
+        Gets the category identifying the actual method. The possible names shall correspond to the symbols of the ECU configuration parameter for the calibration method of the RTE, and can include vendor specific methods.
+
+        Returns:
+            Identifier representing the category, or None if not set
+        """
+        return self.category
+
+    def setCategory(self, value: Optional[Identifier]) -> "McSwEmulationMethodSupport":
+        """
+        Sets the category identifying the actual method. The possible names shall correspond to the symbols of the ECU configuration parameter for the calibration method of the RTE, and can include vendor specific methods.
+        A None value is a no-op and does not overwrite an existing category.
+
+        Args:
+            value: The category identifier to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.category = value
+        return self
+
+    def addElementGroup(self, value: Optional[McParameterElementGroup]) -> "McSwEmulationMethodSupport":
+        """
+        Adds a grouping of calibration parameters in the actual RTE code. Depending on the category, this information maybe required to set up the emulation code.
+        A None value is a no-op and does not append anything.
+
+        Args:
+            value: The McParameterElementGroup to add
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.elementGroups.append(value)
+        return self
+
+    def getElementGroups(self) -> List[McParameterElementGroup]:
+        """
+        Gets the groupings of calibration parameters in the actual RTE code aggregated by this emulation method support.
+
+        Returns:
+            List of McParameterElementGroup instances
+        """
+        return self.elementGroups
+
+    def getReferenceTableRef(self) -> Optional[RefType]:
+        """
+        Gets the reference to the pointer table in case of the single-pointered method.
+
+        Returns:
+            RefType referencing the VariableDataPrototype used as pointer table, or None if not set
+        """
+        return self.referenceTableRef
+
+    def setReferenceTableRef(self, value: Optional[RefType]) -> "McSwEmulationMethodSupport":
+        """
+        Sets the reference to the pointer table in case of the single-pointered method.
+        A None value is a no-op and does not overwrite an existing reference.
+
+        Args:
+            value: The reference table reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.referenceTableRef = value
+        return self
+
+    def getShortLabel(self) -> Optional[Identifier]:
+        """
+        Gets the name assigned to this element.
+
+        Returns:
+            Identifier representing the short label, or None if not set
+        """
+        return self.shortLabel
+
+    def setShortLabel(self, value: Optional[Identifier]) -> "McSwEmulationMethodSupport":
+        """
+        Sets the name assigned to this element.
+        A None value is a no-op and does not overwrite an existing short label.
+
+        Args:
+            value: The short label identifier to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.shortLabel = value
         return self
 
 
-class ImplementationElementInParameterInstanceRef(RefType):
+class ImplementationElementInParameterInstanceRef(ARObject):
     """
-    Represents a reference to an implementation element in a parameter instance.
-    Used for referencing implementation elements within parameter instances in AUTOSAR models.
+    Describes a reference to a particular ImplementationDataTypeElement instance in the context of a given ParameterDataPrototype. Thus it refers to a particular element in the implementation description of a software data structure. Use Case: The RTE generator publishes its generated structure of calibration parameters in its BSW module description using the "constantMemory" role of ParameterDataPrototypes. Each ParameterDataPrototype describes a group of single calibration parameters. In order to point to these single parameters, this "instance ref" is needed. Note that this class follows the pattern of an InstanceRef but is not implemented based on the abstract classes because the ImplementationDataType isn't either, especially because ImplementationDataTypeElement isn't derived from AtpPrototype.
+    [constr_4034] Target and context of MC emulation reference: Within one ImplementationElementInParameterInstanceRef, the target shall refer to a subelement of the ParameterDataPrototype which is referred as context.
+    [constr_4061] Completeness of MC emulation reference: If an McDataInstance in the role of a subElement of another McDataInstance specifies an instanceInMemory, then the containing McDataInstance shall also specify an instanceInMemory. The target of the latter (i.e. upper level) instanceInMemory shall be identical (including array index, if defined) to the context of the first (i.e. lower level) instanceInMemory.
     """
 
     # ImplementationElementInParameterInstanceRef method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 9.7, p.184
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
+    # [x] getContextRef                [x] impl  [x] docstring  [x] test
+    # [x] setContextRef                [x] impl  [x] docstring  [x] test
+    # [x] getTargetRef                 [x] impl  [x] docstring  [x] test
+    # [x] setTargetRef                 [x] impl  [x] docstring  [x] test
 
     def __init__(self):
         """
         Initializes the ImplementationElementInParameterInstanceRef with default values.
         """
         super().__init__()
+
+        # The context for the referred element. [constr_10345] For each ImplementationElementInParameterInstanceRef, the reference in the role context shall exist at the time when the configuration of the BSW module is finished. Tags: xml.sequenceOffset=20
+        self.contextRef: Optional[RefType] = None
+
+        # The referred data element. [constr_10346] For each ImplementationElementInParameterInstanceRef, the reference in the role target shall exist at the time when the configuration of the BSW module is finished. Tags: xml.sequenceOffset=30
+        self.targetRef: Optional[RefType] = None
+
+    def getContextRef(self) -> Optional[RefType]:
+        """
+        Gets the reference to the ParameterDataPrototype providing the context for the referred element.
+        [constr_10345] For each ImplementationElementInParameterInstanceRef, the reference in the role context shall exist at the time when the configuration of the BSW module is finished.
+
+        Returns:
+            RefType referencing the context ParameterDataPrototype, or None if not set
+        """
+        return self.contextRef
+
+    def setContextRef(self, value: Optional[RefType]) -> "ImplementationElementInParameterInstanceRef":
+        """
+        Sets the reference to the ParameterDataPrototype providing the context for the referred element.
+        A None value is a no-op and does not overwrite an existing reference.
+
+        Args:
+            value: The context reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.contextRef = value
+        return self
+
+    def getTargetRef(self) -> Optional[RefType]:
+        """
+        Gets the reference to the referred AbstractImplementationDataTypeElement. [constr_4034] The target shall refer to a subelement of the ParameterDataPrototype which is referred as context.
+        [constr_10346] For each ImplementationElementInParameterInstanceRef, the reference in the role target shall exist at the time when the configuration of the BSW module is finished.
+
+        Returns:
+            RefType referencing the target data element, or None if not set
+        """
+        return self.targetRef
+
+    def setTargetRef(self, value: Optional[RefType]) -> "ImplementationElementInParameterInstanceRef":
+        """
+        Sets the reference to the referred AbstractImplementationDataTypeElement.
+        A None value is a no-op and does not overwrite an existing reference.
+
+        Args:
+            value: The target reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.targetRef = value
+        return self
 
 
 class McFunction(ARObject):
@@ -358,31 +605,31 @@ class McDataInstance(Identifiable):
     # McDataInstance method parity checklist:
     # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 9.4, p.177
     # Spec verified: R23-11
-    # [x] __init__                        [x] impl  [x] docstring  [x] test
-    # [x] getArraySize                    [x] impl  [x] docstring  [x] test
-    # [x] setArraySize                    [x] impl  [x] docstring  [x] test
-    # [x] getDisplayIdentifier            [x] impl  [x] docstring  [x] test
-    # [x] setDisplayIdentifier            [x] impl  [x] docstring  [x] test
-    # [x] getFlatMapEntryRef              [x] impl  [x] docstring  [x] test
-    # [x] setFlatMapEntryRef              [x] impl  [x] docstring  [x] test
-    # [x] getInstanceInMemory             [x] impl  [x] docstring  [x] test
-    # [x] setInstanceInMemory             [x] impl  [x] docstring  [x] test
-    # [x] getMcDataAccessDetails          [x] impl  [x] docstring  [x] test
-    # [x] setMcDataAccessDetails          [x] impl  [x] docstring  [x] test
-    # [x] addMcDataAssignment             [x] impl  [x] docstring  [x] test
-    # [x] getMcDataAssignments            [x] impl  [x] docstring  [x] test
-    # [x] getResultingProperties          [x] impl  [x] docstring  [x] test
-    # [x] setResultingProperties          [x] impl  [x] docstring  [x] test
-    # [x] getResultingRptSwPrototypingAccess [x] impl [x] docstring  [x] test
-    # [x] setResultingRptSwPrototypingAccess [x] impl [x] docstring  [x] test
-    # [x] getRole                         [x] impl  [x] docstring  [x] test
-    # [x] setRole                         [x] impl  [x] docstring  [x] test
-    # [x] getRptImplPolicy                [x] impl  [x] docstring  [x] test
-    # [x] setRptImplPolicy                [x] impl  [x] docstring  [x] test
-    # [x] createSubElement                [x] impl  [x] docstring  [x] test
-    # [x] getSubElements                  [x] impl  [x] docstring  [x] test
-    # [x] getSymbol                       [x] impl  [x] docstring  [x] test
-    # [x] setSymbol                       [x] impl  [x] docstring  [x] test
+    # [x] __init__                            [x] impl  [x] docstring  [x] test
+    # [x] getArraySize                        [x] impl  [x] docstring  [x] test
+    # [x] setArraySize                        [x] impl  [x] docstring  [x] test
+    # [x] getDisplayIdentifier                [x] impl  [x] docstring  [x] test
+    # [x] setDisplayIdentifier                [x] impl  [x] docstring  [x] test
+    # [x] getFlatMapEntryRef                  [x] impl  [x] docstring  [x] test
+    # [x] setFlatMapEntryRef                  [x] impl  [x] docstring  [x] test
+    # [x] getInstanceInMemory                 [x] impl  [x] docstring  [x] test
+    # [x] setInstanceInMemory                 [x] impl  [x] docstring  [x] test
+    # [x] getMcDataAccessDetails              [x] impl  [x] docstring  [x] test
+    # [x] setMcDataAccessDetails              [x] impl  [x] docstring  [x] test
+    # [x] addMcDataAssignment                 [x] impl  [x] docstring  [x] test
+    # [x] getMcDataAssignments                [x] impl  [x] docstring  [x] test
+    # [x] getResultingProperties              [x] impl  [x] docstring  [x] test
+    # [x] setResultingProperties              [x] impl  [x] docstring  [x] test
+    # [x] getResultingRptSwPrototypingAccess  [x] impl  [x] docstring  [x] test
+    # [x] setResultingRptSwPrototypingAccess  [x] impl  [x] docstring  [x] test
+    # [x] getRole                             [x] impl  [x] docstring  [x] test
+    # [x] setRole                             [x] impl  [x] docstring  [x] test
+    # [x] getRptImplPolicy                    [x] impl  [x] docstring  [x] test
+    # [x] setRptImplPolicy                    [x] impl  [x] docstring  [x] test
+    # [x] createSubElement                    [x] impl  [x] docstring  [x] test
+    # [x] getSubElements                      [x] impl  [x] docstring  [x] test
+    # [x] getSymbol                           [x] impl  [x] docstring  [x] test
+    # [x] setSymbol                           [x] impl  [x] docstring  [x] test
 
     def __init__(self, parent: ARObject, short_name: str):
         """
@@ -394,28 +641,28 @@ class McDataInstance(Identifiable):
         """
         super().__init__(parent, short_name)
 
-        # Array size, if this McDataInstance represents an array.
+        # The existence of this attribute turns the data instance into an array of data. The attribute determines the size of the array in terms of number of elements.
         self.arraySize: Optional[PositiveInteger] = None
 
-        # Optional identifier to be used by an MCD system to identify this data instance.
+        # An optional attribute to be used to set the ASAM ASAP2 DISPLAY_IDENTIFIER attribute.
         self.displayIdentifier: Optional[McdIdentifier] = None
 
-        # Reference to the FlatInstanceDescriptor the data instance is linked to.
+        # Reference to the corresponding entry in the ECU Flat Map. This allows to trace back to the original specification of the generated data instance. This link shall be added by the RTE generator mainly for documentation purposes.
         self.flatMapEntryRef: Optional[RefType] = None
 
-        # Reference to the implementation element in parameter instance representing the data instance in memory.
+        # Reference to the corresponding data instance in the description of calibration data structures published by the RTE generator. This is used to support emulation methods inside the ECU, it is not required for A2L generation.
         self.instanceInMemory: Optional[ImplementationElementInParameterInstanceRef] = None
 
-        # Details of the access to the data instance.
+        # Refers to "upstream" information on how the RTE uses this data instance. Use Case: Rapid Prototyping
         self.mcDataAccessDetails: Optional[McDataAccessDetails] = None
 
-        # Role-based assignments of MC data to this data instance.
+        # An assignment between McDataInstances. This supports the indication of related McDataElement implementing the of "RP global buffer", "RP global measurement buffer", "RP enabler flag".
         self.mcDataAssignments: List[RoleBasedMcDataAssignment] = []
 
-        # Resulting properties of the data instance.
+        # These are the generated properties resulting from decisions taken by the RTE generator for the actually implemented data instance. Only those properties are relevant here, which are needed for the measurement and calibration system.
         self.resultingProperties: Optional[SwDataDefProps] = None
 
-        # Resulting rapid prototyping access of the data instance.
+        # Describes the implemented accessibility of data and modes by the rapid prototyping tooling.
         self.resultingRptSwPrototypingAccess: Optional[RptSwPrototypingAccess] = None
 
         # An optional attribute to be used for additional information on the role of this data instance, for example in the context of rapid prototyping.
@@ -432,7 +679,7 @@ class McDataInstance(Identifiable):
 
     def getArraySize(self) -> Optional[PositiveInteger]:
         """
-        Gets the array size of this data instance.
+        Gets the array size. The existence of this attribute turns the data instance into an array of data; the value determines the size of the array in terms of number of elements.
 
         Returns:
             PositiveInteger representing the array size, or None if not set
@@ -441,8 +688,8 @@ class McDataInstance(Identifiable):
 
     def setArraySize(self, value: Optional[PositiveInteger]) -> "McDataInstance":
         """
-        Sets the array size of this data instance.
-        A None value is a no-op and does not overwrite an existing size.
+        Sets the array size. The existence of this attribute turns the data instance into an array of data; the value determines the size of the array in terms of number of elements.
+        A None value is a no-op and does not overwrite an existing arraySize.
 
         Args:
             value: The array size to set
@@ -456,17 +703,17 @@ class McDataInstance(Identifiable):
 
     def getDisplayIdentifier(self) -> Optional[McdIdentifier]:
         """
-        Gets the optional identifier to be used by an MCD system to identify this data instance.
+        Gets the optional ASAM ASAP2 DISPLAY_IDENTIFIER attribute.
 
         Returns:
-            McdIdentifier to be used by the MCD system, or None if not set
+            McdIdentifier used to set the ASAM ASAP2 DISPLAY_IDENTIFIER attribute, or None if not set
         """
         return self.displayIdentifier
 
     def setDisplayIdentifier(self, value: Optional[McdIdentifier]) -> "McDataInstance":
         """
-        Sets the optional identifier to be used by an MCD system to identify this data instance.
-        A None value is a no-op and does not overwrite an existing identifier.
+        Sets the optional ASAM ASAP2 DISPLAY_IDENTIFIER attribute.
+        A None value is a no-op and does not overwrite an existing displayIdentifier.
 
         Args:
             value: The McdIdentifier to set
@@ -480,7 +727,7 @@ class McDataInstance(Identifiable):
 
     def getFlatMapEntryRef(self) -> Optional[RefType]:
         """
-        Gets the reference to the FlatInstanceDescriptor the data instance is linked to.
+        Gets the reference to the corresponding entry in the ECU Flat Map, allowing to trace back to the original specification of the generated data instance. This link shall be added by the RTE generator mainly for documentation purposes.
 
         Returns:
             RefType referencing the flat map entry, or None if not set
@@ -489,8 +736,8 @@ class McDataInstance(Identifiable):
 
     def setFlatMapEntryRef(self, value: Optional[RefType]) -> "McDataInstance":
         """
-        Sets the reference to the FlatInstanceDescriptor the data instance is linked to.
-        A None value is a no-op and does not overwrite an existing reference.
+        Sets the reference to the corresponding entry in the ECU Flat Map, allowing to trace back to the original specification of the generated data instance. This link shall be added by the RTE generator mainly for documentation purposes.
+        A None value is a no-op and does not overwrite an existing flatMapEntryRef.
 
         Args:
             value: The flat map entry reference to set
@@ -504,7 +751,7 @@ class McDataInstance(Identifiable):
 
     def getInstanceInMemory(self) -> Optional[ImplementationElementInParameterInstanceRef]:
         """
-        Gets the reference to the implementation element in parameter instance representing the data instance in memory.
+        Gets the reference to the corresponding data instance in the description of calibration data structures published by the RTE generator. This is used to support emulation methods inside the ECU, it is not required for A2L generation.
 
         Returns:
             ImplementationElementInParameterInstanceRef referencing the data instance in memory, or None if not set
@@ -513,8 +760,8 @@ class McDataInstance(Identifiable):
 
     def setInstanceInMemory(self, value: Optional[ImplementationElementInParameterInstanceRef]) -> "McDataInstance":
         """
-        Sets the reference to the implementation element in parameter instance representing the data instance in memory.
-        A None value is a no-op and does not overwrite an existing reference.
+        Sets the reference to the corresponding data instance in the description of calibration data structures published by the RTE generator. This is used to support emulation methods inside the ECU, it is not required for A2L generation.
+        A None value is a no-op and does not overwrite an existing instanceInMemory.
 
         Args:
             value: The instance in memory reference to set
@@ -528,7 +775,7 @@ class McDataInstance(Identifiable):
 
     def getMcDataAccessDetails(self) -> Optional[McDataAccessDetails]:
         """
-        Gets the details of the access to the data instance.
+        Gets the upstream information on how the RTE uses this data instance (use case: Rapid Prototyping).
 
         Returns:
             McDataAccessDetails instance, or None if not set
@@ -537,8 +784,8 @@ class McDataInstance(Identifiable):
 
     def setMcDataAccessDetails(self, value: Optional[McDataAccessDetails]) -> "McDataInstance":
         """
-        Sets the details of the access to the data instance.
-        A None value is a no-op and does not overwrite existing access details.
+        Sets the upstream information on how the RTE uses this data instance (use case: Rapid Prototyping).
+        A None value is a no-op and does not overwrite an existing mcDataAccessDetails.
 
         Args:
             value: The McDataAccessDetails to set
@@ -552,7 +799,7 @@ class McDataInstance(Identifiable):
 
     def addMcDataAssignment(self, value: Optional[RoleBasedMcDataAssignment]) -> "McDataInstance":
         """
-        Adds a role-based MC data assignment to this data instance.
+        Adds an assignment between McDataInstances. This supports the indication of related McDataElement implementing of "RP global buffer", "RP global measurement buffer", "RP enabler flag".
         A None value is a no-op and does not append anything.
 
         Args:
@@ -567,7 +814,7 @@ class McDataInstance(Identifiable):
 
     def getMcDataAssignments(self) -> List[RoleBasedMcDataAssignment]:
         """
-        Gets the role-based MC data assignments aggregated by this data instance.
+        Gets the assignments between McDataInstances aggregated by this data instance.
 
         Returns:
             List of RoleBasedMcDataAssignment instances
@@ -576,7 +823,7 @@ class McDataInstance(Identifiable):
 
     def getResultingProperties(self) -> Optional[SwDataDefProps]:
         """
-        Gets the resulting properties of the data instance.
+        Gets the generated properties resulting from decisions taken by the RTE generator for the actually implemented data instance. Only those properties are relevant here, which are needed for the measurement and calibration system.
 
         Returns:
             SwDataDefProps instance, or None if not set
@@ -585,8 +832,8 @@ class McDataInstance(Identifiable):
 
     def setResultingProperties(self, value: Optional[SwDataDefProps]) -> "McDataInstance":
         """
-        Sets the resulting properties of the data instance.
-        A None value is a no-op and does not overwrite existing properties.
+        Sets the generated properties resulting from decisions taken by the RTE generator for the actually implemented data instance. Only those properties are relevant here, which are needed for the measurement and calibration system.
+        A None value is a no-op and does not overwrite an existing resultingProperties.
 
         Args:
             value: The SwDataDefProps to set
@@ -600,7 +847,7 @@ class McDataInstance(Identifiable):
 
     def getResultingRptSwPrototypingAccess(self) -> Optional[RptSwPrototypingAccess]:
         """
-        Gets the resulting rapid prototyping access of the data instance.
+        Gets the implemented accessibility of data and modes by the rapid prototyping tooling.
 
         Returns:
             RptSwPrototypingAccess instance, or None if not set
@@ -609,8 +856,8 @@ class McDataInstance(Identifiable):
 
     def setResultingRptSwPrototypingAccess(self, value: Optional[RptSwPrototypingAccess]) -> "McDataInstance":
         """
-        Sets the resulting rapid prototyping access of the data instance.
-        A None value is a no-op and does not overwrite existing access.
+        Sets the implemented accessibility of data and modes by the rapid prototyping tooling.
+        A None value is a no-op and does not overwrite an existing resultingRptSwPrototypingAccess.
 
         Args:
             value: The RptSwPrototypingAccess to set

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -47,7 +47,15 @@ from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview.InstanceRe
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import ApplicationValueSpecification, ArrayValueSpecification, ConstantReference
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import ConstantSpecification, NumericalValueSpecification, RecordValueSpecification
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import TextValueSpecification, ValueSpecification
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import McDataAccessDetails, McDataInstance, McSupportData, McSwEmulationMethodSupport, RoleBasedMcDataAssignment
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import (
+    ImplementationElementInParameterInstanceRef,
+    McDataAccessDetails,
+    McDataInstance,
+    McParameterElementGroup,
+    McSupportData,
+    McSwEmulationMethodSupport,
+    RoleBasedMcDataAssignment,
+)
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport.RptSupport import (
     RptComponent,
     RptExecutableEntity,
@@ -1556,7 +1564,9 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readMcSupportData(self, element: ET.Element, support: McSupportData):
         for child_element in self.findall(element, "EMULATION-SUPPORTS/MC-SW-EMULATION-METHOD-SUPPORT"):
-            support.addEmulationSupport(McSwEmulationMethodSupport())
+            emulation_support = McSwEmulationMethodSupport()
+            self.readMcSwEmulationMethodSupport(child_element, emulation_support)
+            support.addEmulationSupport(emulation_support)
         for child_element in self.findall(element, "MC-PARAMETER-INSTANCES/MC-DATA-INSTANCE"):
             instance = support.createMcParameterInstance(self.getShortName(child_element))
             self.readMcDataInstance(child_element, instance)
@@ -1571,11 +1581,34 @@ class ARXMLParser(AbstractARXMLParser):
             self.readRptSupportData(rpt_support_data_element, rpt_support_data)
             support.setRptSupportData(rpt_support_data)
 
+    def readMcSwEmulationMethodSupport(self, element: ET.Element, support: McSwEmulationMethodSupport):
+        support.setShortLabel(self.getChildElementOptionalLiteral(element, "SHORT-LABEL"))
+        support.setCategory(self.getChildElementOptionalLiteral(element, "CATEGORY"))
+        support.setBaseReferenceRef(self.getChildElementOptionalRefType(element, "BASE-REFERENCE-REF"))
+        for child_element in self.findall(element, "ELEMENT-GROUPS/MC-PARAMETER-ELEMENT-GROUP"):
+            group = McParameterElementGroup()
+            self.readMcParameterElementGroup(child_element, group)
+            support.addElementGroup(group)
+        support.setReferenceTableRef(self.getChildElementOptionalRefType(element, "REFERENCE-TABLE-REF"))
+
+    def readMcParameterElementGroup(self, element: ET.Element, group: McParameterElementGroup):
+        group.setShortLabel(self.getChildElementOptionalLiteral(element, "SHORT-LABEL"))
+        group.setRamLocationRef(self.getChildElementOptionalRefType(element, "RAM-LOCATION-REF"))
+        group.setRomLocationRef(self.getChildElementOptionalRefType(element, "ROM-LOCATION-REF"))
+
+    def readImplementationElementInParameterInstanceRef(self, element: ET.Element, instance_in_memory: ImplementationElementInParameterInstanceRef):
+        instance_in_memory.setContextRef(self.getChildElementOptionalRefType(element, "CONTEXT-REF"))
+        instance_in_memory.setTargetRef(self.getChildElementOptionalRefType(element, "TARGET-REF"))
+
     def readMcDataInstance(self, element: ET.Element, instance: McDataInstance):
         instance.setArraySize(self.getChildElementOptionalPositiveInteger(element, "ARRAY-SIZE"))
         instance.setDisplayIdentifier(self.getChildElementOptionalLiteral(element, "DISPLAY-IDENTIFIER"))
         instance.setFlatMapEntryRef(self.getChildElementOptionalRefType(element, "FLAT-MAP-ENTRY-REF"))
-        instance.setInstanceInMemory(self.getChildElementOptionalRefType(element, "INSTANCE-IN-MEMORY"))
+        instance_in_memory_element = self.find(element, "INSTANCE-IN-MEMORY")
+        if instance_in_memory_element is not None:
+            instance_in_memory = ImplementationElementInParameterInstanceRef()
+            self.readImplementationElementInParameterInstanceRef(instance_in_memory_element, instance_in_memory)
+            instance.setInstanceInMemory(instance_in_memory)
         instance.setRole(self.getChildElementOptionalLiteral(element, "ROLE"))
         instance.setSymbol(self.getChildElementOptionalLiteral(element, "SYMBOL"))
         if self.find(element, "MC-DATA-ACCESS-DETAILS") is not None:

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -48,7 +48,13 @@ from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import B
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import ApplicationValueSpecification, ArrayValueSpecification, ConstantReference
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import ConstantSpecification, NumericalValueSpecification, RecordValueSpecification
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import TextValueSpecification, ValueSpecification
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import McDataInstance, McSupportData, RoleBasedMcDataAssignment
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import (
+    McDataInstance,
+    McParameterElementGroup,
+    McSupportData,
+    McSwEmulationMethodSupport,
+    RoleBasedMcDataAssignment,
+)
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport.RptSupport import (
     RptComponent,
     RptExecutableEntity,
@@ -2254,7 +2260,7 @@ class ARXMLWriter(AbstractARXMLWriter):
         if len(emulation_supports) > 0:
             supports_element = ET.SubElement(child_element, "EMULATION-SUPPORTS")
             for emulation_support in emulation_supports:
-                ET.SubElement(supports_element, "MC-SW-EMULATION-METHOD-SUPPORT")
+                self.writeMcSwEmulationMethodSupport(ET.SubElement(supports_element, "MC-SW-EMULATION-METHOD-SUPPORT"), emulation_support)
         mc_parameter_instances = support.getMcParameterInstances()
         if len(mc_parameter_instances) > 0:
             instances_element = ET.SubElement(child_element, "MC-PARAMETER-INSTANCES")
@@ -2274,12 +2280,32 @@ class ARXMLWriter(AbstractARXMLWriter):
         if rpt_support_data is not None:
             self.writeRptSupportData(child_element, rpt_support_data)
 
+    def writeMcSwEmulationMethodSupport(self, element: ET.Element, support: McSwEmulationMethodSupport):
+        self.setChildElementOptionalLiteral(element, "SHORT-LABEL", support.getShortLabel())
+        self.setChildElementOptionalLiteral(element, "CATEGORY", support.getCategory())
+        self.setChildElementOptionalRefType(element, "BASE-REFERENCE-REF", support.getBaseReferenceRef())
+        element_groups = support.getElementGroups()
+        if len(element_groups) > 0:
+            groups_element = ET.SubElement(element, "ELEMENT-GROUPS")
+            for group in element_groups:
+                self.writeMcParameterElementGroup(ET.SubElement(groups_element, "MC-PARAMETER-ELEMENT-GROUP"), group)
+        self.setChildElementOptionalRefType(element, "REFERENCE-TABLE-REF", support.getReferenceTableRef())
+
+    def writeMcParameterElementGroup(self, element: ET.Element, group: McParameterElementGroup):
+        self.setChildElementOptionalLiteral(element, "SHORT-LABEL", group.getShortLabel())
+        self.setChildElementOptionalRefType(element, "RAM-LOCATION-REF", group.getRamLocationRef())
+        self.setChildElementOptionalRefType(element, "ROM-LOCATION-REF", group.getRomLocationRef())
+
     def writeMcDataInstance(self, element: ET.Element, instance: McDataInstance):
         self.writeIdentifiable(element, instance)
         self.setChildElementOptionalPositiveInteger(element, "ARRAY-SIZE", instance.getArraySize())
         self.setChildElementOptionalLiteral(element, "DISPLAY-IDENTIFIER", instance.getDisplayIdentifier())
         self.setChildElementOptionalRefType(element, "FLAT-MAP-ENTRY-REF", instance.getFlatMapEntryRef())
-        self.setChildElementOptionalRefType(element, "INSTANCE-IN-MEMORY", instance.getInstanceInMemory())
+        instance_in_memory = instance.getInstanceInMemory()
+        if instance_in_memory is not None:
+            instance_in_memory_element = ET.SubElement(element, "INSTANCE-IN-MEMORY")
+            self.setChildElementOptionalRefType(instance_in_memory_element, "CONTEXT-REF", instance_in_memory.getContextRef())
+            self.setChildElementOptionalRefType(instance_in_memory_element, "TARGET-REF", instance_in_memory.getTargetRef())
         if instance.getMcDataAccessDetails() is not None:
             ET.SubElement(element, "MC-DATA-ACCESS-DETAILS")
         mc_data_assignments = instance.getMcDataAssignments()

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/test_ImplementationElementInParameterInstanceRef.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/test_ImplementationElementInParameterInstanceRef.py
@@ -1,0 +1,124 @@
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import ImplementationElementInParameterInstanceRef, McSupportData
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+import tempfile
+
+
+def make_ref(value: str) -> RefType:
+    ref = RefType()
+    ref.setValue(value)
+    return ref
+
+
+class TestImplementationElementInParameterInstanceRefInitialization:
+    def test_initialization(self):
+        """Test ImplementationElementInParameterInstanceRef __init__ defaults"""
+        instance_ref = ImplementationElementInParameterInstanceRef()
+        assert instance_ref is not None
+        assert instance_ref.contextRef is None
+        assert instance_ref.targetRef is None
+
+
+class TestImplementationElementInParameterInstanceRefContext:
+    def test_get_set_context_ref(self):
+        """Test setContextRef returns self and getContextRef round-trips"""
+        instance_ref = ImplementationElementInParameterInstanceRef()
+        ref = make_ref("/Context/Prototype")
+        result = instance_ref.setContextRef(ref)
+        assert result is instance_ref
+        assert instance_ref.getContextRef() is ref
+
+    def test_set_context_ref_none_is_noop(self):
+        """Test setting a None context ref is a no-op"""
+        instance_ref = ImplementationElementInParameterInstanceRef()
+        ref = make_ref("/Context/Prototype")
+        instance_ref.setContextRef(ref)
+        instance_ref.setContextRef(None)
+        assert instance_ref.getContextRef() is ref
+
+
+class TestImplementationElementInParameterInstanceRefTarget:
+    def test_get_set_target_ref(self):
+        """Test setTargetRef returns self and getTargetRef round-trips"""
+        instance_ref = ImplementationElementInParameterInstanceRef()
+        ref = make_ref("/Context/Prototype/Element")
+        result = instance_ref.setTargetRef(ref)
+        assert result is instance_ref
+        assert instance_ref.getTargetRef() is ref
+
+    def test_set_target_ref_none_is_noop(self):
+        """Test setting a None target ref is a no-op"""
+        instance_ref = ImplementationElementInParameterInstanceRef()
+        ref = make_ref("/Context/Prototype/Element")
+        instance_ref.setTargetRef(ref)
+        instance_ref.setTargetRef(None)
+        assert instance_ref.getTargetRef() is ref
+
+
+class TestImplementationElementInParameterInstanceRefRoundTrip:
+    def test_round_trip_via_mc_support_data(self):
+        """Test parse -> write -> re-parse round trip of the typed iref nested under MC-DATA-INSTANCE/INSTANCE-IN-MEMORY."""
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        document = AUTOSAR.getInstance()
+        document.clear()
+        ar_root = document.createARPackage("AUTOSAR")
+        impl = ar_root.createBswImplementation("test_impl")
+        mc_support = McSupportData()
+        impl.setMcSupport(mc_support)
+
+        instance = mc_support.createMcParameterInstance("CalPrm1")
+        instance_in_memory = ImplementationElementInParameterInstanceRef()
+        instance_in_memory.setContextRef(make_ref("/Context/Prototype"))
+        instance_in_memory.setTargetRef(make_ref("/Context/Prototype/Element"))
+        instance.setInstanceInMemory(instance_in_memory)
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, document)
+
+            document_2 = AUTOSAR.getInstance()
+            document_2.clear()
+            ARXMLParser().load(file_path, document_2)
+            mc_support_2 = document_2.getARPackages()[0].getBswImplementations()[0].getMcSupport()
+            instance_2 = mc_support_2.getMcParameterInstances()[0]
+            instance_in_memory_2 = instance_2.getInstanceInMemory()
+            assert instance_in_memory_2 is not None
+            assert instance_in_memory_2.getContextRef().getValue() == "/Context/Prototype"
+            assert instance_in_memory_2.getTargetRef().getValue() == "/Context/Prototype/Element"
+        finally:
+            import os
+
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+    def test_round_trip_unset_emits_no_iref_element(self):
+        """Test an unset instanceInMemory round-trips to no INSTANCE-IN-MEMORY element."""
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        document = AUTOSAR.getInstance()
+        document.clear()
+        ar_root = document.createARPackage("AUTOSAR")
+        impl = ar_root.createBswImplementation("test_impl")
+        mc_support = McSupportData()
+        impl.setMcSupport(mc_support)
+        mc_support.createMcParameterInstance("CalPrm1")
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, document)
+
+            with open(file_path, "r", encoding="utf-8") as file_handle:
+                content = file_handle.read()
+            assert "INSTANCE-IN-MEMORY" not in content
+
+            document_2 = AUTOSAR.getInstance()
+            document_2.clear()
+            ARXMLParser().load(file_path, document_2)
+            mc_support_2 = document_2.getARPackages()[0].getBswImplementations()[0].getMcSupport()
+            assert mc_support_2.getMcParameterInstances()[0].getInstanceInMemory() is None
+        finally:
+            import os
+
+            if os.path.exists(file_path):
+                os.remove(file_path)

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/test_McDataInstance.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/test_McDataInstance.py
@@ -88,7 +88,8 @@ class TestMcDataInstanceAccessors:
         """Test instanceInMemory setter and getter"""
         instance = McDataInstance(AUTOSAR.getInstance(), "TestInstance")
         ref = ImplementationElementInParameterInstanceRef()
-        ref.setValue("/mem/instance")
+        ref.setContextRef(RefType().setValue("/mem/ctx"))
+        ref.setTargetRef(RefType().setValue("/mem/inst"))
         result = instance.setInstanceInMemory(ref)
         assert result is instance
         assert instance.getInstanceInMemory() == ref

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/test_McSwEmulationMethodSupport.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/test_McSwEmulationMethodSupport.py
@@ -1,0 +1,258 @@
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import McParameterElementGroup, McSupportData, McSwEmulationMethodSupport
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Identifier, RefType
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+import tempfile
+
+
+def make_ref(value: str) -> RefType:
+    ref = RefType()
+    ref.setValue(value)
+    return ref
+
+
+class TestMcSwEmulationMethodSupportInitialization:
+    def test_initialization(self):
+        """Test McSwEmulationMethodSupport __init__ defaults"""
+        support = McSwEmulationMethodSupport()
+        assert support is not None
+        assert support.baseReferenceRef is None
+        assert support.category is None
+        assert support.elementGroups == []
+        assert support.referenceTableRef is None
+        assert support.shortLabel is None
+
+
+class TestMcSwEmulationMethodSupportBaseReference:
+    def test_get_set_base_reference_ref(self):
+        """Test setBaseReferenceRef returns self and getBaseReferenceRef round-trips"""
+        support = McSwEmulationMethodSupport()
+        ref = make_ref("/Base/Pointer")
+        result = support.setBaseReferenceRef(ref)
+        assert result is support
+        assert support.getBaseReferenceRef() is ref
+
+    def test_set_base_reference_ref_none_is_noop(self):
+        """Test setting a None base reference is a no-op"""
+        support = McSwEmulationMethodSupport()
+        ref = make_ref("/Base/Pointer")
+        support.setBaseReferenceRef(ref)
+        support.setBaseReferenceRef(None)
+        assert support.getBaseReferenceRef() is ref
+
+
+class TestMcSwEmulationMethodSupportCategory:
+    def test_get_set_category(self):
+        """Test setCategory returns self and getCategory round-trips"""
+        support = McSwEmulationMethodSupport()
+        category = Identifier().setValue("DOUBLE_POINTERED")
+        result = support.setCategory(category)
+        assert result is support
+        assert support.getCategory().getValue() == "DOUBLE_POINTERED"
+
+    def test_set_category_none_is_noop(self):
+        """Test setting a None category is a no-op"""
+        support = McSwEmulationMethodSupport()
+        support.setCategory(Identifier().setValue("DOUBLE_POINTERED"))
+        support.setCategory(None)
+        assert support.getCategory().getValue() == "DOUBLE_POINTERED"
+
+
+class TestMcSwEmulationMethodSupportElementGroup:
+    def test_add_get_element_group(self):
+        """Test addElementGroup appends and returns self for chaining"""
+        support = McSwEmulationMethodSupport()
+        group = McParameterElementGroup()
+        result = support.addElementGroup(group)
+        assert result is support
+        assert support.getElementGroups() == [group]
+
+    def test_add_element_group_none_is_noop(self):
+        """Test adding a None element group is a no-op"""
+        support = McSwEmulationMethodSupport()
+        support.addElementGroup(None)
+        assert support.getElementGroups() == []
+
+
+class TestMcSwEmulationMethodSupportReferenceTable:
+    def test_get_set_reference_table_ref(self):
+        """Test setReferenceTableRef returns self and getReferenceTableRef round-trips"""
+        support = McSwEmulationMethodSupport()
+        ref = make_ref("/Reference/Table")
+        result = support.setReferenceTableRef(ref)
+        assert result is support
+        assert support.getReferenceTableRef() is ref
+
+    def test_set_reference_table_ref_none_is_noop(self):
+        """Test setting a None reference table ref is a no-op"""
+        support = McSwEmulationMethodSupport()
+        ref = make_ref("/Reference/Table")
+        support.setReferenceTableRef(ref)
+        support.setReferenceTableRef(None)
+        assert support.getReferenceTableRef() is ref
+
+
+class TestMcSwEmulationMethodSupportShortLabel:
+    def test_get_set_short_label(self):
+        """Test setShortLabel returns self and getShortLabel round-trips"""
+        support = McSwEmulationMethodSupport()
+        result = support.setShortLabel(Identifier().setValue("EmuLabel"))
+        assert result is support
+        assert support.getShortLabel().getValue() == "EmuLabel"
+
+    def test_set_short_label_none_is_noop(self):
+        """Test setting a None short label is a no-op"""
+        support = McSwEmulationMethodSupport()
+        support.setShortLabel(Identifier().setValue("EmuLabel"))
+        support.setShortLabel(None)
+        assert support.getShortLabel().getValue() == "EmuLabel"
+
+
+class TestMcParameterElementGroupInitialization:
+    def test_initialization(self):
+        """Test McParameterElementGroup __init__ defaults"""
+        group = McParameterElementGroup()
+        assert group is not None
+        assert group.ramLocationRef is None
+        assert group.romLocationRef is None
+        assert group.shortLabel is None
+
+
+class TestMcParameterElementGroupRamLocation:
+    def test_get_set_ram_location_ref(self):
+        """Test setRamLocationRef returns self and getRamLocationRef round-trips"""
+        group = McParameterElementGroup()
+        ref = make_ref("/Ram/Location")
+        result = group.setRamLocationRef(ref)
+        assert result is group
+        assert group.getRamLocationRef() is ref
+
+    def test_set_ram_location_ref_none_is_noop(self):
+        """Test setting a None RAM location ref is a no-op"""
+        group = McParameterElementGroup()
+        ref = make_ref("/Ram/Location")
+        group.setRamLocationRef(ref)
+        group.setRamLocationRef(None)
+        assert group.getRamLocationRef() is ref
+
+
+class TestMcParameterElementGroupRomLocation:
+    def test_get_set_rom_location_ref(self):
+        """Test setRomLocationRef returns self and getRomLocationRef round-trips"""
+        group = McParameterElementGroup()
+        ref = make_ref("/Rom/Location")
+        result = group.setRomLocationRef(ref)
+        assert result is group
+        assert group.getRomLocationRef() is ref
+
+    def test_set_rom_location_ref_none_is_noop(self):
+        """Test setting a None ROM location ref is a no-op"""
+        group = McParameterElementGroup()
+        ref = make_ref("/Rom/Location")
+        group.setRomLocationRef(ref)
+        group.setRomLocationRef(None)
+        assert group.getRomLocationRef() is ref
+
+
+class TestMcParameterElementGroupShortLabel:
+    def test_get_set_short_label(self):
+        """Test setShortLabel returns self and getShortLabel round-trips"""
+        group = McParameterElementGroup()
+        result = group.setShortLabel(Identifier().setValue("GroupLabel"))
+        assert result is group
+        assert group.getShortLabel().getValue() == "GroupLabel"
+
+    def test_set_short_label_none_is_noop(self):
+        """Test setting a None short label is a no-op"""
+        group = McParameterElementGroup()
+        group.setShortLabel(Identifier().setValue("GroupLabel"))
+        group.setShortLabel(None)
+        assert group.getShortLabel().getValue() == "GroupLabel"
+
+
+class TestMcSwEmulationMethodSupportRoundTrip:
+    def test_round_trip_via_bsw_implementation(self):
+        """Test parse -> write -> re-parse round trip of McSwEmulationMethodSupport including its element groups."""
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        document = AUTOSAR.getInstance()
+        document.clear()
+        ar_root = document.createARPackage("AUTOSAR")
+        impl = ar_root.createBswImplementation("test_impl")
+        mc_support = McSupportData()
+        impl.setMcSupport(mc_support)
+
+        support = McSwEmulationMethodSupport()
+        support.setShortLabel(Identifier().setValue("EmuLabel"))
+        support.setCategory(Identifier().setValue("initRam"))
+        support.setBaseReferenceRef(make_ref("/Base/Pointer"))
+        support.setReferenceTableRef(make_ref("/Reference/Table"))
+        group = McParameterElementGroup()
+        group.setShortLabel(Identifier().setValue("GroupLabel"))
+        group.setRamLocationRef(make_ref("/Ram/Location"))
+        group.setRomLocationRef(make_ref("/Rom/Location"))
+        support.addElementGroup(group)
+        mc_support.addEmulationSupport(support)
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, document)
+
+            document_2 = AUTOSAR.getInstance()
+            document_2.clear()
+            ARXMLParser().load(file_path, document_2)
+            mc_support_2 = document_2.getARPackages()[0].getBswImplementations()[0].getMcSupport()
+
+            assert mc_support_2 is not None
+            assert len(mc_support_2.getEmulationSupports()) == 1
+            support_2 = mc_support_2.getEmulationSupports()[0]
+            assert support_2.getShortLabel().getValue() == "EmuLabel"
+            assert support_2.getCategory().getValue() == "initRam"
+            assert support_2.getBaseReferenceRef().getValue() == "/Base/Pointer"
+            assert support_2.getReferenceTableRef().getValue() == "/Reference/Table"
+            assert len(support_2.getElementGroups()) == 1
+            group_2 = support_2.getElementGroups()[0]
+            assert group_2.getShortLabel().getValue() == "GroupLabel"
+            assert group_2.getRamLocationRef().getValue() == "/Ram/Location"
+            assert group_2.getRomLocationRef().getValue() == "/Rom/Location"
+        finally:
+            import os
+
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+    def test_round_trip_empty_element_groups_emits_no_wrapper(self):
+        """Test an empty elementGroups list round-trips to no ELEMENT-GROUPS wrapper element."""
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        document = AUTOSAR.getInstance()
+        document.clear()
+        ar_root = document.createARPackage("AUTOSAR")
+        impl = ar_root.createBswImplementation("test_impl")
+        mc_support = McSupportData()
+        impl.setMcSupport(mc_support)
+
+        support = McSwEmulationMethodSupport()
+        support.setShortLabel(Identifier().setValue("EmuLabel"))
+        mc_support.addEmulationSupport(support)
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, document)
+
+            with open(file_path, "r", encoding="utf-8") as file_handle:
+                content = file_handle.read()
+            assert "ELEMENT-GROUPS" not in content
+
+            document_2 = AUTOSAR.getInstance()
+            document_2.clear()
+            ARXMLParser().load(file_path, document_2)
+            mc_support_2 = document_2.getARPackages()[0].getBswImplementations()[0].getMcSupport()
+            support_2 = mc_support_2.getEmulationSupports()[0]
+            assert support_2.getElementGroups() == []
+            assert support_2.getBaseReferenceRef() is None
+            assert support_2.getReferenceTableRef() is None
+        finally:
+            import os
+
+            if os.path.exists(file_path):
+                os.remove(file_path)

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_FlatMap.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_FlatMap.py
@@ -1,7 +1,8 @@
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.FlatMap import FlatInstanceDescriptor, FlatMap
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.FlatMap import AliasNameAssignment, AliasNameSet, FlatInstanceDescriptor, FlatMap
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import AnyInstanceRef
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Identifier
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Identifier, RefType, String
+from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultilanguageLongName
 
 
 class TestFlatInstanceDescriptor:
@@ -133,6 +134,107 @@ class TestFlatInstanceDescriptor:
         assert flat_instance.getRole() == role
         assert flat_instance.getSwDataDefProps() == sw_data_def
         assert flat_instance.getUpstreamReferenceIRef() == ecu_ref
+
+
+class TestAliasNameAssignment:
+    def test_initialization(self):
+        """Test AliasNameAssignment initialization"""
+        assignment = AliasNameAssignment()
+
+        assert assignment.shortLabel is None
+        assert assignment.label is None
+        assert assignment.identifiableRef is None
+        assert assignment.flatInstanceRef is None
+
+    def test_get_set_short_label(self):
+        """Test getShortLabel/setShortLabel (chaining, round-trip, None no-op)"""
+        assignment = AliasNameAssignment()
+
+        value = String().setValue("aliasName")
+        result = assignment.setShortLabel(value)
+        assert result is assignment  # Method chaining
+        assert assignment.getShortLabel() == value
+
+        assignment.setShortLabel(None)  # No-op
+        assert assignment.getShortLabel() == value
+
+    def test_get_set_label(self):
+        """Test getLabel/setLabel (chaining, round-trip, None no-op)"""
+        assignment = AliasNameAssignment()
+
+        value = MultilanguageLongName()
+        result = assignment.setLabel(value)
+        assert result is assignment  # Method chaining
+        assert assignment.getLabel() == value
+
+        assignment.setLabel(None)  # No-op
+        assert assignment.getLabel() == value
+
+    def test_get_set_identifiable_ref(self):
+        """Test getIdentifiableRef/setIdentifiableRef (chaining, round-trip, None no-op)"""
+        assignment = AliasNameAssignment()
+
+        value = RefType().setValue("/IdentifiableRef")
+        result = assignment.setIdentifiableRef(value)
+        assert result is assignment  # Method chaining
+        assert assignment.getIdentifiableRef() == value
+
+        assignment.setIdentifiableRef(None)  # No-op
+        assert assignment.getIdentifiableRef() == value
+
+    def test_get_set_flat_instance_ref(self):
+        """Test getFlatInstanceRef/setFlatInstanceRef (chaining, round-trip, None no-op)"""
+        assignment = AliasNameAssignment()
+
+        value = RefType().setValue("/FlatInstanceRef")
+        result = assignment.setFlatInstanceRef(value)
+        assert result is assignment  # Method chaining
+        assert assignment.getFlatInstanceRef() == value
+
+        assignment.setFlatInstanceRef(None)  # No-op
+        assert assignment.getFlatInstanceRef() == value
+
+
+class TestAliasNameSet:
+    def test_initialization(self):
+        """Test AliasNameSet initialization"""
+        document = AUTOSAR.getInstance()
+        ar_root = document.createARPackage("AUTOSAR")
+        alias_set = AliasNameSet(ar_root, "TestAliasNameSet")
+
+        assert alias_set is not None
+        assert alias_set.getShortName() == "TestAliasNameSet"
+        assert alias_set.getAliasNames() == []
+
+    def test_add_alias_name(self):
+        """Test addAliasName method"""
+        document = AUTOSAR.getInstance()
+        ar_root = document.createARPackage("AUTOSAR")
+        alias_set = AliasNameSet(ar_root, "TestAliasNameSet")
+
+        assignment = AliasNameAssignment()
+        result = alias_set.addAliasName(assignment)
+        assert result is alias_set  # Method chaining
+        assert len(alias_set.getAliasNames()) == 1
+        assert alias_set.getAliasNames()[0] == assignment
+
+    def test_add_alias_name_none_noop(self):
+        """Test that addAliasName(None) is a no-op"""
+        document = AUTOSAR.getInstance()
+        ar_root = document.createARPackage("AUTOSAR")
+        alias_set = AliasNameSet(ar_root, "TestAliasNameSet")
+
+        alias_set.addAliasName(AliasNameAssignment())
+        alias_set.addAliasName(None)  # Should not append
+        assert len(alias_set.getAliasNames()) == 1
+
+    def test_get_alias_names_empty(self):
+        """Test getAliasNames returns empty list by default"""
+        document = AUTOSAR.getInstance()
+        ar_root = document.createARPackage("AUTOSAR")
+        alias_set = AliasNameSet(ar_root, "TestAliasNameSet")
+
+        assert alias_set.getAliasNames() == []
 
 
 class TestFlatMap:

--- a/tests/test_armodel/test_model_imports.py
+++ b/tests/test_armodel/test_model_imports.py
@@ -67,8 +67,6 @@ INTENTIONALLY_UNEXPORTED_MODULES = {
     "McFunctionDataRefSet",
     "McGroup",
     "McGroupDataRefSet",
-    "McParameterElementGroup",
-    "McSwEmulationMethodSupport",
     "ModeErrorBehavior",
     "ModeErrorReactionPolicyEnum",
     "ModeInBswInstanceRef",
@@ -97,7 +95,6 @@ INTENTIONALLY_UNEXPORTED_MODULES = {
     # Blueprint/Standardization - incomplete/experimental
     "BlueprintGenerator",
     "BlueprintMappingSet",
-    "ImplementationElementInParameterInstanceRef",
 }
 
 


### PR DESCRIPTION
## Summary

Adds and aligns AUTOSAR R23-11 measurement & calibration support model classes with parser/writer round-trip coverage.

## Changes
- `McSwEmulationMethodSupport` and `McParameterElementGroup` model classes with parser/writer serialization
- Typed `ImplementationElementInParameterInstanceRef` under `MC-DATA-INSTANCE/INSTANCE-IN-MEMORY`
- `AliasNameSet`/`AliasNameAssignment` support in `FlatMap`
- Alias model method docstrings to AUTOSAR R23-11 spec wording
- New/updated unit tests + model import tests

Closes #530