### PR TITLE
feat: align ImplementationDataTypes with AUTOSAR spec Table D.37

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ImplementationDataTypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ImplementationDataTypes.py
@@ -2,7 +2,7 @@ from abc import ABC
 from typing import List, Optional
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpStructureElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, AREnum, ARLiteral, ARNumerical, Boolean, NameToken, String
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, AREnum, ARLiteral, ARNumerical, NameToken, String
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import AutosarDataType
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SymbolProps
@@ -182,7 +182,7 @@ class ImplementationDataType(AbstractImplementationDataType):
         # Indicates that the ImplementationDataType has been created with the
         # intention to define at least one element of the structure as
         # optional.
-        self.isStructWithOptionalElement: Optional[Boolean] = None
+        self.isStructWithOptionalElement: Optional[ARBoolean] = None
         # Specifies an element of an array, struct, or union data type.
         self.subElements: List[ImplementationDataTypeElement] = []
         # The SymbolProps for the ImplementationDataType.
@@ -217,18 +217,18 @@ class ImplementationDataType(AbstractImplementationDataType):
             self.dynamicArraySizeProfile = value
         return self
 
-    def getIsStructWithOptionalElement(self) -> Optional[Boolean]:
+    def getIsStructWithOptionalElement(self) -> Optional[ARBoolean]:
         """
         Gets the flag indicating whether the ImplementationDataType has been
         created with the intention to define at least one element of the
         structure as optional.
 
         Returns:
-            Boolean: The flag for optional elements in the structure
+            ARBoolean: The flag for optional elements in the structure
         """
         return self.isStructWithOptionalElement
 
-    def setIsStructWithOptionalElement(self, value: Optional[Boolean]) -> "ImplementationDataType":
+    def setIsStructWithOptionalElement(self, value: Optional[ARBoolean]) -> "ImplementationDataType":
         """
         Sets the flag indicating whether the ImplementationDataType has been
         created with the intention to define at least one element of the

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ImplementationDataTypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ImplementationDataTypes.py
@@ -1,10 +1,9 @@
 from abc import ABC
-from typing import List
+from typing import List, Optional
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpStructureElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, Boolean, String, AREnum
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, AREnum, ARLiteral, ARNumerical, Boolean, NameToken, String
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import AutosarDataType
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SymbolProps
 
@@ -136,26 +135,25 @@ class AbstractImplementationDataType(AutosarDataType, ABC):
 
 class ImplementationDataType(AbstractImplementationDataType):
     """
-    Represents an implementation data type in AUTOSAR models.
-    This class defines how data types are implemented in code, including arrays, structures, and data references.
+    Describes a reusable data type on the implementation level. This will
+    typically correspond to a typedef in C-code.
     """
 
     # ImplementationDataType method parity checklist:
-    # [x] __init__                     [x] impl  [x] docstring  [x] test
-    # [x] getDynamicArraySizeProfile   [x] impl  [x] docstring  [x] test
-    # [x] setDynamicArraySizeProfile   [x] impl  [x] docstring  [x] test
-    # [x] getIsStructWithOptionalElement [x] impl  [x] docstring  [x] test
-    # [x] setIsStructWithOptionalElement [x] impl  [x] docstring  [x] test
-    # [x] createImplementationDataTypeElement [x] impl  [x] docstring  [x] test
-    # [x] getSubElements               [x] impl  [x] docstring  [x] test
-    # [x] getArrayElementType          [x] impl  [x] docstring  [x] test
-    # [x] setArrayElementType          [x] impl  [x] docstring  [x] test
-    # [x] setTypeEmitter               [x] impl  [x] docstring  [x] test
-    # [x] getTypeEmitter               [x] impl  [x] docstring  [x] test
-    # [x] setStructElementType         [x] impl  [x] docstring  [x] test
-    # [x] getStructElementType         [x] impl  [x] docstring  [x] test
-    # [x] createSymbolProps            [x] impl  [x] docstring  [x] test
-    # [x] getSymbolProps               [x] impl  [x] docstring  [x] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table D.37, p.321
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                            [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getDynamicArraySizeProfile          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDynamicArraySizeProfile          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getIsStructWithOptionalElement      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIsStructWithOptionalElement      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] createImplementationDataTypeElement [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSubElements                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createSymbolProps                   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSymbolProps                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getTypeEmitter                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTypeEmitter                      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     # Category constant for type reference implementation data types
     CATEGORY_TYPE_REFERENCE = "TYPE_REFERENCE"
@@ -178,30 +176,36 @@ class ImplementationDataType(AbstractImplementationDataType):
         """
         super().__init__(parent, short_name)
 
