### PR TITLE
feat: align RuleBased value spec classes to AUTOSAR spec

### DIFF
--- a/docs/examples/method_deviation_by_class.md
+++ b/docs/examples/method_deviation_by_class.md
@@ -941,10 +941,7 @@ Table 4.6).
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| `vs` (`addV`) | `List[ARNumerical]` | `v` | `NumericalValue` | — | implemented |
-| `vt` | `VerbatimString` | `vt` | `VerbatimString` | — | implemented |
-| `vtfs` (`addVtf`) | `List[NumericalOrText]` | `vtf` | `NumericalOrText` | — | implemented (spec many vs py list) |
-| — *(missing)* | `—` | `vf` | `NumericalValueVariationPoint` | — | missing |
+| — *(no deviation)* | — | — | — | — | `v` (Numerical 0..1 attr via `getV`/`setV`), `vf` (Numerical 0..1 attr via `getVf`/`setVf`), `vt` (VerbatimString 0..1 attr via `getVt`/`setVt`), `vtf` (NumericalOrText 0..1 aggr via `getVtf`/`setVtf`) all implemented per Table D.57. The old `addV`/`getVs` and `addVtf`/`getVtfs` list shapes and the missing `vf` are resolved. |
 
 ## `RuleBasedValueCont`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 330
@@ -953,7 +950,7 @@ Table 4.6).
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — | — | — | — | — | No deviations — Table D.58 attributes (`ruleBasedValues` 0..1 via `getRuleBasedValues`/`setRuleBasedValues`, `swArraysize` 0..1 via `getSwArraysize`/`setSwArraysize`, `unit` Ref via `getUnitRef`/`setUnitRef`) all implemented per Rule 1.4. |
+| — | — | — | — | — | No deviations — Table D.58 attributes (`ruleBasedValues` 0..1 aggr via `getRuleBasedValues`/`setRuleBasedValues`, `swArraysize` 0..1 aggr via `getSwArraysize`/`setSwArraysize`, `unit` Ref via `getUnitRef`/`setUnitRef`) all implemented per Rule 1.4; member order follows the PDF displayed row order. |
 
 ## `RuleBasedValueSpecification`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 331
@@ -962,9 +959,7 @@ Table 4.6).
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| `arguments` (`addArgument`) | `List[RuleArguments]` | `arguments` | `RuleArguments` | — | implemented (spec many vs py list) |
-| `maxSizeToFill` | `Integer` | `maxSizeToFill` | `Integer` | — | implemented |
-| `rule` | `Identifier` | `rule` | `Identifier` | — | implemented |
+| — *(no deviation)* | — | — | — | — | `arguments` (`*` wrapper list via `addArgument`/`getArguments` — the XSD wrapper `ARGUMENTSS` carries multiple `RULE-ARGUMENTS`), `maxSizeToFill` (Integer 0..1 attr via `getMaxSizeToFill`/`setMaxSizeToFill`), `rule` (Identifier 0..1 attr via `getRule`/`setRule`) all implemented per Table D.59. Base aligned to `ARObject` per the spec `Base` column. |
 
 ## `RunnableEntity`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 331

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Constants/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Constants/__init__.py
@@ -19,6 +19,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     Integer,
     VerbatimString,
 )
+from armodel.models.M2.MSR.DataDictionary.DataDefProperties import ValueList
 
 
 class ValueSpecification(ARObject, ABC):
@@ -863,44 +864,136 @@ class ReferenceValueSpecification(ValueSpecification):
 
 class RuleArguments(ARObject):
     """
-    Represents the arguments for a rule-based value specification.
-
-    This class corresponds to the AUTOSAR meta-class RuleArguments (atpMixed).
+    This represents the arguments for a rule-based value specification.
     """
 
     # RuleArguments method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] addV                         [x] impl  [ ] docstring  [ ] test
-    # [ ] getVs                        [x] impl  [ ] docstring  [ ] test
-    # [ ] getVt                        [x] impl  [ ] docstring  [ ] test
-    # [ ] setVt                        [x] impl  [ ] docstring  [ ] test
-    # [ ] addVtf                       [x] impl  [ ] docstring  [ ] test
-    # [ ] getVtfs                      [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table D.57, p.329
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getV                         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setV                         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getVf                        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setVf                        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getVt                        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setVt                        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getVtf                       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setVtf                       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
-        self.v = []  # type: List[ARNumerical]
-        self.vt = None  # type: VerbatimString
-        self.vtfs = []  # type: List[NumericalOrText]
 
-    def addV(self, v: ARNumerical):
-        self.v.append(v)
+        # This represents a numerical value for the RuleBased ValueSpecification.
+        self.v: Optional[ARNumerical] = None
 
