### PR TITLE
Add DIAG-ARG-INTEGRITY support to ClientServerOperation

### DIFF
--- a/docs/development/class_check_rules.md
+++ b/docs/development/class_check_rules.md
@@ -199,7 +199,11 @@ The class must reflect the AUTOSAR PDF specification for its attributes.
 - [ ] Every spec attribute must map to a field **plus** an accessor pair. The
       method parity checklist (Rule 2) only tracks methods, so a class can be
       checklist-complete while still missing accessors — a field without a
-      getter/setter is a gap.
+      getter/setter is a gap. For an `Identifiable` aggregator, a spec `*`
+      `aggr` row still maps to its **own** typed list field even though the
+      created children also live in the shared `elements` registry; the getter
+      reads that field directly, not a `list(filter(isinstance, elements))`
+      view of the registry (see Rule 4).
 - [ ] No fabricated attributes: the reverse of attribute-level completeness —
       every field in the class must trace back to a spec attribute. A class
       can be checklist-complete (every method `[x] impl/docstring/test`) yet
@@ -1594,6 +1598,8 @@ Check:
       via `->` notation).
 - [ ] `npm run black-check` passes for the file — signatures that fit within
       200 characters are on one line, not hand-broken.
+- [ ] `npm run ruff-check` passes for the file (the broader `E`/`F`/`W`/`I`
+      set, including unused-import `F401` that the syntax-only flake8 set skips).
 - [ ] The method body begins on a new line after the `:`.
 
 Note: a trailing comma after the last parameter is Black's "magic trailing
@@ -1657,6 +1663,67 @@ def setSomeEnumValue(self, value):
       `Identifiable` with `__init__(self, parent, short_name)`) at least far
       enough for the factory to build it; the remainder of the child's own
       alignment is tracked separately in the deviation tracker.
+- [ ] **A spec-`*` aggregated attribute on an `Identifiable` aggregator is
+      backed by a dedicated typed list field, not by filtering the shared
+      `elements` registry.** Rule 1.3 ("every spec attribute maps to a field")
+      applies even when the created children also live in the `elements`
+      registry for short-name lookup: each spec `*` `aggr` row maps to its
+      **own** field (`self.operations: List[ClientServerOperation] = []`,
+      `self.possibleErrors: List[ApplicationError] = []`), declared in
+      `__init__` in spec row order with the spec `Note` as its comment
+      (Rule 13.2 Step 4.2). The `createXxx(short_name)` factory appends to
+      that field **in addition to** `addElement` (keeping the registry and
+      the field in sync), and `getXxxs()` returns the field **directly** —
+      never `list(filter(lambda c: isinstance(c, Xxx), self.elements))`.
+      Filtering the registry on every getter call has two defects: (a) it
+      gives the spec attribute no model field of its own, so the
+      field-to-spec cross-check (Rule 1.3) finds the attribute unmodeled;
+      and (b) it discriminates by Python type rather than by spec role, so
+      two spec attributes whose children share a base type would collapse
+      into one filtered list. The dedicated-field shape is the established
+      sibling pattern (`ParameterInterface.parameters`, and now
+      `ClientServerInterface.operations`/`possibleErrors`). The `elements`
+      registry still does the factory's "return existing on same short
+      name" job (`IsElementExists`/`getElement`, above) — registry and
+      field coexist, each for its own purpose; only the getter reads the
+      field.
+- [ ] **An `Identifiable` aggregator that handles its members *only*
+      through the `elements` registry is a to-fix, not an accepted shape.**
+      The tell-tale is a getter of the form
+      `list(filter(lambda c: isinstance(c, Xxx), self.elements))` (or
+      `sorted(filter(isinstance(...), self.elements), ...)`) for a spec `*`
+      `aggr` attribute that has **no** dedicated field in `__init__` — the
+      class borrows the inherited registry as its only storage and
+      re-derives each attribute's membership by Python type on every call.
+      This is both a Rule 1.3 violation (the spec attribute has no model
+      field of its own) and a Rule 4 violation (the getter does not read an
+      own field), and it survives a fully-`[x]` checklist plus
+      parser/writer coverage exactly like the fabricated-attribute /
+      stale-row anti-patterns do — so do **not** treat a complete checklist
+      or a passing round-trip as evidence the shape is right. Migrate it in
+      one pass, per spec attribute row:
+      1. add the dedicated typed list field in `__init__`, in spec row
+         order, with the spec `Note` as its comment
+         (`self.operations: List[ClientServerOperation] = []`);
+      2. make the `createXxx(short_name)` factory **append** the new
+         instance to that field right after `addElement` (the
+         `IsElementExists`/`getElement` duplicate check stays on the
+         registry);
+      3. rewrite `getXxxs()` to `return self.<field>` (drop the
+         `isinstance` filter entirely); and
+      4. assert the field's `[]` default in the test (Rule 7) so the new
+         `__init__` field is covered.
+      The parser/writer need no change — they already call `createXxx`/
+      `getXxxs`, which now flow through the dedicated field. The previously
+      recorded deviation row (if any) for the attribute is removed once the
+      field is added, since the attribute is now modeled. `ClientServerInterface`
+      is the worked example (migrated from the registry-filter shape to
+      `self.operations`/`self.possibleErrors`); sibling classes still in the
+      old shape (e.g. `NvDataInterface.getNvDatas` returns
+      `list(filter(isinstance(...), self.elements))`) are deviations to
+      reconcile, **not** a pattern to copy — a fully-`[x]` sibling in the
+      elements-only shape is a prior deviation, exactly like Rule 1.6's
+      "an already-aligned sibling is not an authority".
 - [ ] `create*` factories are only used for children that are
       `Referrable`/`Identifiable` per their spec `Base`; non-Identifiable
       children use `setXXX` (multiplicity `0..1`) or `addXxx(value)`
