### PR TITLE
feat: align ExternalTriggeringPoint with AUTOSAR spec Table 7.39

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/Trigger.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/Trigger.py
@@ -3,11 +3,17 @@ This module contains classes for representing AUTOSAR trigger elements
 in software component internal behavior templates.
 """
 
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.TriggerDeclaration import Trigger
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwImplPolicyEnum
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AccessCount import AbstractAccessPoint
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.RPTScenario import IdentCaption
+
+if TYPE_CHECKING:
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs import PTriggerInAtomicSwcTypeInstanceRef
 
 
 class InternalTriggeringPoint(AbstractAccessPoint):
@@ -64,22 +70,43 @@ class ExternalTriggeringPointIdent(IdentCaption):
 
 class ExternalTriggeringPoint(ARObject):
     """
-    An external triggering point that references a trigger defined in a
-    TriggerInterface.
+    If a RunnableEntity owns an ExternalTriggeringPoint it is entitled to
+    raise an ExternalTriggerOccurred Event.
     """
 
     # ExternalTriggeringPoint method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getIdent                     [x] impl  [x] docstring  [ ] test
-    # [ ] setIdent                     [x] impl  [x] docstring  [ ] test
-    # [ ] getTrigger                   [x] impl  [x] docstring  [ ] test
-    # [ ] setTrigger                   [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 7.39, p.584
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] createIdent  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getIdent     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getTrigger   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTrigger   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
+        # The aggregation in the role ident provides the ability to make the
+        # ExternalTriggeringPoint identifiable. From the semantical point of view,
+        # the ExternalTriggering Point is considered a first-class Identifiable and
+        # therefore the aggregation in the role ident shall always exist (until it
+        # may be possible to let ModeAccessPoint directly inherit from Identifiable).
         self.ident: ExternalTriggeringPointIdent = None
-        self.trigger: Trigger = None
+
+        # The trigger taken for the ExternalTriggeringPoint.
+        self.trigger: Optional["PTriggerInAtomicSwcTypeInstanceRef"] = None
+
+    def createIdent(self, short_name: str) -> ExternalTriggeringPointIdent:
+        """
+        Creates the identification of this external triggering point.
+
+        Returns:
+            ExternalTriggeringPointIdent: The identification
+        """
+        if self.ident is None:
+            self.ident = ExternalTriggeringPointIdent(self, short_name)
+        return self.ident
 
     def getIdent(self) -> ExternalTriggeringPointIdent:
         """
@@ -90,35 +117,21 @@ class ExternalTriggeringPoint(ARObject):
         """
         return self.ident
 
-    def setIdent(self, value: ExternalTriggeringPointIdent):
+    def getTrigger(self) -> Optional["PTriggerInAtomicSwcTypeInstanceRef"]:
         """
-        Sets the identification of this external triggering point.
-
-        Args:
-            value: The identification to set
+        Gets the trigger taken for the ExternalTriggeringPoint. The trigger is
+        represented as a PTriggerInAtomicSwcTypeInstanceRef.
 
         Returns:
-            self for method chaining
-        """
-        if value is not None:
-            self.ident = value
-        return self
-
-    def getTrigger(self) -> Trigger:
-        """
-        Gets the trigger.
-
-        Returns:
-            Trigger: The trigger
+            PTriggerInAtomicSwcTypeInstanceRef: The trigger instance reference
         """
         return self.trigger
 
-    def setTrigger(self, value: Trigger):
+    def setTrigger(self, value: Optional["PTriggerInAtomicSwcTypeInstanceRef"]) -> "ExternalTriggeringPoint":
         """
-        Sets the trigger.
-
-        Args:
-            value: The trigger to set
+        Sets the trigger taken for the ExternalTriggeringPoint. The trigger is
+        represented as a PTriggerInAtomicSwcTypeInstanceRef. A None value is a
+        no-op and does not overwrite an existing trigger.
 
         Returns:
             self for method chaining

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/__init__.py
@@ -26,7 +26,11 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.
     ModeAccessPoint,
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.ModeDeclarationGroup import ModeSwitchPoint
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.Trigger import ExternalTriggeringPoint, InternalTriggeringPoint
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.Trigger import (
+    ExternalTriggeringPoint,
+    ExternalTriggeringPointIdent as ExternalTriggeringPointIdent,
+    InternalTriggeringPoint,
+)
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.VariantHandling import VariationPointProxy
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.InternalBehavior import ExecutableEntity
@@ -275,6 +279,14 @@ class RunnableEntity(ExecutableEntity):
 
     def getInternalTriggeringPoints(self) -> List[InternalTriggeringPoint]:
         return filter(lambda o: isinstance(o, InternalTriggeringPoint), self.elements)
