### PR TITLE
docs: add readthedocs link and full API-by-package reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ To support AUTOSAR model with python
 |--|--|--|--|--|
 |[![GitHub version](https://badge.fury.io/gh/melodypapa%2Fpy-armodel.svg)](https://badge.fury.io/gh/melodypapa%2Fpy-armodel)|[![Documentation Status](https://readthedocs.org/projects/py-armodel/badge/?version=latest)](https://py-armodel.readthedocs.io/en/latest)|[![](https://www.travis-ci.com/melodypapa/py-armodel.svg?branch=main)](https://www.travis-ci.com/melodypapa/py-armodel)|[![Coverage Status](https://coveralls.io/repos/github/melodypapa/py-armodel/badge.svg?branch=main)](https://coveralls.io/github/melodypapa/py-armodel?branch=main)|[![PyPI version](https://badge.fury.io/py/armodel.svg)](https://badge.fury.io/py/armodel)|
 
+Full documentation: https://py-armodel.readthedocs.io/en/latest/
+
 ## 1.3. How to create the distribution and upload to pypi
 1. Run `python -m build` to generate distribution (requires `pip install build`)
 2. Run `twine check dist/*` to check the validation of distribution

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -114,6 +114,19 @@ Documentation Structure
 
 .. toctree::
    :maxdepth: 2
+   :caption: Full API (by package):
+
+   api/armodel.models
+   api/armodel.parser
+   api/armodel.writer
+   api/armodel.cli
+   api/armodel.transformer
+   api/armodel.report
+   api/armodel.data_models
+   api/armodel.lib
+
+.. toctree::
+   :maxdepth: 2
    :caption: Examples:
 
    examples/basic_usage


### PR DESCRIPTION
- Add explicit py-armodel.readthedocs.io link below the badge table in README.
- Reorganize the Sphinx API Reference: keep the curated overview pages and add a "Full API (by package)" toctree linking the auto-generated package index pages so every class is reachable by its package name.