### PR TITLE
docs: add 1.9.1-1.9.3 change notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,22 @@ $connector-update src/armodel/tests/test_files/SoftwareComponents.arxml data/Sof
 
 ## 1.12. Change notes:
 
+**Version 1.9.3**
+
+* Added parse/write support for `NvDataInterface` (PR #485)
+* Added `--unescape-entities` parameter to `arxml-format` CLI to normalize `&quot;` / `&apos;` entities in attribute values (PR #495)
+* Bumped project version metadata to 1.9.3
+
+**Version 1.9.2**
+
+* Added parse/write support for `PREDEFINED-VARIANT` and related reference lists under variant handling (PR #481)
+* Added `PredefinedVariant` model reference and suffix APIs
+
+**Version 1.9.1**
+
+* Added `SW-SYSTEMCONSTANT-VALUE-SET` ARXML input/output support (PR #479)
+* Added `ARPackage` APIs and tests for system constant value sets
+
 **Version 1.9.0**
 
 1. **Testing Infrastructure**


### PR DESCRIPTION
## Summary
- Sync README change notes with `docs/changelog.rst` by adding the missing **Version 1.9.3**, **1.9.2**, and **1.9.1** entries above the existing 1.9.0 entry.
- Version is already 1.9.3 across the codebase (`src/armodel/__init__.py`) and documentation; this PR only updates the README change-notes section.

## Test plan
- [x] Review rendered README "Change notes" section shows 1.9.3 / 1.9.2 / 1.9.1 above 1.9.0.