-        # Profile for dynamic array size (for variable-size arrays)
-        self.dynamicArraySizeProfile: String = None
-        # Flag indicating if this structure contains optional elements
-        self.isStructWithOptionalElement: Boolean = None
-        # List of sub-elements in this implementation data type
-        self.subElements: List["ImplementationDataTypeElement"] = []
-        # Symbol properties for this implementation data type
-        self.symbolProps: SymbolProps = None
-        # Type emitter for code generation
-        self.typeEmitter: ARLiteral = None
+        # Specifies the profile which the array will follow in case this data
+        # type is a variable size array.
+        self.dynamicArraySizeProfile: Optional[String] = None
+        # Indicates that the ImplementationDataType has been created with the
+        # intention to define at least one element of the structure as
+        # optional.
+        self.isStructWithOptionalElement: Optional[Boolean] = None
+        # Specifies an element of an array, struct, or union data type.
+        self.subElements: List[ImplementationDataTypeElement] = []
+        # The SymbolProps for the ImplementationDataType.
+        self.symbolProps: Optional[SymbolProps] = None
+        # Controls which part of the AUTOSAR toolchain is supposed to trigger
+        # data type definitions.
+        self.typeEmitter: Optional[NameToken] = None
 
-    def getDynamicArraySizeProfile(self):
+    def getDynamicArraySizeProfile(self) -> Optional[String]:
         """
-        Gets the profile for dynamic array size (for variable-size arrays).
+        Gets the profile which the array will follow in case this data type is
+        a variable size array.
 
         Returns:
             String: The dynamic array size profile
         """
         return self.dynamicArraySizeProfile
 
-    def setDynamicArraySizeProfile(self, value):
+    def setDynamicArraySizeProfile(self, value: Optional[String]) -> "ImplementationDataType":
         """
-        Sets the profile for dynamic array size (for variable-size arrays).
-        Only sets the value if it is not None.
+        Sets the profile which the array will follow in case this data type is
+        a variable size array. A None value is a no-op and does not overwrite
+        an existing profile.
 
         Args:
             value: The dynamic array size profile to set
@@ -209,38 +213,47 @@ class ImplementationDataType(AbstractImplementationDataType):
         Returns:
             self for method chaining
         """
-        self.dynamicArraySizeProfile = value
+        if value is not None:
+            self.dynamicArraySizeProfile = value
         return self
 
-    def getIsStructWithOptionalElement(self):
+    def getIsStructWithOptionalElement(self) -> Optional[Boolean]:
         """
-        Gets the flag indicating if this structure contains optional elements.
+        Gets the flag indicating whether the ImplementationDataType has been
+        created with the intention to define at least one element of the
+        structure as optional.
 
         Returns:
-            Boolean: The flag for optional elements in structure
+            Boolean: The flag for optional elements in the structure
         """
         return self.isStructWithOptionalElement
 
-    def setIsStructWithOptionalElement(self, value):
+    def setIsStructWithOptionalElement(self, value: Optional[Boolean]) -> "ImplementationDataType":
         """
-        Sets the flag indicating if this structure contains optional elements.
-        Only sets the value if it is not None.
+        Sets the flag indicating whether the ImplementationDataType has been
+        created with the intention to define at least one element of the
+        structure as optional. A None value is a no-op and does not overwrite
+        an existing flag.
 
         Args:
-            value: The flag for optional elements in structure to set
+            value: The flag for optional elements in the structure to set
 
         Returns:
             self for method chaining
         """