@@ -2005,10 +2072,14 @@ field-to-spec cross-check is the gate, not the checklist.
       obsolete and must not be applied by hand.
 - [ ] No trailing whitespace on blank lines (`W293`) or after code (`W291`),
       and at most one blank line between definitions (`E303`).
-      (CI flake8 enforces only the syntax set `E9/F63/F7/F82`; line length (127)
-      and style codes like `W291`/`W293`/`E303` run exit-zero, so violations are
-      warnings only and are tracked as a separate cleanup, but new or edited code
-      must not introduce them.)
+      The project runs two linters: `npm run flake8` (CI, syntax-only set
+      `E9/F63/F7/F82`) and `npm run ruff-check` (the broader `E`/`F`/`W`/`I`
+      set from `pyproject.toml` `[tool.ruff]`, ignoring only `E501`). Ruff
+      therefore **enforces** `W291`/`W293`/`E303` and unused-import `F401`
+      that the flake8 syntax set leaves as warnings — so new or edited code
+      must pass `npm run ruff-check` (or the file-scoped `ruff check <file>`,
+      which reads the same config) as well as `npm run black-check`; an
+      outstanding whole-tree cleanup is tracked separately.
 - [ ] No comments are added unless they carry spec information (per AGENTS.md,
       comments are only written when asked).
 
@@ -2023,11 +2094,14 @@ separate logical units within the class.
 Check:
 - [ ] Every attribute in `__init__` has a blank line before and after its
       comment + assignment block.
-      **This is a manual-only check — Black and flake8 do not enforce it.**
-      Black leaves a run of contiguous `# comment / self.field = …` blocks
-      untouched (it only separates top-level statements), and the flake8 syntax
-      set catches nothing, so a class can pass `black-check`, `flake8`, the
-      set-based checklist, and all tests while its `__init__` fields are glued
+      **This is a manual-only check — Black, flake8, and ruff do not enforce
+      it.** Black leaves a run of contiguous `# comment / self.field = …` blocks
+      untouched (it only separates top-level statements); ruff's `E303` caps
+      the *maximum* number of blank lines but enforces no *minimum* between
+      statements, so it does not require a blank line between field blocks
+      either. A class can therefore pass `black-check`, `npm run ruff-check`,
+      `flake8`, the set-based checklist, and all tests while its `__init__`
+      fields are glued
       together (this happened to `AliasNameAssignment` and
       `SupervisedEntityNeeds` during alignment — the fields were written
       contiguously and nothing flagged it). Verify spacing by eye or with a