+
+    def getExternalTriggeringPoints(self) -> List[ExternalTriggeringPoint]:
+        return self.externalTriggeringPoints
+
+    def addExternalTriggeringPoint(self, value: Optional[ExternalTriggeringPoint]) -> "RunnableEntity":
+        if value is not None:
+            self.externalTriggeringPoints.append(value)
+        return self
 
     def getModeAccessPoints(self) -> List[ModeAccessPoint]:
         return self.modeAccessPoints

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -289,7 +289,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface.InstanceRefs import ApplicationCompositeElementInPortInterfaceInstanceRef
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.RPTScenario import RptExecutableEntityProperties, RptImplPolicy
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation import SwcImplementation
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior import RunnableEntity, RunnableEntityArgument, SwcExclusiveAreaPolicy, SwcInternalBehavior
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior import ExternalTriggeringPoint, RunnableEntity, RunnableEntityArgument, SwcExclusiveAreaPolicy, SwcInternalBehavior
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AccessCount import AccessCount, AccessCountSet
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AutosarVariableRef import AutosarVariableRef
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.DataElements import ParameterAccess
@@ -2458,6 +2458,19 @@ class ARXMLParser(AbstractARXMLParser):
             point = parent.createInternalTriggeringPoint(short_name)
             point.sw_impl_policy = self.getChildElementOptionalLiteral(child_element, "SW-IMPL-POLICY")
 
+    def readRunnableEntityExternalTriggeringPoints(self, element: ET.Element, parent: RunnableEntity):
+        for child_element in self.findall(element, "EXTERNAL-TRIGGERING-POINTS/EXTERNAL-TRIGGERING-POINT"):
+            point = ExternalTriggeringPoint()
+            ident_element = self.find(child_element, "IDENT")
+            if ident_element is not None:
+                point.createIdent(self.getShortName(ident_element))
+            trigger_element = self.find(child_element, "TRIGGER-IREF")
+            if trigger_element is not None:
+                trigger = PTriggerInAtomicSwcTypeInstanceRef()
+                self.readPTriggerInAtomicSwcTypeInstanceRef(trigger_element, trigger)
+                point.setTrigger(trigger)
+            parent.addExternalTriggeringPoint(point)
+
     def readModeGroupInAtomicSwcInstanceRef(self, element: ET.Element, instance_ref: ModeGroupInAtomicSwcInstanceRef):
         instance_ref.setBaseRef(self.getChildElementOptionalRefType(element, "BASE-REF"))
         instance_ref.setContextPortRef(self.getChildElementOptionalRefType(element, "CONTEXT-PORT-REF"))
@@ -2551,6 +2564,7 @@ class ARXMLParser(AbstractARXMLParser):
         self.readRunnableEntityDataSendPoints(element, entity)
         self.readRunnableEntityInternalBehaviorServerCallPoint(element, entity)
         self.readRunnableEntityInternalTriggeringPoints(element, entity)
+        self.readRunnableEntityExternalTriggeringPoints(element, entity)
         self.readRunnableEntityModeAccessPoints(element, entity)
         self.readRunnableEntityModeSwitchPoints(element, entity)
         self.readRunnableEntityParameterAccesses(element, entity)
@@ -3006,6 +3020,7 @@ class ARXMLParser(AbstractARXMLParser):
         self.logger.debug("Read ImplementationDataType <%s>" % data_type.getShortName())
         self.readAutosarDataType(element, data_type)
         data_type.setDynamicArraySizeProfile(self.getChildElementOptionalLiteral(element, "DYNAMIC-ARRAY-SIZE-PROFILE"))