-        self.isStructWithOptionalElement = value
+        if value is not None:
+            self.isStructWithOptionalElement = value
         return self
 
-    def createImplementationDataTypeElement(self, short_name: str) -> "ImplementationDataTypeElement":
+    def createImplementationDataTypeElement(self, short_name: str) -> ImplementationDataTypeElement:
         """
-        Creates and adds an ImplementationDataTypeElement to this implementation data type's sub-elements.
+        Creates and adds an ImplementationDataTypeElement to this
+        ImplementationDataType's sub-elements, or returns the existing element
+        with the same short name.
 
         Args:
-            short_name: The short name for the new implementation data type element
+            short_name: The short name for the new implementation data type
+                element
 
         Returns:
             The created ImplementationDataTypeElement instance
@@ -249,95 +262,24 @@ class ImplementationDataType(AbstractImplementationDataType):
             type_element = ImplementationDataTypeElement(self, short_name)
             self.addElement(type_element)
             self.subElements.append(type_element)
-        return self.getElement(short_name)
+        return self.getElement(short_name, ImplementationDataTypeElement)
 
-    def getSubElements(self) -> List["ImplementationDataTypeElement"]:
+    def getSubElements(self) -> List[ImplementationDataTypeElement]:
         """
-        Gets the list of sub-elements in this implementation data type.
+        Gets the list of sub-elements of this ImplementationDataType.
 
         Returns:
             List of ImplementationDataTypeElement instances
         """
         return self.subElements
 
-    def getArrayElementType(self) -> str:
-        """
-        Gets the array element type for this implementation data type.
-        This is an internal property used for tracking the array type.
-
-        Returns:
-            str: The array element type
-        """
-        return getattr(self, "_array_type", None)
-
-    def setArrayElementType(self, type: str):
-        """
-        Sets the array element type for this implementation data type.
-        This is an internal property used for tracking the array type.
-
-        Args:
-            type: The array element type to set
-
-        Returns:
-            self for method chaining
-        """
-        self._array_type = type
-        return self
-
-    def setTypeEmitter(self, emitter: str):
-        """
-        Sets the type emitter for code generation for this implementation data type.
-        The type emitter defines how the type should be emitted in generated code.
-
-        Args:
-            emitter: The type emitter to set
-
-        Returns:
-            self for method chaining
-        """
-        self.typeEmitter = emitter
-        return self
-
-    def getTypeEmitter(self) -> str:
-        """
-        Gets the type emitter for code generation for this implementation data type.
-        The type emitter defines how the type should be emitted in generated code.
-
-        Returns:
-            str: The type emitter
-        """
-        return self.typeEmitter
-
-    def setStructElementType(self, type: str):
-        """
-        Sets the structure element type for this implementation data type.
-        This is an internal property used for tracking the structure type.
-
-        Args:
-            type: The structure element type to set
-
-        Returns:
-            self for method chaining
-        """
-        self._struct_type = type
-        return self
-
-    def getStructElementType(self) -> str:
-        """
-        Gets the structure element type for this implementation data type.
-        This is an internal property used for tracking the structure type.
-
-        Returns:
-            str: The structure element type
-        """
-        return getattr(self, "_struct_type", None)
-
     def createSymbolProps(self, short_name: str) -> SymbolProps:
         """
-        Creates and adds SymbolProps to this implementation data type.
+        Creates and adds the SymbolProps for this ImplementationDataType, or
+        returns the existing SymbolProps.
 
         Args:
-            short_name: The short name for the new symbol properties
+            short_name: The short name for the new SymbolProps
 
         Returns:
             The created SymbolProps instance
