### PR TITLE
feat: align PortPrototype annotations with AUTOSAR spec

### DIFF
--- a/.agents/skills/aligning-autosar-class/SKILL.md
+++ b/.agents/skills/aligning-autosar-class/SKILL.md
@@ -52,8 +52,8 @@ trivial edits that don't touch the class's spec contract.
 | model test | `tests/test_armodel/models/M2/AUTOSARTemplates/<pkg>/test_<ClassName>.py` → `class Test<ClassName>` — pairs 1:1 with source `<ClassName>.py` (Step 2) |
 | parser test | `tests/test_armodel/parser/test_*.py` → `class Test*` (load with `ARXMLParser`, assert model fields; Step 5) |
 | writer test | `tests/test_armodel/writer/test_*.py` → `class Test*` (set → save → reload round-trip; Step 5) |
-| spec PDF | `autosar/pdf/AUTOSAR_CP_TPS_*.pdf` — **PDF name, Table ID, and page (p.NN) come from the PDF file directly** |
-| spec table | `grep "Table N.M: <ClassName>" autosar/markdown/AUTOSAR_CP_TPS_*.md` (table content only; the markdown carries no page numbers) |
+| spec markdown | `grep "Table N.M: <ClassName>" autosar/markdown/AUTOSAR_*_TPS_*.md` — **primary source for all text**: `Note` (→ docstrings), `Attribute`/`Base`, `Table N.M` id, table name (via filename). Covers **both** `CP_TPS` (Classic) and `FO_TPS` (Foundation) |
+| spec PDF | `autosar/pdf/AUTOSAR_*_TPS_*.pdf` — **opened only to read the page number** (`p.NN`); the markdown carries no page numbers |
 | deviation records | the project deviation tracker (format in *Rule 0014*) |
 | XSD ground truth | `autosar-pdf/examples/xsd/` |
 
@@ -87,8 +87,9 @@ implementation before its failing test.
   report referenced non-existent classes (do **not** block). **Enum (`AREnum`)?** produce
   literals not accessors (*Rules 0010–0011*).
 - **4** — Class docstring, inline `__init__` comments, and getter/setter docstrings copy
-  the PDF `Note` **verbatim** (no summarizing/rephrasing); a guarded setter also appends
-  the None-no-op code-behavior sentence.
+  the spec `Note` **verbatim from the markdown** (no summarizing/rephrasing); the PDF is
+  opened only for the `p.NN` page. A guarded setter also appends the None-no-op
+  code-behavior sentence.
 - **5** — **Reader/writer tests live in their own folders**, not the per-class mirror:
   parser → `tests/test_armodel/parser/`, writer → `tests/test_armodel/writer/`
   (both `class Test*`, organized by feature/handler). Assert **field values** (not just
@@ -117,7 +118,7 @@ implementation before its failing test.
 
 ```
 # ClassName method parity checklist:
-# Spec: AUTOSAR_CP_TPS_<Template>.pdf, Table X.Y, p.NN
+# Spec: AUTOSAR_<Platform>_TPS_<Template>.pdf, Table X.Y, p.NN
 # Spec verified: R<YY>-<MM>
 # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
 # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
@@ -127,9 +128,11 @@ implementation before its failing test.
 # [x] getBar       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 ```
 
-**Citation source:** the `# Spec:` PDF name, Table ID, and `p.NN` page come from the
-PDF file directly (`autosar/pdf/AUTOSAR_CP_TPS_*.pdf`); the markdown carries no page
-numbers.
+**Citation source:** the `# Spec:` table name, `Table N.M` id, and `Note` text come from
+the **markdown** (`autosar/markdown/AUTOSAR_*_TPS_*.md` — covers `CP_TPS` and `FO_TPS`);
+only the `p.NN` **page** is read from the **PDF** (`autosar/pdf/...`) — the markdown
+carries no page numbers. In the `# Spec:` line, `<Platform>` is `CP` (Classic) or `FO`
+(Foundation), taken from the spec markdown filename.
 
 `reader [x]` on the **mutator** row (reader's `readXxx` calls `setXxx`/`createXxx`/
 `addXxx`); `writer [x]` on the **getter** row (writer's `writeXxx` calls `getXxx`);
@@ -163,6 +166,6 @@ detail: *Rule 0002*.
 
 - **Rules (self-contained):** `rules.md` in this skill folder — *Rule 0001*–*Rule 0014*.
 - Coding standards: `docs/development/coding_rules.md`.
-- Spec PDFs (authoritative — source of the PDF name, Table ID, and page): `autosar/pdf/AUTOSAR_CP_TPS_*.pdf`.
-- Spec markdown (derived table content; carries no page numbers): `autosar/markdown/AUTOSAR_CP_TPS_*.md`.
+- Spec markdown (primary — source of all text: `Note`, `Table N.M` id, table name): `autosar/markdown/AUTOSAR_*_TPS_*.md` (`CP_TPS` + `FO_TPS`).
+- Spec PDFs (opened only for the `p.NN` page number): `autosar/pdf/AUTOSAR_*_TPS_*.pdf`.
 - XSD ground truth: `autosar-pdf/examples/xsd/`.

--- a/.agents/skills/aligning-autosar-class/rules.md
+++ b/.agents/skills/aligning-autosar-class/rules.md
@@ -6,10 +6,12 @@ Self-contained rule reference for aligning any AUTOSAR model class in py-armodel
 - source: `src/armodel/models/M2/AUTOSARTemplates/<package>/<ClassName>.py`
   (or `<package>/<ClassName>/__init__.py`)
 - mirrored test: `tests/test_armodel/models/M2/AUTOSARTemplates/<package>/test_<ClassName>.py`
-- spec table: the class's attribute table in the AUTOSAR PDF
-  (PDF `autosar/pdf/AUTOSAR_CP_TPS_*.pdf`, markdown `autosar/markdown/AUTOSAR_CP_TPS_*.md`,
-  XSD `autosar-pdf/examples/xsd/`). The **PDF name, Table ID, and page number come from
-  the PDF file directly** — the markdown carries no page numbers.
+- spec table: the class's attribute table (markdown
+  `autosar/markdown/AUTOSAR_*_TPS_*.md` (covers `CP_TPS` + `FO_TPS`), derived from PDF
+  `autosar/pdf/AUTOSAR_*_TPS_*.pdf`, XSD `autosar-pdf/examples/xsd/`). **All text** —
+  `Note`, `Attribute`, `Base`, the `Table N.M` id, and the table name (from the markdown
+  filename) — **is read from the markdown**; the **PDF is opened only for the page
+  number** (`p.NN`), because the markdown carries no page numbers.
 
 **IDs:** rules carry contiguous 4-digit IDs (`Rule 0001` …). Each notes its former
 number for traceability. The 9-step workflow in `SKILL.md` references these IDs.
@@ -265,7 +267,7 @@ the checklist title cites the spec table, then the version marker:
 
 ```
 # ClassName method parity checklist:
-# Spec: AUTOSAR_CP_TPS_<Template>.pdf, Table X.Y, p.NN
+# Spec: AUTOSAR_<Platform>_TPS_<Template>.pdf, Table X.Y, p.NN
 # Spec verified: R<YY>-<MM>
 # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
 # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
@@ -288,9 +290,12 @@ the checklist title cites the spec table, then the version marker:
   applicable); a `[ ]` whose obligation is actually done is stale — cross it. A row is
   `[x]` only when all obligations are complete and verified.
 - Rows in **source order** matching the methods (Rule 0011).
-- The `# Spec:` line names the correct PDF/table/page — the **PDF name, Table ID, and
-  page number come from the PDF file directly** (`autosar/pdf/AUTOSAR_CP_TPS_*.pdf`); the
-  markdown (`autosar/markdown/...`) carries no page numbers. Cite the header-row page
+- The `# Spec:` line names the correct PDF/table/page — the table name and the `Table
+  N.M` id are read from the **markdown** (`autosar/markdown/AUTOSAR_*_TPS_*.md`, `CP_TPS` or
+  `FO_TPS`); only the **`p.NN` page number** is read from the **PDF**
+  (`autosar/pdf/AUTOSAR_*_TPS_*.pdf`) — the markdown carries no page numbers. In
+  `AUTOSAR_<Platform>_TPS_<Template>.pdf`, `<Platform>` is `CP` (Classic) or `FO`
+  (Foundation), from the spec markdown filename. Cite the header-row page
   (where `Class <Name>` first appears), in format `Table X.Y, p.NN`. A class rendered in >1 PDF
   cites the PDF its sibling family uses. For the enum attribute type, cite the PDF that
   renders the enum's own `Enumeration` table (independent of the class's PDF).
@@ -547,8 +552,9 @@ string values (`MEMBER = "member_value"`).
   (`DependencyUsageEnum.BUILD = "build"`); the **XSD** serializes enum literals in
   **UPPERCASE**. Keep the member matching the spec; write UPPERCASE only in test XML
   fixtures/XSD-valid fragments.
-- Class docstring: the spec `Note` **verbatim** (do not paraphrase). Each member has an
-  inline comment citing the literal's description + Tags (`atp.EnumerationLiteralIndex=N`).
+- Class docstring: the spec `Note` **verbatim from the markdown** (do not paraphrase). Each
+  member has an inline comment citing the literal's description + Tags
+  (`atp.EnumerationLiteralIndex=N`).
 - Tests reference members like `MyEnum.MEMBER_NAME` for reading; to **set** an enum
   attribute construct `MyEnum().setValue(MyEnum.MEMBER_NAME)`; assert round-tripped values
   with `.getValue() == "memberName"` (the parser returns a generic `ARLiteral`). An
@@ -559,10 +565,13 @@ string values (`MEMBER = "member_value"`).
 
 ## Rule 0012 — Docstring & Comment Sync *(formerly Rule 13)*
 
-Class docstrings, inline `__init__` comments, and getter/setter docstrings copy the PDF
-`Note` **verbatim** — never summarize, paraphrase, or rephrase the wording — and stay
-synced across AUTOSAR upgrades. This is one ordered procedure per class (Rule 0006's
-mechanical check only confirms the marker *string* exists, not that content is correct).
+Class docstrings, inline `__init__` comments, and getter/setter docstrings copy the spec
+`Note` **verbatim from the markdown table** (`autosar/markdown/*.md`) — never summarize,
+paraphrase, or rephrase the wording — and stay synced across AUTOSAR upgrades. The PDF
+(`autosar/pdf/*.pdf`) is opened **only to read the page number** for the `p.NN` citation;
+all `Note`/`Attribute`/`Base` text (and the `Table N.M` id) comes from the markdown. This
+is one ordered procedure per class (Rule 0006's mechanical check only confirms the marker
+*string* exists, not that content is correct).
 
 ### 0012.1 Versioning
 
@@ -581,28 +590,33 @@ mechanical check only confirms the marker *string* exists, not that content is c
 
 0. **Exception gate:** XSD-only class (no own table)? Stop — no `# Spec:`, no marker,
    `[ ]` rows; record in the tracker. Otherwise continue.
-1. Locate the spec table + page (`grep "Table N.M: <ClassName>" autosar/markdown/*.md`;
-   confirm the page in the PDF via `pypdf`, matching the printed footer).
+1. Locate the spec table in the **markdown** (`grep "Table N.M: <ClassName>
+   autosar/markdown/*.md`) — its `Note`/`Attribute`/`Base` text and the `Table N.M` id are
+   the extraction source; then read **only the page number** from the **PDF** via `pypdf`
+   (matching the printed footer) for the `p.NN` citation.
 2. Add the version marker.
