### PR TITLE
Align ArgumentDataPrototype with spec rules

### DIFF
--- a/docs/development/class_check_rules.md
+++ b/docs/development/class_check_rules.md
@@ -1167,8 +1167,15 @@ Check:
       "fix" the member value to UPPERCASE to satisfy the schema: keep the member
       matching the spec's `mmt.qualifiedName`, and write the UPPERCASE form only
       in test XML fixtures and fragments.
-- [ ] Class docstring: summarize the spec table's "Note" row (the enum's purpose
-      and scope).
+- [ ] Class docstring: lead with the spec table's "Note" row **verbatim**, the
+      same as a class docstring (13.2 Step 3) — do **not** paraphrase or
+      summarize it into invented prose. The enum's purpose and scope are the
+      Note; a "summarize the purpose" instruction invites a loose paraphrase
+      that drifts from the PDF wording (the `ServerArgumentImplPolicyEnum`/
+      `ArgumentDirectionEnum` passes showed the correct shape: a verbatim,
+      wrapped Note, e.g. `ArgumentDirectionEnum`'s "Use cases: • Arguments in
+      ClientServerOperation can have different directions …" exactly as
+      written).
 - [ ] Enum member documentation: each member must have an inline comment that
       cites the spec literal's description (not paraphrased, use the PDF wording).
       Include Tags information (e.g., `atp.EnumerationLiteralIndex=0`) to document
@@ -1740,6 +1747,21 @@ Check:
   SoftwareComponentTemplate even though the class that uses it cites the BSW
   template). Verify the enum's page in *its* PDF (with `pypdf`, matching the
   printed footer) rather than reusing the class's page.
+- **An enum that renders in more than one PDF is itself a "class in more than
+  one PDF" and uses the same sibling-family rule — but its sibling family is
+  the *enums* in the same template, not the class that references it.** A
+  shared enum (Rule 1.8) can have its own `Enumeration` table in several
+  templates with the same package and literal rows (e.g.
+  `ArgumentDirectionEnum` renders as BSW Table 4.8, SWC Table 4.9, and
+  SystemTemplate Table F.16; `ServerArgumentImplPolicyEnum` renders only as
+  SWC Table 4.10). Cite the PDF that the enum's *sibling enums* already use
+  (e.g. `ArgumentDirectionEnum` cites the SWC template because its sibling
+  `ServerArgumentImplPolicyEnum` — the other enum used by
+  `ArgumentDataPrototype` — cites SWC Table 4.10), and keep that choice stable
+  across the enum family; the referencing class's own PDF choice does **not**
+  dictate the enum's (the class may cite BSW Table D.7 while its enum
+  attributes cite the SWC template). When an enum has no aligned sibling yet,
+  fall back to the template that renders the enum's most complete table.
 - Table number must be in format `X.Y` (e.g., `5.38`, not `5-38` or `538`).
 - The page number must **always** be present — a `# Spec:` line without
   `p.<page>` is a violation. Page number is from the PDF's own printed page
@@ -2192,10 +2214,27 @@ vs. getter vs. setter) and a fix to one does not propagate to the others.
         wording) — never silently substitute the XSD text for the PDF
         `Note`, never invent prose to "expand" a terse note.
 - [ ] **Step 4 — Per-attribute sync loop.** For **every** attribute row in
-      the spec table (not just the ones that look wrong), do all four of the
-      following before moving to the next attribute — treat this as one unit
-      of work per attribute, not four separate passes over the whole class:
-       1. **Inline `__init__` comment**: quote the attribute's PDF `Note`
+      the spec table (not just the ones that look wrong), do all **five** of
+      the following before moving to the next attribute — treat this as one
+      unit of work per attribute, not separate passes over the whole class:
+       1. **Referenced type must exist and be aligned before typing.**
+          Check the attribute row's `Type` column first: if it names a model
+          class or enum (e.g. an `Enumeration` like
+          `ServerArgumentImplPolicyEnum`), that type must **exist** in the
+          codebase and carry its own `# Spec:`/`# Spec verified:` markers —
+          Rule 1.10 applies to **every** referenced type, not only
+          `<name>InstanceRef`s. The field and accessor annotations are typed
+          against that class, so if it is missing, implement it first from
+          its own spec table (checklist, marker, tests, parser/writer
+          coverage) and only then type the attribute. The referenced type's
+          `# Spec:` citation is **independent** of the owning class's: it
+          cites the PDF/table/page that renders the referenced type's **own**
+          table. E.g. the enum `ServerArgumentImplPolicyEnum` is spec'd by
+          SWC Table 4.10 even though the `ArgumentDataPrototype` field using
+          it cites BSW Table D.7 — never copy the owning class's citation
+          onto the referenced type or vice versa, and give the new type its
+          own table location/version search.
+       2. **Inline `__init__` comment**: quote the attribute's PDF `Note`
           **semantic sentence** verbatim/near-verbatim; do **not** paste the
           `Stereotypes:`/`Tags:` tail (e.g. `Stereotypes: atpSplitable;
           atpVariation Tags: atp.Splitkey=...`) — that tail is tooling