-    def getVs(self) -> List[ARNumerical]:
+        # This represents a numerical value for the RuleBased ValueSpecification which may subject to variability.
+        # The latest binding time of the VariationPoint shall be pre CompileTime.
+        self.vf: Optional[ARNumerical] = None
+
+        # This represents a textual value for the RuleBasedValue Specification.
+        self.vt: Optional[VerbatimString] = None
+
+        # This aggregation represents the ability to provide a value that is either numerical or text which existence is subject to variability.
+        self.vtf: Optional[NumericalOrText] = None
+
+    def getV(self) -> Optional[ARNumerical]:
+        """
+        This represents a numerical value for the RuleBased ValueSpecification.
+
+        Returns:
+            Optional[ARNumerical]: The numerical value, or None if not set
+        """
         return self.v
 
-    def getVt(self) -> VerbatimString:
-        return self.vt
+    def setV(self, value: Optional[ARNumerical]) -> "RuleArguments":
+        """
+        This represents a numerical value for the RuleBased ValueSpecification.
+        A None value is a no-op and does not overwrite an existing v.
 
-    def setVt(self, value: VerbatimString):
-        self.vt = value
+        Args:
+            value: The numerical value to set
+
+        Returns:
+            RuleArguments: self for method chaining
+        """
+        if value is not None:
+            self.v = value
         return self
 
-    def addVtf(self, vtf: NumericalOrText):
-        self.vtfs.append(vtf)
+    def getVf(self) -> Optional[ARNumerical]:
+        """
+        This represents a numerical value for the RuleBased ValueSpecification which may subject to variability.
+        The latest binding time of the VariationPoint shall be pre CompileTime.
 
-    def getVtfs(self) -> List[NumericalOrText]:
-        return self.vtfs
+        Returns:
+            Optional[ARNumerical]: The numerical value, or None if not set
+        """
+        return self.vf
+
+    def setVf(self, value: Optional[ARNumerical]) -> "RuleArguments":
+        """
+        This represents a numerical value for the RuleBased ValueSpecification which may subject to variability.
+        The latest binding time of the VariationPoint shall be pre CompileTime.
+        A None value is a no-op and does not overwrite an existing vf.
+
+        Args:
+            value: The numerical value to set
+
+        Returns:
+            RuleArguments: self for method chaining
+        """
+        if value is not None:
+            self.vf = value
+        return self
+
+    def getVt(self) -> Optional[VerbatimString]:
+        """
+        This represents a textual value for the RuleBasedValue Specification.
+
+        Returns:
+            Optional[VerbatimString]: The textual value, or None if not set
+        """
+        return self.vt
+
+    def setVt(self, value: Optional[VerbatimString]) -> "RuleArguments":
+        """
+        This represents a textual value for the RuleBasedValue Specification.
+        A None value is a no-op and does not overwrite an existing vt.
+
+        Args:
+            value: The textual value to set
+
+        Returns:
+            RuleArguments: self for method chaining
+        """
+        if value is not None:
+            self.vt = value
+        return self
+
+    def getVtf(self) -> Optional[NumericalOrText]:
+        """
+        This aggregation represents the ability to provide a value that is either numerical or text which existence is subject to variability.
+
+        Returns:
+            Optional[NumericalOrText]: The value, or None if not set
+        """
+        return self.vtf
+
+    def setVtf(self, value: Optional[NumericalOrText]) -> "RuleArguments":
+        """
+        This aggregation represents the ability to provide a value that is either numerical or text which existence is subject to variability.
+        A None value is a no-op and does not overwrite an existing vtf.
+
+        Args:
+            value: The value to set
+
+        Returns:
+            RuleArguments: self for method chaining
+        """
+        if value is not None:
+            self.vtf = value
+        return self
 
 
 class RuleBasedAxisCont(ARObject):
@@ -969,82 +1062,208 @@ class RuleBasedAxisCont(ARObject):
 
 class RuleBasedValueCont(ARObject):
     """
-    Represents the values of a compound primitive (CURVE, MAP, CUBOID, CUBE_4, CUBE_5, VAL_BLK) or an array.
+    This represents the values of a compound primitive (CURVE, MAP, CUBOID, CUBE_4, CUBE_5, VAL_BLK) or an array.
     """
 
     # RuleBasedValueCont method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getUnitRef                   [x] impl  [ ] docstring  [ ] test
-    # [ ] setUnitRef                   [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwArraysize               [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwArraysize               [x] impl  [ ] docstring  [ ] test
-    # [ ] getRuleBasedValues           [x] impl  [ ] docstring  [ ] test
-    # [ ] setRuleBasedValues           [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table D.58, p.330
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getRuleBasedValues           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setRuleBasedValues           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwArraysize               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwArraysize               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getUnitRef                   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setUnitRef                   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
-        self.unitRef = None  # type: RefType
-        self.swArraysize = None  # type: ValueList
-        self.ruleBasedValues = None  # type: RuleBasedValueSpecification
 