-3. **Class docstring** = the PDF `Note` **verbatim** (no invented recap prose, no `Base`
-   chain summary); append class-level `constr_*` rows (including ones targeting inherited
-   attributes). For a terse citation Note, append the XSD complexType doc as an
-   elaboration (also verbatim).
+3. **Class docstring** = the spec `Note` **copied verbatim from the markdown table** (no
+   invented recap prose, no `Base` chain summary); append class-level `constr_*` rows
+   (including ones targeting inherited attributes). For a terse citation Note, append the
+   XSD complexType doc as an elaboration (also verbatim).
 4. **Per-attribute loop** (all five, per attribute, before the next):
    1. Referenced type must exist and be aligned before typing (Rule 0010/0011); its
       `# Spec:` cites its **own** table, independent of the owning class.
-   2. Inline `__init__` comment: the attribute's `Note` semantic sentence verbatim
-      (drop `Stereotypes:`/`Tags:` tail); append any `constr_*` wording + id.
-   3. Getter docstring: the PDF `Note` **verbatim** + constraint — never summarize or
-      rephrase into "Gets the value of X"; for an `iref`, name the concrete
-      `<name>InstanceRef` class.
-   4. Setter docstring: the PDF `Note` **verbatim** (same wording as the getter) +
-      constraint; the chainable-return and (if guarded) None-no-op lines are **added
-      code-behavior notes, not Note content** — append them without altering the Note
-      text: *"A None value is a no-op and does not overwrite an existing `<attr>`."*
+   2. Inline `__init__` comment: the attribute's `Note` (markdown) semantic sentence,
+      copied verbatim (drop `Stereotypes:`/`Tags:` tail); append any `constr_*` wording
+      + id.
+   3. Getter docstring: the spec `Note` **copied verbatim from the markdown** + constraint
+      — never summarize or rephrase into "Gets the value of X"; for an `iref`, name the
+      concrete `<name>InstanceRef` class.
+   4. Setter docstring: the spec `Note` **copied verbatim from the markdown** (same
+      wording as the getter) + constraint; the chainable-return and (if guarded)
+      None-no-op lines are **added code-behavior notes, not Note content** — append them
+      without altering the Note text: *"A None value is a no-op and does not overwrite an
+      existing `<attr>`."*
    5. Cross-check comment/getter/setter for consistency.
-5. Verify by **diff**, not status — no mechanical check proves wording matches the PDF;
-   re-open the Note/XSD doc and diff against the comment and both docstrings.
+5. Verify by **diff**, not status — no mechanical check proves wording matches the spec;
+   re-open the markdown `Note` (and the XSD doc) and diff against the comment and both
+   docstrings. Re-open the PDF only if the page number is in doubt.
 
 ### 0012.3 Drift on upgrade
 
@@ -675,7 +689,7 @@ tracker. Each class entry has a header and a deviation table:
 
 ```
 ## `ClassName`
-- **PDF:** `AUTOSAR_CP_TPS_<Template>.pdf`  | **page:** NN
+- **PDF:** `AUTOSAR_<Platform>_TPS_<Template>.pdf`  | **page:** NN
 - **Package:** `M2::AUTOSARTemplates::…`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/…/<ClassName>.py`
 

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/__init__.py
@@ -905,19 +905,19 @@ class McFunction(Identifiable):
 
 class RoleBasedMcDataAssignment(ARObject):
     """
-    This class specifies an assignment of a role to a particular McDataInstance, enabling the reuse of data in different contexts of rapid prototyping.
+    This meta-class allows to define links that specify logical relationships between single McDataInstances. The details on the existence and semantics of such links are not standardized. Possible Use Case: Rapid Prototyping solutions in which additional communication buffers and switches are implemented in the RTE that allow to switch between the usage of the original and the bypass buffers. The different buffers and the switch can be represented by McDataInstances (in order to be accessed by MC tools) which have relationships to each other.
     """
 
     # RoleBasedMcDataAssignment method parity checklist:
-    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table D.55, p.195
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table D.55, p.329
     # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test
-    # [x] getExecutionContextRef       [x] impl  [x] docstring  [x] test
-    # [x] setExecutionContextRef       [x] impl  [x] docstring  [x] test
-    # [x] getMcDataInstanceRef         [x] impl  [x] docstring  [x] test
-    # [x] setMcDataInstanceRef         [x] impl  [x] docstring  [x] test
-    # [x] getRole                      [x] impl  [x] docstring  [x] test
-    # [x] setRole                      [x] impl  [x] docstring  [x] test
+    # [x] addExecutionContextRef       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getExecutionContextRefs      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addMcDataInstanceRef         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMcDataInstanceRefs        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getRole                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setRole                      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         """
@@ -925,61 +925,61 @@ class RoleBasedMcDataAssignment(ARObject):
         """
         super().__init__()
 
-        # Reference to the execution context the assigned data instance is used in.
-        self.executionContextRef: Optional[RefType] = None
+        # Determines the executionContext in which the McDataInstance describing a local (e.g Task-Local) buffer of a global buffer is valid.
+        self.executionContextRefs: List[RefType] = []
 
-        # Reference to the McDataInstance the role is assigned to.
-        self.mcDataInstanceRef: Optional[RefType] = None
+        # The target of the assignment.
+        self.mcDataInstanceRefs: List[RefType] = []
 
         # Shall be used to specify the role of the assigned data instance in relation to the instance that owns the assignment.
         self.role: Optional[Identifier] = None
 
-    def getExecutionContextRef(self) -> Optional[RefType]:
+    def getExecutionContextRefs(self) -> List[RefType]:
         """
-        Gets the reference to the execution context the assigned data instance is used in.
+        Gets the references to the execution context the assigned data instance is used in.
 
         Returns:
-            RefType referencing the execution context, or None if not set
+            List of RefType referencing the execution context
         """
-        return self.executionContextRef
+        return self.executionContextRefs
 
-    def setExecutionContextRef(self, value: Optional[RefType]) -> "RoleBasedMcDataAssignment":
+    def addExecutionContextRef(self, value: Optional[RefType]) -> "RoleBasedMcDataAssignment":
         """
-        Sets the reference to the execution context the assigned data instance is used in.
-        A None value is a no-op and does not overwrite an existing reference.
+        Adds a reference to the execution context the assigned data instance is used in.
+        A None value is a no-op and does not append anything.
 
         Args:
-            value: The execution context reference to set
+            value: The execution context reference to add
 
         Returns:
             self for method chaining
         """
         if value is not None:
-            self.executionContextRef = value
+            self.executionContextRefs.append(value)
         return self
 
-    def getMcDataInstanceRef(self) -> Optional[RefType]:
+    def getMcDataInstanceRefs(self) -> List[RefType]:
         """
-        Gets the reference to the McDataInstance the role is assigned to.
+        Gets the references to the McDataInstance the role is assigned to.
 
         Returns:
-            RefType referencing the McDataInstance, or None if not set
+            List of RefType referencing the McDataInstance
         """
-        return self.mcDataInstanceRef
+        return self.mcDataInstanceRefs
 
-    def setMcDataInstanceRef(self, value: Optional[RefType]) -> "RoleBasedMcDataAssignment":
+    def addMcDataInstanceRef(self, value: Optional[RefType]) -> "RoleBasedMcDataAssignment":
         """
-        Sets the reference to the McDataInstance the role is assigned to.
-        A None value is a no-op and does not overwrite an existing reference.
+        Adds a reference to the McDataInstance the role is assigned to.
+        A None value is a no-op and does not append anything.
 
         Args:
-            value: The McDataInstance reference to set
+            value: The McDataInstance reference to add
 
         Returns:
             self for method chaining
         """
         if value is not None:
-            self.mcDataInstanceRef = value
+            self.mcDataInstanceRefs.append(value)
         return self
 
     def getRole(self) -> Optional[Identifier]:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ApplicationAttributes/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ApplicationAttributes/__init__.py
@@ -2,115 +2,636 @@
 This module contains application attribute classes for AUTOSAR software components.
 """
 
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum
+from typing import Optional
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARBoolean, RefType
+from armodel.models.M2.MSR.Documentation.Annotation import GeneralAnnotation
 
 
 class DataLimitKindEnum(AREnum):
     """
-    Enumeration for data limit kinds in AUTOSAR.
+    Indicates whether the data element carries a minimum or maximum value, thereby limiting the current range of another value.
     """
 
     # DataLimitKindEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.45, p.153
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [ ] test
 
-    UNLIMITED = "unlimited"
-    LIMITED = "limited"
+    # Limitation to maximum value Tags: atp.EnumerationLiteralIndex=0
+    MAX = "max"
+
+    # Limitation to minimum value Tags: atp.EnumerationLiteralIndex=1
+    MIN = "min"
+
+    # No limitation applicable Tags: atp.EnumerationLiteralIndex=2
+    NONE = "none"
 
     def __init__(self):
         super().__init__(
             (
-                DataLimitKindEnum.UNLIMITED,
-                DataLimitKindEnum.LIMITED,
+                DataLimitKindEnum.MAX,
+                DataLimitKindEnum.MIN,
+                DataLimitKindEnum.NONE,
             )
         )
 
 
 class FilterDebouncingEnum(AREnum):
     """
-    Enumeration for filter debouncing in AUTOSAR.
+    This enumeration defines possible values for the filter debouncing strategy.
     """
 
     # FilterDebouncingEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.48, p.157
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [ ] test
 
-    FILTER = "filter"
-    DEBOUNCE = "debounce"
-    NONE = "none"
+    # The signal is a mean value Tags: atp.EnumerationLiteralIndex=0
+    DEBOUNCE_DATA = "debounceData"
+
+    # Means that no modification of the signal has been applied. This is the default value Tags: atp.EnumerationLiteralIndex=1
+    RAW_DATA = "rawData"
+
+    # The signal is delivered by a GET operation after a certain amount of time Tags: atp.EnumerationLiteralIndex=2
+    WAIT_TIME_DATE = "waitTimeDate"
 
     def __init__(self):
         super().__init__(
             (
-                FilterDebouncingEnum.FILTER,
-                FilterDebouncingEnum.DEBOUNCE,
-                FilterDebouncingEnum.NONE,
+                FilterDebouncingEnum.DEBOUNCE_DATA,
+                FilterDebouncingEnum.RAW_DATA,
+                FilterDebouncingEnum.WAIT_TIME_DATE,
             )
         )
 
 
 class ProcessingKindEnum(AREnum):
     """
-    Enumeration for processing kinds in AUTOSAR.
+    Kind of processing which has been applied to a data element.
     """
 
     # ProcessingKindEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.44, p.153
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [ ] test
 
-    EVENT_TRIGGERED = "event-triggered"
-    PERIODIC = "periodic"
-    DATA_TRIGGERED = "data-triggered"
+    # Indicates that a raw signal has been manipulated by some application software components by using filters. Tags: atp.EnumerationLiteralIndex=0
+    FILTERED = "filtered"
+
+    # Indicates that none of the other option apply. Tags: atp.EnumerationLiteralIndex=1
+    NONE = "none"
+
+    # Specifies that a signal is taken directly from the basic software modules, i.e. from the ECU abstraction layer. It indicates to a developer that the control algorithm in the software has to provide filters. Tags: atp.EnumerationLiteralIndex=2
+    RAW = "raw"
 
     def __init__(self):
         super().__init__(
             (
-                ProcessingKindEnum.EVENT_TRIGGERED,
-                ProcessingKindEnum.PERIODIC,
-                ProcessingKindEnum.DATA_TRIGGERED,
+                ProcessingKindEnum.FILTERED,
+                ProcessingKindEnum.NONE,
+                ProcessingKindEnum.RAW,
             )
         )
 
 
 class PulseTestEnum(AREnum):
     """
-    Enumeration for pulse test in AUTOSAR.
+    This element indicates to the connected Actuator Software component whether the data-element can be used to generate pulse test sequences using the IoHwAbstraction layer
     """
 
     # PulseTestEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.49, p.157
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [ ] test
 