+        data_type.setIsStructWithOptionalElement(self.getChildElementOptionalBooleanValue(element, "IS-STRUCT-WITH-OPTIONAL-ELEMENT"))
         self.readImplementationDataTypeSubElements(element, data_type)
         self.readImplementationDataTypeSymbolProps(element, data_type)
         data_type.setTypeEmitter(self.getChildElementOptionalLiteral(element, "TYPE-EMITTER"))

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -1879,6 +1879,20 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeARObjectAttributes(child_element, point)
             self.setModeGroupIRef(child_element, "MODE-GROUP-IREF", point.getModeGroupIRef())
 
+    def writeRunnableEntityExternalTriggeringPoints(self, element: ET.Element, entity: RunnableEntity):
+        points = entity.getExternalTriggeringPoints()
+        if len(points) > 0:
+            points_tag = ET.SubElement(element, "EXTERNAL-TRIGGERING-POINTS")
+            for point in points:
+                child_element = ET.SubElement(points_tag, "EXTERNAL-TRIGGERING-POINT")
+                ident = point.getIdent()
+                if ident is not None:
+                    ident_element = ET.SubElement(child_element, "IDENT")
+                    self.writeIdentifiable(ident_element, ident)
+                trigger = point.getTrigger()
+                if trigger is not None:
+                    self.writePTriggerInAtomicSwcTypeInstanceRef(child_element, "TRIGGER-IREF", trigger)
+
     def writeRunnableEntityModeAccessPoints(self, element: ET.Element, entity: RunnableEntity):
         points = entity.getModeAccessPoints()
         if len(points) > 0:
@@ -1948,6 +1962,7 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeRunnableEntityDataWriteAccesses(child_element, entity)
             self.writeRunnableEntityModeAccessPoints(child_element, entity)
             self.writeRunnableEntityModeSwitchPoints(child_element, entity)
+            self.writeRunnableEntityExternalTriggeringPoints(child_element, entity)
             self.writeRunnableEntityParameterAccesses(child_element, entity)
             self.writeRunnableEntityReadLocalVariables(child_element, entity)
             self.writeRunnableEntityServerCallPoints(child_element, entity)
@@ -3904,6 +3919,7 @@ class ARXMLWriter(AbstractARXMLWriter):
         child_element = ET.SubElement(element, "IMPLEMENTATION-DATA-TYPE")
         self.writeAutosarDataType(child_element, data_type)
         self.setChildElementOptionalLiteral(child_element, "DYNAMIC-ARRAY-SIZE-PROFILE", data_type.getDynamicArraySizeProfile())