@@ -2163,6 +2237,8 @@ check):
 ```bash
 python -m pytest tests/test_armodel/models/M2/AUTOSARTemplates/<package>/test_<ClassName>.py -q
 PATH=".venv/Scripts:$PATH" flake8 --exclude=.venv,build --select=E9,F63,F7,F82 \
+  src/armodel/models/M2/AUTOSARTemplates/<package>/<ClassName>.py
+PATH=".venv/Scripts:$PATH" ruff check \
   src/armodel/models/M2/AUTOSARTemplates/<package>/<ClassName>.py
 ```
 
@@ -2590,10 +2666,10 @@ Verification:
   grep -nE 'AUTOSAR\.getInstance\(\)\.' \
       src/armodel/parser/arxml_parser.py src/armodel/writer/arxml_writer.py
   ```
-- After any parser/writer edit, run `npm run black-check` and the full suite
-  (`python scripts/run_tests.py`). Enforcing this rule is a purely mechanical,
-  behavior-preserving refactor: round-trip parse → write → re-parse must still
-  match for every integration fixture (29 ARXML files).
+- After any parser/writer edit, run `npm run ruff-check`, `npm run black-check`,
+  and the full suite (`python scripts/run_tests.py`). Enforcing this rule is a
+  purely mechanical, behavior-preserving refactor: round-trip parse → write →
+  re-parse must still match for every integration fixture (29 ARXML files).
 
 ---
 

--- a/docs/development/class_check_rules.md
+++ b/docs/development/class_check_rules.md
@@ -1132,13 +1132,36 @@ The class must reflect the AUTOSAR PDF specification for its attributes.
       the subtype name and use *its* table for the `# Spec:` citation, the
       member order, and the attribute set. A subtype's own attributes are
       invisible if you only read the family's parent table.
-- [ ] Within one attribute, the accessor pair order is `getXxx` then
-      `setXxx` (or `addXxx`/`getXxxs` for list attributes) — getter before
-      setter for each attribute, mirroring the sibling classes that are already
-      aligned (e.g. `Compiler` lists `getName`/`setName`, `getOptions`/
-      `setOptions`, ...). The getter-first pairing is uniform across aligned
-      classes; only the *attribute* sequence varies, and that sequence comes
-      from the PDF.
+- [ ] **Group accessors per attribute, in spec row order** — the accessor
+      pair(s) of one attribute are contiguous, immediately followed by the
+      next attribute's pair(s), and the checklist rows (Rule 2) follow that
+      same sequence. A class whose accessors are grouped by *method kind*
+      instead (all `create*`/`add*` factories together, then all `get*`
+      getters together) violates this even when every method is present and
+      the checklist is complete — e.g. `ClientServerInterface` (PDF order
+      `operation`, `possibleError`) must read `createOperation`,
+      `getOperations`, `createApplicationError`, `getPossibleErrors`, **not**
+      `createOperation`, `createApplicationError`, `getOperations`,
+      `getPossibleErrors`. The grouped-by-method-kind shape is easy to miss
+      because the set-based check (Rule 2/7) is order-blind, so verify the
+      *source order* of methods against the spec rows explicitly.
+      Within one attribute the pair order depends on the accessor kind:
+      1. **Scalar pair** (`getXxx`/`setXxx`): **getter first** —
+         `getName`/`setName`, `getOptions`/`setOptions` (the `Compiler`
+         precedent).
+      2. **List/aggregated pair** (`addXxx`/`getXxxs` or
+         `createXxx`/`getXxxs`): **mutator first** —
+         `addEmulationSupport`/`getEmulationSupports`,
+         `createMcParameterInstance`/`getMcParameterInstances`
+         (`McSupportData`), `createOperation`/`getOperations`
+         (`ClientServerInterface`). The "getter before setter" rule for the
+         scalar shape applies *only* to `getXxx`/`setXxx`; do **not** read it
+         as requiring `getOperations` before `createOperation` (that would
+         contradict the aligned `addXxx`/`getXxxs` convention, which always
+         writes the mutator that *builds* the element before the getter that
+         *reads* the resulting list).
+      Only the *attribute* sequence varies, and that sequence comes from the
+      PDF.
 
 Verification: cross-check each attribute (name, multiplicity, **type**)
 against the PDF table and the corresponding XSD in