-    PULSE = "pulse"
-    TEST = "test"
-    NONE = "none"
+    # Disables the pulse test Tags: atp.EnumerationLiteralIndex=0
+    DISABLE = "disable"
+
+    # Enables the pulse test Tags: atp.EnumerationLiteralIndex=1
+    ENABLE = "enable"
 
     def __init__(self):
         super().__init__(
             (
-                PulseTestEnum.PULSE,
-                PulseTestEnum.TEST,
-                PulseTestEnum.NONE,
+                PulseTestEnum.DISABLE,
+                PulseTestEnum.ENABLE,
             )
         )
 
 
 class SignalFanEnum(AREnum):
     """
-    Enumeration for signal fan in AUTOSAR.
+    Signal Fan inside the Composition Component Type.
     """
 
     # SignalFanEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.55, p.162
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [ ] test
 
-    IN = "in"
-    OUT = "out"
-    IN_OUT = "in-out"
+    # The connections internally in the CompositionSwComponentType via DelegationSwConnectors and AssemblySwConnectors are defined in a way that at least one data element present in the S/R interface or one ClientServerOperation in the C/S interface of the outer PortPrototype is involved in a 1:n or n:1 communication pattern. Tags: atp.EnumerationLiteralIndex=0
+    NFOLD = "nfold"
+
+    # The connections internally in the CompositionSwComponentType via DelegationSwConnectors and AssemblySwConnectors are defined in a way that each VariableDataPrototype present in the S/R interface or ClientServerOperation in the C/S interface of the outer PortPrototype is involved in a 1:1 communication pattern only. Tags: atp.EnumerationLiteralIndex=1
+    SINGLE = "single"
 
     def __init__(self):
         super().__init__(
             (
-                SignalFanEnum.IN,
-                SignalFanEnum.OUT,
-                SignalFanEnum.IN_OUT,
+                SignalFanEnum.NFOLD,
+                SignalFanEnum.SINGLE,
             )
         )
+
+
+class SenderReceiverAnnotation(GeneralAnnotation):
+    """
+    Annotation of the data elements in a port that realizes a sender/receiver interface.
+    """
+
+    # SenderReceiverAnnotation method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.41, p.152
+    # Spec verified: R23-11
+    # [x] __init__                  [x] impl  [x] docstring  [x] test
+    # [x] getComputed               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setComputed               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDataElementRef         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDataElementRef         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getLimitKind              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setLimitKind              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getProcessingKind         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setProcessingKind         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # Flag whether this data element was not measured directly but instead was calculated from possibly several other measured or calculated values.
+        self.computed: Optional[ARBoolean] = None
+
+        # The instance of VariableDataPrototype annotated.
+        self.dataElementRef: Optional[RefType] = None
+
+        # This min or max has not to be mismatched with the min- and max for data-value in a compu-method.
+        self.limitKind: Optional[DataLimitKindEnum] = None
+
+        # This attribute controls how data is processed according to the possible values of ProcessingKindEnum.
+        self.processingKind: Optional[ProcessingKindEnum] = None
+
+    def getComputed(self) -> Optional[ARBoolean]:
+        """
+        Gets the flag whether this data element was not measured directly but instead was calculated from possibly several other measured or calculated values.
+
+        Returns:
+            ARBoolean flag, or None if not set
+        """
+        return self.computed
+
+    def setComputed(self, value: Optional[ARBoolean]) -> "SenderReceiverAnnotation":
+        """
+        Sets the flag whether this data element was not measured directly but instead was calculated from possibly several other measured or calculated values.
+        A None value is a no-op and does not overwrite an existing value.
+
+        Args:
+            value: The ARBoolean flag to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.computed = value
+        return self
+
+    def getDataElementRef(self) -> Optional[RefType]:
+        """
+        Gets the instance of VariableDataPrototype annotated.
+
+        Returns:
+            RefType referencing the VariableDataPrototype, or None if not set
+        """
+        return self.dataElementRef
+
+    def setDataElementRef(self, value: Optional[RefType]) -> "SenderReceiverAnnotation":
+        """
+        Sets the instance of VariableDataPrototype annotated.
+        A None value is a no-op and does not overwrite an existing reference.
+
+        Args:
+            value: The RefType to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.dataElementRef = value
+        return self
+
+    def getLimitKind(self) -> Optional[DataLimitKindEnum]:
+        """
+        Gets the limit kind of this data element annotation.
+
+        Returns:
+            DataLimitKindEnum, or None if not set
+        """
+        return self.limitKind
+
+    def setLimitKind(self, value: Optional[DataLimitKindEnum]) -> "SenderReceiverAnnotation":
+        """
+        Sets the limit kind of this data element annotation.
+        A None value is a no-op and does not overwrite an existing value.
+
+        Args:
+            value: The DataLimitKindEnum to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.limitKind = value
+        return self
+
+    def getProcessingKind(self) -> Optional[ProcessingKindEnum]:
+        """
+        Gets the processing kind of this data element annotation.
+
+        Returns:
+            ProcessingKindEnum, or None if not set
+        """
+        return self.processingKind
+
+    def setProcessingKind(self, value: Optional[ProcessingKindEnum]) -> "SenderReceiverAnnotation":
+        """
+        Sets the processing kind of this data element annotation.
+        A None value is a no-op and does not overwrite an existing value.
+
+        Args:
+            value: The ProcessingKindEnum to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.processingKind = value
+        return self
+
+
+class ClientServerAnnotation(GeneralAnnotation):
+    """
+    Annotation to a port regarding a certain Operation.
+    """
+
+    # ClientServerAnnotation method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.46, p.155
+    # Spec verified: R23-11
+    # [x] __init__                  [x] impl  [x] docstring  [x] test
+    # [x] getOperationRef           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setOperationRef           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This represents the ClientServerOperation that the ClientServerAnnotation corresponds to.
+        self.operationRef: Optional[RefType] = None
+
+    def getOperationRef(self) -> Optional[RefType]:
+        """
+        Gets the ClientServerOperation that the ClientServerAnnotation corresponds to.
+
+        Returns:
+            RefType referencing the ClientServerOperation, or None if not set
+        """
+        return self.operationRef
+
+    def setOperationRef(self, value: Optional[RefType]) -> "ClientServerAnnotation":
+        """
+        Sets the ClientServerOperation that the ClientServerAnnotation corresponds to.
+        A None value is a no-op and does not overwrite an existing reference.
+
+        Args:
+            value: The RefType to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.operationRef = value
+        return self
+
+
+class IoHwAbstractionServerAnnotation(GeneralAnnotation):
+    """
+    The IoHwAbstractionServerAnnotation will only be used from a sensor- or an actuator component while interacting with the IoHwAbstraction layer. Note that the 'server' in the name of this meta-class is not meant to restrict the usage to ClientServer Interfaces.
+    """
+
+    # IoHwAbstractionServerAnnotation method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.47, p.157
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
+    # [x] getFilteringDebouncing       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFilteringDebouncing       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPulseTest                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setPulseTest                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTriggerRef                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTriggerRef                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This attribute is used to indicate what kind of filtering/debouncing has been put to the signal in the IoHwAbstraction layer.
+        self.filteringDebouncing: Optional[FilterDebouncingEnum] = None
+
+        # This attribute indicates to the connected SensorActuatorSwComponentType whether the VariableDataPrototype can be used to generate pulse test sequences using the IoHwAbstraction layer
+        self.pulseTest: Optional[PulseTestEnum] = None
+
+        # Reference to the corresponding Trigger.
+        self.triggerRef: Optional[RefType] = None
+
+    def getFilteringDebouncing(self) -> Optional[FilterDebouncingEnum]:
+        """
+        Gets the filtering/debouncing kind that has been put to the signal in the IoHwAbstraction layer.
+
+        Returns:
+            FilterDebouncingEnum, or None if not set
+        """
+        return self.filteringDebouncing
+
+    def setFilteringDebouncing(self, value: Optional[FilterDebouncingEnum]) -> "IoHwAbstractionServerAnnotation":
+        """
+        Sets the filtering/debouncing kind that has been put to the signal in the IoHwAbstraction layer.
+        A None value is a no-op and does not overwrite an existing value.
+
+        Args:
+            value: The FilterDebouncingEnum to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.filteringDebouncing = value
+        return self
+
+    def getPulseTest(self) -> Optional[PulseTestEnum]:
+        """
+        Gets the pulse test indication for the connected SensorActuatorSwComponentType.
+
+        Returns:
+            PulseTestEnum, or None if not set
+        """
+        return self.pulseTest
+
+    def setPulseTest(self, value: Optional[PulseTestEnum]) -> "IoHwAbstractionServerAnnotation":
+        """
+        Sets the pulse test indication for the connected SensorActuatorSwComponentType.
+        A None value is a no-op and does not overwrite an existing value.
+
+        Args:
+            value: The PulseTestEnum to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.pulseTest = value
+        return self
+
+    def getTriggerRef(self) -> Optional[RefType]:
+        """
+        Gets the reference to the corresponding Trigger.
+
+        Returns:
+            RefType referencing the Trigger, or None if not set
+        """
+        return self.triggerRef
+
+    def setTriggerRef(self, value: Optional[RefType]) -> "IoHwAbstractionServerAnnotation":
+        """
+        Sets the reference to the corresponding Trigger.
+        A None value is a no-op and does not overwrite an existing reference.
+
+        Args:
+            value: The RefType to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.triggerRef = value
+        return self
+
+
+class ModePortAnnotation(GeneralAnnotation):
+    """
+    Annotation to a port used for calibration regarding a certain ModeDeclarationGroupPrototype.
+    """
+
+    # ModePortAnnotation method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.51, p.159
+    # Spec verified: R23-11
+    # [x] __init__                  [x] impl  [x] docstring  [x] test
+    # [x] getModeGroupRef           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setModeGroupRef           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # The instance of annotated ModeDeclarationGroupPrototype.
+        self.modeGroupRef: Optional[RefType] = None
+
+    def getModeGroupRef(self) -> Optional[RefType]:
+        """
+        Gets the instance of annotated ModeDeclarationGroupPrototype.
+
+        Returns:
+            RefType referencing the ModeDeclarationGroupPrototype, or None if not set
+        """
+        return self.modeGroupRef
+
+    def setModeGroupRef(self, value: Optional[RefType]) -> "ModePortAnnotation":
+        """
+        Sets the instance of annotated ModeDeclarationGroupPrototype.
+        A None value is a no-op and does not overwrite an existing reference.
+
+        Args:
+            value: The RefType to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.modeGroupRef = value
+        return self
+
+
+class NvDataPortAnnotation(GeneralAnnotation):
+    """
+    Annotation to a port regarding a certain VariableDataPrototype.
+    """
+
+    # NvDataPortAnnotation method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.53, p.160
+    # Spec verified: R23-11
+    # [x] __init__                  [x] impl  [x] docstring  [x] test
+    # [x] getVariableRef            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setVariableRef            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # The instance of nv data annotated.
+        self.variableRef: Optional[RefType] = None
+
+    def getVariableRef(self) -> Optional[RefType]:
+        """
+        Gets the instance of nv data annotated.
+
+        Returns:
+            RefType referencing the VariableDataPrototype, or None if not set
+        """
+        return self.variableRef
+
+    def setVariableRef(self, value: Optional[RefType]) -> "NvDataPortAnnotation":
+        """
+        Sets the instance of nv data annotated.
+        A None value is a no-op and does not overwrite an existing reference.
+
+        Args:
+            value: The RefType to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.variableRef = value
+        return self
+
+
+class ParameterPortAnnotation(GeneralAnnotation):
+    """
+    Annotation to a port used for calibration regarding a certain ParameterDataPrototype.
+    """
+
+    # ParameterPortAnnotation method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.50, p.159
+    # Spec verified: R23-11
+    # [x] __init__                  [x] impl  [x] docstring  [x] test
+    # [x] getParameterRef           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setParameterRef           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # The instance of annotated ParameterDataPrototype.
+        self.parameterRef: Optional[RefType] = None
+
+    def getParameterRef(self) -> Optional[RefType]:
+        """
+        Gets the instance of annotated ParameterDataPrototype.
+
+        Returns:
+            RefType referencing the ParameterDataPrototype, or None if not set
+        """
+        return self.parameterRef
+
+    def setParameterRef(self, value: Optional[RefType]) -> "ParameterPortAnnotation":
+        """
+        Sets the instance of annotated ParameterDataPrototype.
+        A None value is a no-op and does not overwrite an existing reference.
+
+        Args:
+            value: The RefType to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.parameterRef = value
+        return self
+
+
+class TriggerPortAnnotation(GeneralAnnotation):
+    """
+    Annotation to a port used for calibration regarding a certain Trigger.
+    """
+
+    # TriggerPortAnnotation method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.52, p.160
+    # Spec verified: R23-11
+    # [x] __init__                  [x] impl  [x] docstring  [x] test
+    # [x] getTriggerRef             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTriggerRef             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # The instance of annotated trigger.
+        self.triggerRef: Optional[RefType] = None
+
+    def getTriggerRef(self) -> Optional[RefType]:
+        """
+        Gets the instance of annotated trigger.
+
+        Returns:
+            RefType referencing the Trigger, or None if not set
+        """
+        return self.triggerRef
+
+    def setTriggerRef(self, value: Optional[RefType]) -> "TriggerPortAnnotation":
+        """
+        Sets the instance of annotated trigger.
+        A None value is a no-op and does not overwrite an existing reference.
+
+        Args:
+            value: The RefType to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.triggerRef = value
+        return self
+
+
+class DelegatedPortAnnotation(GeneralAnnotation):
+    """
+    Annotation to a 'delegated port' to specify the Signal Fan In or Signal Fan Out inside the CompositionSwComponentType.
+    """
+
+    # DelegatedPortAnnotation method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.54, p.162
+    # Spec verified: R23-11
+    # [x] __init__                  [x] impl  [x] docstring  [x] test
+    # [x] getSignalFan              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSignalFan              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # Specifies the Signal Fan In or Signal Fan Out of a delegated port.
+        self.signalFan: Optional[SignalFanEnum] = None
+
+    def getSignalFan(self) -> Optional[SignalFanEnum]:
+        """
+        Gets the Signal Fan In or Signal Fan Out of a delegated port.
+
+        Returns:
+            SignalFanEnum, or None if not set
+        """
+        return self.signalFan
+
+    def setSignalFan(self, value: Optional[SignalFanEnum]) -> "DelegatedPortAnnotation":
+        """
+        Sets the Signal Fan In or Signal Fan Out of a delegated port.
+        A None value is a no-op and does not overwrite an existing value.
+
+        Args:
+            value: The SignalFanEnum to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.signalFan = value
+        return self
 
 
 __all__ = [
@@ -119,4 +640,12 @@ __all__ = [
     "ProcessingKindEnum",
     "PulseTestEnum",
     "SignalFanEnum",
+    "SenderReceiverAnnotation",
+    "ClientServerAnnotation",
+    "IoHwAbstractionServerAnnotation",
+    "ModePortAnnotation",
+    "NvDataPortAnnotation",
+    "ParameterPortAnnotation",
+    "TriggerPortAnnotation",
+    "DelegatedPortAnnotation",
 ]

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
@@ -25,6 +25,16 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import NonqueuedReceiverComSpec, NonqueuedSenderComSpec, PPortComSpec
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import ParameterRequireComSpec, QueuedReceiverComSpec, QueuedSenderComSpec
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import RPortComSpec, ServerComSpec
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
+    ClientServerAnnotation,
+    DelegatedPortAnnotation,
+    IoHwAbstractionServerAnnotation,
+    ModePortAnnotation,
+    NvDataPortAnnotation,
+    ParameterPortAnnotation,
+    SenderReceiverAnnotation,
+    TriggerPortAnnotation,
+)
 
 
 class SymbolProps(ImplementationProps):
@@ -36,93 +46,250 @@ class SymbolProps(ImplementationProps):
 
 
 class PortPrototype(AtpPrototype, ABC):
+    """
+    Base class for the ports of an AUTOSAR software component. The aggregation of PortPrototypes is subject to variability with the purpose to support the conditional existence of ports.
+    """
+
     # PortPrototype method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getClientServerAnnotations   [x] impl  [ ] docstring  [ ] test
-    # [ ] addClientServerAnnotation    [x] impl  [ ] docstring  [ ] test
-    # [ ] getDelegatedPortAnnotation   [x] impl  [ ] docstring  [ ] test
-    # [ ] setDelegatedPortAnnotation   [x] impl  [ ] docstring  [ ] test
-    # [ ] getIoHwAbstractionServerAnnotations [x] impl  [ ] docstring  [ ] test
-    # [ ] addIoHwAbstractionServerAnnotation [x] impl  [ ] docstring  [ ] test
-    # [ ] getModePortAnnotations       [x] impl  [ ] docstring  [ ] test
-    # [ ] addModePortAnnotation        [x] impl  [ ] docstring  [ ] test
-    # [ ] getNvDataPortAnnotations     [x] impl  [ ] docstring  [ ] test
-    # [ ] addNvDataPortAnnotation      [x] impl  [ ] docstring  [ ] test
-    # [ ] getParameterPortAnnotations  [x] impl  [ ] docstring  [ ] test
-    # [ ] addParameterPortAnnotation   [x] impl  [ ] docstring  [ ] test
-    # [ ] getSenderReceiverAnnotations [x] impl  [ ] docstring  [ ] test
-    # [ ] addSenderReceiverAnnotation  [x] impl  [ ] docstring  [ ] test
-    # [ ] getTriggerPortAnnotations    [x] impl  [ ] docstring  [ ] test
-    # [ ] addTriggerPortAnnotation     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 3.2, p.66
+    # Spec verified: R23-11
+    # [x] __init__                         [x] impl  [x] docstring  [x] test
+    # [x] addClientServerAnnotation       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getClientServerAnnotations      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDelegatedPortAnnotation      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDelegatedPortAnnotation      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addIoHwAbstractionServerAnnotation [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getIoHwAbstractionServerAnnotations [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addModePortAnnotation           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getModePortAnnotations          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addNvDataPortAnnotation         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getNvDataPortAnnotations        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addParameterPortAnnotation      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getParameterPortAnnotations     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addSenderReceiverAnnotation     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSenderReceiverAnnotations    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addTriggerPortAnnotation        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTriggerPortAnnotations       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         if type(self) is PortPrototype:
             raise TypeError("PortPrototype is an abstract class.")
         super().__init__(parent, short_name)
 
-        self.clientServerAnnotations = []
-        self.delegatedPortAnnotation = None
-        self.ioHwAbstractionServerAnnotations = []
-        self.modePortAnnotations = []
-        self.nvDataPortAnnotations = []
-        self.parameterPortAnnotations = []
-        self.senderReceiverAnnotations = []
-        self.triggerPortAnnotations = []
+        # Annotation of this PortPrototype with respect to client/server communication.
+        self.clientServerAnnotations: List[ClientServerAnnotation] = []
 
-    def getClientServerAnnotations(self):
+        # Annotations on this delegated port.
+        self.delegatedPortAnnotation: Optional[DelegatedPortAnnotation] = None
+
+        # Annotations on this IO Hardware Abstraction port.
+        self.ioHwAbstractionServerAnnotations: List[IoHwAbstractionServerAnnotation] = []
+
+        # Annotations on this mode port.
+        self.modePortAnnotations: List[ModePortAnnotation] = []
+
+        # Annotations on this non voilatile data port.
+        self.nvDataPortAnnotations: List[NvDataPortAnnotation] = []
+
+        # Annotations on this parameter port.
+        self.parameterPortAnnotations: List[ParameterPortAnnotation] = []
+
+        # Collection of annotations of this ports sender/receiver communication.
+        self.senderReceiverAnnotations: List[SenderReceiverAnnotation] = []
+
+        # Annotations on this trigger port.
+        self.triggerPortAnnotations: List[TriggerPortAnnotation] = []
+
+    def getClientServerAnnotations(self) -> List[ClientServerAnnotation]:
+        """
+        Gets the annotations of this PortPrototype with respect to client/server communication.
+
+        Returns:
+            List of ClientServerAnnotation instances
+        """
         return self.clientServerAnnotations
 
-    def addClientServerAnnotation(self, value):
-        self.clientServerAnnotations.append(value)
+    def addClientServerAnnotation(self, value: Optional[ClientServerAnnotation]) -> "PortPrototype":
+        """
+        Adds an annotation of this PortPrototype with respect to client/server communication.
+        A None value is a no-op and does not append anything.
+
+        Args:
+            value: The ClientServerAnnotation to add
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.clientServerAnnotations.append(value)
         return self
 