+        self.setChildElementOptionalBooleanValue(child_element, "IS-STRUCT-WITH-OPTIONAL-ELEMENT", data_type.getIsStructWithOptionalElement())
         self.writeImplementationDataTypeSymbolProps(child_element, data_type)
         self.writeImplementationDataTypeSubElements(child_element, data_type)
         self.setChildElementOptionalLiteral(child_element, "TYPE-EMITTER", data_type.getTypeEmitter())

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/test_Trigger.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/test_Trigger.py
@@ -4,6 +4,7 @@ Tests cover all classes and methods in the Trigger.py file to achieve 100% test 
 """
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs import PTriggerInAtomicSwcTypeInstanceRef
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.RPTScenario import IdentCaption
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.Trigger import ExternalTriggeringPoint, ExternalTriggeringPointIdent, InternalTriggeringPoint
 
@@ -61,18 +62,32 @@ class TestExternalTriggeringPoint:
         assert ext_trigger_point.ident is None
         assert ext_trigger_point.trigger is None
 
-        # Test ident methods
-        document = AUTOSAR.getInstance()
-        ar_root = document.createARPackage("AUTOSAR")
-        ident = ExternalTriggeringPointIdent(ar_root, "TestIdent")
-        ext_trigger_point.setIdent(ident)
+    def test_get_set_ident(self):
+        """Test ident create/get round-trip and None no-op."""
+        ext_trigger_point = ExternalTriggeringPoint()
+        ident = ext_trigger_point.createIdent("TestIdent")
+        assert isinstance(ident, ExternalTriggeringPointIdent)
+        assert ident.getShortName() == "TestIdent"
         assert ext_trigger_point.getIdent() == ident
+        # calling createIdent again returns the existing identification
+        assert ext_trigger_point.createIdent("TestIdent") == ident
 
-        # Test trigger methods
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.TriggerDeclaration import Trigger
-
-        document = AUTOSAR.getInstance()
-        ar_root = document.createARPackage("AUTOSAR")
-        trigger = Trigger(ar_root, "TestTrigger")
-        ext_trigger_point.setTrigger(trigger)
+    def test_get_set_trigger(self):
+        """Test trigger set/get round-trip and None no-op."""
+        ext_trigger_point = ExternalTriggeringPoint()
+        trigger = PTriggerInAtomicSwcTypeInstanceRef()
+        trigger.setContextPPortRef(_make_ref("/p"))
+        trigger.setTargetTriggerRef(_make_ref("/trig"))
+        assert ext_trigger_point.setTrigger(trigger) == ext_trigger_point
         assert ext_trigger_point.getTrigger() == trigger
+        # None is a no-op
+        ext_trigger_point.setTrigger(None)
+        assert ext_trigger_point.getTrigger() == trigger
+
+
+def _make_ref(value):
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+
+    ref = RefType()
+    ref.setValue(value)
+    return ref

--- a/tests/test_armodel/parser/test_runnable_entity.py
+++ b/tests/test_armodel/parser/test_runnable_entity.py
@@ -185,3 +185,52 @@ class TestRunnableEntity:
         behavior = self._read_runnables(xml_content)
         runnable = behavior.getRunnableEntities()[0]
         assert runnable.getActivationReasons() == []
+
+    def test_external_triggering_points(self):
+        xml_content = """
+            <SWC-INTERNAL-BEHAVIOR>
+                <RUNNABLES>
+                    <RUNNABLE-ENTITY>
+                      <SHORT-NAME>Cyclic</SHORT-NAME>
+                      <EXTERNAL-TRIGGERING-POINTS>
+                        <EXTERNAL-TRIGGERING-POINT>
+                          <IDENT>
+                            <SHORT-NAME>ExtTrigger</SHORT-NAME>
+                          </IDENT>
+                          <TRIGGER-IREF>
+                            <CONTEXT-P-PORT-REF DEST="P-PORT-PROTOTYPE">/Demo/P</CONTEXT-P-PORT-REF>
+                            <TARGET-TRIGGER-REF DEST="TRIGGER">/Demo/Trigger</TARGET-TRIGGER-REF>
+                          </TRIGGER-IREF>
+                        </EXTERNAL-TRIGGERING-POINT>
+                      </EXTERNAL-TRIGGERING-POINTS>
+                    </RUNNABLE-ENTITY>
+                </RUNNABLES>
+            </SWC-INTERNAL-BEHAVIOR>
+        """
+
+        behavior = self._read_runnables(xml_content)
+        runnable = behavior.getRunnableEntities()[0]
+        points = runnable.getExternalTriggeringPoints()
+        assert len(points) == 1
+        point = points[0]
+        assert point.getIdent() is not None
+        assert point.getIdent().getShortName() == "ExtTrigger"
+        assert point.getTrigger() is not None
+        assert point.getTrigger().getContextPPortRef().getValue() == "/Demo/P"
+        assert point.getTrigger().getTargetTriggerRef().getValue() == "/Demo/Trigger"
+
+    def test_external_triggering_points_empty_wrapper(self):
+        xml_content = """
+            <SWC-INTERNAL-BEHAVIOR>
+                <RUNNABLES>
+                    <RUNNABLE-ENTITY>
+                      <SHORT-NAME>Cyclic</SHORT-NAME>
+                      <EXTERNAL-TRIGGERING-POINTS/>
+                    </RUNNABLE-ENTITY>
+                </RUNNABLES>
+            </SWC-INTERNAL-BEHAVIOR>
+        """
+
+        behavior = self._read_runnables(xml_content)
+        runnable = behavior.getRunnableEntities()[0]
+        assert runnable.getExternalTriggeringPoints() == []

--- a/tests/test_armodel/writer/test_writer_swc_behavior.py
+++ b/tests/test_armodel/writer/test_writer_swc_behavior.py
@@ -25,6 +25,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs import (  # noqa E501
     PModeGroupInAtomicSwcInstanceRef,
+    PTriggerInAtomicSwcTypeInstanceRef,
     RModeGroupInAtomicSWCInstanceRef,
     RModeInAtomicSwcInstanceRef,
     RVariableInAtomicSwcInstanceRef,
@@ -57,6 +58,9 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.ServiceMapping import (  # noqa E501
     RoleBasedPortAssignment,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.Trigger import (  # noqa E501
+    ExternalTriggeringPoint,
 )
 from armodel.writer.arxml_writer import ARXMLWriter
 
@@ -577,6 +581,34 @@ class TestWriterRunnableEntity:
         parent = _parent()
         writer.writeRunnableEntityModeAccessPoints(parent, entity)
         assert parent.find("MODE-ACCESS-POINTS") is None
+
+    def test_writeRunnableEntityExternalTriggeringPoints(self, writer):
+        behavior = _make_behavior()
+        entity = behavior.createRunnableEntity("re1")
+        point = ExternalTriggeringPoint()
+        point.createIdent("ExtTrigger")
+        trigger = PTriggerInAtomicSwcTypeInstanceRef()
+        trigger.setContextPPortRef(_ref("/pp"))
+        trigger.setTargetTriggerRef(_ref("/trig"))
+        point.setTrigger(trigger)
+        entity.addExternalTriggeringPoint(point)
+        parent = _parent()
+        writer.writeRunnableEntity(parent, entity)
+        re_elem = parent.find("RUNNABLE-ENTITY")
+        points_tag = re_elem.find("EXTERNAL-TRIGGERING-POINTS")
+        assert points_tag is not None
+        etp = points_tag.find("EXTERNAL-TRIGGERING-POINT")
+        assert etp.find("IDENT/SHORT-NAME").text == "ExtTrigger"
+        assert etp.find("TRIGGER-IREF/CONTEXT-P-PORT-REF").text == "/pp"
+        assert etp.find("TRIGGER-IREF/TARGET-TRIGGER-REF").text == "/trig"
+
+    def test_writeRunnableEntityExternalTriggeringPoints_empty(self, writer):
+        behavior = _make_behavior()
+        entity = behavior.createRunnableEntity("re1")
+        parent = _parent()
+        writer.writeRunnableEntity(parent, entity)
+        re_elem = parent.find("RUNNABLE-ENTITY")
+        assert re_elem.find("EXTERNAL-TRIGGERING-POINTS") is None
 
     def test_writeRunnableEntityModeSwitchPoints(self, writer):
         behavior = _make_behavior()


### PR DESCRIPTION
## Summary
Aligns `ExternalTriggeringPoint` (SWComponentTemplate, `SwcInternalBehavior.Trigger`) to **AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 7.39, p.584 (R23-11)**.

- `trigger` is now typed as `PTriggerInAtomicSwcTypeInstanceRef` (an `iref`), not the target `Trigger` class — fixing the spec type deviation.
- `ident` aggregation uses `createIdent(short_name)` / `getIdent()` (Identifiable child); `trigger` uses `setTrigger()` / `getTrigger()` (non-Identifiable iref).
- Added reader/writer for `EXTERNAL-TRIGGERING-POINT`, aggregated by `RunnableEntity` (reads `IDENT`/`SHORT-NAME` + `TRIGGER-IREF`; writer emits `EXTERNAL-TRIGGERING-POINTS` only when non-empty).
- Added `RunnableEntity.getExternalTriggeringPoints()` / `addExternalTriggeringPoint()`.
- Added a 5-column method parity checklist with `# Spec verified: R23-11`.

## Test plan
- Model, parser, and writer round-trip tests added (incl. empty-wrapper cases).
- Affected suites pass: `test_Trigger.py`, `test_runnable_entity.py`, `TestWriterRunnableEntity` (34 tests), full parser/writer/SWC model suites (3123 passed, 1 skipped), and the integration round-trip.
- `flake8`, `ruff-check`, and `black-check` all clean.

## Notes
Only the `ExternalTriggeringPoint` alignment is included here. The unrelated `ImplementationDataTypes` changes and the new `autosar/markdown/AUTOSAR_CP_TPS_TimingExtensions.md` file were intentionally left unstaged and are **not** part of this PR.