--- a/docs/development/method_deviation_by_class.md
+++ b/docs/development/method_deviation_by_class.md
@@ -831,16 +831,30 @@ on the member set and order; SWC Table 4.6 is cited as the complete rendering (P
 Note, Base, Aggregated-by and Attribute rows).
 
 ## `ClientServerOperation`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 309
+- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 102
 - **Package:** `M2::AUTOSARTemplates::SWComponentTemplate::PortInterface`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/__init__.py`
 
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `diagArgIntegrity` | `Boolean` | — | missing |
-| — *(missing)* | `—` | `fireAndForget` | `Boolean` | — | missing |
-| — *(missing)* | `—` | `possibleApErrorRefs` | `Ref (ApApplicationError)` | Refs | missing |
-| — *(missing)* | `—` | `possibleApErrorSetRefs` | `Ref (ApApplicationErrorSet)` | Refs | missing |
+No deviations — Table 4.7 attributes (`argument`, `diagArgIntegrity`, `possibleError`) are
+implemented with parser/writer coverage and tests. The previously recorded `diagArgIntegrity`
+`missing` row is removed: the member is now implemented as a `0..1` `Boolean` attribute
+(field + `getDiagArgIntegrity`/`setDiagArgIntegrity` pair) wired into
+`parser/arxml_parser.py` (`readClientServerOperation`) and
+`writer/arxml_writer.py` (`writeClientServerOperation`) via `DIAG-ARG-INTEGRITY`.
+
+The previously recorded `fireAndForget`, `possibleApErrorRefs` (`possibleApError`),
+and `possibleApErrorSetRefs` (`possibleApErrorSet`) `missing` rows are removed as
+stale, not modeled: each is an `mmt.RestrictToStandards="AP"`, `atp.Status="draft"`
+member of the old-release XSD (`docs/requirements/xsd/AUTOSAR_00046.xsd`) only, absent
+from **every** CP R23-11 rendering of the class's table (SWC Table 4.7, BSW Table D.18,
+DiagnosticExtract Table C.14) — they are AP-restricted draft attributes, not CP spec
+attributes of `ClientServerOperation`, so no field is required and no deviation applies.
+
+Cross-checked across the renderings (SWC Table 4.7, BSW Table D.18, DiagnosticExtract
+Table C.14) — all agree on the member set and order (`argument`, `diagArgIntegrity`,
+`possibleError`) and on the Package/Note/Base rows; SWC Table 4.7 is cited as the
+complete rendering, matching the sibling family (`ClientServerInterface` cites SWC
+Table 4.6).
 
 ## `ExecutableEntityActivationReason`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 315

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/__init__.py
@@ -485,12 +485,18 @@ class ClientServerInterface(PortInterface):
     # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test
     # [x] createOperation              [x] impl  [x] docstring  [x] test
-    # [x] createApplicationError       [x] impl  [x] docstring  [x] test
     # [x] getOperations                [x] impl  [x] docstring  [x] test
+    # [x] createApplicationError       [x] impl  [x] docstring  [x] test
     # [x] getPossibleErrors            [x] impl  [x] docstring  [x] test
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
+
+        # ClientServerOperation(s) of this ClientServerInterface.
+        self.operations: List[ClientServerOperation] = []
+
+        # Application errors that are defined as part of this interface.
+        self.possibleErrors: List[ApplicationError] = []
 
     def createOperation(self, short_name: str) -> ClientServerOperation:
         """
@@ -506,7 +512,17 @@ class ClientServerInterface(PortInterface):
         if not self.IsElementExists(short_name):
             operation = ClientServerOperation(self, short_name)
             self.addElement(operation)
+            self.operations.append(operation)
         return self.getElement(short_name, ClientServerOperation)
+
+    def getOperations(self) -> List[ClientServerOperation]:
+        """
+        Gets the ClientServerOperation(s) of this ClientServerInterface.
+
+        Returns:
+            The list of ClientServerOperation instances
+        """
+        return self.operations
 
     def createApplicationError(self, short_name: str) -> ApplicationError:
         """
@@ -522,16 +538,8 @@ class ClientServerInterface(PortInterface):
         if not self.IsElementExists(short_name):
             error = ApplicationError(self, short_name)
             self.addElement(error)
+            self.possibleErrors.append(error)
         return self.getElement(short_name, ApplicationError)
-
-    def getOperations(self) -> List[ClientServerOperation]:
-        """
-        Gets the ClientServerOperation(s) of this ClientServerInterface.
-
-        Returns:
-            The list of ClientServerOperation instances
-        """
-        return list(filter(lambda c: isinstance(c, ClientServerOperation), self.elements))
 
     def getPossibleErrors(self) -> List[ApplicationError]:
         """
@@ -540,7 +548,7 @@ class ClientServerInterface(PortInterface):
         Returns:
             The list of ApplicationError instances
         """
-        return list(filter(lambda c: isinstance(c, ApplicationError), self.elements))
+        return self.possibleErrors
 
 
 class TriggerInterface(PortInterface):

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/__init__.py
@@ -422,56 +422,135 @@ class ApplicationError(Identifiable):
 class ClientServerOperation(AtpStructureElement):
     """
     An operation declared within the scope of a client/server interface.
-    Package: M2::AUTOSARTemplates::SWComponentTemplate::PortInterface
-    Base: ARObject, AtpClassifier , AtpBlueprintable, AtpStructureElement, Identifiable, MultilanguageReferrable, Referrable
-
-    Attributes:
-    -----------
-    _argument: ArgumentDataPrototype (optional)
-        An argument of this ClientServerOperation
-
-    _possibleError: RefType -> ApplicationError (optional)
-        Possible errors that may by raised by the referring operation
-
-    Methods:
-    --------
-    addArgumentDataPrototype    add the argument
-    getArgumentDataPrototypes   get the arguments
-    addPossibleErrorRef         add the possible error
-    getPossbileErrorRefs        get the possible errors
-
     """
 
     # ClientServerOperation method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getArguments                 [x] impl  [ ] docstring  [ ] test
-    # [ ] createArgumentDataPrototype  [x] impl  [ ] docstring  [ ] test
-    # [ ] getPossibleErrorRefs         [x] impl  [ ] docstring  [ ] test
-    # [ ] addPossibleErrorRef          [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.7, p.102
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
+    # [x] createArgumentDataPrototype  [x] impl  [x] docstring  [x] test
+    # [x] getArguments                 [x] impl  [x] docstring  [x] test
+    # [x] getDiagArgIntegrity          [x] impl  [x] docstring  [x] test
+    # [x] setDiagArgIntegrity          [x] impl  [x] docstring  [x] test
+    # [x] addPossibleErrorRef          [x] impl  [x] docstring  [x] test
+    # [x] getPossibleErrorRefs         [x] impl  [x] docstring  [x] test
 
     def __init__(self, parent: ARObject, short_name: str):
+        """
+        Constructs a ClientServerOperation.
+
+        Args:
+            parent: The parent ARObject
+            short_name: The short name of the operation
+        """
         super().__init__(parent, short_name)
 
+        # An argument of this ClientServerOperation
         self.arguments: List[ArgumentDataPrototype] = []
+
+        # This attribute shall only be used in the implementation of diagnostic routines to support
+        # the case where input and output arguments are allocated in a shared buffer and might
+        # unintentionally overwrite input arguments by tentative write operations to output
+        # arguments. The value true means that the ClientServerOperation is aware of the usage of a
+        # shared buffer and takes precautions to avoid unintentional overwrite of input arguments.
+        # [constr_1724]
+        self.diagArgIntegrity: Optional[Boolean] = None
+
+        # Possible errors that may by raised by the referring operation.
         self.possibleErrorRefs: List[RefType] = []
 
-    def getArguments(self):
-        return self.arguments
+    def createArgumentDataPrototype(self, short_name: str) -> ArgumentDataPrototype:
+        """
+        Creates an ArgumentDataPrototype of this ClientServerOperation with the given short name,
+        or returns the existing one if it already exists.
 
-    def createArgumentDataPrototype(self, short_name):
+        An argument of this ClientServerOperation.
+
+        Args:
+            short_name: The short name for the new ArgumentDataPrototype
+
+        Returns:
+            The created (or existing) ArgumentDataPrototype
+        """
         if not self.IsElementExists(short_name):
             prototype = ArgumentDataPrototype(self, short_name)
             self.addElement(prototype)
             self.arguments.append(prototype)
-        return self.getElement(short_name)
+        return self.getElement(short_name, ArgumentDataPrototype)
 
-    def getPossibleErrorRefs(self):
-        return self.possibleErrorRefs
+    def getArguments(self) -> List[ArgumentDataPrototype]:
+        """
+        Gets the ArgumentDataPrototype objects of this ClientServerOperation.
 
-    def addPossibleErrorRef(self, value):
+        An argument of this ClientServerOperation.
+
+        Returns:
+            The list of ArgumentDataPrototype instances
+        """
+        return self.arguments
+
+    def getDiagArgIntegrity(self) -> Optional[Boolean]:
+        """
+        Returns the diagArgIntegrity flag of this ClientServerOperation.
+
+        This attribute shall only be used in the implementation of diagnostic routines to support the
+        case where input and output arguments are allocated in a shared buffer and might
+        unintentionally overwrite input arguments by tentative write operations to output arguments.
+        The value true means that the ClientServerOperation is aware of the usage of a shared buffer
+        and takes precautions to avoid unintentional overwrite of input arguments. [constr_1724]
+
+        Returns:
+            Optional[Boolean]: The diagArgIntegrity flag, or None if not set
+        """
+        return self.diagArgIntegrity
+
+    def setDiagArgIntegrity(self, value: Optional[Boolean]) -> "ClientServerOperation":
+        """
+        Sets the diagArgIntegrity flag of this ClientServerOperation.
+
+        This attribute shall only be used in the implementation of diagnostic routines to support the
+        case where input and output arguments are allocated in a shared buffer and might
+        unintentionally overwrite input arguments by tentative write operations to output arguments.
+        The value true means that the ClientServerOperation is aware of the usage of a shared buffer
+        and takes precautions to avoid unintentional overwrite of input arguments. [constr_1724]
+        A None value is a no-op and does not overwrite an existing diagArgIntegrity.
+
+        Args:
+            value: The diagArgIntegrity flag to set
+
+        Returns:
+            ClientServerOperation: self for method chaining
+        """
+        if value is not None:
+            self.diagArgIntegrity = value
+        return self
+
+    def addPossibleErrorRef(self, value: Optional[RefType]) -> "ClientServerOperation":
+        """
+        Adds a possible error to this ClientServerOperation.
+
+        Possible errors that may by raised by the referring operation.
+
+        Args:
+            value: The possible error reference to add
+
+        Returns:
+            ClientServerOperation: self for method chaining
+        """
         if value is not None:
             self.possibleErrorRefs.append(value)
         return self
+
+    def getPossibleErrorRefs(self) -> List[RefType]:
+        """
+        Gets the possible errors that may be raised by this ClientServerOperation.
+
+        Possible errors that may by raised by the referring operation.
+
+        Returns:
+            The list of possible error references
+        """
+        return self.possibleErrorRefs
 
 
 class ClientServerInterface(PortInterface):

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -3564,6 +3564,7 @@ class ARXMLParser(AbstractARXMLParser):
     def readClientServerOperation(self, element: ET.Element, operation: ClientServerOperation):
         self.readIdentifiable(element, operation)
         self.readClientServerOperationArguments(element, operation)
+        operation.setDiagArgIntegrity(self.getChildElementOptionalBooleanValue(element, "DIAG-ARG-INTEGRITY"))
         self.readPossibleErrorRefs(element, operation)
 
     def readClientServerInterfaceOperations(self, element: ET.Element, parent: ClientServerInterface):

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -3921,6 +3921,7 @@ class ARXMLWriter(AbstractARXMLWriter):
         child_element = ET.SubElement(element, "CLIENT-SERVER-OPERATION")
         self.writeIdentifiable(child_element, operation)
         self.writeClientServerOperationArguments(child_element, operation)
+        self.setChildElementOptionalBooleanValue(child_element, "DIAG-ARG-INTEGRITY", operation.getDiagArgIntegrity())
         self.writeClientServerOperationPossibleErrorRefs(child_element, operation)
 
     def writeClientServerInterfaceOperations(self, element: ET.Element, parent: ClientServerInterface):

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/test_PortInterface.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/test_PortInterface.py
@@ -4,7 +4,7 @@ from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpBlueprintable, AtpType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, MultilanguageReferrable, Referrable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, RefType
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.DataPrototypes import AtpPrototype, AutosarDataPrototype, DataPrototype, VariableDataPrototype
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import (
     ApplicationError,
@@ -138,11 +138,18 @@ class Test_M2_AUTOSARTemplates_SWComponentTemplate_PortInterface:
         assert isinstance(operation, ClientServerOperation)
         assert operation.short_name == "client_server_operation"
 
+        assert operation.getDiagArgIntegrity() is None
+
         prototype = operation.createArgumentDataPrototype("argument_data_prototype1")
         assert prototype.short_name == "argument_data_prototype1"
 
         assert len(operation.getArguments()) == 1
         assert operation.getArguments()[0] == prototype
+
+        # creating an existing argument returns the existing instance
+        prototype2 = operation.createArgumentDataPrototype("argument_data_prototype1")
+        assert prototype2 == prototype
+        assert len(operation.getArguments()) == 1
 
         refType = RefType()
         refType.dest = "APPLICATION-ERROR"
@@ -151,6 +158,25 @@ class Test_M2_AUTOSARTemplates_SWComponentTemplate_PortInterface:
 
         assert len(operation.getPossibleErrorRefs()) == 1
         assert operation.getPossibleErrorRefs()[0] == refType
+
+    def test_ClientServerOperation_diagArgIntegrity(self):
+        document = AUTOSAR.getInstance()
+        ar_root = document.createARPackage("AUTOSAR")
+        operation = ClientServerOperation(ar_root, "client_server_operation")
+
+        bool_true = Boolean()
+        bool_true.value = True
+        assert operation.setDiagArgIntegrity(bool_true) == operation
+        assert operation.getDiagArgIntegrity() == bool_true
+
+        # None is a no-op: existing value is preserved
+        operation.setDiagArgIntegrity(None)
+        assert operation.getDiagArgIntegrity() == bool_true
+
+        bool_false = Boolean()
+        bool_false.value = False
+        operation.setDiagArgIntegrity(bool_false)
+        assert operation.getDiagArgIntegrity() == bool_false
 
     def test_ClientServerInterface(self):
         document = AUTOSAR.getInstance()

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/test_PortInterface.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/test_PortInterface.py
@@ -162,6 +162,8 @@ class Test_M2_AUTOSARTemplates_SWComponentTemplate_PortInterface:
         assert isinstance(cs_if, MultilanguageReferrable)
         assert isinstance(cs_if, PortInterface)
         assert isinstance(cs_if, Referrable)
+        assert cs_if.getOperations() == []
+        assert cs_if.getPossibleErrors() == []
 
         element = cs_if.createOperation("operation")
         assert isinstance(element, ClientServerOperation)

--- a/tests/test_armodel/parser/test_arxml_parser_orchestrators.py
+++ b/tests/test_armodel/parser/test_arxml_parser_orchestrators.py
@@ -1050,6 +1050,19 @@ class TestPortInterfaceHandlers:
         parser.readClientServerOperation(element, op)
         assert len(op.getArguments()) == 1
 
+    def test_readClientServerOperation_diagArgIntegrity(self, parser):
+        from armodel.models import ClientServerInterface
+
+        cs_if = ClientServerInterface(parent=_autosar_root(), short_name="cs_if")
+        op = cs_if.createOperation("op")
+        element = _snip(
+            "<SHORT-NAME>op</SHORT-NAME>" "<DIAG-ARG-INTEGRITY>true</DIAG-ARG-INTEGRITY>",
+            root_tag="CLIENT-SERVER-OPERATION",
+        )
+        parser.readClientServerOperation(element, op)
+        assert op.getDiagArgIntegrity() is not None
+        assert op.getDiagArgIntegrity().value is True
+
     def test_readArgumentDataPrototype_sets_direction(self, parser):
         from armodel.models import ClientServerInterface
 

--- a/tests/test_armodel/writer/test_writer_impl_types_ports.py
+++ b/tests/test_armodel/writer/test_writer_impl_types_ports.py
@@ -651,6 +651,36 @@ class TestClientServerOperationWriter:
         writer.writeClientServerOperationPossibleErrorRefs(parent, op)
         assert len(parent) == 0
 
+    def test_write_cs_operation_diag_arg_integrity(self, writer):
+        autosar = AUTOSAR.getInstance()
+        pkg = autosar.createARPackage("Pkg")
+        cs_if = pkg.createClientServerInterface("CsIf")
+        op = cs_if.createOperation("Op")
+        arg_integrity = _make_bool("true")
+        op.setDiagArgIntegrity(arg_integrity)
+
+        parent = _parent()
+        writer.writeClientServerOperation(parent, op)
+
+        assert len(parent) == 1
+        child = parent[0]
+        assert child.tag == "CLIENT-SERVER-OPERATION"
+        assert child.find("DIAG-ARG-INTEGRITY").text == "true"
+
+    def test_write_cs_operation_diag_arg_integrity_unset(self, writer):
+        autosar = AUTOSAR.getInstance()
+        pkg = autosar.createARPackage("Pkg")
+        cs_if = pkg.createClientServerInterface("CsIf")
+        op = cs_if.createOperation("Op")
+
+        parent = _parent()
+        writer.writeClientServerOperation(parent, op)
+
+        assert len(parent) == 1
+        child = parent[0]
+        assert child.tag == "CLIENT-SERVER-OPERATION"
+        assert child.find("DIAG-ARG-INTEGRITY") is None
+
     def test_write_client_server_operation(self, writer):
         autosar = AUTOSAR.getInstance()
         pkg = autosar.createARPackage("Pkg")


### PR DESCRIPTION
## Summary
- Add `diagArgIntegrity` attribute with `getDiagArgIntegrity()` / `setDiagArgIntegrity()` accessors to `ClientServerOperation` (spec AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.7, constr_1724).
- Parse and write the `DIAG-ARG-INTEGRITY` XML element in `arxml_parser.py` / `arxml_writer.py`.
- Add spec-based docstrings and unit tests for the new accessors, aligned with `class_check_rules`.
- Update development docs (`class_check_rules.md`, `method_deviation_by_class.md`).

## Test plan
- [x] `python scripts/run_tests.py --unit` passes
- [x] Verify round-trip parse → write → re-parse preserves `DIAG-ARG-INTEGRITY`