-    def getDelegatedPortAnnotation(self):
+    def getDelegatedPortAnnotation(self) -> Optional[DelegatedPortAnnotation]:
+        """
+        Gets the annotations on this delegated port.
+
+        Returns:
+            DelegatedPortAnnotation, or None if not set
+        """
         return self.delegatedPortAnnotation
 
-    def setDelegatedPortAnnotation(self, value):
-        self.delegatedPortAnnotation = value
+    def setDelegatedPortAnnotation(self, value: Optional[DelegatedPortAnnotation]) -> "PortPrototype":
+        """
+        Sets the annotations on this delegated port.
+        A None value is a no-op and does not overwrite an existing annotation.
+
+        Args:
+            value: The DelegatedPortAnnotation to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.delegatedPortAnnotation = value
         return self
 
-    def getIoHwAbstractionServerAnnotations(self):
+    def getIoHwAbstractionServerAnnotations(self) -> List[IoHwAbstractionServerAnnotation]:
+        """
+        Gets the annotations on this IO Hardware Abstraction port.
+
+        Returns:
+            List of IoHwAbstractionServerAnnotation instances
+        """
         return self.ioHwAbstractionServerAnnotations
 
-    def addIoHwAbstractionServerAnnotation(self, value):
-        self.ioHwAbstractionServerAnnotations.append(value)
+    def addIoHwAbstractionServerAnnotation(self, value: Optional[IoHwAbstractionServerAnnotation]) -> "PortPrototype":
+        """
+        Adds an annotation on this IO Hardware Abstraction port.
+        A None value is a no-op and does not append anything.
+
+        Args:
+            value: The IoHwAbstractionServerAnnotation to add
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.ioHwAbstractionServerAnnotations.append(value)
         return self
 
-    def getModePortAnnotations(self):
+    def getModePortAnnotations(self) -> List[ModePortAnnotation]:
+        """
+        Gets the annotations on this mode port.
+
+        Returns:
+            List of ModePortAnnotation instances
+        """
         return self.modePortAnnotations
 
-    def addModePortAnnotation(self, value):
-        self.modePortAnnotations.append(value)
+    def addModePortAnnotation(self, value: Optional[ModePortAnnotation]) -> "PortPrototype":
+        """
+        Adds an annotation on this mode port.
+        A None value is a no-op and does not append anything.
+
+        Args:
+            value: The ModePortAnnotation to add
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.modePortAnnotations.append(value)
         return self
 
-    def getNvDataPortAnnotations(self):
+    def getNvDataPortAnnotations(self) -> List[NvDataPortAnnotation]:
+        """
+        Gets the annotations on this non voilatile data port.
+
+        Returns:
+            List of NvDataPortAnnotation instances
+        """
         return self.nvDataPortAnnotations
 
-    def addNvDataPortAnnotation(self, value):
-        self.nvDataPortAnnotations.append(value)
+    def addNvDataPortAnnotation(self, value: Optional[NvDataPortAnnotation]) -> "PortPrototype":
+        """
+        Adds an annotation on this non voilatile data port.
+        A None value is a no-op and does not append anything.
+
+        Args:
+            value: The NvDataPortAnnotation to add
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.nvDataPortAnnotations.append(value)
         return self
 