-    def getUnitRef(self):
-        return self.unitRef
+        # This represents the rule based value specification for the array or compound primitive (CURVE, MAP, CUBOID, CUBE_4, CUBE_5, VAL_BLK).
+        self.ruleBasedValues: Optional[RuleBasedValueSpecification] = None
 
-    def setUnitRef(self, value):
-        self.unitRef = value
-        return self
+        # This attribute defines the size of each dimension for compound primitives CURVE, MAP, CUBOID, CUBE_4, CUBE_5, COM_AXIS, RES_AXIS, VAL_BLK.
+        # For each dimension one value has to be defined, e.g. one in case of COM_AXIS and two or more in case of MAP.
+        self.swArraysize: Optional[ValueList] = None
 
-    def getSwArraysize(self):
-        return self.swArraysize
+        # This represents the physical unit of the provided values.
+        self.unitRef: Optional[RefType] = None
 
-    def setSwArraysize(self, value):
-        self.swArraysize = value
-        return self
+    def getRuleBasedValues(self) -> Optional[RuleBasedValueSpecification]:
+        """
+        This represents the rule based value specification for the array or compound primitive (CURVE, MAP, CUBOID, CUBE_4, CUBE_5, VAL_BLK).
 
-    def getRuleBasedValues(self):
+        Returns:
+            Optional[RuleBasedValueSpecification]: The value specification, or None if not set
+        """
         return self.ruleBasedValues
 
-    def setRuleBasedValues(self, value):
-        self.ruleBasedValues = value
+    def setRuleBasedValues(self, value: Optional[RuleBasedValueSpecification]) -> "RuleBasedValueCont":
+        """
+        This represents the rule based value specification for the array or compound primitive (CURVE, MAP, CUBOID, CUBE_4, CUBE_5, VAL_BLK).
+        A None value is a no-op and does not overwrite an existing ruleBasedValues.
+
+        Args:
+            value: The value specification to set
+
+        Returns:
+            RuleBasedValueCont: self for method chaining
+        """
+        if value is not None:
+            self.ruleBasedValues = value
+        return self
+
+    def getSwArraysize(self) -> Optional[ValueList]:
+        """
+        This attribute defines the size of each dimension for compound primitives CURVE, MAP, CUBOID, CUBE_4, CUBE_5, COM_AXIS, RES_AXIS, VAL_BLK.
+        For each dimension one value has to be defined, e.g. one in case of COM_AXIS and two or more in case of MAP.
+
+        Returns:
+            Optional[ValueList]: The array size, or None if not set
+        """
+        return self.swArraysize
+
+    def setSwArraysize(self, value: Optional[ValueList]) -> "RuleBasedValueCont":
+        """
+        This attribute defines the size of each dimension for compound primitives CURVE, MAP, CUBOID, CUBE_4, CUBE_5, COM_AXIS, RES_AXIS, VAL_BLK.
+        For each dimension one value has to be defined, e.g. one in case of COM_AXIS and two or more in case of MAP.
+        A None value is a no-op and does not overwrite an existing swArraysize.
+
+        Args:
+            value: The array size to set
+
+        Returns:
+            RuleBasedValueCont: self for method chaining
+        """
+        if value is not None:
+            self.swArraysize = value
+        return self
+
+    def getUnitRef(self) -> Optional[RefType]:
+        """
+        This represents the physical unit of the provided values.
+
+        Returns:
+            Optional[RefType]: The unit reference, or None if not set
+        """
+        return self.unitRef
+
+    def setUnitRef(self, value: Optional[RefType]) -> "RuleBasedValueCont":
+        """
+        This represents the physical unit of the provided values.
+        A None value is a no-op and does not overwrite an existing unitRef.
+
+        Args:
+            value: The unit reference to set
+
+        Returns:
+            RuleBasedValueCont: self for method chaining
+        """
+        if value is not None:
+            self.unitRef = value
         return self
 
 
-class RuleBasedValueSpecification(AbstractRuleBasedValueSpecification):
+class RuleBasedValueSpecification(ARObject):
     """
-    This meta-class is used to support a rule-based initialization approach for data types with an array-nature.
+    This meta-class is used to support a rule-based initialization approach for data types with an array-nature (ApplicationArrayDataType and ImplementationDataType of category ARRAY) or a compound Application PrimitiveDataType (which also boils down to an array-nature).
     """
 
     # RuleBasedValueSpecification method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getRule                      [x] impl  [ ] docstring  [ ] test
-    # [ ] setRule                      [x] impl  [ ] docstring  [ ] test
-    # [ ] addArgument                  [x] impl  [ ] docstring  [ ] test
-    # [ ] getArguments                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getMaxSizeToFill             [x] impl  [ ] docstring  [ ] test
-    # [ ] setMaxSizeToFill             [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table D.59, p.331
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addArgument                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getArguments                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getMaxSizeToFill             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMaxSizeToFill             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRule                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setRule                      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
-        self.rule: Identifier = None
-        self.arguments = []  # type: List[RuleArguments]
-        self.maxSizeToFill: Integer = None
 