@@ -2219,27 +2258,27 @@ vs. getter vs. setter) and a fix to one does not propagate to the others.
           (`...ApplicationRuleBasedValueSpecification.swAxisCont.category
           shall not be set to fixAXIS. [constr_10041]`), not pasted as a
           `Note` replacement.
-      2. **Getter docstring**: summarize the same `Note` + constraint — not
-         "Gets the value of X". Mention what the attribute represents in
-         AUTOSAR, cite the applicable `constr_*` id (an attribute-level
-         constraint, e.g. `constr_4072` on
-         `SectionNamePrefix.implementedIn`, is cited in **both** the
-         `__init__` comment and the getter/setter docstrings — not just
-         one), and for an `iref` attribute name the concrete
-         `<name>InstanceRef` implementing class (so the concrete iref type
-         is discoverable in the code, not only in the deviation tracker).
-      3. **Setter docstring**: same `Note`/constraint summary as the getter,
-         plus the chainable-return behavior. **If the setter is guarded**
-         (`if value is not None:`), it **must** also state, verbatim: *"A
-         None value is a no-op and does not overwrite an existing
-         `<attr>`."* This is not optional — a guarded setter without this
-         sentence is an incomplete sync even if the rest of the docstring is
-         correct.
-      4. **Cross-check the four against each other**: the comment, getter,
-         and setter for the same attribute should tell a consistent story —
-         a getter that was updated but a setter left with the old wording
-         (or a constraint cited in one but not the others) is a common
-         half-sync failure.
+       3. **Getter docstring**: summarize the same `Note` + constraint — not
+          "Gets the value of X". Mention what the attribute represents in
+          AUTOSAR, cite the applicable `constr_*` id (an attribute-level
+          constraint, e.g. `constr_4072` on
+          `SectionNamePrefix.implementedIn`, is cited in **both** the
+          `__init__` comment and the getter/setter docstrings — not just
+          one), and for an `iref` attribute name the concrete
+          `<name>InstanceRef` implementing class (so the concrete iref type
+          is discoverable in the code, not only in the deviation tracker).
+       4. **Setter docstring**: same `Note`/constraint summary as the getter,
+          plus the chainable-return behavior. **If the setter is guarded**
+          (`if value is not None:`), it **must** also state, verbatim: *"A
+          None value is a no-op and does not overwrite an existing
+          `<attr>`."* This is not optional — a guarded setter without this
+          sentence is an incomplete sync even if the rest of the docstring is
+          correct.
+       5. **Cross-check the four against each other**: the comment, getter,
+          and setter for the same attribute should tell a consistent story —
+          a getter that was updated but a setter left with the old wording
+          (or a constraint cited in one but not the others) is a common
+          half-sync failure.
 
       Two worked examples of an inline comment quoting the spec `Note`:
       ```python

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
@@ -943,18 +943,32 @@ class DiagRequirementIdString(ARLiteral):
 
 class ArgumentDirectionEnum(AREnum):
     """
-    Enumeration for argument direction in AUTOSAR models.
-    Defines the direction of arguments in function interfaces.
+    Use cases: • Arguments in ClientServerOperation can have different directions
+    that need to be formally indicated because they have an impact on how the
+    function signature looks like eventually. • Arguments in BswModuleEntry
+    already determine a function signature, but the direction is used to specify
+    the semantics, especially of pointer arguments.
     """
 
     # ArgumentDirectionEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [x] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.9, p.104
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
 
+    # The argument value is passed to the callee. Tags: atp.EnumerationLiteralIndex=0
     IN = "in"
+
+    # The argument value is passed to the callee but also passed back from the callee
+    # to the caller. Tags: atp.EnumerationLiteralIndex=1
     INOUT = "inout"
+
+    # The argument value is passed from the callee to the caller. Tags: atp.EnumerationLiteralIndex=2
     OUT = "out"
 
     def __init__(self):
+        """
+        Initializes an ArgumentDirectionEnum instance with the spec-defined literals.
+        """
         super().__init__((ArgumentDirectionEnum.IN, ArgumentDirectionEnum.INOUT, ArgumentDirectionEnum.OUT))
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/__init__.py
@@ -6,14 +6,14 @@ parameter interfaces, as well as mapping classes for interface mappings.
 """
 
 from abc import ABC
-from typing import List
+from typing import List, Optional
 
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import TextValueSpecification
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.TriggerDeclaration import Trigger, TriggerMapping
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpStructureElement, AtpType, AtpBlueprintable
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, ArgumentDirectionEnum, Boolean
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARLiteral, ARNumerical, ArgumentDirectionEnum, Boolean
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.DataPrototypes import ParameterDataPrototype, VariableDataPrototype, AutosarDataPrototype
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean
@@ -275,32 +275,129 @@ class SenderReceiverInterface(DataInterface):
         return list(filter(lambda c: isinstance(c, InvalidationPolicy), self.invalidationPolicies))
 
 
+class ServerArgumentImplPolicyEnum(AREnum):
+    """
+    This defines how the argument type of the servers RunnableEntity is implemented.
+    """
+
+    # ServerArgumentImplPolicyEnum method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.10, p.105
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
+
+    # The argument type of the RunnableEntity is derived from the AutosarDataType of the
+    # Argument Prototype. Tags: atp.EnumerationLiteralIndex=0
+    USE_ARGUMENT_TYPE = "useArgumentType"
+
+    # The argument type of the RunnableEntity is void. Tags: atp.EnumerationLiteralIndex=2
+    USE_VOID = "useVoid"
+
+    def __init__(self):
+        """
+        Initializes a ServerArgumentImplPolicyEnum instance with the spec-defined literals.
+        """
+        super().__init__((ServerArgumentImplPolicyEnum.USE_ARGUMENT_TYPE, ServerArgumentImplPolicyEnum.USE_VOID))
+
+
 class ArgumentDataPrototype(AutosarDataPrototype):
+    """
+    An argument of an operation, much like a data element, but also carries direction
+    information and is owned by a particular ClientServerOperation.
+    The overriding value of attribute swImplPolicy of an ArgumentDataPrototype shall be
+    standard. [constr_2047]
+    """
+
     # ArgumentDataPrototype method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getDirection                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setDirection                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getServerArgumentImplPolicy  [x] impl  [ ] docstring  [ ] test
-    # [ ] setServerArgumentImplPolicy  [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table D.7, p.303
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
+    # [x] getDirection                 [x] impl  [x] docstring  [x] test
+    # [x] setDirection                 [x] impl  [x] docstring  [x] test
+    # [x] getServerArgumentImplPolicy  [x] impl  [x] docstring  [x] test
+    # [x] setServerArgumentImplPolicy  [x] impl  [x] docstring  [x] test
 
     def __init__(self, parent: ARObject, short_name: str):
+        """
+        Initializes an ArgumentDataPrototype instance with an argument direction and a server
+        argument implementation policy.
+        """
         super().__init__(parent, short_name)
 
-        self.direction: ArgumentDirectionEnum = None
-        self.serverArgumentImplPolicy = None
+        # This attribute specifies the direction of the argument prototype.
+        # For each ArgumentDataPrototype, attribute direction shall be defined at the time
+        # when the contract phase generation is executed. [constr_1869]
+        self.direction: Optional[ArgumentDirectionEnum] = None
 
-    def getDirection(self):
+        # This defines how the argument type of the servers RunnableEntity is implemented.
+        # If the attribute is not defined this has the same semantics as if the attribute is set
+        # to the value useArgumentType for primitive arguments and structures.
+        # The value of the attribute ArgumentDataPrototype.serverArgumentImplPolicy shall not be
+        # set to useVoid for an ArgumentDataPrototype of direction in that is typed by an
+        # AutosarDataType that boils down to a primitive C data type. [constr_1286]
+        self.serverArgumentImplPolicy: Optional[ServerArgumentImplPolicyEnum] = None
+
+    def getDirection(self) -> Optional[ArgumentDirectionEnum]:
+        """
+        Gets the direction of the argument prototype.
+        This attribute specifies the direction of the argument prototype.
+        For each ArgumentDataPrototype, attribute direction shall be defined at the time
+        when the contract phase generation is executed. [constr_1869]
+
+        Returns:
+            Optional[ArgumentDirectionEnum]: The direction, or None if not set
+        """
         return self.direction
 
-    def setDirection(self, value):
+    def setDirection(self, value: Optional[ArgumentDirectionEnum]) -> "ArgumentDataPrototype":
+        """
+        Sets the direction of the argument prototype.
+        This attribute specifies the direction of the argument prototype.
+        For each ArgumentDataPrototype, attribute direction shall be defined at the time
+        when the contract phase generation is executed. [constr_1869]
+        A None value is a no-op and does not overwrite an existing direction.
+
+        Args:
+            value: The direction to set
+
+        Returns:
+            ArgumentDataPrototype: self for method chaining
+        """
         if value is not None:
             self.direction = value
         return self
 
-    def getServerArgumentImplPolicy(self):
+    def getServerArgumentImplPolicy(self) -> Optional[ServerArgumentImplPolicyEnum]:
+        """
+        Gets the server argument implementation policy.
+        This defines how the argument type of the servers RunnableEntity is implemented.
+        If the attribute is not defined this has the same semantics as if the attribute is set
+        to the value useArgumentType for primitive arguments and structures.
+        The value of the attribute ArgumentDataPrototype.serverArgumentImplPolicy shall not be
+        set to useVoid for an ArgumentDataPrototype of direction in that is typed by an
+        AutosarDataType that boils down to a primitive C data type. [constr_1286]
+
+        Returns:
+            Optional[ServerArgumentImplPolicyEnum]: The policy, or None if not set
+        """
         return self.serverArgumentImplPolicy
 
-    def setServerArgumentImplPolicy(self, value):
+    def setServerArgumentImplPolicy(self, value: Optional[ServerArgumentImplPolicyEnum]) -> "ArgumentDataPrototype":
+        """
+        Sets the server argument implementation policy.
+        This defines how the argument type of the servers RunnableEntity is implemented.
+        If the attribute is not defined this has the same semantics as if the attribute is set
+        to the value useArgumentType for primitive arguments and structures.
+        The value of the attribute ArgumentDataPrototype.serverArgumentImplPolicy shall not be
+        set to useVoid for an ArgumentDataPrototype of direction in that is typed by an
+        AutosarDataType that boils down to a primitive C data type. [constr_1286]
+        A None value is a no-op and does not overwrite an existing policy.
+
+        Args:
+            value: The policy to set
+
+        Returns:
+            ArgumentDataPrototype: self for method chaining
+        """
         if value is not None:
             self.serverArgumentImplPolicy = value
         return self

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_PortInterface.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_PortInterface.py
@@ -14,6 +14,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import
     MetaDataItemSet,
     SenderReceiverInterface,
     ArgumentDataPrototype,
+    ServerArgumentImplPolicyEnum,
     ApplicationError,
     ClientServerOperation,
     ClientServerInterface,
@@ -215,6 +216,24 @@ class TestSenderReceiverInterface:
         assert policy_created in sr_interface.getInvalidationPolicys()
 
 
+class TestServerArgumentImplPolicyEnum:
+    """Test class for ServerArgumentImplPolicyEnum class."""
+
+    def test_server_argument_impl_policy_enum_initialization(self):
+        """Test ServerArgumentImplPolicyEnum initialization."""
+        enum = ServerArgumentImplPolicyEnum()
+
+        assert enum.getEnumValues() == ("useArgumentType", "useVoid")
+
+        arg_type_enum = ServerArgumentImplPolicyEnum()
+        arg_type_enum.setValue("useArgumentType")
+        assert arg_type_enum.getValue() == ServerArgumentImplPolicyEnum.USE_ARGUMENT_TYPE
+
+        void_enum = ServerArgumentImplPolicyEnum()
+        void_enum.setValue("useVoid")
+        assert void_enum.getValue() == ServerArgumentImplPolicyEnum.USE_VOID
+
+
 class TestArgumentDataPrototype:
     """Test class for ArgumentDataPrototype class."""
 
@@ -238,7 +257,8 @@ class TestArgumentDataPrototype:
         assert arg_proto.getDirection() == direction
 
         # Test serverArgumentImplPolicy methods
-        policy = "test_policy"
+        policy = ServerArgumentImplPolicyEnum()
+        policy.setValue("useArgumentType")
         arg_proto.setServerArgumentImplPolicy(policy)
         assert arg_proto.getServerArgumentImplPolicy() == policy
 


### PR DESCRIPTION
## Summary
- Add `ServerArgumentImplPolicyEnum` (SWC Table 4.10, R23-11) with spec markers, literals, and tests.
- Align `ArgumentDataPrototype`: spec citations (BSW Table D.7), `Optional` typed fields, getter/setter docstrings, guarded-setter "None is a no-op" note, and `constr_1869`/`constr_1286` references.
- Update `ArgumentDirectionEnum` docstring to the verbatim spec Note plus per-literal `atp.EnumerationLiteralIndex` tags.
- Extend `class_check_rules.md` with referenced-type (Rule 1.10) and sibling-enum PDF-citation rules.

## Test plan
- [ ] `python scripts/run_tests.py` passes (unit + integration)
- [ ] `npm run ruff-check` and `npm run flake8` clean
- [ ] `npm run black-check` passes
- [ ] Review spec markers (`# Spec:` / `# Spec verified:`) match cited PDF/table/page