-    def getParameterPortAnnotations(self):
+    def getParameterPortAnnotations(self) -> List[ParameterPortAnnotation]:
+        """
+        Gets the annotations on this parameter port.
+
+        Returns:
+            List of ParameterPortAnnotation instances
+        """
         return self.parameterPortAnnotations
 
-    def addParameterPortAnnotation(self, value):
-        self.parameterPortAnnotations.append(value)
+    def addParameterPortAnnotation(self, value: Optional[ParameterPortAnnotation]) -> "PortPrototype":
+        """
+        Adds an annotation on this parameter port.
+        A None value is a no-op and does not append anything.
+
+        Args:
+            value: The ParameterPortAnnotation to add
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.parameterPortAnnotations.append(value)
         return self
 
-    def getSenderReceiverAnnotations(self):
+    def getSenderReceiverAnnotations(self) -> List[SenderReceiverAnnotation]:
+        """
+        Gets the collection of annotations of this ports sender/receiver communication.
+
+        Returns:
+            List of SenderReceiverAnnotation instances
+        """
         return self.senderReceiverAnnotations
 
-    def addSenderReceiverAnnotation(self, value):
-        self.senderReceiverAnnotations.append(value)
+    def addSenderReceiverAnnotation(self, value: Optional[SenderReceiverAnnotation]) -> "PortPrototype":
+        """
+        Adds an annotation of this ports sender/receiver communication.
+        A None value is a no-op and does not append anything.
+
+        Args:
+            value: The SenderReceiverAnnotation to add
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.senderReceiverAnnotations.append(value)
         return self
 
-    def getTriggerPortAnnotations(self):
+    def getTriggerPortAnnotations(self) -> List[TriggerPortAnnotation]:
+        """
+        Gets the annotations on this trigger port.
+
+        Returns:
+            List of TriggerPortAnnotation instances
+        """
         return self.triggerPortAnnotations
 