-    def getRule(self):
-        return self.rule
+        # This represents the arguments for the RuleBasedValue Specification.
+        self.arguments: List[RuleArguments] = []
 
-    def setRule(self, value):
-        self.rule = value
+        # If a rule is chosen which does not fill until the end, this determines until which size the rule shall fill the values.
+        self.maxSizeToFill: Optional[Integer] = None
+
+        # This denotes the name of the rule of the RuleBasedValue Specification.
+        # The rule determines the calculation specification according which the arguments are used to calculated the values.
+        self.rule: Optional[Identifier] = None
+
+    def addArgument(self, argument: RuleArguments) -> "RuleBasedValueSpecification":
+        """
+        This represents the arguments for the RuleBasedValue Specification.
+
+        Args:
+            argument: The argument to add
+
+        Returns:
+            RuleBasedValueSpecification: self for method chaining
+        """
+        if argument is not None:
+            self.arguments.append(argument)
         return self
 
-    def addArgument(self, argument: RuleArguments):
-        self.arguments.append(argument)
+    def getArguments(self) -> List[RuleArguments]:
+        """
+        This represents the arguments for the RuleBasedValue Specification.
 
-    def getArguments(self):
+        Returns:
+            List[RuleArguments]: The list of arguments
+        """
         return self.arguments
 
-    def getMaxSizeToFill(self):
+    def getMaxSizeToFill(self) -> Optional[Integer]:
+        """
+        If a rule is chosen which does not fill until the end, this determines until which size the rule shall fill the values.
+
+        Returns:
+            Optional[Integer]: The max size to fill, or None if not set
+        """
         return self.maxSizeToFill
 
-    def setMaxSizeToFill(self, value):
-        self.maxSizeToFill = value
+    def setMaxSizeToFill(self, value: Optional[Integer]) -> "RuleBasedValueSpecification":
+        """
+        If a rule is chosen which does not fill until the end, this determines until which size the rule shall fill the values.
+        A None value is a no-op and does not overwrite an existing maxSizeToFill.
+
+        Args:
+            value: The max size to fill
+
+        Returns:
+            RuleBasedValueSpecification: self for method chaining
+        """
+        if value is not None:
+            self.maxSizeToFill = value
+        return self
+
+    def getRule(self) -> Optional[Identifier]:
+        """
+        This denotes the name of the rule of the RuleBasedValue Specification.
+        The rule determines the calculation specification according which the arguments are used to calculated the values.
+
+        Returns:
+            Optional[Identifier]: The rule name, or None if not set
+        """
+        return self.rule
+
+    def setRule(self, value: Optional[Identifier]) -> "RuleBasedValueSpecification":
+        """
+        This denotes the name of the rule of the RuleBasedValue Specification.
+        The rule determines the calculation specification according which the arguments are used to calculated the values.
+        A None value is a no-op and does not overwrite an existing rule.
+
+        Args:
+            value: The rule name
+
+        Returns:
+            RuleBasedValueSpecification: self for method chaining
+        """
+        if value is not None:
+            self.rule = value
         return self

--- a/src/armodel/parser/abstract_arxml_parser.py
+++ b/src/armodel/parser/abstract_arxml_parser.py
@@ -21,6 +21,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     RefType,
     RevisionLabelString,
     TimeValue,
+    VerbatimString,
 )
 
 
@@ -114,6 +115,18 @@ class AbstractARXMLParser(ABC):
             literal = ARLiteral()
             self.readARObjectAttributes(child_element, literal)
             # Patch for empty element <USED-CODE-GENERATOR></USED-CODE-GENERATOR>
+            if child_element.text is None:
+                literal.setValue("")
+            else:
+                literal.setValue(child_element.text)
+        return literal
+
+    def getChildElementOptionalVerbatimString(self, element: ET.Element, key: str) -> VerbatimString:
+        child_element = self.find(element, key)
+        literal = None
+        if child_element is not None:
+            literal = VerbatimString()
+            self.readARObjectAttributes(child_element, literal)
             if child_element.text is None:
                 literal.setValue("")
             else:

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -3931,11 +3931,12 @@ class ARXMLParser(AbstractARXMLParser):
     def getRuleArguments(self, element: ET.Element) -> RuleArguments:
         arguments = RuleArguments()
         self.readARObjectAttributes(element, arguments)
-        for v in self.getChildElementNumericalValueList(element, "V"):
-            arguments.addV(v)
-        arguments.setVt(self.getChildElementOptionalLiteral(element, "VT"))
-        for child_element in self.findall(element, "VTF"):
-            arguments.addVtf(self.getNumericalOrText(child_element))
+        arguments.setV(self.getChildElementOptionalNumericalValue(element, "V"))
+        arguments.setVf(self.getChildElementOptionalNumericalValue(element, "VF"))
+        arguments.setVt(self.getChildElementOptionalVerbatimString(element, "VT"))
+        vtf = self.find(element, "VTF")
+        if vtf is not None:
+            arguments.setVtf(self.getNumericalOrText(vtf))
         return arguments
 
     def getRuleBasedValueSpecification(self, element: ET.Element) -> RuleBasedValueSpecification:
@@ -3943,7 +3944,7 @@ class ARXMLParser(AbstractARXMLParser):
             return None
         value_spec = RuleBasedValueSpecification()
         self.readARObjectAttributes(element, value_spec)
-        value_spec.setRule(self.getChildElementOptionalLiteral(element, "RULE"))
+        value_spec.setRule(self.getChildElementOptionalIdentifier(element, "RULE"))
         for child_element in self.findall(element, "ARGUMENTSS/RULE-ARGUMENTS"):
             value_spec.addArgument(self.getRuleArguments(child_element))
         value_spec.setMaxSizeToFill(self.getChildElementOptionalIntegerValue(element, "MAX-SIZE-TO-FILL"))

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -1535,17 +1535,16 @@ class ARXMLWriter(AbstractARXMLWriter):
         if arguments is not None:
             child_element = ET.SubElement(element, "RULE-ARGUMENTS")
             self.writeARObjectAttributes(child_element, arguments)
-            for v in arguments.getVs():
-                self.setChildElementOptionalNumericalValue(child_element, "V", v)
+            self.setChildElementOptionalNumericalValue(child_element, "V", arguments.getV())
+            self.setChildElementOptionalNumericalValue(child_element, "VF", arguments.getVf())
             self.setChildElementOptionalLiteral(child_element, "VT", arguments.getVt())
-            for vtf in arguments.getVtfs():
-                self.writeNumericalOrText(child_element, "VTF", vtf)
+            self.writeNumericalOrText(child_element, "VTF", arguments.getVtf())
 
     def writeRuleBasedValueSpecification(self, element: ET.Element, key: str, value_spec: RuleBasedValueSpecification):
         if value_spec is not None:
             child_element = ET.SubElement(element, key)
             self.writeARObjectAttributes(child_element, value_spec)
-            self.setChildElementOptionalLiteral(child_element, "RULE", value_spec.getRule())
+            self.setChildElementOptionalIdentifier(child_element, "RULE", value_spec.getRule())
             arguments = value_spec.getArguments()
             if len(arguments) > 0:
                 arguments_tag = ET.SubElement(child_element, "ARGUMENTSS")

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_CommonStructure_init.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_CommonStructure_init.py
@@ -25,7 +25,13 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure import (
     TextValueSpecification,
     ValueSpecification,
 )
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    ARLiteral,
+    ARNumerical,
+    Identifier,
+    RefType,
+    VerbatimString,
+)
 
 
 class TestValueSpecification:
@@ -281,46 +287,88 @@ class TestRuleArguments:
         arguments = RuleArguments()
 
         assert arguments is not None
-        assert arguments.getVs() == []
+        assert arguments.getV() is None
+        assert arguments.getVf() is None
         assert arguments.getVt() is None
-        assert arguments.getVtfs() == []
+        assert arguments.getVtf() is None
 
-    def test_add_v(self):
-        """Test addV method appends to the list"""
+    def test_get_set_v(self):
+        """Test setV/getV round-trip with a numerical value"""
         arguments = RuleArguments()
         v = ARNumerical()
         v.setValue("1.5")
-        arguments.addV(v)
-        assert arguments.getVs() == [v]
+        result = arguments.setV(v)
+        assert result is arguments
+        assert arguments.getV() == v
 
-    def test_add_v_multiple(self):
-        """Test addV accumulates multiple entries"""
+    def test_set_v_none_noop(self):
+        """Test setV(None) is a no-op and does not overwrite an existing value"""
         arguments = RuleArguments()
-        v_1 = ARNumerical()
-        v_1.setValue("1")
-        v_2 = ARNumerical()
-        v_2.setValue("2")
-        arguments.addV(v_1)
-        arguments.addV(v_2)
-        assert arguments.getVs() == [v_1, v_2]
+        v = ARNumerical()
+        v.setValue("1.5")
+        arguments.setV(v)
+        result = arguments.setV(None)
+        assert result is arguments
+        assert arguments.getV() == v
 
-    def test_set_vt(self):
-        """Test setVt method"""
+    def test_get_set_vf(self):
+        """Test setVf/getVf round-trip with a numerical value"""
         arguments = RuleArguments()