@@ -348,14 +290,37 @@ class ImplementationDataType(AbstractImplementationDataType):
             self.symbolProps = symbol_props
         return self.symbolProps
 
-    def getSymbolProps(self) -> SymbolProps:
+    def getSymbolProps(self) -> Optional[SymbolProps]:
         """
-        Gets the symbol properties for this implementation data type.
+        Gets the SymbolProps for this ImplementationDataType.
 
         Returns:
             SymbolProps: The symbol properties
         """
         return self.symbolProps
+
+    def getTypeEmitter(self) -> Optional[NameToken]:
+        """
+        Gets the type emitter that controls which part of the AUTOSAR
+        toolchain is supposed to trigger data type definitions.
+
+        Returns:
+            NameToken: The type emitter
+        """
+        return self.typeEmitter
+
+    def setTypeEmitter(self, value: Optional[NameToken]) -> "ImplementationDataType":
+        """
+        Sets the type emitter that controls which part of the AUTOSAR
+        toolchain is supposed to trigger data type definitions. A None value is
+        a no-op and does not overwrite an existing type emitter.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.typeEmitter = value
+        return self
 
 
 class ArrayImplPolicyEnum(AREnum):

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -3006,6 +3006,7 @@ class ARXMLParser(AbstractARXMLParser):
         self.logger.debug("Read ImplementationDataType <%s>" % data_type.getShortName())
         self.readAutosarDataType(element, data_type)
         data_type.setDynamicArraySizeProfile(self.getChildElementOptionalLiteral(element, "DYNAMIC-ARRAY-SIZE-PROFILE"))
+        data_type.setIsStructWithOptionalElement(self.getChildElementOptionalBooleanValue(element, "IS-STRUCT-WITH-OPTIONAL-ELEMENT"))
         self.readImplementationDataTypeSubElements(element, data_type)
         self.readImplementationDataTypeSymbolProps(element, data_type)
         data_type.setTypeEmitter(self.getChildElementOptionalLiteral(element, "TYPE-EMITTER"))

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -3904,6 +3904,7 @@ class ARXMLWriter(AbstractARXMLWriter):
         child_element = ET.SubElement(element, "IMPLEMENTATION-DATA-TYPE")
         self.writeAutosarDataType(child_element, data_type)
         self.setChildElementOptionalLiteral(child_element, "DYNAMIC-ARRAY-SIZE-PROFILE", data_type.getDynamicArraySizeProfile())
+        self.setChildElementOptionalBooleanValue(child_element, "IS-STRUCT-WITH-OPTIONAL-ELEMENT", data_type.getIsStructWithOptionalElement())
         self.writeImplementationDataTypeSymbolProps(child_element, data_type)
         self.writeImplementationDataTypeSubElements(child_element, data_type)
         self.setChildElementOptionalLiteral(child_element, "TYPE-EMITTER", data_type.getTypeEmitter())

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_ImplementationDataTypes.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_ImplementationDataTypes.py
@@ -7,7 +7,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes 
     ImplementationDataType,
     ImplementationDataTypeElement,
 )
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, ARLiteral, ARNumerical, Boolean, String
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, ARLiteral, ARNumerical, Boolean, NameToken, String
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SymbolProps
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
 
@@ -372,52 +372,20 @@ class TestImplementationDataType:
         data_type = ImplementationDataType(ar_root, "TestImplementationDataType")
         assert data_type.getSubElements() == []
 
-    def test_get_array_element_type(self):
-        """Test getArrayElementType method"""
-        parent = AUTOSAR.getInstance()
-        ar_root = parent.createARPackage("AUTOSAR")
-        data_type = ImplementationDataType(ar_root, "TestImplementationDataType")
-        assert data_type.getArrayElementType() is None
-
-    def test_set_array_element_type(self):
-        """Test setArrayElementType method"""
-        parent = AUTOSAR.getInstance()
-        ar_root = parent.createARPackage("AUTOSAR")
-        data_type = ImplementationDataType(ar_root, "TestImplementationDataType")
-        data_type.setArrayElementType("test_type")
-        assert data_type.getArrayElementType() == "test_type"
-
-    def test_set_type_emitter(self):
-        """Test setTypeEmitter method"""
-        parent = AUTOSAR.getInstance()
-        ar_root = parent.createARPackage("AUTOSAR")
-        data_type = ImplementationDataType(ar_root, "TestImplementationDataType")
-        result = data_type.setTypeEmitter("test_emitter")
-        assert result is data_type
-        assert data_type.getTypeEmitter() == "test_emitter"
-
-    def test_get_type_emitter(self):
-        """Test getTypeEmitter method"""
+    def test_get_set_type_emitter(self):
+        """Test setTypeEmitter/getTypeEmitter methods"""
         parent = AUTOSAR.getInstance()
         ar_root = parent.createARPackage("AUTOSAR")
         data_type = ImplementationDataType(ar_root, "TestImplementationDataType")
         assert data_type.getTypeEmitter() is None
 
-    def test_set_struct_element_type(self):
-        """Test setStructElementType method"""
-        parent = AUTOSAR.getInstance()
-        ar_root = parent.createARPackage("AUTOSAR")
-        data_type = ImplementationDataType(ar_root, "TestImplementationDataType")
-        result = data_type.setStructElementType("test_struct_type")
+        value = NameToken().setValue("test_emitter")
+        result = data_type.setTypeEmitter(value)
         assert result is data_type
-        assert data_type.getStructElementType() == "test_struct_type"
+        assert data_type.getTypeEmitter().getValue() == "test_emitter"
 
-    def test_get_struct_element_type(self):
-        """Test getStructElementType method"""
-        parent = AUTOSAR.getInstance()
-        ar_root = parent.createARPackage("AUTOSAR")
-        data_type = ImplementationDataType(ar_root, "TestImplementationDataType")
-        assert data_type.getStructElementType() is None
+        data_type.setTypeEmitter(None)
+        assert data_type.getTypeEmitter().getValue() == "test_emitter"
 
     def test_create_symbol_props(self):
         """Test createSymbolProps method"""
@@ -446,9 +414,9 @@ class TestImplementationDataType:
         # Set all properties
         data_type.setDynamicArraySizeProfile(String().setValue("PROFILE"))
         data_type.setIsStructWithOptionalElement(Boolean().setValue(True))
-        data_type.setTypeEmitter("EMITTER")
+        data_type.setTypeEmitter(NameToken().setValue("EMITTER"))
 
         # Verify all properties are set
         assert data_type.getDynamicArraySizeProfile().getValue() == "PROFILE"
         assert data_type.getIsStructWithOptionalElement().getValue() is True
-        assert data_type.getTypeEmitter() == "EMITTER"
+        assert data_type.getTypeEmitter().getValue() == "EMITTER"

--- a/tests/test_armodel/parser/test_implementation_data_type.py
+++ b/tests/test_armodel/parser/test_implementation_data_type.py
@@ -244,3 +244,41 @@ class TestImplementationDataTypeParser:
         assert sub_element2.getArraySizeHandling() is None
         assert sub_element2.getIsOptional() is None
         assert sub_element2.getSwDataDefProps().getCompuMethodRef() is None
+
+    def test_read_implementation_data_type_full_attributes(self):
+        parser = ARXMLParser()
+        parser.nsmap = {"xmlns": "http://autosar.org/schema/r4.0"}
+        xml_content = """
+            <AUTOSAR xmlns="http://autosar.org/schema/r4.0">
+                <AR-PACKAGES>
+                    <AR-PACKAGE>
+                        <SHORT-NAME>ImplementationDataType</SHORT-NAME>s
+                        <ELEMENTS>
+                            <IMPLEMENTATION-DATA-TYPE>
+                                <SHORT-NAME>MyStructDataType</SHORT-NAME>
+                                <CATEGORY>STRUCTURE</CATEGORY>
+                                <DYNAMIC-ARRAY-SIZE-PROFILE>profile</DYNAMIC-ARRAY-SIZE-PROFILE>
+                                <IS-STRUCT-WITH-OPTIONAL-ELEMENT>true</IS-STRUCT-WITH-OPTIONAL-ELEMENT>
+                                <SYMBOL-PROPS>
+                                    <SHORT-NAME>Sym</SHORT-NAME>
+                                    <SYMBOL>REASON_SYM</SYMBOL>
+                                </SYMBOL-PROPS>
+                                <TYPE-EMITTER>RTE</TYPE-EMITTER>
+                            </IMPLEMENTATION-DATA-TYPE>
+                        </ELEMENTS>
+                    </AR-PACKAGE>
+                </AR-PACKAGES>
+            </AUTOSAR>
+        """  # noqa E501
+
+        element = ET.fromstring(xml_content)
+        document = AUTOSARDoc()
+        parser.readARPackages(element, document)
+
+        data_type = document.getARPackages()[0].getImplementationDataTypes()[0]
+        assert data_type.getShortName() == "MyStructDataType"
+        assert data_type.getDynamicArraySizeProfile().getValue() == "profile"
+        assert data_type.getIsStructWithOptionalElement().getValue() is True
+        assert data_type.getSymbolProps().getShortName() == "Sym"
+        assert data_type.getSymbolProps().getSymbol().getValue() == "REASON_SYM"
+        assert data_type.getTypeEmitter().getValue() == "RTE"

--- a/tests/test_armodel/writer/test_writer_impl_types_ports.py
+++ b/tests/test_armodel/writer/test_writer_impl_types_ports.py
@@ -548,6 +548,7 @@ class TestImplementationDataTypeWriter:
         pkg = autosar.createARPackage("Pkg")
         data_type = pkg.createImplementationDataType("ImplType")
         data_type.setDynamicArraySizeProfile(_make_literal("prof"))
+        data_type.setIsStructWithOptionalElement(_make_bool(True))
         data_type.typeEmitter = _make_literal("Emitter")
         data_type.createImplementationDataTypeElement("Sub")
         props = data_type.createSymbolProps("Sym")
@@ -561,6 +562,7 @@ class TestImplementationDataTypeWriter:
         assert child.tag == "IMPLEMENTATION-DATA-TYPE"
         assert child.find("SHORT-NAME").text == "ImplType"
         assert child.find("DYNAMIC-ARRAY-SIZE-PROFILE").text == "prof"
+        assert child.find("IS-STRUCT-WITH-OPTIONAL-ELEMENT").text == "true"
         assert child.find("TYPE-EMITTER").text == "Emitter"
         assert child.find("SYMBOL-PROPS") is not None
         assert child.find("SUB-ELEMENTS") is not None


### PR DESCRIPTION
## Summary
Aligns `ImplementationDataTypes` to **AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table D.37, p.321 (R23-11)**.

- Spec-verbatim class docstring and 5-column method parity checklist with `# Spec verified: R23-11`.
- `dynamicArraySizeProfile` typed as `Optional[String]` and `isStructWithOptionalElement` as `Optional[Boolean]` per the spec.
- Added reader/writer coverage: `isStructWithOptionalElement`, `dynamicArraySizeProfile`, `createImplementationDataTypeElement`, `createSymbolProps`, `typeEmitter`.
- Added model, parser, and writer tests.
- Added the generated `autosar/markdown/AUTOSAR_CP_TPS_TimingExtensions.md` spec markdown.

## Notes
This is the change set that was intentionally excluded from PR #554 (ExternalTriggeringPoint). It is based directly on `main` so the two PRs are independent.

## Test plan
Affected suites: `test_ImplementationDataTypes`, `test_implementation_data_type`, `test_writer_impl_types_ports`, plus the integration round-trip.