-    def addTriggerPortAnnotation(self, value):
-        self.triggerPortAnnotations.append(value)
+    def addTriggerPortAnnotation(self, value: Optional[TriggerPortAnnotation]) -> "PortPrototype":
+        """
+        Adds an annotation on this trigger port.
+        A None value is a no-op and does not append anything.
+
+        Args:
+            value: The TriggerPortAnnotation to add
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.triggerPortAnnotations.append(value)
         return self
 
 

--- a/src/armodel/parser/abstract_arxml_parser.py
+++ b/src/armodel/parser/abstract_arxml_parser.py
@@ -14,6 +14,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     ARNumerical,
     Boolean,
     DateTime,
+    Identifier,
     Integer,
     Limit,
     PositiveInteger,
@@ -118,6 +119,19 @@ class AbstractARXMLParser(ABC):
             else:
                 literal.setValue(child_element.text)
         return literal
+
+    def getChildElementOptionalIdentifier(self, element: ET.Element, key: str) -> Identifier:
+        child_element = self.find(element, key)
+        identifier = None
+        if child_element is not None:
+            identifier = Identifier()
+            self.readARObjectAttributes(child_element, identifier)
+            # Patch for empty element <USED-CODE-GENERATOR></USED-CODE-GENERATOR>
+            if child_element.text is None:
+                identifier.setValue("")
+            else:
+                identifier.setValue(child_element.text)
+        return identifier
 
     def getChildElementOptionalRevisionLabelString(self, element: ET.Element, key: str) -> RevisionLabelString:
         child_element = self.find(element, key)

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -189,6 +189,21 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import 
     SwSystemconstantValueSet,
     SwSystemconstValue,
 )
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
+    ClientServerAnnotation,
+    DataLimitKindEnum,
+    DelegatedPortAnnotation,
+    FilterDebouncingEnum,
+    IoHwAbstractionServerAnnotation,
+    ModePortAnnotation,
+    NvDataPortAnnotation,
+    ParameterPortAnnotation,
+    ProcessingKindEnum,
+    PulseTestEnum,
+    SenderReceiverAnnotation,
+    SignalFanEnum,
+    TriggerPortAnnotation,
+)
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import (
     ClientComSpec,
     CompositeNetworkRepresentation,
@@ -219,6 +234,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import (
     ComplexDeviceDriverSwComponentType,
     EcuAbstractionSwComponentType,
     PortGroup,
+    PortPrototype,
     PPortPrototype,
     PRPortPrototype,
     RPortPrototype,
@@ -2248,9 +2264,11 @@ class ARXMLParser(AbstractARXMLParser):
             self.readMcDataInstance(sub_element, instance.createSubElement(self.getShortName(sub_element)))
 
     def readRoleBasedMcDataAssignment(self, element: ET.Element, assignment: RoleBasedMcDataAssignment):
-        assignment.setExecutionContextRef(self.getChildElementOptionalRefType(element, "EXECUTION-CONTEXT-REF"))
-        assignment.setMcDataInstanceRef(self.getChildElementOptionalRefType(element, "MC-DATA-INSTANCE-REF"))
-        assignment.setRole(self.getChildElementOptionalLiteral(element, "ROLE"))
+        for ref in self.getChildElementRefTypeList(element, "EXECUTION-CONTEXT-REFS/EXECUTION-CONTEXT-REF"):
+            assignment.addExecutionContextRef(ref)
+        for ref in self.getChildElementRefTypeList(element, "MC-DATA-INSTANCE-REFS/MC-DATA-INSTANCE-REF"):
+            assignment.addMcDataInstanceRef(ref)
+        assignment.setRole(self.getChildElementOptionalIdentifier(element, "ROLE"))
 
     def readRptSwPrototypingAccess(self, element: ET.Element, access: RptSwPrototypingAccess):
         access.setRptHookAccess(self.getChildElementOptionalLiteral(element, "RPT-HOOK-ACCESS"))
@@ -3228,6 +3246,7 @@ class ARXMLParser(AbstractARXMLParser):
         self.readIdentifiable(element, prototype)
         self.readAbstractRequiredPortPrototype(element, prototype)
         prototype.setProvidedInterfaceTRef(self.getChildElementOptionalRefType(element, "PROVIDED-INTERFACE-TREF"))
+        self.readPortPrototype(element, prototype)
 
     def readAbstractProvidedPortPrototype(self, element: ET.Element, prototype: AbstractProvidedPortPrototype):
         self.readRequiredComSpec(element, prototype)
@@ -3237,6 +3256,7 @@ class ARXMLParser(AbstractARXMLParser):
         self.readIdentifiable(element, prototype)
         self.readAbstractProvidedPortPrototype(element, prototype)
         prototype.setRequiredInterfaceTRef(self.getChildElementOptionalRefType(element, "REQUIRED-INTERFACE-TREF"))
+        self.readPortPrototype(element, prototype)
 
     def readPRPortPrototype(self, element: ET.Element, prototype: PRPortPrototype):
         # self.logger.debug("Read PRPortPrototype %s" % prototype.getShortName())
@@ -3244,6 +3264,57 @@ class ARXMLParser(AbstractARXMLParser):
         self.readAbstractRequiredPortPrototype(element, prototype)
         self.readAbstractProvidedPortPrototype(element, prototype)
         prototype.setProvidedRequiredInterface(self.getChildElementOptionalRefType(element, "PROVIDED-REQUIRED-INTERFACE-TREF"))
+        self.readPortPrototype(element, prototype)
+
+    def readPortPrototype(self, element: ET.Element, prototype: PortPrototype):
+        for child in self.findall(element, "CLIENT-SERVER-ANNOTATIONS/CLIENT-SERVER-ANNOTATION"):
+            annotation = ClientServerAnnotation()
+            annotation.setOperationRef(self.getChildElementOptionalRefType(child, "OPERATION-REF"))
+            prototype.addClientServerAnnotation(annotation)
+        child = self.find(element, "DELEGATED-PORT-ANNOTATION")
+        if child is not None:
+            annotation = DelegatedPortAnnotation()
+            signal_fan = self.getChildElementOptionalLiteral(child, "SIGNAL-FAN")
+            if signal_fan is not None:
+                annotation.setSignalFan(SignalFanEnum().setValue(signal_fan.getValue()))
+            prototype.setDelegatedPortAnnotation(annotation)
+        for child in self.findall(element, "IO-HW-ABSTRACTION-SERVER-ANNOTATIONS/IO-HW-ABSTRACTION-SERVER-ANNOTATION"):
+            annotation = IoHwAbstractionServerAnnotation()
+            filtering_debouncing = self.getChildElementOptionalLiteral(child, "FILTERING-DEBOUNCING")
+            if filtering_debouncing is not None:
+                annotation.setFilteringDebouncing(FilterDebouncingEnum().setValue(filtering_debouncing.getValue()))
+            pulse_test = self.getChildElementOptionalLiteral(child, "PULSE-TEST")
+            if pulse_test is not None:
+                annotation.setPulseTest(PulseTestEnum().setValue(pulse_test.getValue()))
+            annotation.setTriggerRef(self.getChildElementOptionalRefType(child, "TRIGGER-REF"))
+            prototype.addIoHwAbstractionServerAnnotation(annotation)
+        for child in self.findall(element, "MODE-PORT-ANNOTATIONS/MODE-PORT-ANNOTATION"):
+            annotation = ModePortAnnotation()
+            annotation.setModeGroupRef(self.getChildElementOptionalRefType(child, "MODE-GROUP-REF"))
+            prototype.addModePortAnnotation(annotation)
+        for child in self.findall(element, "NV-DATA-PORT-ANNOTATIONS/NV-DATA-PORT-ANNOTATION"):
+            annotation = NvDataPortAnnotation()
+            annotation.setVariableRef(self.getChildElementOptionalRefType(child, "VARIABLE-REF"))
+            prototype.addNvDataPortAnnotation(annotation)
+        for child in self.findall(element, "PARAMETER-PORT-ANNOTATIONS/PARAMETER-PORT-ANNOTATION"):
+            annotation = ParameterPortAnnotation()
+            annotation.setParameterRef(self.getChildElementOptionalRefType(child, "PARAMETER-REF"))
+            prototype.addParameterPortAnnotation(annotation)
+        for child in self.findall(element, "SENDER-RECEIVER-ANNOTATIONS/SENDER-RECEIVER-ANNOTATION"):
+            annotation = SenderReceiverAnnotation()
+            annotation.setComputed(self.getChildElementOptionalBooleanValue(child, "COMPUTED"))
+            annotation.setDataElementRef(self.getChildElementOptionalRefType(child, "DATA-ELEMENT-REF"))
+            limit_kind = self.getChildElementOptionalLiteral(child, "LIMIT-KIND")
+            if limit_kind is not None:
+                annotation.setLimitKind(DataLimitKindEnum().setValue(limit_kind.getValue()))
+            processing_kind = self.getChildElementOptionalLiteral(child, "PROCESSING-KIND")
+            if processing_kind is not None:
+                annotation.setProcessingKind(ProcessingKindEnum().setValue(processing_kind.getValue()))
+            prototype.addSenderReceiverAnnotation(annotation)
+        for child in self.findall(element, "TRIGGER-PORT-ANNOTATIONS/TRIGGER-PORT-ANNOTATION"):
+            annotation = TriggerPortAnnotation()
+            annotation.setTriggerRef(self.getChildElementOptionalRefType(child, "TRIGGER-REF"))
+            prototype.addTriggerPortAnnotation(annotation)
 
     def readSwComponentTypePorts(self, element: ET.Element, sw_component: SwComponentType):
         for child_element in self.findall(element, "PORTS/*"):

--- a/src/armodel/writer/abstract_arxml_writer.py
+++ b/src/armodel/writer/abstract_arxml_writer.py
@@ -14,6 +14,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     ARLiteral,
     ARNumerical,
     DateTime,
+    Identifier,
     Integer,
     RefType,
     RevisionLabelString,
@@ -134,6 +135,13 @@ class AbstractARXMLWriter(ABC):
         return element
 
     def setChildElementOptionalLiteral(self, element: ET.Element, key: str, value: ARLiteral) -> ET.Element:
+        if value is not None:
+            child_element = ET.SubElement(element, key)
+            self.writeARObjectAttributes(child_element, value)
+            child_element.text = value.getText()
+        return element
+
+    def setChildElementOptionalIdentifier(self, element: ET.Element, key: str, value: Identifier) -> ET.Element:
         if value is not None:
             child_element = ET.SubElement(element, key)
             self.writeARObjectAttributes(child_element, value)

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -181,6 +181,16 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import 
     SwSystemconstantValueSet,
     SwSystemconstValue,
 )
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
+    ClientServerAnnotation,
+    DelegatedPortAnnotation,
+    IoHwAbstractionServerAnnotation,
+    ModePortAnnotation,
+    NvDataPortAnnotation,
+    ParameterPortAnnotation,
+    SenderReceiverAnnotation,
+    TriggerPortAnnotation,
+)
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import (
     ClientComSpec,
     CompositeNetworkRepresentation,
@@ -211,6 +221,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import (
     ComplexDeviceDriverSwComponentType,
     EcuAbstractionSwComponentType,
     PortGroup,
+    PortPrototype,
     PPortPrototype,
     PRPortPrototype,
     RPortPrototype,
@@ -964,6 +975,7 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.logger.debug("write PPortPrototype %s" % prototype.getShortName())
         self.setAbstractProvidedPortPrototype(prototype_tag, prototype)
         self.setChildElementOptionalRefType(prototype_tag, "PROVIDED-INTERFACE-TREF", prototype.getProvidedInterfaceTRef())
+        self.setPortPrototype(prototype_tag, prototype)
 
     def setAbstractRequiredPortPrototype(self, element: ET.Element, prototype: AbstractRequiredPortPrototype):
         com_specs = prototype.getRequiredComSpecs()
@@ -978,6 +990,7 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.writeIdentifiable(prototype_tag, prototype)
         self.setAbstractRequiredPortPrototype(prototype_tag, prototype)
         self.setChildElementOptionalRefType(prototype_tag, "REQUIRED-INTERFACE-TREF", prototype.getRequiredInterfaceTRef())
+        self.setPortPrototype(prototype_tag, prototype)
 
     def writePRPortPrototype(self, ports_tag: ET.Element, prototype: PRPortPrototype):
         self.logger.debug("write PRPortPrototype %s" % prototype.getShortName())
@@ -986,6 +999,84 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.setAbstractProvidedPortPrototype(prototype_tag, prototype)
         self.setAbstractRequiredPortPrototype(prototype_tag, prototype)
         self.setChildElementOptionalRefType(prototype_tag, "PROVIDED-REQUIRED-INTERFACE-TREF", prototype.getProvidedRequiredInterface())
+        self.setPortPrototype(prototype_tag, prototype)
+
+    def setPortPrototype(self, element: ET.Element, prototype: PortPrototype):
+        client_server_annotations = prototype.getClientServerAnnotations()
+        if len(client_server_annotations) > 0:
+            annotations_tag = ET.SubElement(element, "CLIENT-SERVER-ANNOTATIONS")
+            for annotation in client_server_annotations:
+                self.writeClientServerAnnotation(annotations_tag, annotation)
+        delegated_port_annotation = prototype.getDelegatedPortAnnotation()
+        if delegated_port_annotation is not None:
+            self.writeDelegatedPortAnnotation(element, delegated_port_annotation)
+        io_hw_annotations = prototype.getIoHwAbstractionServerAnnotations()
+        if len(io_hw_annotations) > 0:
+            annotations_tag = ET.SubElement(element, "IO-HW-ABSTRACTION-SERVER-ANNOTATIONS")
+            for annotation in io_hw_annotations:
+                self.writeIoHwAbstractionServerAnnotation(annotations_tag, annotation)
+        mode_annotations = prototype.getModePortAnnotations()
+        if len(mode_annotations) > 0:
+            annotations_tag = ET.SubElement(element, "MODE-PORT-ANNOTATIONS")
+            for annotation in mode_annotations:
+                self.writeModePortAnnotation(annotations_tag, annotation)
+        nv_data_annotations = prototype.getNvDataPortAnnotations()
+        if len(nv_data_annotations) > 0:
+            annotations_tag = ET.SubElement(element, "NV-DATA-PORT-ANNOTATIONS")
+            for annotation in nv_data_annotations:
+                self.writeNvDataPortAnnotation(annotations_tag, annotation)
+        parameter_annotations = prototype.getParameterPortAnnotations()
+        if len(parameter_annotations) > 0:
+            annotations_tag = ET.SubElement(element, "PARAMETER-PORT-ANNOTATIONS")
+            for annotation in parameter_annotations:
+                self.writeParameterPortAnnotation(annotations_tag, annotation)
+        sender_receiver_annotations = prototype.getSenderReceiverAnnotations()
+        if len(sender_receiver_annotations) > 0:
+            annotations_tag = ET.SubElement(element, "SENDER-RECEIVER-ANNOTATIONS")
+            for annotation in sender_receiver_annotations:
+                self.writeSenderReceiverAnnotation(annotations_tag, annotation)
+        trigger_annotations = prototype.getTriggerPortAnnotations()
+        if len(trigger_annotations) > 0:
+            annotations_tag = ET.SubElement(element, "TRIGGER-PORT-ANNOTATIONS")
+            for annotation in trigger_annotations:
+                self.writeTriggerPortAnnotation(annotations_tag, annotation)
+
+    def writeClientServerAnnotation(self, element: ET.Element, annotation: ClientServerAnnotation):
+        child_element = ET.SubElement(element, "CLIENT-SERVER-ANNOTATION")
+        self.setChildElementOptionalRefType(child_element, "OPERATION-REF", annotation.getOperationRef())
+
+    def writeDelegatedPortAnnotation(self, element: ET.Element, annotation: DelegatedPortAnnotation):
+        child_element = ET.SubElement(element, "DELEGATED-PORT-ANNOTATION")
+        self.setChildElementOptionalLiteral(child_element, "SIGNAL-FAN", annotation.getSignalFan())
+
+    def writeIoHwAbstractionServerAnnotation(self, element: ET.Element, annotation: IoHwAbstractionServerAnnotation):
+        child_element = ET.SubElement(element, "IO-HW-ABSTRACTION-SERVER-ANNOTATION")
+        self.setChildElementOptionalLiteral(child_element, "FILTERING-DEBOUNCING", annotation.getFilteringDebouncing())
+        self.setChildElementOptionalLiteral(child_element, "PULSE-TEST", annotation.getPulseTest())
+        self.setChildElementOptionalRefType(child_element, "TRIGGER-REF", annotation.getTriggerRef())
+
+    def writeModePortAnnotation(self, element: ET.Element, annotation: ModePortAnnotation):
+        child_element = ET.SubElement(element, "MODE-PORT-ANNOTATION")
+        self.setChildElementOptionalRefType(child_element, "MODE-GROUP-REF", annotation.getModeGroupRef())
+
+    def writeNvDataPortAnnotation(self, element: ET.Element, annotation: NvDataPortAnnotation):
+        child_element = ET.SubElement(element, "NV-DATA-PORT-ANNOTATION")
+        self.setChildElementOptionalRefType(child_element, "VARIABLE-REF", annotation.getVariableRef())
+
+    def writeParameterPortAnnotation(self, element: ET.Element, annotation: ParameterPortAnnotation):
+        child_element = ET.SubElement(element, "PARAMETER-PORT-ANNOTATION")
+        self.setChildElementOptionalRefType(child_element, "PARAMETER-REF", annotation.getParameterRef())
+
+    def writeSenderReceiverAnnotation(self, element: ET.Element, annotation: SenderReceiverAnnotation):
+        child_element = ET.SubElement(element, "SENDER-RECEIVER-ANNOTATION")
+        self.setChildElementOptionalBooleanValue(child_element, "COMPUTED", annotation.getComputed())
+        self.setChildElementOptionalRefType(child_element, "DATA-ELEMENT-REF", annotation.getDataElementRef())
+        self.setChildElementOptionalLiteral(child_element, "LIMIT-KIND", annotation.getLimitKind())
+        self.setChildElementOptionalLiteral(child_element, "PROCESSING-KIND", annotation.getProcessingKind())
+
+    def writeTriggerPortAnnotation(self, element: ET.Element, annotation: TriggerPortAnnotation):
+        child_element = ET.SubElement(element, "TRIGGER-PORT-ANNOTATION")
+        self.setChildElementOptionalRefType(child_element, "TRIGGER-REF", annotation.getTriggerRef())
 
     def writeSwComponentTypePorts(self, element: ET.Element, sw_component: SwComponentType):
         ports = sw_component.getPorts()
@@ -2984,9 +3075,17 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.setChildElementOptionalLiteral(element, "SYMBOL", instance.getSymbol())
 
     def writeRoleBasedMcDataAssignment(self, element: ET.Element, assignment: RoleBasedMcDataAssignment):
-        self.setChildElementOptionalRefType(element, "EXECUTION-CONTEXT-REF", assignment.getExecutionContextRef())
-        self.setChildElementOptionalRefType(element, "MC-DATA-INSTANCE-REF", assignment.getMcDataInstanceRef())
-        self.setChildElementOptionalLiteral(element, "ROLE", assignment.getRole())
+        execution_context_refs = assignment.getExecutionContextRefs()
+        if len(execution_context_refs) > 0:
+            refs_element = ET.SubElement(element, "EXECUTION-CONTEXT-REFS")
+            for ref in execution_context_refs:
+                self.setChildElementOptionalRefType(refs_element, "EXECUTION-CONTEXT-REF", ref)
+        mc_data_instance_refs = assignment.getMcDataInstanceRefs()
+        if len(mc_data_instance_refs) > 0:
+            refs_element = ET.SubElement(element, "MC-DATA-INSTANCE-REFS")
+            for ref in mc_data_instance_refs:
+                self.setChildElementOptionalRefType(refs_element, "MC-DATA-INSTANCE-REF", ref)
+        self.setChildElementOptionalIdentifier(element, "ROLE", assignment.getRole())
 
     def writeRptSwPrototypingAccess(self, element: ET.Element, access: RptSwPrototypingAccess):
         self.setChildElementOptionalLiteral(element, "RPT-HOOK-ACCESS", access.getRptHookAccess())

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RptSupport/test_RptSupport.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RptSupport/test_RptSupport.py
@@ -252,8 +252,8 @@ class TestRoleBasedMcDataAssignment:
         """Test RoleBasedMcDataAssignment initialization defaults"""
         assignment = RoleBasedMcDataAssignment()
         assert assignment is not None
-        assert assignment.executionContextRef is None
-        assert assignment.mcDataInstanceRef is None
+        assert assignment.executionContextRefs == []
+        assert assignment.mcDataInstanceRefs == []
         assert assignment.role is None
 
     def test_mc_data_instance_ref_setter_getter(self):
@@ -261,18 +261,18 @@ class TestRoleBasedMcDataAssignment:
         assignment = RoleBasedMcDataAssignment()
         ref = RefType()
         ref.setValue("/mc/instance")
-        result = assignment.setMcDataInstanceRef(ref)
+        result = assignment.addMcDataInstanceRef(ref)
         assert result is assignment
-        assert assignment.getMcDataInstanceRef() == ref
+        assert assignment.getMcDataInstanceRefs() == [ref]
 
     def test_execution_context_ref_setter_getter(self):
         """Test executionContextRef setter and getter"""
         assignment = RoleBasedMcDataAssignment()
         ref = RefType()
         ref.setValue("/exec/context")
-        result = assignment.setExecutionContextRef(ref)
+        result = assignment.addExecutionContextRef(ref)
         assert result is assignment
-        assert assignment.getExecutionContextRef() == ref
+        assert assignment.getExecutionContextRefs() == [ref]
 
     def test_role_setter_getter(self):
         """Test role setter and getter"""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/test_McSupportData.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/test_McSupportData.py
@@ -188,7 +188,7 @@ class TestMcSupportDataRoundTrip:
         sub_element = instance.createSubElement("StructElem")
         sub_element.setSymbol(SymbolString().setValue("sub_sym"))
         assignment = RoleBasedMcDataAssignment()
-        assignment.setMcDataInstanceRef(make_ref("/mc/inst")).setRole(Identifier().setValue("RpEnablerFlag"))
+        assignment.addMcDataInstanceRef(make_ref("/mc/inst")).setRole(Identifier().setValue("RpEnablerFlag"))
         instance.addMcDataAssignment(assignment)
         access = RptSwPrototypingAccess()
         access.setRptHookAccess(RptAccessEnum().setValue(RptAccessEnum.ENABLED)).setRptReadAccess(RptAccessEnum().setValue(RptAccessEnum.NONE))
@@ -238,7 +238,7 @@ class TestMcSupportDataRoundTrip:
             assert instance_2.getRptImplPolicy().getRptPreparationLevel().getValue() == "rptLevel2"
             assert len(instance_2.getSubElements()) == 1
             assert instance_2.getSubElements()[0].getSymbol().getValue() == "sub_sym"
-            assert instance_2.getMcDataAssignments()[0].getMcDataInstanceRef().getValue() == "/mc/inst"
+            assert instance_2.getMcDataAssignments()[0].getMcDataInstanceRefs()[0].getValue() == "/mc/inst"
             assert instance_2.getMcDataAssignments()[0].getRole().getValue() == "RpEnablerFlag"
             assert instance_2.getResultingRptSwPrototypingAccess().getRptHookAccess().getValue() == "enabled"
             assert support_2.getMcVariableInstances()[0].getDisplayIdentifier().getValue() == "meas_1"
@@ -254,7 +254,7 @@ class TestMcSupportDataRoundTrip:
             assert entity_2.getShortName() == "Run1"
             assert entity_2.getSymbol().getValue() == "Run1_func"
             assert len(entity_2.getRptReads()) == 1
-            assert entity_2.getRptReads()[0].getMcDataInstanceRef().getValue() == "/mc/inst"
+            assert entity_2.getRptReads()[0].getMcDataInstanceRefs()[0].getValue() == "/mc/inst"
             assert len(entity_2.getRptWrites()) == 1
             event_2 = entity_2.getRptExecutableEntityEvents()[0]
             assert event_2.getShortName() == "TimingEvent1"

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ApplicationAttributes/test_ApplicationAttributes.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ApplicationAttributes/test_ApplicationAttributes.py
@@ -1,0 +1,231 @@
+"""Tests for the PortPrototype annotation classes (ApplicationAttributes)."""
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, ARLiteral, RefType
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
+    ClientServerAnnotation,
+    DataLimitKindEnum,
+    DelegatedPortAnnotation,
+    FilterDebouncingEnum,
+    IoHwAbstractionServerAnnotation,
+    ModePortAnnotation,
+    NvDataPortAnnotation,
+    ParameterPortAnnotation,
+    ProcessingKindEnum,
+    PulseTestEnum,
+    SenderReceiverAnnotation,
+    SignalFanEnum,
+    TriggerPortAnnotation,
+)
+
+
+def _ref(value="/Pkg/Elem", dest="VARIABLE-DATA-PROTOTYPE"):
+    r = RefType()
+    r.setValue(value)
+    r.setDest(dest)
+    return r
+
+
+def _literal(text="val"):
+    lit = ARLiteral()
+    lit.setValue(text)
+    return lit
+
+
+def _bool(value=True):
+    b = ARBoolean()
+    b.setValue("true" if value else "false")
+    return b
+
+
+class TestSenderReceiverAnnotation:
+    def test_initialization(self):
+        annotation = SenderReceiverAnnotation()
+        assert annotation.getComputed() is None
+        assert annotation.getDataElementRef() is None
+        assert annotation.getLimitKind() is None
+        assert annotation.getProcessingKind() is None
+
+    def test_computed_setter_getter(self):
+        annotation = SenderReceiverAnnotation()
+        value = _bool(True)
+        assert annotation.setComputed(value) is annotation
+        assert annotation.getComputed() == value
+
+    def test_computed_none_is_noop(self):
+        annotation = SenderReceiverAnnotation()
+        value = _bool(True)
+        annotation.setComputed(value)
+        annotation.setComputed(None)
+        assert annotation.getComputed() == value
+
+    def test_data_element_ref_setter_getter(self):
+        annotation = SenderReceiverAnnotation()
+        ref = _ref()
+        assert annotation.setDataElementRef(ref) is annotation
+        assert annotation.getDataElementRef() == ref
+
+    def test_data_element_ref_none_is_noop(self):
+        annotation = SenderReceiverAnnotation()
+        ref = _ref()
+        annotation.setDataElementRef(ref)
+        annotation.setDataElementRef(None)
+        assert annotation.getDataElementRef() == ref
+
+    def test_limit_kind_setter_getter(self):
+        annotation = SenderReceiverAnnotation()
+        value = DataLimitKindEnum().setValue(DataLimitKindEnum.MAX)
+        assert annotation.setLimitKind(value) is annotation
+        assert annotation.getLimitKind() == value
+
+    def test_processing_kind_setter_getter(self):
+        annotation = SenderReceiverAnnotation()
+        value = ProcessingKindEnum().setValue(ProcessingKindEnum.FILTERED)
+        assert annotation.setProcessingKind(value) is annotation
+        assert annotation.getProcessingKind() == value
+
+
+class TestClientServerAnnotation:
+    def test_initialization(self):
+        annotation = ClientServerAnnotation()
+        assert annotation.getOperationRef() is None
+
+    def test_operation_ref_setter_getter(self):
+        annotation = ClientServerAnnotation()
+        ref = _ref(dest="CLIENT-SERVER-OPERATION")
+        assert annotation.setOperationRef(ref) is annotation
+        assert annotation.getOperationRef() == ref
+
+    def test_operation_ref_none_is_noop(self):
+        annotation = ClientServerAnnotation()
+        ref = _ref(dest="CLIENT-SERVER-OPERATION")
+        annotation.setOperationRef(ref)
+        annotation.setOperationRef(None)
+        assert annotation.getOperationRef() == ref
+
+
+class TestIoHwAbstractionServerAnnotation:
+    def test_initialization(self):
+        annotation = IoHwAbstractionServerAnnotation()
+        assert annotation.getFilteringDebouncing() is None
+        assert annotation.getPulseTest() is None
+        assert annotation.getTriggerRef() is None
+
+    def test_filtering_debouncing_setter_getter(self):
+        annotation = IoHwAbstractionServerAnnotation()
+        value = FilterDebouncingEnum().setValue(FilterDebouncingEnum.DEBOUNCE_DATA)
+        assert annotation.setFilteringDebouncing(value) is annotation
+        assert annotation.getFilteringDebouncing() == value
+
+    def test_pulse_test_setter_getter(self):
+        annotation = IoHwAbstractionServerAnnotation()
+        value = PulseTestEnum().setValue(PulseTestEnum.ENABLE)
+        assert annotation.setPulseTest(value) is annotation
+        assert annotation.getPulseTest() == value
+
+    def test_trigger_ref_setter_getter(self):
+        annotation = IoHwAbstractionServerAnnotation()
+        ref = _ref(dest="TRIGGER")
+        assert annotation.setTriggerRef(ref) is annotation
+        assert annotation.getTriggerRef() == ref
+
+    def test_trigger_ref_none_is_noop(self):
+        annotation = IoHwAbstractionServerAnnotation()
+        ref = _ref(dest="TRIGGER")
+        annotation.setTriggerRef(ref)
+        annotation.setTriggerRef(None)
+        assert annotation.getTriggerRef() == ref
+
+
+class TestModePortAnnotation:
+    def test_initialization(self):
+        annotation = ModePortAnnotation()
+        assert annotation.getModeGroupRef() is None
+
+    def test_mode_group_ref_setter_getter(self):
+        annotation = ModePortAnnotation()
+        ref = _ref(dest="MODE-DECLARATION-GROUP-PROTOTYPE")
+        assert annotation.setModeGroupRef(ref) is annotation
+        assert annotation.getModeGroupRef() == ref
+
+    def test_mode_group_ref_none_is_noop(self):
+        annotation = ModePortAnnotation()
+        ref = _ref(dest="MODE-DECLARATION-GROUP-PROTOTYPE")
+        annotation.setModeGroupRef(ref)
+        annotation.setModeGroupRef(None)
+        assert annotation.getModeGroupRef() == ref
+
+
+class TestNvDataPortAnnotation:
+    def test_initialization(self):
+        annotation = NvDataPortAnnotation()
+        assert annotation.getVariableRef() is None
+
+    def test_variable_ref_setter_getter(self):
+        annotation = NvDataPortAnnotation()
+        ref = _ref()
+        assert annotation.setVariableRef(ref) is annotation
+        assert annotation.getVariableRef() == ref
+
+    def test_variable_ref_none_is_noop(self):
+        annotation = NvDataPortAnnotation()
+        ref = _ref()
+        annotation.setVariableRef(ref)
+        annotation.setVariableRef(None)
+        assert annotation.getVariableRef() == ref
+
+
+class TestParameterPortAnnotation:
+    def test_initialization(self):
+        annotation = ParameterPortAnnotation()
+        assert annotation.getParameterRef() is None
+
+    def test_parameter_ref_setter_getter(self):
+        annotation = ParameterPortAnnotation()
+        ref = _ref(dest="PARAMETER-DATA-PROTOTYPE")
+        assert annotation.setParameterRef(ref) is annotation
+        assert annotation.getParameterRef() == ref
+
+    def test_parameter_ref_none_is_noop(self):
+        annotation = ParameterPortAnnotation()
+        ref = _ref(dest="PARAMETER-DATA-PROTOTYPE")
+        annotation.setParameterRef(ref)
+        annotation.setParameterRef(None)
+        assert annotation.getParameterRef() == ref
+
+
+class TestTriggerPortAnnotation:
+    def test_initialization(self):
+        annotation = TriggerPortAnnotation()
+        assert annotation.getTriggerRef() is None
+
+    def test_trigger_ref_setter_getter(self):
+        annotation = TriggerPortAnnotation()
+        ref = _ref(dest="TRIGGER")
+        assert annotation.setTriggerRef(ref) is annotation
+        assert annotation.getTriggerRef() == ref
+
+    def test_trigger_ref_none_is_noop(self):
+        annotation = TriggerPortAnnotation()
+        ref = _ref(dest="TRIGGER")
+        annotation.setTriggerRef(ref)
+        annotation.setTriggerRef(None)
+        assert annotation.getTriggerRef() == ref
+
+
+class TestDelegatedPortAnnotation:
+    def test_initialization(self):
+        annotation = DelegatedPortAnnotation()
+        assert annotation.getSignalFan() is None
+
+    def test_signal_fan_setter_getter(self):
+        annotation = DelegatedPortAnnotation()
+        value = SignalFanEnum().setValue(SignalFanEnum.SINGLE)
+        assert annotation.setSignalFan(value) is annotation
+        assert annotation.getSignalFan() == value
+
+    def test_signal_fan_none_is_noop(self):
+        annotation = DelegatedPortAnnotation()
+        value = SignalFanEnum().setValue(SignalFanEnum.SINGLE)
+        annotation.setSignalFan(value)
+        annotation.setSignalFan(None)
+        assert annotation.getSignalFan() == value

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/test_Components.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/test_Components.py
@@ -6,6 +6,10 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, CIdentifier, RefType, TRefType
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
+    ClientServerAnnotation,
+    DelegatedPortAnnotation,
+)
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import (
     ClientComSpec,
     ModeSwitchReceiverComSpec,
@@ -67,12 +71,20 @@ class Test_M2_AUTOSARTemplates_SWComponentTemplate_Components:
         assert port_prototype.senderReceiverAnnotations == []
         assert port_prototype.triggerPortAnnotations == []
 
-        # Test setters and getters
-        port_prototype.addClientServerAnnotation("Annotation1")
-        assert "Annotation1" in port_prototype.getClientServerAnnotations()
+        # Test setters and getters with real annotation objects
+        cs_annotation = ClientServerAnnotation()
+        port_prototype.addClientServerAnnotation(cs_annotation)
+        assert cs_annotation in port_prototype.getClientServerAnnotations()
 
-        port_prototype.setDelegatedPortAnnotation("DelegatedAnnotation")
-        assert port_prototype.getDelegatedPortAnnotation() == "DelegatedAnnotation"
+        delegated_annotation = DelegatedPortAnnotation()
+        port_prototype.setDelegatedPortAnnotation(delegated_annotation)
+        assert port_prototype.getDelegatedPortAnnotation() == delegated_annotation
+
+        # None no-ops
+        port_prototype.addClientServerAnnotation(None)
+        assert len(port_prototype.getClientServerAnnotations()) == 1
+        port_prototype.setDelegatedPortAnnotation(None)
+        assert port_prototype.getDelegatedPortAnnotation() == delegated_annotation
 
     def test_AbstractProvidedPortPrototype(self):
         """Test AbstractProvidedPortPrototype class."""
@@ -614,24 +626,43 @@ class Test_M2_AUTOSARTemplates_SWComponentTemplate_Components:
 
     def test_PortPrototype_all_annotation_methods(self):
         """Test all annotation methods for PortPrototype."""
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
+            IoHwAbstractionServerAnnotation,
+            ModePortAnnotation,
+            NvDataPortAnnotation,
+            ParameterPortAnnotation,
+            SenderReceiverAnnotation,
+            TriggerPortAnnotation,
+        )
+
         document = AUTOSAR.getInstance()
         ar_root = document.createARPackage("AUTOSAR")
         port = PRPortPrototype(ar_root, "TestPort")
 
-        # Test all add annotation methods
-        port.addIoHwAbstractionServerAnnotation("io_hw")
-        port.addModePortAnnotation("mode")
-        port.addNvDataPortAnnotation("nv_data")
-        port.addParameterPortAnnotation("param")
-        port.addSenderReceiverAnnotation("sender_recv")
-        port.addTriggerPortAnnotation("trigger")
+        # Test all add annotation methods with real annotation objects
+        io_hw = IoHwAbstractionServerAnnotation()
+        port.addIoHwAbstractionServerAnnotation(io_hw)
+        mode = ModePortAnnotation()
+        port.addModePortAnnotation(mode)
+        nv_data = NvDataPortAnnotation()
+        port.addNvDataPortAnnotation(nv_data)
+        param = ParameterPortAnnotation()
+        port.addParameterPortAnnotation(param)
+        sender_recv = SenderReceiverAnnotation()
+        port.addSenderReceiverAnnotation(sender_recv)
+        trigger = TriggerPortAnnotation()
+        port.addTriggerPortAnnotation(trigger)
 
-        assert "io_hw" in port.getIoHwAbstractionServerAnnotations()
-        assert "mode" in port.getModePortAnnotations()
-        assert "nv_data" in port.getNvDataPortAnnotations()
-        assert "param" in port.getParameterPortAnnotations()
-        assert "sender_recv" in port.getSenderReceiverAnnotations()
-        assert "trigger" in port.getTriggerPortAnnotations()
+        assert io_hw in port.getIoHwAbstractionServerAnnotations()
+        assert mode in port.getModePortAnnotations()
+        assert nv_data in port.getNvDataPortAnnotations()
+        assert param in port.getParameterPortAnnotations()
+        assert sender_recv in port.getSenderReceiverAnnotations()
+        assert trigger in port.getTriggerPortAnnotations()
+
+        # None no-ops for the add annotation methods
+        port.addIoHwAbstractionServerAnnotation(None)
+        assert len(port.getIoHwAbstractionServerAnnotations()) == 1
 
     def test_SwComponentType_port_creation(self):
         """Test SwComponentType port creation methods."""

--- a/tests/test_armodel/parser/test_port_prototype_annotations.py
+++ b/tests/test_armodel/parser/test_port_prototype_annotations.py
@@ -1,0 +1,145 @@
+"""Reader/writer round-trip tests for PortPrototype annotation classes."""
+
+import tempfile
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, RefType
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
+    ClientServerAnnotation,
+    DataLimitKindEnum,
+    DelegatedPortAnnotation,
+    FilterDebouncingEnum,
+    IoHwAbstractionServerAnnotation,
+    ModePortAnnotation,
+    NvDataPortAnnotation,
+    ParameterPortAnnotation,
+    ProcessingKindEnum,
+    PulseTestEnum,
+    SenderReceiverAnnotation,
+    SignalFanEnum,
+    TriggerPortAnnotation,
+)
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+def _ref(value, dest):
+    ref = RefType()
+    ref.setValue(value)
+    ref.setDest(dest)
+    return ref
+
+
+def _bool(value):
+    b = ARBoolean()
+    b.setValue("true" if value else "false")
+    return b
+
+
+class TestPortPrototypeAnnotationsRoundTrip:
+    def _build(self):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        document = AUTOSAR.getInstance()
+        document.clear()
+        pkg = document.createARPackage("AUTOSAR")
+        swc = pkg.createApplicationSwComponentType("App")
+        port = swc.createPRPortPrototype("Port")
+
+        cs = ClientServerAnnotation()
+        cs.setOperationRef(_ref("/If/Op", "CLIENT-SERVER-OPERATION"))
+        port.addClientServerAnnotation(cs)
+
+        delegated = DelegatedPortAnnotation()
+        delegated.setSignalFan(SignalFanEnum().setValue(SignalFanEnum.NFOLD))
+        port.setDelegatedPortAnnotation(delegated)
+
+        io = IoHwAbstractionServerAnnotation()
+        io.setFilteringDebouncing(FilterDebouncingEnum().setValue(FilterDebouncingEnum.DEBOUNCE_DATA))
+        io.setPulseTest(PulseTestEnum().setValue(PulseTestEnum.ENABLE))
+        io.setTriggerRef(_ref("/Trig", "TRIGGER"))
+        port.addIoHwAbstractionServerAnnotation(io)
+
+        mode = ModePortAnnotation()
+        mode.setModeGroupRef(_ref("/Mode", "MODE-DECLARATION-GROUP-PROTOTYPE"))
+        port.addModePortAnnotation(mode)
+
+        nv = NvDataPortAnnotation()
+        nv.setVariableRef(_ref("/Nv", "VARIABLE-DATA-PROTOTYPE"))
+        port.addNvDataPortAnnotation(nv)
+
+        param = ParameterPortAnnotation()
+        param.setParameterRef(_ref("/Param", "PARAMETER-DATA-PROTOTYPE"))
+        port.addParameterPortAnnotation(param)
+
+        sr = SenderReceiverAnnotation()
+        sr.setComputed(_bool(True))
+        sr.setDataElementRef(_ref("/Data", "VARIABLE-DATA-PROTOTYPE"))
+        sr.setLimitKind(DataLimitKindEnum().setValue(DataLimitKindEnum.MAX))
+        sr.setProcessingKind(ProcessingKindEnum().setValue(ProcessingKindEnum.FILTERED))
+        port.addSenderReceiverAnnotation(sr)
+
+        trig = TriggerPortAnnotation()
+        trig.setTriggerRef(_ref("/Trig2", "TRIGGER"))
+        port.addTriggerPortAnnotation(trig)
+
+        return document
+
+    def test_round_trip(self):
+        document = self._build()
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, document)
+
+            document_2 = AUTOSAR.getInstance()
+            document_2.clear()
+            ARXMLParser().load(file_path, document_2)
+
+            port_2 = document_2.getARPackages()[0].getAtomicSwComponentTypes()[0].getPRPortPrototypes()[0]
+
+            cs_list = port_2.getClientServerAnnotations()
+            assert len(cs_list) == 1
+            assert cs_list[0].getOperationRef().getValue() == "/If/Op"
+            assert cs_list[0].getOperationRef().getDest() == "CLIENT-SERVER-OPERATION"
+
+            delegated = port_2.getDelegatedPortAnnotation()
+            assert delegated is not None
+            assert isinstance(delegated.getSignalFan(), SignalFanEnum)
+            assert delegated.getSignalFan().getValue() == SignalFanEnum.NFOLD
+
+            io_list = port_2.getIoHwAbstractionServerAnnotations()
+            assert len(io_list) == 1
+            assert isinstance(io_list[0].getFilteringDebouncing(), FilterDebouncingEnum)
+            assert io_list[0].getFilteringDebouncing().getValue() == FilterDebouncingEnum.DEBOUNCE_DATA
+            assert isinstance(io_list[0].getPulseTest(), PulseTestEnum)
+            assert io_list[0].getPulseTest().getValue() == PulseTestEnum.ENABLE
+            assert io_list[0].getTriggerRef().getValue() == "/Trig"
+
+            mode_list = port_2.getModePortAnnotations()
+            assert len(mode_list) == 1
+            assert mode_list[0].getModeGroupRef().getValue() == "/Mode"
+
+            nv_list = port_2.getNvDataPortAnnotations()
+            assert len(nv_list) == 1
+            assert nv_list[0].getVariableRef().getValue() == "/Nv"
+
+            param_list = port_2.getParameterPortAnnotations()
+            assert len(param_list) == 1
+            assert param_list[0].getParameterRef().getValue() == "/Param"
+
+            sr_list = port_2.getSenderReceiverAnnotations()
+            assert len(sr_list) == 1
+            assert sr_list[0].getComputed().getValue() is True
+            assert sr_list[0].getDataElementRef().getValue() == "/Data"
+            assert isinstance(sr_list[0].getLimitKind(), DataLimitKindEnum)
+            assert sr_list[0].getLimitKind().getValue() == DataLimitKindEnum.MAX
+            assert isinstance(sr_list[0].getProcessingKind(), ProcessingKindEnum)
+            assert sr_list[0].getProcessingKind().getValue() == ProcessingKindEnum.FILTERED
+
+            trig_list = port_2.getTriggerPortAnnotations()
+            assert len(trig_list) == 1
+            assert trig_list[0].getTriggerRef().getValue() == "/Trig2"
+        finally:
+            import os
+
+            if os.path.exists(file_path):
+                os.remove(file_path)


### PR DESCRIPTION
## Summary
Add round-trip parser/writer support for PortPrototype annotations (client-server, delegated-port, IO-HW-abstraction-server, mode-port, NV-data-port, parameter-port, sender-receiver, trigger-port) and align RoleBasedMcDataAssignment to multi-element refs per AUTOSAR spec.

## Changes
- Parser: getChildElementOptionalIdentifier helper; readPortPrototype for PPort/RPort/PRPort prototypes; RoleBasedMcDataAssignment multi-refs using lists + Identifier ROLE
- Writer: setPortPrototype and per-annotation writers; Identifier-typed optional element helper
- Extended model exports in ApplicationAttributes and Components `__init__.py`

## Files Modified
- src/armodel/parser/abstract_arxml_parser.py, arxml_parser.py
- src/armodel/writer/abstract_arxml_writer.py, arxml_writer.py
- src/armodel/models/.../ApplicationAttributes/\_\_init\_\_.py, Components/\_\_init\_\_.py, MeasurementCalibrationSupport/\_\_init\_\_.py
- tests: test_ApplicationAttributes.py, test_Components.py, test_port_prototype_annotations.py, RptSupport/test_RptSupport.py, test_McSupportData.py

## Test Coverage
- pytest: 5647 passed, 1 skipped
- ruff check: clean
- Round-trip: parse → write → re-parse covered in integration suite

Closes #560