-        vt = ARLiteral()
+        vf = ARNumerical()
+        vf.setValue("2.5")
+        result = arguments.setVf(vf)
+        assert result is arguments
+        assert arguments.getVf() == vf
+
+    def test_set_vf_none_noop(self):
+        """Test setVf(None) is a no-op and does not overwrite an existing value"""
+        arguments = RuleArguments()
+        vf = ARNumerical()
+        vf.setValue("2.5")
+        arguments.setVf(vf)
+        result = arguments.setVf(None)
+        assert result is arguments
+        assert arguments.getVf() == vf
+
+    def test_get_set_vt(self):
+        """Test setVt/getVt round-trip with a textual value"""
+        arguments = RuleArguments()
+        vt = VerbatimString()
         vt.setValue("label")
         result = arguments.setVt(vt)
         assert result is arguments
         assert arguments.getVt() == vt
 
-    def test_add_vtf(self):
-        """Test addVtf method appends to the list"""
+    def test_set_vt_none_noop(self):
+        """Test setVt(None) is a no-op and does not overwrite an existing value"""
+        arguments = RuleArguments()
+        vt = VerbatimString()
+        vt.setValue("label")
+        arguments.setVt(vt)
+        result = arguments.setVt(None)
+        assert result is arguments
+        assert arguments.getVt() == vt
+
+    def test_get_set_vtf(self):
+        """Test setVtf/getVtf round-trip with a NumericalOrText value"""
         arguments = RuleArguments()
         from armodel.models.M2.AUTOSARTemplates.CommonStructure.Constants import NumericalOrText
 
         vtf = NumericalOrText()
-        arguments.addVtf(vtf)
-        assert arguments.getVtfs() == [vtf]
+        result = arguments.setVtf(vtf)
+        assert result is arguments
+        assert arguments.getVtf() == vtf
+
+    def test_set_vtf_none_noop(self):
+        """Test setVtf(None) is a no-op and does not overwrite an existing value"""
+        arguments = RuleArguments()
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.Constants import NumericalOrText
+
+        vtf = NumericalOrText()
+        arguments.setVtf(vtf)
+        result = arguments.setVtf(None)
+        assert result is arguments
+        assert arguments.getVtf() == vtf
 
 
 class TestNumericalOrText:
@@ -432,22 +480,29 @@ class TestRuleBasedValueCont:
         cont = RuleBasedValueCont()
 
         assert cont is not None
-        assert cont.getUnitRef() is None
-        assert cont.getSwArraysize() is None
         assert cont.getRuleBasedValues() is None
+        assert cont.getSwArraysize() is None
+        assert cont.getUnitRef() is None
 
-    def test_set_unit_ref(self):
-        """Test setUnitRef method"""
+    def test_get_set_rule_based_values(self):
+        """Test setRuleBasedValues/getRuleBasedValues round-trip"""
         cont = RuleBasedValueCont()
-        ref = RefType()
-        ref.setDest("Unit")
-        ref.setValue("/p/u")
-        result = cont.setUnitRef(ref)
+        values = RuleBasedValueSpecification()
+        result = cont.setRuleBasedValues(values)
         assert result is cont
-        assert cont.getUnitRef() == ref
+        assert cont.getRuleBasedValues() == values
 
-    def test_set_sw_arraysize(self):
-        """Test setSwArraysize method"""
+    def test_set_rule_based_values_none_noop(self):
+        """Test setRuleBasedValues(None) is a no-op"""
+        cont = RuleBasedValueCont()
+        values = RuleBasedValueSpecification()
+        cont.setRuleBasedValues(values)
+        result = cont.setRuleBasedValues(None)
+        assert result is cont
+        assert cont.getRuleBasedValues() == values
+
+    def test_get_set_sw_arraysize(self):
+        """Test setSwArraysize/getSwArraysize round-trip"""
         cont = RuleBasedValueCont()
         from armodel.models.M2.MSR.DataDictionary.DataDefProperties import ValueList
 
@@ -456,13 +511,37 @@ class TestRuleBasedValueCont:
         assert result is cont
         assert cont.getSwArraysize() == size
 
-    def test_set_rule_based_values(self):
-        """Test setRuleBasedValues method"""
+    def test_set_sw_arraysize_none_noop(self):
+        """Test setSwArraysize(None) is a no-op"""
         cont = RuleBasedValueCont()
-        values = RuleBasedValueSpecification()
-        result = cont.setRuleBasedValues(values)
+        from armodel.models.M2.MSR.DataDictionary.DataDefProperties import ValueList
+
+        size = ValueList()
+        cont.setSwArraysize(size)
+        result = cont.setSwArraysize(None)
         assert result is cont
-        assert cont.getRuleBasedValues() == values
+        assert cont.getSwArraysize() == size
+
+    def test_get_set_unit_ref(self):
+        """Test setUnitRef/getUnitRef round-trip"""
+        cont = RuleBasedValueCont()
+        ref = RefType()
+        ref.setDest("Unit")
+        ref.setValue("/p/u")
+        result = cont.setUnitRef(ref)
+        assert result is cont
+        assert cont.getUnitRef() == ref
+
+    def test_set_unit_ref_none_noop(self):
+        """Test setUnitRef(None) is a no-op"""
+        cont = RuleBasedValueCont()
+        ref = RefType()
+        ref.setDest("Unit")
+        ref.setValue("/p/u")
+        cont.setUnitRef(ref)
+        result = cont.setUnitRef(None)
+        assert result is cont
+        assert cont.getUnitRef() == ref
 
 
 class TestRuleBasedValueSpecification:
@@ -471,26 +550,19 @@ class TestRuleBasedValueSpecification:
         spec = RuleBasedValueSpecification()
 
         assert spec is not None
-        assert spec.getRule() is None
         assert spec.getArguments() == []
         assert spec.getMaxSizeToFill() is None
-
-    def test_set_rule(self):
-        """Test setRule method"""
-        spec = RuleBasedValueSpecification()
-        result = spec.setRule("FILL_UNTIL_END")
-        assert result is spec
-        assert spec.getRule() == "FILL_UNTIL_END"
+        assert spec.getRule() is None
 
     def test_add_argument(self):
-        """Test addArgument method appends to the list"""
+        """Test addArgument appends to the list"""
         spec = RuleBasedValueSpecification()
         argument = RuleArguments()
         spec.addArgument(argument)
         assert spec.getArguments() == [argument]
 
-    def test_set_max_size_to_fill(self):
-        """Test setMaxSizeToFill method"""
+    def test_get_set_max_size_to_fill(self):
+        """Test setMaxSizeToFill/getMaxSizeToFill round-trip"""
         spec = RuleBasedValueSpecification()
         from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer
 
@@ -499,6 +571,37 @@ class TestRuleBasedValueSpecification:
         result = spec.setMaxSizeToFill(size)
         assert result is spec
         assert spec.getMaxSizeToFill() == size
+
+    def test_set_max_size_to_fill_none_noop(self):
+        """Test setMaxSizeToFill(None) is a no-op"""
+        spec = RuleBasedValueSpecification()
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer
+
+        size = Integer()
+        size.setValue("8")
+        spec.setMaxSizeToFill(size)
+        result = spec.setMaxSizeToFill(None)
+        assert result is spec
+        assert spec.getMaxSizeToFill() == size
+
+    def test_get_set_rule(self):
+        """Test setRule/getRule round-trip"""
+        spec = RuleBasedValueSpecification()
+        rule = Identifier()
+        rule.setValue("FILL_UNTIL_END")
+        result = spec.setRule(rule)
+        assert result is spec
+        assert spec.getRule() == rule
+
+    def test_set_rule_none_noop(self):
+        """Test setRule(None) is a no-op"""
+        spec = RuleBasedValueSpecification()
+        rule = Identifier()
+        rule.setValue("FILL_UNTIL_END")
+        spec.setRule(rule)
+        result = spec.setRule(None)
+        assert result is spec
+        assert spec.getRule() == rule
 
 
 class TestRecordValueSpecification:

--- a/tests/test_armodel/parser/test_arxml_parser_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_handlers.py
@@ -526,14 +526,16 @@ class TestRuleBasedValueSpecHandlers:
 
     def test_getRuleArguments_full(self, parser):
         element = _snip(
-            "<V>1</V><V>2</V>" "<VT>label</VT>" "<VTF><VF>1.5</VF><VT>alt</VT></VTF>",
+            "<V>1</V><VF>2</VF><VT>label</VT><VTF><VF>1.5</VF><VT>alt</VT></VTF>",
             root_tag="RULE-ARGUMENTS",
         )
         arguments = parser.getRuleArguments(element)
         assert arguments is not None
-        assert len(arguments.getVs()) == 2
+        assert arguments.getV().getValue() == 1
+        assert arguments.getVf().getValue() == 2
         assert arguments.getVt().getValue() == "label"
-        assert len(arguments.getVtfs()) == 1
+        assert arguments.getVtf() is not None
+        assert arguments.getVtf().getVf().getValue() == 1.5
 
     def test_getRuleBasedValueSpecification_full(self, parser):
         element = _snip(
@@ -550,6 +552,13 @@ class TestRuleBasedValueSpecHandlers:
     def test_getRuleBasedValueSpecification_missing_returns_None(self, parser):
         _element = _snip("<X/>")
         assert parser.getRuleBasedValueSpecification(None) is None
+
+    def test_getRuleBasedValueSpecification_empty_arguments(self, parser):
+        element = _snip("<RULE>FILL_UNTIL_END</RULE>", root_tag="RULE-BASED-VALUES")
+        value_spec = parser.getRuleBasedValueSpecification(element)
+        assert value_spec is not None
+        assert value_spec.getArguments() == []
+        assert value_spec.getRule().getValue() == "FILL_UNTIL_END"
 
     def test_getRuleBasedAxisCont_full(self, parser):
         element = _snip(

--- a/tests/test_armodel/writer/test_writer_data_types.py
+++ b/tests/test_armodel/writer/test_writer_data_types.py
@@ -21,9 +21,11 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     ARFloat,
     ARLiteral,
     ARNumerical,
+    Identifier,
     Integer,
     Limit,
     RefType,
+    VerbatimString,
 )
 from armodel.models.M2.MSR.AsamHdo.BaseTypes import BaseTypeDirectDefinition
 from armodel.models.M2.MSR.AsamHdo.ComputationMethod import (
@@ -91,6 +93,18 @@ def _numerical(text):
     num = ARNumerical()
     num.value = text
     return num
+
+
+def _identifier(text):
+    ident = Identifier()
+    ident.setValue(text)
+    return ident
+
+
+def _verbatim(text):
+    verbatim = VerbatimString()
+    verbatim.setValue(text)
+    return verbatim
 
 
 def _float(text):
@@ -888,10 +902,10 @@ class TestRuleBasedValueSpecificationWriter:
         axis.setSwArraysize(size)
         axis.setSwAxisIndex(_literal("1"))
         axis_rule = RuleBasedValueSpecification()
-        axis_rule.setRule(_literal("FILL_UNTIL_END"))
+        axis_rule.setRule(_identifier("FILL_UNTIL_END"))
         axis_args = RuleArguments()
-        axis_args.addV(_numerical("1"))
-        axis_args.addV(_numerical("2"))
+        axis_args.setV(_numerical("1"))
+        axis_args.setVf(_numerical("2"))
         axis_rule.addArgument(axis_args)
         axis.setRuleBasedValues(axis_rule)
         spec.addSwAxisCont(axis)
@@ -902,7 +916,7 @@ class TestRuleBasedValueSpecificationWriter:
         cont_size.setV(_float("10"))
         cont.setSwArraysize(cont_size)
         cont_rule = RuleBasedValueSpecification()
-        cont_rule.setRule(_literal("FILL_UNTIL_END"))
+        cont_rule.setRule(_identifier("FILL_UNTIL_END"))
         max_size = Integer()
         max_size.setValue("8")
         cont_rule.setMaxSizeToFill(max_size)
@@ -922,16 +936,17 @@ class TestRuleBasedValueSpecificationWriter:
         assert child.find("SW-AXIS-CONTS/RULE-BASED-AXIS-CONT/RULE-BASED-VALUES/RULE").text == "FILL_UNTIL_END"
         argss = child.find("SW-AXIS-CONTS/RULE-BASED-AXIS-CONT/RULE-BASED-VALUES/ARGUMENTSS")
         assert argss is not None
-        assert len(argss.findall("RULE-ARGUMENTS/V")) == 2
+        assert argss.find("RULE-ARGUMENTS/V").text == "1"
+        assert argss.find("RULE-ARGUMENTS/VF").text == "2"
         assert child.find("SW-VALUE-CONT/RULE-BASED-VALUES/MAX-SIZE-TO-FILL").text == "8"
 
     def test_write_rule_based_axis_cont_with_vt(self, writer):
         axis = RuleBasedAxisCont()
         rule = RuleBasedValueSpecification()
-        rule.setRule(_literal("FILL_UNTIL_END"))
+        rule.setRule(_identifier("FILL_UNTIL_END"))
         args = RuleArguments()
-        args.addV(_numerical("1.5"))
-        args.setVt(_literal("label"))
+        args.setV(_numerical("1.5"))
+        args.setVt(_verbatim("label"))
         rule.addArgument(args)
         axis.setRuleBasedValues(rule)
 
@@ -957,6 +972,15 @@ class TestRuleBasedValueSpecificationWriter:
         parent = _parent()
         writer.writeRuleBasedValueSpecification(parent, "RULE-BASED-VALUES", None)
         assert len(parent) == 0
+
+    def test_write_rule_based_value_specification_empty_arguments_no_wrapper(self, writer):
+        spec = RuleBasedValueSpecification()
+        spec.setRule(_identifier("FILL_UNTIL_END"))
+        parent = _parent()
+        writer.writeRuleBasedValueSpecification(parent, "RULE-BASED-VALUES", spec)
+        child = parent[0]
+        assert child.find("RULE").text == "FILL_UNTIL_END"
+        assert child.find("ARGUMENTSS") is None
 
     def test_write_rule_arguments_none(self, writer):
         parent = _parent()


### PR DESCRIPTION
Closes #563

Align `RuleArguments`, `RuleBasedValueCont`, and `RuleBasedValueSpecification` with `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf` Tables D.57–D.59.

- `RuleArguments`: list shapes → spec 0..1 attributes (`v`, `vf`, `vt`, `vtf`)
- `RuleBasedValueCont`: member order per PDF row order
- `RuleBasedValueSpecification`: base aligned to `ARObject`, `rule` as `Identifier`
- New `getChildElementOptionalVerbatimString` parser helper
- Updated tests: 5669 passed (51 new/updated)