### PR TITLE
feat(model): sync SwDataDefProps to R23-11 and align Fibex/PDU writers

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -171,17 +171,18 @@ def run_unit_tests(args: argparse.Namespace, pytest_args: List[str], run_coverag
             if " passed" in line:
                 parts = line.split()
                 for i, part in enumerate(parts):
-                    if part == "passed":
+                    token = part.strip(",")
+                    if token == "passed":
                         try:
                             passed = int(parts[i - 1])
                         except (ValueError, IndexError):
                             pass
-                    elif part == "failed":
+                    elif token == "failed":
                         try:
                             failed = int(parts[i - 1])
                         except (ValueError, IndexError):
                             pass
-                    elif part == "skipped":
+                    elif token == "skipped":
                         try:
                             skipped = int(parts[i - 1])
                         except (ValueError, IndexError):
@@ -244,17 +245,18 @@ def run_integration_tests(args: argparse.Namespace, pytest_args: List[str], run_
             if " passed" in line:
                 parts = line.split()
                 for i, part in enumerate(parts):
-                    if part == "passed":
+                    token = part.strip(",")
+                    if token == "passed":
                         try:
                             passed = int(parts[i - 1])
                         except (ValueError, IndexError):
                             pass
-                    elif part == "failed":
+                    elif token == "failed":
                         try:
                             failed = int(parts[i - 1])
                         except (ValueError, IndexError):
                             pass
-                    elif part == "skipped":
+                    elif token == "skipped":
                         try:
                             skipped = int(parts[i - 1])
                         except (ValueError, IndexError):

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
@@ -399,6 +399,66 @@ class CseCodeType(ARLiteral):
         super().__init__()
 
 
+class DisplayFormatString(ARLiteral):
+    """
+    This is a display format specifier for the display of values e.g. in documents or in measurement and calibration systems. The display format specifier is a subset of the ANSI C printf specifiers with the following form: %[flags] [width] [.prec] type character.
+
+    Tags:
+        * xml.xsd.customType=DISPLAY-FORMAT-STRING
+        * xml.xsd.type=string
+    """
+
+    # DisplayFormatString method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.42, p.334
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [ ] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+
+class NativeDeclarationString(ARLiteral):
+    """
+    This string contains a native data declaration of a data type in a programming language. It is basically a string, but white-space shall be preserved.
+
+    Tags:
+        * xml.xsd.customType=NATIVE-DECLARATION-STRING
+        * xml.xsd.type=string
+        * xml.xsd.whiteSpace=preserve
+    """
+
+    # NativeDeclarationString method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.40, p.333
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [ ] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+
+class PrimitiveIdentifier(ARLiteral):
+    """
+    This meta-class has the ability to contain a string. Please note that this meta-class has only been introduced to fix an issue with the generation of attributes on primitives in context with [TPS_XMLSPR_00024].
+
+    Tags:
+        * xml.xsd.customType=PRIMITIVE-IDENTIFIER
+        * xml.xsd.maxLength=128
+        * xml.xsd.pattern=[a-zA-Z]([a-zA-Z0-9]|_[a-zA-Z0-9])*_?
+        * xml.xsd.type=string
+    """
+
+    # PrimitiveIdentifier method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.58, p.112
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [ ] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+
 class ReferrableSubtypesEnum(ARLiteral):
     """
     Represents an enum for referrable subtypes in AUTOSAR models.

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from abc import ABC
-from typing import List
+from typing import List, Optional
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Identifiable, Describable, PackageableElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, ARPositiveInteger, Boolean, ByteOrderEnum
@@ -398,168 +400,237 @@ class IPdu(Pdu, ABC):
 
 class SecureCommunicationProps(ARObject):
     """
-    Defines properties for secure communication, including authentication
-    data freshness, integrity protection, and secured area specifications
-    for protected communication channels.
+    This meta-class contains configuration settings that are specific for an individual SecuredIPdu.
     """
 
     # SecureCommunicationProps method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getAuthDataFreshnessLength   [x] impl  [ ] docstring  [ ] test
-    # [ ] setAuthDataFreshnessLength   [x] impl  [ ] docstring  [ ] test
-    # [ ] getAuthDataFreshnessStartPosition [x] impl  [ ] docstring  [ ] test
-    # [ ] setAuthDataFreshnessStartPosition [x] impl  [ ] docstring  [ ] test
-    # [ ] getAuthInfoTxLength          [x] impl  [ ] docstring  [ ] test
-    # [ ] setAuthInfoTxLength          [x] impl  [ ] docstring  [ ] test
-    # [ ] getAuthenticationBuildAttempts [x] impl  [ ] docstring  [ ] test
-    # [ ] setAuthenticationBuildAttempts [x] impl  [ ] docstring  [ ] test
-    # [ ] getAuthenticationRetries     [x] impl  [ ] docstring  [ ] test
-    # [ ] setAuthenticationRetries     [x] impl  [ ] docstring  [ ] test
-    # [ ] getDataId                    [x] impl  [ ] docstring  [ ] test
-    # [ ] setDataId                    [x] impl  [ ] docstring  [ ] test
-    # [ ] getFreshnessValueId          [x] impl  [ ] docstring  [ ] test
-    # [ ] setFreshnessValueId          [x] impl  [ ] docstring  [ ] test
-    # [ ] getFreshnessValueLength      [x] impl  [ ] docstring  [ ] test
-    # [ ] setFreshnessValueLength      [x] impl  [ ] docstring  [ ] test
-    # [ ] getFreshnessValueTxLength    [x] impl  [ ] docstring  [ ] test
-    # [ ] setFreshnessValueTxLength    [x] impl  [ ] docstring  [ ] test
-    # [ ] getMessageLinkLength         [x] impl  [ ] docstring  [ ] test
-    # [ ] setMessageLinkLength         [x] impl  [ ] docstring  [ ] test
-    # [ ] getMessageLinkPosition       [x] impl  [ ] docstring  [ ] test
-    # [ ] setMessageLinkPosition       [x] impl  [ ] docstring  [ ] test
-    # [ ] getSecondaryFreshnessValueId [x] impl  [ ] docstring  [ ] test
-    # [ ] setSecondaryFreshnessValueId [x] impl  [ ] docstring  [ ] test
-    # [ ] getSecuredAreaLength         [x] impl  [ ] docstring  [ ] test
-    # [ ] setSecuredAreaLength         [x] impl  [ ] docstring  [ ] test
-    # [ ] getSecuredAreaOffset         [x] impl  [ ] docstring  [ ] test
-    # [ ] setSecuredAreaOffset         [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.44, p.369
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                               [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getAuthDataFreshnessLength             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setAuthDataFreshnessLength             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getAuthDataFreshnessStartPosition      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setAuthDataFreshnessStartPosition      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getAuthenticationBuildAttempts         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setAuthenticationBuildAttempts         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getAuthenticationRetries               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setAuthenticationRetries               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDataId                              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDataId                              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFreshnessValueId                    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFreshnessValueId                    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMessageLinkLength                   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMessageLinkLength                   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMessageLinkPosition                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMessageLinkPosition                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSecondaryFreshnessValueId           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSecondaryFreshnessValueId           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSecuredAreaLength                   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSecuredAreaLength                   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSecuredAreaOffset                   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSecuredAreaOffset                   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
+        """
+        Initializes the SecureCommunicationProps.
+        """
         super().__init__()
 
-        self.authDataFreshnessLength: PositiveInteger = None
-        self.authDataFreshnessStartPosition: PositiveInteger = None
-        self.authInfoTxLength: PositiveInteger = None
-        self.authenticationBuildAttempts: PositiveInteger = None
-        self.authenticationRetries: PositiveInteger = None
-        self.dataId: PositiveInteger = None
-        self.freshnessValueId: PositiveInteger = None
-        self.freshnessValueLength: PositiveInteger = None
-        self.freshnessValueTxLength: PositiveInteger = None
-        self.messageLinkLength: PositiveInteger = None
-        self.messageLinkPosition: PositiveInteger = None
-        self.secondaryFreshnessValueId: PositiveInteger = None
-        self.securedAreaLength: PositiveInteger = None
-        self.securedAreaOffset: PositiveInteger = None
+        # This attribute defines the length in bits of the authentic PDU data that is passed to the SWC that verifies and generates the Freshness.
+        self.authDataFreshnessLength: Optional[PositiveInteger] = None
 
-    def getAuthDataFreshnessLength(self):
+        # This value determines the start position in bits of the Authentic PDU that shall be passed on to the SWC that verifies and generates the Freshness. The bit counting is done according to TPS_SYST_01068.
+        self.authDataFreshnessStartPosition: Optional[PositiveInteger] = None
+
+        # This attribute specifies the number of authentication build attempts.
+        self.authenticationBuildAttempts: Optional[PositiveInteger] = None
+
+        # This attribute defines the additional number of authentication attempts that are to be carried out when the generation of the authentication information failed for a given SecuredIPdu. If zero is set than only one authentication attempt is done.
+        self.authenticationRetries: Optional[PositiveInteger] = None
+
+        # This attribute defines a numerical identifier for the Secured I-PDU.
+        self.dataId: Optional[PositiveInteger] = None
+
+        # This attribute defines the Id of the Freshness Value. The Freshness Value might be a normal counter or a time value.
+        self.freshnessValueId: Optional[PositiveInteger] = None
+
+        # SecOC links an AuthenticIPdu and CryptographicIPdu together by repeating a specific part (Message Linker) of the AuthenticIPdu in the CryptographicIPdu. This attribute defines the length in bits of the messageLinker.
+        self.messageLinkLength: Optional[PositiveInteger] = None
+
+        # SecOC links an AuthenticIPdu and CryptographicIPdu together by repeating a specific part (Message Linker) of the AuthenticIPdu in the CryptographicIPdu. This attribute defines the startPosition in bits of the messageLinker.
+        self.messageLinkPosition: Optional[PositiveInteger] = None
+
+        # This attribute defines the Id of the Secondary Freshness Value. The Secondary Freshness Value might be a normal counter or a time value. Please note that this attribute is for documentation only to allow the configuration of required freshness value manager and no upstream mapping is defined for it.
+        self.secondaryFreshnessValueId: Optional[PositiveInteger] = None
+
+        # This attribute defines the length in bytes of the area within the payload Pdu which will be secured.
+        self.securedAreaLength: Optional[PositiveInteger] = None
+
+        # This attribute defines the start position (offset in byte) of the area within the payload Pdu which will be secured.
+        self.securedAreaOffset: Optional[PositiveInteger] = None
+
+    def getAuthDataFreshnessLength(self) -> Optional[PositiveInteger]:
+        """
+        This attribute defines the length in bits of the authentic PDU data that is passed to the SWC that verifies and generates the Freshness.
+        """
         return self.authDataFreshnessLength
 
-    def setAuthDataFreshnessLength(self, value):
+    def setAuthDataFreshnessLength(self, value: Optional[PositiveInteger]) -> "SecureCommunicationProps":
+        """
+        This attribute defines the length in bits of the authentic PDU data that is passed to the SWC that verifies and generates the Freshness.
+        A None value is a no-op and does not overwrite an existing authDataFreshnessLength.
+        """
         if value is not None:
             self.authDataFreshnessLength = value
         return self
 
-    def getAuthDataFreshnessStartPosition(self):
+    def getAuthDataFreshnessStartPosition(self) -> Optional[PositiveInteger]:
+        """
+        This value determines the start position in bits of the Authentic PDU that shall be passed on to the SWC that verifies and generates the Freshness. The bit counting is done according to TPS_SYST_01068.
+        """
         return self.authDataFreshnessStartPosition
 
-    def setAuthDataFreshnessStartPosition(self, value):
+    def setAuthDataFreshnessStartPosition(self, value: Optional[PositiveInteger]) -> "SecureCommunicationProps":
+        """
+        This value determines the start position in bits of the Authentic PDU that shall be passed on to the SWC that verifies and generates the Freshness. The bit counting is done according to TPS_SYST_01068.
+        A None value is a no-op and does not overwrite an existing authDataFreshnessStartPosition.
+        """
         if value is not None:
             self.authDataFreshnessStartPosition = value
         return self
 
-    def getAuthInfoTxLength(self):
-        return self.authInfoTxLength
-
-    def setAuthInfoTxLength(self, value):
-        if value is not None:
-            self.authInfoTxLength = value
-        return self
-
-    def getAuthenticationBuildAttempts(self):
+    def getAuthenticationBuildAttempts(self) -> Optional[PositiveInteger]:
+        """
+        This attribute specifies the number of authentication build attempts.
+        """
         return self.authenticationBuildAttempts
 
-    def setAuthenticationBuildAttempts(self, value):
+    def setAuthenticationBuildAttempts(self, value: Optional[PositiveInteger]) -> "SecureCommunicationProps":
+        """
+        This attribute specifies the number of authentication build attempts.
+        A None value is a no-op and does not overwrite an existing authenticationBuildAttempts.
+        """
         if value is not None:
             self.authenticationBuildAttempts = value
         return self
 
-    def getAuthenticationRetries(self):
+    def getAuthenticationRetries(self) -> Optional[PositiveInteger]:
+        """
+        This attribute defines the additional number of authentication attempts that are to be carried out when the generation of the authentication information failed for a given SecuredIPdu. If zero is set than only one authentication attempt is done.
+        """
         return self.authenticationRetries
 
-    def setAuthenticationRetries(self, value):
+    def setAuthenticationRetries(self, value: Optional[PositiveInteger]) -> "SecureCommunicationProps":
+        """
+        This attribute defines the additional number of authentication attempts that are to be carried out when the generation of the authentication information failed for a given SecuredIPdu. If zero is set than only one authentication attempt is done.
+        A None value is a no-op and does not overwrite an existing authenticationRetries.
+        """
         if value is not None:
             self.authenticationRetries = value
         return self
 
-    def getDataId(self):
+    def getDataId(self) -> Optional[PositiveInteger]:
+        """
+        This attribute defines a numerical identifier for the Secured I-PDU.
+        """
         return self.dataId
 
-    def setDataId(self, value):
+    def setDataId(self, value: Optional[PositiveInteger]) -> "SecureCommunicationProps":
+        """
+        This attribute defines a numerical identifier for the Secured I-PDU.
+        A None value is a no-op and does not overwrite an existing dataId.
+        """
         if value is not None:
             self.dataId = value
         return self
 
-    def getFreshnessValueId(self):
+    def getFreshnessValueId(self) -> Optional[PositiveInteger]:
+        """
+        This attribute defines the Id of the Freshness Value. The Freshness Value might be a normal counter or a time value.
+        """
         return self.freshnessValueId
 
-    def setFreshnessValueId(self, value):
+    def setFreshnessValueId(self, value: Optional[PositiveInteger]) -> "SecureCommunicationProps":
+        """
+        This attribute defines the Id of the Freshness Value. The Freshness Value might be a normal counter or a time value.
+        A None value is a no-op and does not overwrite an existing freshnessValueId.
+        """
         if value is not None:
             self.freshnessValueId = value
         return self
 
-    def getFreshnessValueLength(self):
-        return self.freshnessValueLength
-
-    def setFreshnessValueLength(self, value):
-        if value is not None:
-            self.freshnessValueLength = value
-        return self
-
-    def getFreshnessValueTxLength(self):
-        return self.freshnessValueTxLength
-
-    def setFreshnessValueTxLength(self, value):
-        if value is not None:
-            self.freshnessValueTxLength = value
-        return self
-
-    def getMessageLinkLength(self):
+    def getMessageLinkLength(self) -> Optional[PositiveInteger]:
+        """
+        SecOC links an AuthenticIPdu and CryptographicIPdu together by repeating a specific part (Message Linker) of the AuthenticIPdu in the CryptographicIPdu. This attribute defines the length in bits of the messageLinker.
+        """
         return self.messageLinkLength
 
-    def setMessageLinkLength(self, value):
+    def setMessageLinkLength(self, value: Optional[PositiveInteger]) -> "SecureCommunicationProps":
+        """
+        SecOC links an AuthenticIPdu and CryptographicIPdu together by repeating a specific part (Message Linker) of the AuthenticIPdu in the CryptographicIPdu. This attribute defines the length in bits of the messageLinker.
+        A None value is a no-op and does not overwrite an existing messageLinkLength.
+        """
         if value is not None:
             self.messageLinkLength = value
         return self
 
-    def getMessageLinkPosition(self):
+    def getMessageLinkPosition(self) -> Optional[PositiveInteger]:
+        """
+        SecOC links an AuthenticIPdu and CryptographicIPdu together by repeating a specific part (Message Linker) of the AuthenticIPdu in the CryptographicIPdu. This attribute defines the startPosition in bits of the messageLinker.
+        """
         return self.messageLinkPosition
 
-    def setMessageLinkPosition(self, value):
+    def setMessageLinkPosition(self, value: Optional[PositiveInteger]) -> "SecureCommunicationProps":
+        """
+        SecOC links an AuthenticIPdu and CryptographicIPdu together by repeating a specific part (Message Linker) of the AuthenticIPdu in the CryptographicIPdu. This attribute defines the startPosition in bits of the messageLinker.
+        A None value is a no-op and does not overwrite an existing messageLinkPosition.
+        """
         if value is not None:
             self.messageLinkPosition = value
         return self
 
-    def getSecondaryFreshnessValueId(self):
+    def getSecondaryFreshnessValueId(self) -> Optional[PositiveInteger]:
+        """
+        This attribute defines the Id of the Secondary Freshness Value. The Secondary Freshness Value might be a normal counter or a time value. Please note that this attribute is for documentation only to allow the configuration of required freshness value manager and no upstream mapping is defined for it.
+        """
         return self.secondaryFreshnessValueId
 
-    def setSecondaryFreshnessValueId(self, value):
+    def setSecondaryFreshnessValueId(self, value: Optional[PositiveInteger]) -> "SecureCommunicationProps":
+        """
+        This attribute defines the Id of the Secondary Freshness Value. The Secondary Freshness Value might be a normal counter or a time value. Please note that this attribute is for documentation only to allow the configuration of required freshness value manager and no upstream mapping is defined for it.
+        A None value is a no-op and does not overwrite an existing secondaryFreshnessValueId.
+        """
         if value is not None:
             self.secondaryFreshnessValueId = value
         return self
 
-    def getSecuredAreaLength(self):
+    def getSecuredAreaLength(self) -> Optional[PositiveInteger]:
+        """
+        This attribute defines the length in bytes of the area within the payload Pdu which will be secured.
+        """
         return self.securedAreaLength
 
-    def setSecuredAreaLength(self, value):
+    def setSecuredAreaLength(self, value: Optional[PositiveInteger]) -> "SecureCommunicationProps":
+        """
+        This attribute defines the length in bytes of the area within the payload Pdu which will be secured.
+        A None value is a no-op and does not overwrite an existing securedAreaLength.
+        """
         if value is not None:
             self.securedAreaLength = value
         return self
 
-    def getSecuredAreaOffset(self):
+    def getSecuredAreaOffset(self) -> Optional[PositiveInteger]:
+        """
+        This attribute defines the start position (offset in byte) of the area within the payload Pdu which will be secured.
+        """
         return self.securedAreaOffset
 
-    def setSecuredAreaOffset(self, value):
+    def setSecuredAreaOffset(self, value: Optional[PositiveInteger]) -> "SecureCommunicationProps":
+        """
+        This attribute defines the start position (offset in byte) of the area within the payload Pdu which will be secured.
+        A None value is a no-op and does not overwrite an existing securedAreaOffset.
+        """
         if value is not None:
             self.securedAreaOffset = value
         return self
@@ -1554,17 +1625,62 @@ class GeneralPurposeIPdu(IPdu):
 
 class SecureCommunicationPropsSet(FibexElement):
     """
-    Represents a set of secure communication properties that can be grouped
-    together to define common security configurations for communication channels.
+    Collection of properties used to configure SecuredIPdus.
     """
 
     # SecureCommunicationPropsSet method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.45, p.370
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                                         [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] createSecureCommunicationAuthenticationProps     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getAuthenticationProps                           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createSecureCommunicationFreshnessProps          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFreshnessProps                                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self, parent: ARObject, short_name: str):
+        """
+        Initializes the SecureCommunicationPropsSet.
+        """
         super().__init__(parent, short_name)
 
-        self.secureComProps: List[SecureCommunicationProps] = []
+        # Authentication properties used to configure Secured IPdus.
+        self.authenticationProps: List[SecureCommunicationAuthenticationProps] = []
+
+        # Freshness properties used to configure SecuredIPdus.
+        self.freshnessProps: List[SecureCommunicationFreshnessProps] = []
+
+    def createSecureCommunicationAuthenticationProps(self, short_name: str) -> SecureCommunicationAuthenticationProps:
+        """
+        Authentication properties used to configure Secured IPdus.
+        """
+        if not self.IsElementExists(short_name, SecureCommunicationAuthenticationProps):
+            props = SecureCommunicationAuthenticationProps(self, short_name)
+            self.addElement(props)
+            self.authenticationProps.append(props)
+        return self.getElement(short_name, SecureCommunicationAuthenticationProps)
+
+    def getAuthenticationProps(self) -> List[SecureCommunicationAuthenticationProps]:
+        """
+        Authentication properties used to configure Secured IPdus.
+        """
+        return self.authenticationProps
+
+    def createSecureCommunicationFreshnessProps(self, short_name: str) -> SecureCommunicationFreshnessProps:
+        """
+        Freshness properties used to configure SecuredIPdus.
+        """
+        if not self.IsElementExists(short_name, SecureCommunicationFreshnessProps):
+            props = SecureCommunicationFreshnessProps(self, short_name)
+            self.addElement(props)
+            self.freshnessProps.append(props)
+        return self.getElement(short_name, SecureCommunicationFreshnessProps)
+
+    def getFreshnessProps(self) -> List[SecureCommunicationFreshnessProps]:
+        """
+        Freshness properties used to configure SecuredIPdus.
+        """
+        return self.freshnessProps
 
 
 class UserDefinedPdu(Pdu):
@@ -1625,150 +1741,155 @@ class UserDefinedIPdu(IPdu):
 
 class SecureCommunicationAuthenticationProps(Identifiable):
     """
-    Defines authentication properties for secure communication,
-    including authentication build attempts, retries, and other
-    authentication-related security parameters.
+    Authentication properties used to configure SecuredIPdus.
     """
 
     # SecureCommunicationAuthenticationProps method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getAuthenticationBuildAttempts [x] impl  [ ] docstring  [ ] test
-    # [ ] setAuthenticationBuildAttempts [x] impl  [ ] docstring  [ ] test
-    # [ ] getAuthenticationRetries     [x] impl  [ ] docstring  [ ] test
-    # [ ] setAuthenticationRetries     [x] impl  [ ] docstring  [ ] test
-    # [ ] getDataId                    [x] impl  [ ] docstring  [ ] test
-    # [ ] setDataId                    [x] impl  [ ] docstring  [ ] test
-    # [ ] getSecuredComAuthenticationType [x] impl  [ ] docstring  [ ] test
-    # [ ] setSecuredComAuthenticationType [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.47, p.371
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                       [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getAuthInfoTxLength            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setAuthInfoTxLength            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
+        """
+        Initializes the SecureCommunicationAuthenticationProps.
+        """
         super().__init__(parent, short_name)
 
-        self.authenticationBuildAttempts: PositiveInteger = None
-        self.authenticationRetries: PositiveInteger = None
-        self.dataId: PositiveInteger = None
-        self.securedComAuthenticationType: ARLiteral = None
+        # This attribute defines the length in bits of the authentication code to be included in the payload of the authenticated Pdu.
+        self.authInfoTxLength: Optional[PositiveInteger] = None
 
-    def getAuthenticationBuildAttempts(self):
-        return self.authenticationBuildAttempts
+    def getAuthInfoTxLength(self) -> Optional[PositiveInteger]:
+        """
+        This attribute defines the length in bits of the authentication code to be included in the payload of the authenticated Pdu.
+        """
+        return self.authInfoTxLength
 
-    def setAuthenticationBuildAttempts(self, value):
+    def setAuthInfoTxLength(self, value: Optional[PositiveInteger]) -> "SecureCommunicationAuthenticationProps":
+        """
+        This attribute defines the length in bits of the authentication code to be included in the payload of the authenticated Pdu.
+        A None value is a no-op and does not overwrite an existing authInfoTxLength.
+        """
         if value is not None:
-            self.authenticationBuildAttempts = value
-        return self
-
-    def getAuthenticationRetries(self):
-        return self.authenticationRetries
-
-    def setAuthenticationRetries(self, value):
-        if value is not None:
-            self.authenticationRetries = value
-        return self
-
-    def getDataId(self):
-        return self.dataId
-
-    def setDataId(self, value):
-        if value is not None:
-            self.dataId = value
-        return self
-
-    def getSecuredComAuthenticationType(self):
-        return self.securedComAuthenticationType
-
-    def setSecuredComAuthenticationType(self, value):
-        if value is not None:
-            self.securedComAuthenticationType = value
+            self.authInfoTxLength = value
         return self
 
 
 class SecureCommunicationFreshnessProps(Identifiable):
     """
-    Defines freshness properties for secure communication,
-    including freshness value IDs, lengths, and other
-    freshness-related security parameters to prevent replay attacks.
+    Freshness properties used to configure SecuredIPdus.
     """
 
     # SecureCommunicationFreshnessProps method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getFreshnessValueId          [x] impl  [ ] docstring  [ ] test
-    # [ ] setFreshnessValueId          [x] impl  [ ] docstring  [ ] test
-    # [ ] getFreshnessValueLength      [x] impl  [ ] docstring  [ ] test
-    # [ ] setFreshnessValueLength      [x] impl  [ ] docstring  [ ] test
-    # [ ] getFreshnessValueTxLength    [x] impl  [ ] docstring  [ ] test
-    # [ ] setFreshnessValueTxLength    [x] impl  [ ] docstring  [ ] test
-    # [ ] getMessageLinkLength         [x] impl  [ ] docstring  [ ] test
-    # [ ] setMessageLinkLength         [x] impl  [ ] docstring  [ ] test
-    # [ ] getMessageLinkPosition       [x] impl  [ ] docstring  [ ] test
-    # [ ] setMessageLinkPosition       [x] impl  [ ] docstring  [ ] test
-    # [ ] getSecondaryFreshnessValueId [x] impl  [ ] docstring  [ ] test
-    # [ ] setSecondaryFreshnessValueId [x] impl  [ ] docstring  [ ] test
-    # [ ] getSecuredComFreshnessType   [x] impl  [ ] docstring  [ ] test
-    # [ ] setSecuredComFreshnessType   [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.46, p.371
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                                   [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getFreshnessCounterSyncAttempts            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFreshnessCounterSyncAttempts            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFreshnessTimestampTimePeriodFactor      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFreshnessTimestampTimePeriodFactor      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFreshnessValueLength                    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFreshnessValueLength                    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFreshnessValueTxLength                  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFreshnessValueTxLength                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getUseFreshnessTimestamp                   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setUseFreshnessTimestamp                   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
+        """
+        Initializes the SecureCommunicationFreshnessProps.
+        """
         super().__init__(parent, short_name)
 
-        self.freshnessValueId: PositiveInteger = None
-        self.freshnessValueLength: PositiveInteger = None
-        self.freshnessValueTxLength: PositiveInteger = None
-        self.messageLinkLength: PositiveInteger = None
-        self.messageLinkPosition: PositiveInteger = None
-        self.secondaryFreshnessValueId: PositiveInteger = None
-        self.securedComFreshnessType: ARLiteral = None
+        # This attribute defines the number of Freshness Counter re-synchronization attempts when a verification failed for a Secured I-PDU. If the value is zero, there will be no additional verification attempt to synchronize with a potentially better fitting Freshness Counter value. This attribute is only applicable if useFreshnessTimestamp is FALSE.
+        self.freshnessCounterSyncAttempts: Optional[PositiveInteger] = None
 
-    def getFreshnessValueId(self):
-        return self.freshnessValueId
+        # This attribute defines a factor that specifies the time period for the Freshness Timestamp. It holds a multiplication factor that specifies the concrete meaning of a Freshness Timestamp increment by one on basis of microseconds.
+        self.freshnessTimestampTimePeriodFactor: Optional[PositiveInteger] = None
 
-    def setFreshnessValueId(self, value):
+        # This attribute defines the complete length in bits of the Freshness Value. As long as the key doesn't change the counter shall not overflow. The length of the counter shall be determined based on the expected life time of the corresponding key and frequency of usage of the counter.
+        self.freshnessValueLength: Optional[PositiveInteger] = None
+
+        # This attribute defines the length in bits of the Freshness Value to be included in the payload of the Secured I-PDU. This length is specific to the least significant bits of the complete Freshness Counter. If the attribute is 0 no Freshness Value is included in the Secured I-PDU.
+        self.freshnessValueTxLength: Optional[PositiveInteger] = None
+
+        # This attribute specifies whether the Freshness Value is generated through individual Freshness Counters or by a Timestamps. The value is set to TRUE when Timestamps are used.
+        self.useFreshnessTimestamp: Optional[Boolean] = None
+
+    def getFreshnessCounterSyncAttempts(self) -> Optional[PositiveInteger]:
+        """
+        This attribute defines the number of Freshness Counter re-synchronization attempts when a verification failed for a Secured I-PDU. If the value is zero, there will be no additional verification attempt to synchronize with a potentially better fitting Freshness Counter value. This attribute is only applicable if useFreshnessTimestamp is FALSE.
+        """
+        return self.freshnessCounterSyncAttempts
+
+    def setFreshnessCounterSyncAttempts(self, value: Optional[PositiveInteger]) -> "SecureCommunicationFreshnessProps":
+        """
+        This attribute defines the number of Freshness Counter re-synchronization attempts when a verification failed for a Secured I-PDU. If the value is zero, there will be no additional verification attempt to synchronize with a potentially better fitting Freshness Counter value. This attribute is only applicable if useFreshnessTimestamp is FALSE.
+        A None value is a no-op and does not overwrite an existing freshnessCounterSyncAttempts.
+        """
         if value is not None:
-            self.freshnessValueId = value
+            self.freshnessCounterSyncAttempts = value
         return self
 
-    def getFreshnessValueLength(self):
+    def getFreshnessTimestampTimePeriodFactor(self) -> Optional[PositiveInteger]:
+        """
+        This attribute defines a factor that specifies the time period for the Freshness Timestamp. It holds a multiplication factor that specifies the concrete meaning of a Freshness Timestamp increment by one on basis of microseconds.
+        """
+        return self.freshnessTimestampTimePeriodFactor
+
+    def setFreshnessTimestampTimePeriodFactor(self, value: Optional[PositiveInteger]) -> "SecureCommunicationFreshnessProps":
+        """
+        This attribute defines a factor that specifies the time period for the Freshness Timestamp. It holds a multiplication factor that specifies the concrete meaning of a Freshness Timestamp increment by one on basis of microseconds.
+        A None value is a no-op and does not overwrite an existing freshnessTimestampTimePeriodFactor.
+        """
+        if value is not None:
+            self.freshnessTimestampTimePeriodFactor = value
+        return self
+
+    def getFreshnessValueLength(self) -> Optional[PositiveInteger]:
+        """
+        This attribute defines the complete length in bits of the Freshness Value. As long as the key doesn't change the counter shall not overflow. The length of the counter shall be determined based on the expected life time of the corresponding key and frequency of usage of the counter.
+        """
         return self.freshnessValueLength
 
-    def setFreshnessValueLength(self, value):
+    def setFreshnessValueLength(self, value: Optional[PositiveInteger]) -> "SecureCommunicationFreshnessProps":
+        """
+        This attribute defines the complete length in bits of the Freshness Value. As long as the key doesn't change the counter shall not overflow. The length of the counter shall be determined based on the expected life time of the corresponding key and frequency of usage of the counter.
+        A None value is a no-op and does not overwrite an existing freshnessValueLength.
+        """
         if value is not None:
             self.freshnessValueLength = value
         return self
 
-    def getFreshnessValueTxLength(self):
+    def getFreshnessValueTxLength(self) -> Optional[PositiveInteger]:
+        """
+        This attribute defines the length in bits of the Freshness Value to be included in the payload of the Secured I-PDU. This length is specific to the least significant bits of the complete Freshness Counter. If the attribute is 0 no Freshness Value is included in the Secured I-PDU.
+        """
         return self.freshnessValueTxLength
 
-    def setFreshnessValueTxLength(self, value):
+    def setFreshnessValueTxLength(self, value: Optional[PositiveInteger]) -> "SecureCommunicationFreshnessProps":
+        """
+        This attribute defines the length in bits of the Freshness Value to be included in the payload of the Secured I-PDU. This length is specific to the least significant bits of the complete Freshness Counter. If the attribute is 0 no Freshness Value is included in the Secured I-PDU.
+        A None value is a no-op and does not overwrite an existing freshnessValueTxLength.
+        """
         if value is not None:
             self.freshnessValueTxLength = value
         return self
 
-    def getMessageLinkLength(self):
-        return self.messageLinkLength
+    def getUseFreshnessTimestamp(self) -> Optional[Boolean]:
+        """
+        This attribute specifies whether the Freshness Value is generated through individual Freshness Counters or by a Timestamps. The value is set to TRUE when Timestamps are used.
+        """
+        return self.useFreshnessTimestamp
 
-    def setMessageLinkLength(self, value):
+    def setUseFreshnessTimestamp(self, value: Optional[Boolean]) -> "SecureCommunicationFreshnessProps":
+        """
+        This attribute specifies whether the Freshness Value is generated through individual Freshness Counters or by a Timestamps. The value is set to TRUE when Timestamps are used.
+        A None value is a no-op and does not overwrite an existing useFreshnessTimestamp.
+        """
         if value is not None:
-            self.messageLinkLength = value
-        return self
-
-    def getMessageLinkPosition(self):
-        return self.messageLinkPosition
-
-    def setMessageLinkPosition(self, value):
-        if value is not None:
-            self.messageLinkPosition = value
-        return self
-
-    def getSecondaryFreshnessValueId(self):
-        return self.secondaryFreshnessValueId
-
-    def setSecondaryFreshnessValueId(self, value):
-        if value is not None:
-            self.secondaryFreshnessValueId = value
-        return self
-
-    def getSecuredComFreshnessType(self):
-        return self.securedComFreshnessType
-
-    def setSecuredComFreshnessType(self, value):
-        if value is not None:
-            self.securedComFreshnessType = value
+            self.useFreshnessTimestamp = value
         return self

--- a/src/armodel/models/M2/MSR/DataDictionary/DataDefProperties.py
+++ b/src/armodel/models/M2/MSR/DataDictionary/DataDefProperties.py
@@ -221,7 +221,7 @@ class SwVariableRefProxy(ARObject):
 
 class SwCalprmRefProxy(ARObject):
     """
-    Proxy class for several kinds of references to a calibration parameter.
+    Wrapper class for different kinds of references to a calibration parameter.
     """
 
     # SwCalprmRefProxy method parity checklist:
@@ -237,21 +237,21 @@ class SwCalprmRefProxy(ARObject):
     def __init__(self):
         super().__init__()
 
-        # This represents the reference to a calibration parameter in an Autosar system.
+        # This represents a Parameter within AUTOSAR. Note that the Datatype of the referenced ParameterDataPrototype shall be an ApplicationDataType of category VALUE.
         self.arParameter: Optional["AutosarParameterRef"] = None
 
-        # This reference is used in the McSupport file to express the final instance of input values etc.
+        # This reference is used in the McSupport file to express the final instance of group axis etc. It is not allowed to use this outside of an McDataInstance. The referenced mcDataInstance shall be originated from a ParameterDataPrototype.
         self.mcDataInstanceRef: Optional[RefType] = None
 
     def getArParameter(self) -> Optional["AutosarParameterRef"]:
         """
-        This represents the reference to a calibration parameter in an Autosar system.
+        This represents a Parameter within AUTOSAR. Note that the Datatype of the referenced ParameterDataPrototype shall be an ApplicationDataType of category VALUE.
         """
         return self.arParameter
 
     def setArParameter(self, value: Optional["AutosarParameterRef"]) -> "SwCalprmRefProxy":
         """
-        This represents the reference to a calibration parameter in an Autosar system. A None value is a no-op and does not overwrite an existing arParameter.
+        This represents a Parameter within AUTOSAR. Note that the Datatype of the referenced ParameterDataPrototype shall be an ApplicationDataType of category VALUE. A None value is a no-op and does not overwrite an existing arParameter.
         """
         if value is not None:
             self.arParameter = value
@@ -259,13 +259,13 @@ class SwCalprmRefProxy(ARObject):
 
     def getMcDataInstanceRef(self) -> Optional[RefType]:
         """
-        This reference is used in the McSupport file to express the final instance of input values etc.
+        This reference is used in the McSupport file to express the final instance of group axis etc. It is not allowed to use this outside of an McDataInstance. The referenced mcDataInstance shall be originated from a ParameterDataPrototype.
         """
         return self.mcDataInstanceRef
 
     def setMcDataInstanceRef(self, value: Optional[RefType]) -> "SwCalprmRefProxy":
         """
-        This reference is used in the McSupport file to express the final instance of input values etc. A None value is a no-op and does not overwrite an existing mcDataInstanceRef.
+        This reference is used in the McSupport file to express the final instance of group axis etc. It is not allowed to use this outside of an McDataInstance. The referenced mcDataInstance shall be originated from a ParameterDataPrototype. A None value is a no-op and does not overwrite an existing mcDataInstanceRef.
         """
         if value is not None:
             self.mcDataInstanceRef = value
@@ -290,21 +290,21 @@ class SwDataDependencyArgs(ARObject):
     def __init__(self):
         super().__init__()
 
-        # This property specifies the calibration parameter which serves as the input axis.
+        # Specifies a calibration parameter as an input argument to the dependency.
         self.swCalprmRef: Optional[SwCalprmRefProxy] = None
 
-        # This property specifies the variable which is used in the data dependency.
+        # Specifies a variable as an input argument to the dependency.
         self.swVariable: Optional[SwVariableRefProxy] = None
 
     def getSwCalprmRef(self) -> Optional[SwCalprmRefProxy]:
         """
-        This property specifies the calibration parameter which serves as the input axis.
+        Specifies a calibration parameter as an input argument to the dependency.
         """
         return self.swCalprmRef
 
     def setSwCalprmRef(self, value: Optional[SwCalprmRefProxy]) -> "SwDataDependencyArgs":
         """
-        This property specifies the calibration parameter which serves as the input axis. A None value is a no-op and does not overwrite an existing swCalprmRef.
+        Specifies a calibration parameter as an input argument to the dependency. A None value is a no-op and does not overwrite an existing swCalprmRef.
         """
         if value is not None:
             self.swCalprmRef = value
@@ -312,13 +312,13 @@ class SwDataDependencyArgs(ARObject):
 
     def getSwVariable(self) -> Optional[SwVariableRefProxy]:
         """
-        This property specifies the variable which is used in the data dependency.
+        Specifies a variable as an input argument to the dependency.
         """
         return self.swVariable
 
     def setSwVariable(self, value: Optional[SwVariableRefProxy]) -> "SwDataDependencyArgs":
         """
-        This property specifies the variable which is used in the data dependency. A None value is a no-op and does not overwrite an existing swVariable.
+        Specifies a variable as an input argument to the dependency. A None value is a no-op and does not overwrite an existing swVariable.
         """
         if value is not None:
             self.swVariable = value
@@ -361,7 +361,7 @@ class CompuGenericMath(ARObject):
 
 class SwDataDependency(ARObject):
     """
-    This element describes the interdependencies of data objects, e.g. variables and parameters. Use cases: Calculate the value of a calibration parameter (by the MCD system) from the value(s) of other calibration parameters. Virtual data - that means the data object is not directly in the ecu and this property describes how the "virtual variable" can be computed from the real ones (by the MCD system).
+    This element describes the interdependencies of data objects, e.g. variables and parameters. Use cases: • Calculate the value of a calibration parameter (by the MCD system) from the value(s) of other calibration parameters. • Virtual data - that means the data object is not directly in the ecu and this property describes how the "virtual variable" can be computed from the real ones (by the MCD system).
     """
 
     # SwDataDependency method parity checklist:
@@ -377,10 +377,10 @@ class SwDataDependency(ARObject):
     def __init__(self):
         super().__init__()
 
-        # This element describes the formula with which the dependencies between the participating objects are defined. Tags: xml.sequenceOffset=30
+        # This element describes the formula with which the dependencies between the participating objects are defined.
         self.swDataDependencyFormula: Optional[CompuGenericMath] = None
 
-        # Specifies the arguments used in the data dependency. Note that this is 0..1 since the aggregated class is a container (atpMixed). Tags: xml.sequenceOffset=40
+        # Specifies the arguments used in the data dependency. Note that this is 0..1 since the aggregated class is a container (atpMixed).
         self.swDataDependencyArgs: Optional[SwDataDependencyArgs] = None
 
     def getSwDataDependencyFormula(self) -> Optional[CompuGenericMath]:
@@ -414,7 +414,7 @@ class SwDataDependency(ARObject):
 
 class SwDataDefProps(ARObject):
     """
-    The properties of data are summarized in the meta-class SwDataDefProps. This meta-class itself is the superset of all applicable properties.
+    This class is a collection of properties relevant for data objects under various aspects. One could consider this class as a "pattern of inheritance by aggregation". The properties can be applied to all objects of all classes in which SwDataDefProps is aggregated. Note that not all of the attributes or associated elements are useful all of the time. Hence, the process definition (e.g. expressed with an OCL or a Document Control Instance MSR-DCI) has the task of implementing limitations. SwDataDefProps covers various aspects: • Structure of the data element for calibration use cases: is it a single value, a curve, or a map, but also the recordLayouts which specify how such elements are mapped/converted to the DataTypes in the programming language (or in AUTOSAR). This is mainly expressed by properties like swRecordLayout and swCalprmAxisSet • Implementation aspects, mainly expressed by swImplPolicy, swVariableAccessImplPolicy, swAddr Method, swPointerTagetProps, baseType, implementationDataType and additionalNativeTypeQualifier • Access policy for the MCD system, mainly expressed by swCalibrationAccess • Semantics of the data element, mainly expressed by compuMethod and/or unit, dataConstr, invalid Value • Code generation policy provided by swRecordLayout
     """
 
     # SwDataDefProps method parity checklist:
@@ -501,7 +501,7 @@ class SwDataDefProps(ARObject):
         # Addressing method related to this data object. Via an association to the same SwAddrMethod it can be specified that several DataPrototypes shall be located in the same memory without already specifying the memory section itself.
         self.swAddrMethodRef: Optional[RefType] = None
 
-        # The attribute describes the intended alignment of the DataPrototype. If the attribute is not defined the alignment is determined by the swBaseType size and the memoryAllocationKeywordPolicy of the referenced SwAddrMethod.
+        # The attribute describes the intended typical alignment of the DataPrototype. If the attribute is not defined the alignment is determined by the swBaseType size and the memoryAllocationKeywordPolicy of the referenced SwAddrMethod.
         self.swAlignment: Optional[AlignmentType] = None
 
         # Base type associated with the containing data object.
@@ -522,55 +522,55 @@ class SwDataDefProps(ARObject):
         # the specific properties if the data object is a text object.
         self.swTextProps: Optional[SwTextProps] = None
 
-        # This element is used to express that a data object is a comparison variable.
+        # Variables used for comparison in an MCD process.
         self.swComparisonVariables: List[SwVariableRefProxy] = []
 
-        # Compu method associated with the containing data object.
+        # Computation method associated with the semantics of this data object.
         self.compuMethodRef: Optional[RefType] = None
 
-        # Data constraint associated with the containing data object.
+        # Data constraint for this data object.
         self.dataConstrRef: Optional[RefType] = None
 
-        # This element describes the interdependencies of data objects, e.g. variables and parameters.
+        # Describes how the value of the data object has to be calculated from the value of another data object (by the MCD system).
         self.swDataDependency: Optional[SwDataDependency] = None
 
-        # This is a display format specifier for the display of values e.g. in documents or in measurement and calibration systems.
+        # This property describes how a number is to be rendered e.g. in documents or in a measurement and calibration system.
         self.displayFormat: Optional[DisplayFormatString] = None
 
-        # This association denotes the ImplementationDataType of a data declaration via its aggregated SwDataDefProps.
+        # This association denotes the ImplementationDataType of a data declaration via its aggregated SwDataDefProps. It is used whenever a data declaration is not directly referring to a base type. Especially • redefinition of an ImplementationDataType via a "typedef" to another ImplementationDatatype • the target type of a pointer (see SwPointerTargetProps), if it does not refer to a base type directly • the data type of an array or record element within an ImplementationDataType, if it does not refer to a base type directly • the data type of an SwServiceArg, if it does not refer to a base type directly
         self.implementationDataTypeRef: Optional[RefType] = None
 
-        # Proxy class for several kinds of references to a variable.
+        # Contains a reference to a variable which serves as a host-variable for a bit variable. Only applicable to bit objects.
         self.swHostVariable: Optional[SwVariableRefProxy] = None
 
-        # This indicates the intended implementation policy of the data object.
+        # Implementation policy for this data object.
         self.swImplPolicy: Optional[SwImplPolicyEnum] = None
 
-        # This string contains a native data declaration of a data type in a programming language. It is basically a string, but white-space shall be preserved.
+        # This attribute is used to declare native qualifiers of the programming language which can neither be deduced from the baseType (e.g. because the data object describes a pointer) nor from other more abstract attributes. Examples are qualifiers like "volatile", "strict" or "enum" of the C-language. All such declarations have to be put into one string.
         self.additionalNativeTypeQualifier: Optional[NativeDeclarationString] = None
 
-        # This attribute can be used to specify the intended resolution of the data object.
+        # The purpose of this element is to describe the requested quantization of data objects early on in the design process. The resolution ultimately occurs via the conversion formula present (compuMethod), which specifies the transition from the physical world to the standardized world (and vice-versa) (here, "the slope per bit" is present implicitly in the conversion formula). In the case of a development phase without a fixed conversion formula, a pre-specification can occur through swIntendedResolution. The resolution is specified in the physical domain according to the property "unit".
         self.swIntendedResolution: Optional[ARNumerical] = None
 
-        # This is the name of the interpolation method which is implemented by the referenced bswModuleEntry. It corresponds to swInterpolationMethod in SwDataDefProps.
+        # This is a keyword identifying the mathematical method to be applied for interpolation. The keyword needs to be related to the interpolation routine which needs to be invoked.
         self.swInterpolationMethod: Optional[Identifier] = None
 
-        # The value which indicates that the data object is invalid.
+        # Optional value to express invalidity of the actual data element.
         self.invalidValue: Optional[ValueSpecification] = None
 
         # This element distinguishes virtual objects. Virtual objects do not appear in the memory, their derivation is much more dependent on other objects and hence they shall have a swDataDependency.
         self.swIsVirtual: Optional[Boolean] = None
 
-        # Specifies that the containing data object is a pointer to another data object.
+        # Specifies that the containing data object is a pointer to another data object. Note: This atpSplitable property has no atp.Splitkey due to atpVariation (PropertySetPattern).
         self.swPointerTargetProps: Optional[SwPointerTargetProps] = None
 
         # Record layout for this data object.
         self.swRecordLayoutRef: Optional[RefType] = None
 
-        # This element specifies the frequency in which the object involved shall be or is called or calculated.
+        # This element specifies the frequency in which the object involved shall be or is called or calculated. This timing can be collected from the task in which write access processes to the variable run. But this cannot be done by the MCD system. So this attribute can be used in an early phase to express the desired refresh timing and later on to specify the real refresh timing.
         self.swRefreshTiming: Optional[MultidimensionalTime] = None
 
-        # Physical unit associated with the semantics of this data object. This attribute applies if no compuMethod is specified.
+        # Physical unit associated with the semantics of this data object. This attribute applies if no compuMethod is specified. If both units (this as well as via compuMethod) are specified the units shall be compatible.
         self.unitRef: Optional[RefType] = None
 
         # The referenced ApplicationPrimitiveDataType represents the primitive data type of the value axis within a compound primitive (e.g. curve, map). It supersedes CompuMethod, Unit, and BaseType.
@@ -648,13 +648,13 @@ class SwDataDefProps(ARObject):
 
     def getSwAlignment(self) -> Optional[AlignmentType]:
         """
-        The attribute describes the intended alignment of the DataPrototype. If the attribute is not defined the alignment is determined by the swBaseType size and the memoryAllocationKeywordPolicy of the referenced SwAddrMethod.
+        The attribute describes the intended typical alignment of the DataPrototype. If the attribute is not defined the alignment is determined by the swBaseType size and the memoryAllocationKeywordPolicy of the referenced SwAddrMethod.
         """
         return self.swAlignment
 
     def setSwAlignment(self, value: Optional[AlignmentType]) -> "SwDataDefProps":
         """
-        The attribute describes the intended alignment of the DataPrototype. If the attribute is not defined the alignment is determined by the swBaseType size and the memoryAllocationKeywordPolicy of the referenced SwAddrMethod. A None value is a no-op and does not overwrite an existing swAlignment.
+        The attribute describes the intended typical alignment of the DataPrototype. If the attribute is not defined the alignment is determined by the swBaseType size and the memoryAllocationKeywordPolicy of the referenced SwAddrMethod. A None value is a no-op and does not overwrite an existing swAlignment.
         """
         if value is not None:
             self.swAlignment = value
@@ -746,13 +746,13 @@ class SwDataDefProps(ARObject):
 
     def getSwComparisonVariables(self) -> List[SwVariableRefProxy]:
         """
-        This element is used to express that a data object is a comparison variable.
+        Variables used for comparison in an MCD process.
         """
         return self.swComparisonVariables
 
     def addSwComparisonVariable(self, value: Optional[SwVariableRefProxy]) -> "SwDataDefProps":
         """
-        This element is used to express that a data object is a comparison variable. Appends a comparison variable. A None value is a no-op.
+        Variables used for comparison in an MCD process. Appends a comparison variable. A None value is a no-op.
         """
         if value is not None:
             self.swComparisonVariables.append(value)
@@ -760,13 +760,13 @@ class SwDataDefProps(ARObject):
 
     def getCompuMethodRef(self) -> Optional[RefType]:
         """
-        Compu method associated with the containing data object.
+        Computation method associated with the semantics of this data object.
         """
         return self.compuMethodRef
 
     def setCompuMethodRef(self, value: Optional[RefType]) -> "SwDataDefProps":
         """
-        Compu method associated with the containing data object. A None value is a no-op and does not overwrite an existing compuMethodRef.
+        Computation method associated with the semantics of this data object. A None value is a no-op and does not overwrite an existing compuMethodRef.
         """
         if value is not None:
             self.compuMethodRef = value
@@ -774,13 +774,13 @@ class SwDataDefProps(ARObject):
 
     def getDataConstrRef(self) -> Optional[RefType]:
         """
-        Data constraint associated with the containing data object.
+        Data constraint for this data object.
         """
         return self.dataConstrRef
 
     def setDataConstrRef(self, value: Optional[RefType]) -> "SwDataDefProps":
         """
-        Data constraint associated with the containing data object. A None value is a no-op and does not overwrite an existing dataConstrRef.
+        Data constraint for this data object. A None value is a no-op and does not overwrite an existing dataConstrRef.
         """
         if value is not None:
             self.dataConstrRef = value
@@ -788,13 +788,13 @@ class SwDataDefProps(ARObject):
 
     def getSwDataDependency(self) -> Optional[SwDataDependency]:
         """
-        This element describes the interdependencies of data objects, e.g. variables and parameters.
+        Describes how the value of the data object has to be calculated from the value of another data object (by the MCD system).
         """
         return self.swDataDependency
 
     def setSwDataDependency(self, value: Optional[SwDataDependency]) -> "SwDataDefProps":
         """
-        This element describes the interdependencies of data objects, e.g. variables and parameters. A None value is a no-op and does not overwrite an existing swDataDependency.
+        Describes how the value of the data object has to be calculated from the value of another data object (by the MCD system). A None value is a no-op and does not overwrite an existing swDataDependency.
         """
         if value is not None:
             self.swDataDependency = value
@@ -802,13 +802,13 @@ class SwDataDefProps(ARObject):
 
     def getDisplayFormat(self) -> Optional[DisplayFormatString]:
         """
-        This is a display format specifier for the display of values e.g. in documents or in measurement and calibration systems.
+        This property describes how a number is to be rendered e.g. in documents or in a measurement and calibration system.
         """
         return self.displayFormat
 
     def setDisplayFormat(self, value: Optional[DisplayFormatString]) -> "SwDataDefProps":
         """
-        This is a display format specifier for the display of values e.g. in documents or in measurement and calibration systems. A None value is a no-op and does not overwrite an existing displayFormat.
+        This property describes how a number is to be rendered e.g. in documents or in a measurement and calibration system. A None value is a no-op and does not overwrite an existing displayFormat.
         """
         if value is not None:
             self.displayFormat = value
@@ -816,13 +816,13 @@ class SwDataDefProps(ARObject):
 
     def getImplementationDataTypeRef(self) -> Optional[RefType]:
         """
-        This association denotes the ImplementationDataType of a data declaration via its aggregated SwDataDefProps.
+        This association denotes the ImplementationDataType of a data declaration via its aggregated SwDataDefProps. It is used whenever a data declaration is not directly referring to a base type. Especially • redefinition of an ImplementationDataType via a "typedef" to another ImplementationDatatype • the target type of a pointer (see SwPointerTargetProps), if it does not refer to a base type directly • the data type of an array or record element within an ImplementationDataType, if it does not refer to a base type directly • the data type of an SwServiceArg, if it does not refer to a base type directly
         """
         return self.implementationDataTypeRef
 
     def setImplementationDataTypeRef(self, value: Optional[RefType]) -> "SwDataDefProps":
         """
-        This association denotes the ImplementationDataType of a data declaration via its aggregated SwDataDefProps. A None value is a no-op and does not overwrite an existing implementationDataTypeRef.
+        This association denotes the ImplementationDataType of a data declaration via its aggregated SwDataDefProps. It is used whenever a data declaration is not directly referring to a base type. Especially • redefinition of an ImplementationDataType via a "typedef" to another ImplementationDatatype • the target type of a pointer (see SwPointerTargetProps), if it does not refer to a base type directly • the data type of an array or record element within an ImplementationDataType, if it does not refer to a base type directly • the data type of an SwServiceArg, if it does not refer to a base type directly. A None value is a no-op and does not overwrite an existing implementationDataTypeRef.
         """
         if value is not None:
             self.implementationDataTypeRef = value
@@ -830,13 +830,13 @@ class SwDataDefProps(ARObject):
 
     def getSwHostVariable(self) -> Optional[SwVariableRefProxy]:
         """
-        Proxy class for several kinds of references to a variable.
+        Contains a reference to a variable which serves as a host-variable for a bit variable. Only applicable to bit objects.
         """
         return self.swHostVariable
 
     def setSwHostVariable(self, value: Optional[SwVariableRefProxy]) -> "SwDataDefProps":
         """
-        Proxy class for several kinds of references to a variable. A None value is a no-op and does not overwrite an existing swHostVariable.
+        Contains a reference to a variable which serves as a host-variable for a bit variable. Only applicable to bit objects. A None value is a no-op and does not overwrite an existing swHostVariable.
         """
         if value is not None:
             self.swHostVariable = value
@@ -844,13 +844,13 @@ class SwDataDefProps(ARObject):
 
     def getSwImplPolicy(self) -> Optional[SwImplPolicyEnum]:
         """
-        This indicates the intended implementation policy of the data object.
+        Implementation policy for this data object.
         """
         return self.swImplPolicy
 
     def setSwImplPolicy(self, value: Optional[SwImplPolicyEnum]) -> "SwDataDefProps":
         """
-        This indicates the intended implementation policy of the data object. A None value is a no-op and does not overwrite an existing swImplPolicy.
+        Implementation policy for this data object. A None value is a no-op and does not overwrite an existing swImplPolicy.
         """
         if value is not None:
             self.swImplPolicy = value
@@ -858,13 +858,13 @@ class SwDataDefProps(ARObject):
 
     def getAdditionalNativeTypeQualifier(self) -> Optional[NativeDeclarationString]:
         """
-        This string contains a native data declaration of a data type in a programming language. It is basically a string, but white-space shall be preserved.
+        This attribute is used to declare native qualifiers of the programming language which can neither be deduced from the baseType (e.g. because the data object describes a pointer) nor from other more abstract attributes. Examples are qualifiers like "volatile", "strict" or "enum" of the C-language. All such declarations have to be put into one string.
         """
         return self.additionalNativeTypeQualifier
 
     def setAdditionalNativeTypeQualifier(self, value: Optional[NativeDeclarationString]) -> "SwDataDefProps":
         """
-        This string contains a native data declaration of a data type in a programming language. It is basically a string, but white-space shall be preserved. A None value is a no-op and does not overwrite an existing additionalNativeTypeQualifier.
+        This attribute is used to declare native qualifiers of the programming language which can neither be deduced from the baseType (e.g. because the data object describes a pointer) nor from other more abstract attributes. Examples are qualifiers like "volatile", "strict" or "enum" of the C-language. All such declarations have to be put into one string. A None value is a no-op and does not overwrite an existing additionalNativeTypeQualifier.
         """
         if value is not None:
             self.additionalNativeTypeQualifier = value
@@ -872,13 +872,13 @@ class SwDataDefProps(ARObject):
 
     def getSwIntendedResolution(self) -> Optional[ARNumerical]:
         """
-        This attribute can be used to specify the intended resolution of the data object.
+        The purpose of this element is to describe the requested quantization of data objects early on in the design process. The resolution ultimately occurs via the conversion formula present (compuMethod), which specifies the transition from the physical world to the standardized world (and vice-versa) (here, "the slope per bit" is present implicitly in the conversion formula). In the case of a development phase without a fixed conversion formula, a pre-specification can occur through swIntendedResolution. The resolution is specified in the physical domain according to the property "unit".
         """
         return self.swIntendedResolution
 
     def setSwIntendedResolution(self, value: Optional[ARNumerical]) -> "SwDataDefProps":
         """
-        This attribute can be used to specify the intended resolution of the data object. A None value is a no-op and does not overwrite an existing swIntendedResolution.
+        The purpose of this element is to describe the requested quantization of data objects early on in the design process. The resolution ultimately occurs via the conversion formula present (compuMethod), which specifies the transition from the physical world to the standardized world (and vice-versa) (here, "the slope per bit" is present implicitly in the conversion formula). In the case of a development phase without a fixed conversion formula, a pre-specification can occur through swIntendedResolution. The resolution is specified in the physical domain according to the property "unit". A None value is a no-op and does not overwrite an existing swIntendedResolution.
         """
         if value is not None:
             self.swIntendedResolution = value
@@ -886,13 +886,13 @@ class SwDataDefProps(ARObject):
 
     def getSwInterpolationMethod(self) -> Optional[Identifier]:
         """
-        This is the name of the interpolation method which is implemented by the referenced bswModuleEntry. It corresponds to swInterpolationMethod in SwDataDefProps.
+        This is a keyword identifying the mathematical method to be applied for interpolation. The keyword needs to be related to the interpolation routine which needs to be invoked.
         """
         return self.swInterpolationMethod
 
     def setSwInterpolationMethod(self, value: Optional[Identifier]) -> "SwDataDefProps":
         """
-        This is the name of the interpolation method which is implemented by the referenced bswModuleEntry. It corresponds to swInterpolationMethod in SwDataDefProps. A None value is a no-op and does not overwrite an existing swInterpolationMethod.
+        This is a keyword identifying the mathematical method to be applied for interpolation. The keyword needs to be related to the interpolation routine which needs to be invoked. A None value is a no-op and does not overwrite an existing swInterpolationMethod.
         """
         if value is not None:
             self.swInterpolationMethod = value
@@ -900,13 +900,13 @@ class SwDataDefProps(ARObject):
 
     def getInvalidValue(self) -> Optional[ValueSpecification]:
         """
-        The value which indicates that the data object is invalid.
+        Optional value to express invalidity of the actual data element.
         """
         return self.invalidValue
 
     def setInvalidValue(self, value: Optional[ValueSpecification]) -> "SwDataDefProps":
         """
-        The value which indicates that the data object is invalid. A None value is a no-op and does not overwrite an existing invalidValue.
+        Optional value to express invalidity of the actual data element. A None value is a no-op and does not overwrite an existing invalidValue.
         """
         if value is not None:
             self.invalidValue = value
@@ -928,13 +928,13 @@ class SwDataDefProps(ARObject):
 
     def getSwPointerTargetProps(self) -> Optional[SwPointerTargetProps]:
         """
-        Specifies that the containing data object is a pointer to another data object.
+        Specifies that the containing data object is a pointer to another data object. Note: This atpSplitable property has no atp.Splitkey due to atpVariation (PropertySetPattern).
         """
         return self.swPointerTargetProps
 
     def setSwPointerTargetProps(self, value: Optional[SwPointerTargetProps]) -> "SwDataDefProps":
         """
-        Specifies that the containing data object is a pointer to another data object. A None value is a no-op and does not overwrite an existing swPointerTargetProps.
+        Specifies that the containing data object is a pointer to another data object. Note: This atpSplitable property has no atp.Splitkey due to atpVariation (PropertySetPattern). A None value is a no-op and does not overwrite an existing swPointerTargetProps.
         """
         if value is not None:
             self.swPointerTargetProps = value
@@ -956,13 +956,13 @@ class SwDataDefProps(ARObject):
 
     def getSwRefreshTiming(self) -> Optional[MultidimensionalTime]:
         """
-        This element specifies the frequency in which the object involved shall be or is called or calculated.
+        This element specifies the frequency in which the object involved shall be or is called or calculated. This timing can be collected from the task in which write access processes to the variable run. But this cannot be done by the MCD system. So this attribute can be used in an early phase to express the desired refresh timing and later on to specify the real refresh timing.
         """
         return self.swRefreshTiming
 
     def setSwRefreshTiming(self, value: Optional[MultidimensionalTime]) -> "SwDataDefProps":
         """
-        This element specifies the frequency in which the object involved shall be or is called or calculated. A None value is a no-op and does not overwrite an existing swRefreshTiming.
+        This element specifies the frequency in which the object involved shall be or is called or calculated. This timing can be collected from the task in which write access processes to the variable run. But this cannot be done by the MCD system. So this attribute can be used in an early phase to express the desired refresh timing and later on to specify the real refresh timing. A None value is a no-op and does not overwrite an existing swRefreshTiming.
         """
         if value is not None:
             self.swRefreshTiming = value
@@ -970,13 +970,13 @@ class SwDataDefProps(ARObject):
 
     def getUnitRef(self) -> Optional[RefType]:
         """
-        Physical unit associated with the semantics of this data object. This attribute applies if no compuMethod is specified.
+        Physical unit associated with the semantics of this data object. This attribute applies if no compuMethod is specified. If both units (this as well as via compuMethod) are specified the units shall be compatible.
         """
         return self.unitRef
 
     def setUnitRef(self, value: Optional[RefType]) -> "SwDataDefProps":
         """
-        Physical unit associated with the semantics of this data object. This attribute applies if no compuMethod is specified. A None value is a no-op and does not overwrite an existing unitRef.
+        Physical unit associated with the semantics of this data object. This attribute applies if no compuMethod is specified. If both units (this as well as via compuMethod) are specified the units shall be compatible. A None value is a no-op and does not overwrite an existing unitRef.
         """
         if value is not None:
             self.unitRef = value
@@ -999,7 +999,7 @@ class SwDataDefProps(ARObject):
 
 class SwPointerTargetProps(ARObject):
     """
-    Properties for pointer targets including function pointer signature and target category.
+    This element defines, that the data object (which is specified by the aggregating element) contains a reference to another data object or to a function in the CPU code. This corresponds to a pointer in the C-language. The attributes of this element describe the category and the detailed properties of the target which is either a data description or a function signature.
     """
 
     # SwPointerTargetProps method parity checklist:
@@ -1007,8 +1007,8 @@ class SwPointerTargetProps(ARObject):
     # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__                       [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] getFunctionPointerSignatureRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
-    # [x] setFunctionPointerSignatureRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFunctionPointerSignatureRef [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setFunctionPointerSignatureRef [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
     # [x] getSwDataDefProps              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
     # [x] setSwDataDefProps              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
     # [x] getTargetCategory              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
@@ -1017,24 +1017,24 @@ class SwPointerTargetProps(ARObject):
     def __init__(self):
         super().__init__()
 
-        # The signature of the function the pointer refers to.
+        # The referenced BswModuleEntry serves as the signature of a function pointer definition. Primary use case: function pointer passed as argument to other function.
         self.functionPointerSignatureRef: Optional[RefType] = None
 
-        # The properties of the data which is referenced by the pointer.
+        # The properties of the target data type.
         self.swDataDefProps: Optional[SwDataDefProps] = None
 
-        # Specifies the category of the target (the object the pointer points to).
+        # This specifies the category of the target: • In case of a data pointer, it shall specify the category of the referenced data. • In case of a function pointer, it could be used to denote the category of the referenced BswModuleEntry.
         self.targetCategory: Optional[Identifier] = None
 
     def getFunctionPointerSignatureRef(self) -> Optional[RefType]:
         """
-        The signature of the function the pointer refers to.
+        The referenced BswModuleEntry serves as the signature of a function pointer definition. Primary use case: function pointer passed as argument to other function.
         """
         return self.functionPointerSignatureRef
 
     def setFunctionPointerSignatureRef(self, value: Optional[RefType]) -> "SwPointerTargetProps":
         """
-        The signature of the function the pointer refers to. A None value is a no-op and does not overwrite an existing functionPointerSignatureRef.
+        The referenced BswModuleEntry serves as the signature of a function pointer definition. Primary use case: function pointer passed as argument to other function. A None value is a no-op and does not overwrite an existing functionPointerSignatureRef.
         """
         if value is not None:
             self.functionPointerSignatureRef = value
@@ -1042,13 +1042,13 @@ class SwPointerTargetProps(ARObject):
 
     def getSwDataDefProps(self) -> Optional[SwDataDefProps]:
         """
-        The properties of the data which is referenced by the pointer.
+        The properties of the target data type.
         """
         return self.swDataDefProps
 
     def setSwDataDefProps(self, value: Optional[SwDataDefProps]) -> "SwPointerTargetProps":
         """
-        The properties of the data which is referenced by the pointer. A None value is a no-op and does not overwrite an existing swDataDefProps.
+        The properties of the target data type. A None value is a no-op and does not overwrite an existing swDataDefProps.
         """
         if value is not None:
             self.swDataDefProps = value
@@ -1056,13 +1056,13 @@ class SwPointerTargetProps(ARObject):
 
     def getTargetCategory(self) -> Optional[Identifier]:
         """
-        Specifies the category of the target (the object the pointer points to).
+        This specifies the category of the target: • In case of a data pointer, it shall specify the category of the referenced data. • In case of a function pointer, it could be used to denote the category of the referenced BswModuleEntry.
         """
         return self.targetCategory
 
     def setTargetCategory(self, value: Optional[Identifier]) -> "SwPointerTargetProps":
         """
-        Specifies the category of the target (the object the pointer points to). A None value is a no-op and does not overwrite an existing targetCategory.
+        This specifies the category of the target: • In case of a data pointer, it shall specify the category of the referenced data. • In case of a function pointer, it could be used to denote the category of the referenced BswModuleEntry. A None value is a no-op and does not overwrite an existing targetCategory.
         """
         if value is not None:
             self.targetCategory = value

--- a/src/armodel/models/M2/MSR/DataDictionary/DataDefProperties.py
+++ b/src/armodel/models/M2/MSR/DataDictionary/DataDefProperties.py
@@ -3,10 +3,27 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List, Optional
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARLiteral, Integer, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    AREnum,
+    ARNumerical,
+    ARFloat,
+    AlignmentType,
+    Boolean,
+    Identifier,
+    Integer,
+    NativeDeclarationString,
+    PrimitiveIdentifier,
+    RefType,
+    DisplayFormatString,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
 
 if TYPE_CHECKING:
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.Constants import ValueSpecification
     from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes import ArraySizeSemanticsEnum
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AutosarVariableRef import AutosarVariableRef
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.InstanceRefsUsage import AutosarParameterRef
+    from armodel.models.M2.MSR.DataDictionary.CalibrationParameter import SwCalprmAxisSet
 
 
 class SwImplPolicyEnum(AREnum):
@@ -33,7 +50,11 @@ class SwImplPolicyEnum(AREnum):
     """
 
     # SwImplPolicyEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.45, p.336
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods) — enum value form serialized on SwDataDefProps.swImplPolicy
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     CONST = "const"
     FIXED = "fixed"
@@ -45,376 +66,1006 @@ class SwImplPolicyEnum(AREnum):
         super().__init__([SwImplPolicyEnum.CONST, SwImplPolicyEnum.FIXED, SwImplPolicyEnum.MEASUREMENT_POINT, SwImplPolicyEnum.QUEUED, SwImplPolicyEnum.STANDARD])
 
 
-class SwDataDefPropsConditional(ARObject):
+class SwCalibrationAccessEnum(AREnum):
     """
-    Patch for the time-stamp
+    Determines the access rights to a data object w.r.t. measurement and calibration.
     """
 
-    # SwDataDefPropsConditional method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # SwCalibrationAccessEnum method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.44, p.335
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods) — enum value form serialized on SwDataDefProps.swCalibrationAccess
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+
+    # The element will not be accessible via MCD tools, i.e. will not appear in the ASAP file. Tags: atp.EnumerationLiteralIndex=0
+    NOT_ACCESSIBLE = "notAccessible"
+
+    # The element will only appear as read-only in an ASAP file. Tags: atp.EnumerationLiteralIndex=1
+    READ_ONLY = "readOnly"
+
+    # The element will appear in the ASAP file with both read and write access. Tags: atp.EnumerationLiteralIndex=2
+    READ_WRITE = "readWrite"
+
+    def __init__(self):
+        super().__init__([SwCalibrationAccessEnum.NOT_ACCESSIBLE, SwCalibrationAccessEnum.READ_ONLY, SwCalibrationAccessEnum.READ_WRITE])
+
+
+class DisplayPresentationEnum(AREnum):
+    """
+    This meta-class represents the ability to provide values for controlling the presentation of data within measurement and calibration tools.
+    """
+
+    # DisplayPresentationEnum method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.107, p.432
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods) — enum value form serialized on SwDataDefProps.displayPresentation
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+
+    # The presentation of data shall form a continuous graph between data points. Tags: atp.EnumerationLiteralIndex=0
+    PRESENTATION_CONTINUOUS = "presentationContinuous"
+
+    # The presentation of data shall be step-shaped between data points. Tags: atp.EnumerationLiteralIndex=1
+    PRESENTATION_DISCRETE = "presentationDiscrete"
+
+    def __init__(self):
+        super().__init__([DisplayPresentationEnum.PRESENTATION_CONTINUOUS, DisplayPresentationEnum.PRESENTATION_DISCRETE])
+
+
+class SwBitRepresentation(ARObject):
+    """
+    Description of the structure of a bit variable: Comprises of the bitPosition in a memory object (e.g. sw HostVariable, which stands parallel to swBitRepresentation) and the numberOfBits . In this way, interrelated memory areas can be described. Non-related memory areas are not supported.
+    """
+
+    # SwBitRepresentation method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.41, p.333
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                 [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBitPosition           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBitPosition           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getNumberOfBits          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setNumberOfBits          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
+
+        # If the "bit data object" is hosted within another data object (e.g. if the memory can be accessed via byte as well as bit address), this attribute specifies the position of the data object. The count starts at zero (0). Tags: xml.sequenceOffset=20
+        self.bitPosition: Optional[Integer] = None
+
+        # Number of bits allocated by a "bit data object" within its host data object. Tags: xml.sequenceOffset=30
+        self.numberOfBits: Optional[Integer] = None
+
+    def getBitPosition(self) -> Optional[Integer]:
+        """
+        If the "bit data object" is hosted within another data object (e.g. if the memory can be accessed via byte as well as bit address), this attribute specifies the position of the data object. The count starts at zero (0).
+        """
+        return self.bitPosition
+
+    def setBitPosition(self, value: Optional[Integer]) -> "SwBitRepresentation":
+        """
+        If the "bit data object" is hosted within another data object (e.g. if the memory can be accessed via byte as well as bit address), this attribute specifies the position of the data object. The count starts at zero (0). A None value is a no-op and does not overwrite an existing bitPosition.
+        """
+        if value is not None:
+            self.bitPosition = value
+        return self
+
+    def getNumberOfBits(self) -> Optional[Integer]:
+        """
+        Number of bits allocated by a "bit data object" within its host data object.
+        """
+        return self.numberOfBits
+
+    def setNumberOfBits(self, value: Optional[Integer]) -> "SwBitRepresentation":
+        """
+        Number of bits allocated by a "bit data object" within its host data object. A None value is a no-op and does not overwrite an existing numberOfBits.
+        """
+        if value is not None:
+            self.numberOfBits = value
+        return self
+
+
+class SwVariableRefProxy(ARObject):
+    """
+    Proxy class for several kinds of references to a variable.
+    """
+
+    # SwVariableRefProxy method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.57, p.370
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                 [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getAutosarVariable       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setAutosarVariable       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMcDataInstanceVarRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMcDataInstanceVarRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This represents the reference to a Variable in an Autosar system. Note that the target of the reference within AutosarVariableRef shall be typed by a primitive data type
+        self.autosarVariable: Optional["AutosarVariableRef"] = None
+
+        # This reference is used in the McSupport file to express the final instance of input values etc. It is not allowed to use this outside of an McDataInstance. The referenced mcDataInstance shall be originated from a VariableDataPrototype.
+        self.mcDataInstanceVarRef: Optional[RefType] = None
+
+    def getAutosarVariable(self) -> Optional["AutosarVariableRef"]:
+        """
+        This represents the reference to a Variable in an Autosar system. Note that the target of the reference within AutosarVariableRef shall be typed by a primitive data type.
+        """
+        return self.autosarVariable
+
+    def setAutosarVariable(self, value: Optional["AutosarVariableRef"]) -> "SwVariableRefProxy":
+        """
+        This represents the reference to a Variable in an Autosar system. Note that the target of the reference within AutosarVariableRef shall be typed by a primitive data type. A None value is a no-op and does not overwrite an existing autosarVariable.
+        """
+        if value is not None:
+            self.autosarVariable = value
+        return self
+
+    def getMcDataInstanceVarRef(self) -> Optional[RefType]:
+        """
+        This reference is used in the McSupport file to express the final instance of input values etc. It is not allowed to use this outside of an McDataInstance. The referenced mcDataInstance shall be originated from a VariableDataPrototype.
+        """
+        return self.mcDataInstanceVarRef
+
+    def setMcDataInstanceVarRef(self, value: Optional[RefType]) -> "SwVariableRefProxy":
+        """
+        This reference is used in the McSupport file to express the final instance of input values etc. It is not allowed to use this outside of an McDataInstance. The referenced mcDataInstance shall be originated from a VariableDataPrototype. A None value is a no-op and does not overwrite an existing mcDataInstanceVarRef.
+        """
+        if value is not None:
+            self.mcDataInstanceVarRef = value
+        return self
+
+
+class SwCalprmRefProxy(ARObject):
+    """
+    Proxy class for several kinds of references to a calibration parameter.
+    """
+
+    # SwCalprmRefProxy method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.56, p.370
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                 [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getArParameter           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setArParameter           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMcDataInstanceRef     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMcDataInstanceRef     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This represents the reference to a calibration parameter in an Autosar system.
+        self.arParameter: Optional["AutosarParameterRef"] = None
+
+        # This reference is used in the McSupport file to express the final instance of input values etc.
+        self.mcDataInstanceRef: Optional[RefType] = None
+
+    def getArParameter(self) -> Optional["AutosarParameterRef"]:
+        """
+        This represents the reference to a calibration parameter in an Autosar system.
+        """
+        return self.arParameter
+
+    def setArParameter(self, value: Optional["AutosarParameterRef"]) -> "SwCalprmRefProxy":
+        """
+        This represents the reference to a calibration parameter in an Autosar system. A None value is a no-op and does not overwrite an existing arParameter.
+        """
+        if value is not None:
+            self.arParameter = value
+        return self
+
+    def getMcDataInstanceRef(self) -> Optional[RefType]:
+        """
+        This reference is used in the McSupport file to express the final instance of input values etc.
+        """
+        return self.mcDataInstanceRef
+
+    def setMcDataInstanceRef(self, value: Optional[RefType]) -> "SwCalprmRefProxy":
+        """
+        This reference is used in the McSupport file to express the final instance of input values etc. A None value is a no-op and does not overwrite an existing mcDataInstanceRef.
+        """
+        if value is not None:
+            self.mcDataInstanceRef = value
+        return self
+
+
+class SwDataDependencyArgs(ARObject):
+    """
+    This element specifies the elements used in a SwDataDependency.
+    """
+
+    # SwDataDependencyArgs method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.59, p.374
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                 [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getSwCalprmRef           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwCalprmRef           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwVariable            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwVariable            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This property specifies the calibration parameter which serves as the input axis.
+        self.swCalprmRef: Optional[SwCalprmRefProxy] = None
+
+        # This property specifies the variable which is used in the data dependency.
+        self.swVariable: Optional[SwVariableRefProxy] = None
+
+    def getSwCalprmRef(self) -> Optional[SwCalprmRefProxy]:
+        """
+        This property specifies the calibration parameter which serves as the input axis.
+        """
+        return self.swCalprmRef
+
+    def setSwCalprmRef(self, value: Optional[SwCalprmRefProxy]) -> "SwDataDependencyArgs":
+        """
+        This property specifies the calibration parameter which serves as the input axis. A None value is a no-op and does not overwrite an existing swCalprmRef.
+        """
+        if value is not None:
+            self.swCalprmRef = value
+        return self
+
+    def getSwVariable(self) -> Optional[SwVariableRefProxy]:
+        """
+        This property specifies the variable which is used in the data dependency.
+        """
+        return self.swVariable
+
+    def setSwVariable(self, value: Optional[SwVariableRefProxy]) -> "SwDataDependencyArgs":
+        """
+        This property specifies the variable which is used in the data dependency. A None value is a no-op and does not overwrite an existing swVariable.
+        """
+        if value is not None:
+            self.swVariable = value
+        return self
+
+
+class CompuGenericMath(ARObject):
+    """
+    This meta-class represents the ability to specify a generic formula expression.
+    """
+
+    # CompuGenericMath method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.60, p.374
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                 [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getLevel                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setLevel                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # Placeholder to describe an indicator of a language level for the mathematics e.g. INFORMAL, ASAMHDO. May be refined by particular use-cases.
+        self.level: Optional[PrimitiveIdentifier] = None
+
+    def getLevel(self) -> Optional[PrimitiveIdentifier]:
+        """
+        Placeholder to describe an indicator of a language level for the mathematics e.g. INFORMAL, ASAMHDO. May be refined by particular use-cases.
+        """
+        return self.level
+
+    def setLevel(self, value: Optional[PrimitiveIdentifier]) -> "CompuGenericMath":
+        """
+        Placeholder to describe an indicator of a language level for the mathematics e.g. INFORMAL, ASAMHDO. May be refined by particular use-cases. A None value is a no-op and does not overwrite an existing level.
+        """
+        if value is not None:
+            self.level = value
+        return self
+
+
+class SwDataDependency(ARObject):
+    """
+    This element describes the interdependencies of data objects, e.g. variables and parameters. Use cases: Calculate the value of a calibration parameter (by the MCD system) from the value(s) of other calibration parameters. Virtual data - that means the data object is not directly in the ecu and this property describes how the "virtual variable" can be computed from the real ones (by the MCD system).
+    """
+
+    # SwDataDependency method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.58, p.374
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                       [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getSwDataDependencyFormula     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwDataDependencyFormula     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwDataDependencyArgs        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwDataDependencyArgs        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This element describes the formula with which the dependencies between the participating objects are defined. Tags: xml.sequenceOffset=30
+        self.swDataDependencyFormula: Optional[CompuGenericMath] = None
+
+        # Specifies the arguments used in the data dependency. Note that this is 0..1 since the aggregated class is a container (atpMixed). Tags: xml.sequenceOffset=40
+        self.swDataDependencyArgs: Optional[SwDataDependencyArgs] = None
+
+    def getSwDataDependencyFormula(self) -> Optional[CompuGenericMath]:
+        """
+        This element describes the formula with which the dependencies between the participating objects are defined.
+        """
+        return self.swDataDependencyFormula
+
+    def setSwDataDependencyFormula(self, value: Optional[CompuGenericMath]) -> "SwDataDependency":
+        """
+        This element describes the formula with which the dependencies between the participating objects are defined. A None value is a no-op and does not overwrite an existing swDataDependencyFormula.
+        """
+        if value is not None:
+            self.swDataDependencyFormula = value
+        return self
+
+    def getSwDataDependencyArgs(self) -> Optional[SwDataDependencyArgs]:
+        """
+        Specifies the arguments used in the data dependency. Note that this is 0..1 since the aggregated class is a container (atpMixed).
+        """
+        return self.swDataDependencyArgs
+
+    def setSwDataDependencyArgs(self, value: Optional[SwDataDependencyArgs]) -> "SwDataDependency":
+        """
+        Specifies the arguments used in the data dependency. Note that this is 0..1 since the aggregated class is a container (atpMixed). A None value is a no-op and does not overwrite an existing swDataDependencyArgs.
+        """
+        if value is not None:
+            self.swDataDependencyArgs = value
+        return self
 
 
 class SwDataDefProps(ARObject):
     """
-    Software data definition properties describing data characteristics
-    including type references, calibration parameters, memory addressing,
-    and display properties.
+    The properties of data are summarized in the meta-class SwDataDefProps. This meta-class itself is the superset of all applicable properties.
     """
 
     # SwDataDefProps method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getAdditionalNativeTypeQualifier [x] impl  [ ] docstring  [ ] test
-    # [ ] setAdditionalNativeTypeQualifier [x] impl  [ ] docstring  [ ] test
-    # [ ] getAnnotations               [x] impl  [ ] docstring  [ ] test
-    # [ ] addAnnotation                [x] impl  [ ] docstring  [ ] test
-    # [ ] getBaseTypeRef               [x] impl  [ ] docstring  [ ] test
-    # [ ] setBaseTypeRef               [x] impl  [ ] docstring  [ ] test
-    # [ ] getCompuMethodRef            [x] impl  [ ] docstring  [ ] test
-    # [ ] setCompuMethodRef            [x] impl  [ ] docstring  [ ] test
-    # [ ] getDataConstrRef             [x] impl  [ ] docstring  [ ] test
-    # [ ] setDataConstrRef             [x] impl  [ ] docstring  [ ] test
-    # [ ] getDisplayFormat             [x] impl  [ ] docstring  [ ] test
-    # [ ] setDisplayFormat             [x] impl  [ ] docstring  [ ] test
-    # [ ] getDisplayPresentation       [x] impl  [ ] docstring  [ ] test
-    # [ ] setDisplayPresentation       [x] impl  [ ] docstring  [ ] test
-    # [ ] getImplementationDataTypeRef [x] impl  [ ] docstring  [ ] test
-    # [ ] setImplementationDataTypeRef [x] impl  [ ] docstring  [ ] test
-    # [ ] getInvalidValue              [x] impl  [ ] docstring  [ ] test
-    # [ ] setInvalidValue              [x] impl  [ ] docstring  [ ] test
-    # [ ] getStepSize                  [x] impl  [ ] docstring  [ ] test
-    # [ ] setStepSize                  [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwAddrMethodRef           [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwAddrMethodRef           [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwAlignment               [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwAlignment               [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwBitRepresentation       [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwBitRepresentation       [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwCalibrationAccess       [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwCalibrationAccess       [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwCalprmAxisSet           [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwCalprmAxisSet           [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwComparisonVariables     [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwComparisonVariables     [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwDataDependency          [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwDataDependency          [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwHostVariable            [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwHostVariable            [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwImplPolicy              [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwImplPolicy              [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwIntendedResolution      [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwIntendedResolution      [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwInterpolationMethod     [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwInterpolationMethod     [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwIsVirtual               [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwIsVirtual               [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwPointerTargetProps      [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwPointerTargetProps      [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwRecordLayoutRef         [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwRecordLayoutRef         [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwRefreshTiming           [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwRefreshTiming           [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwTextProps               [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwTextProps               [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwValueBlockSize          [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwValueBlockSize          [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwValueBlockSizeMults     [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwValueBlockSizeMults     [x] impl  [ ] docstring  [ ] test
-    # [ ] getUnitRef                   [x] impl  [ ] docstring  [ ] test
-    # [ ] setUnitRef                   [x] impl  [ ] docstring  [ ] test
-    # [ ] getValueAxisDataTypeRef      [x] impl  [ ] docstring  [ ] test
-    # [ ] setValueAxisDataTypeRef      [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.39, p.332
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                       [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getDisplayPresentation         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDisplayPresentation         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getStepSize                    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setStepSize                    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwValueBlockSizeMults       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addSwValueBlockSizeMult        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getAnnotations                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addAnnotation                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwAddrMethodRef             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwAddrMethodRef             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwAlignment                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwAlignment                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getBaseTypeRef                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBaseTypeRef                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwBitRepresentation         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwBitRepresentation         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwCalibrationAccess         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwCalibrationAccess         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwValueBlockSize            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwValueBlockSize            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwCalprmAxisSet             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwCalprmAxisSet             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwTextProps                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwTextProps                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwComparisonVariables       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addSwComparisonVariable        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCompuMethodRef              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCompuMethodRef              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDataConstrRef               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDataConstrRef               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwDataDependency            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwDataDependency            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDisplayFormat               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDisplayFormat               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getImplementationDataTypeRef   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setImplementationDataTypeRef   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwHostVariable              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwHostVariable              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwImplPolicy                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwImplPolicy                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getAdditionalNativeTypeQualifier [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setAdditionalNativeTypeQualifier [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwIntendedResolution        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwIntendedResolution        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwInterpolationMethod       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwInterpolationMethod       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getInvalidValue                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setInvalidValue                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwIsVirtual                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwIsVirtual                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwPointerTargetProps        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwPointerTargetProps        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwRecordLayoutRef           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwRecordLayoutRef           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwRefreshTiming             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwRefreshTiming             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getUnitRef                     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setUnitRef                     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getValueAxisDataTypeRef        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setValueAxisDataTypeRef        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.additionalNativeTypeQualifier = None
-        self.annotations = []  # type: List[Annotation]
-        self.baseTypeRef = None  # type: RefType
-        self.compuMethodRef = None  # type: RefType
-        self.dataConstrRef = None  # type: RefType
-        self.displayFormat = None  # type: ARLiteral
-        self.displayPresentation = None  # type: ARLiteral
-        self.implementationDataTypeRef = None  # type: RefType
-        self.invalidValue = None  # type: ValueSpecification
-        self.stepSize = None  # type: ARFloat
-        self.swAddrMethodRef = None  # type: RefType
-        self.swAlignment = None  # type: ARLiteral
-        self.swBitRepresentation = None  # type: ARLiteral
-        self.swCalibrationAccess = None  # type: ARLiteral
-        self.swCalprmAxisSet = None  # type: SwCalprmAxisSet
-        self.swComparisonVariables = []
-        self.swDataDependency = None
-        self.swHostVariable = None
-        self.swImplPolicy = None  # type: ARLiteral
-        self.swIntendedResolution = None
-        self.swInterpolationMethod = None
-        self.swIsVirtual = None
-        self.swPointerTargetProps = None  # type: SwPointerTargetProps
-        self.swRecordLayoutRef = None  # type: RefType
-        self.swRefreshTiming = None
-        self.swTextProps = None
-        self.swValueBlockSize = None
-        self.swValueBlockSizeMults = []
-        self.unitRef = None  # type: RefType
-        self.valueAxisDataTypeRef = None  # type: RefType
+        # This attribute controls the presentation of the related data for measurement and calibration tools.
+        self.displayPresentation: Optional[DisplayPresentationEnum] = None
 
-        self.conditional = SwDataDefPropsConditional()  # type: SwDataDefPropsConditional
+        # This attribute can be used to define a value which is added to or subtracted from the value of a DataPrototype when using up/down keys while calibrating.
+        self.stepSize: Optional[ARFloat] = None
 
-    def getAdditionalNativeTypeQualifier(self):
-        return self.additionalNativeTypeQualifier
+        # This attribute is used to specify the dimensions of a value block (VAL_BLK) for the case that that value block has more than one dimension. The dimensions given in this attribute are ordered such that the first entry represents the first dimension, the second entry represents the second dimension, and so on. For one-dimensional value blocks the attribute swValueBlockSize shall be used and this attribute shall not exist.
+        self.swValueBlockSizeMults: List[ARNumerical] = []
 
-    def setAdditionalNativeTypeQualifier(self, value):
-        self.additionalNativeTypeQualifier = value
+        # This aggregation allows to add annotations (yellow pads ...) related to the current data object.
+        self.annotations: List[Annotation] = []
+
+        # Addressing method related to this data object. Via an association to the same SwAddrMethod it can be specified that several DataPrototypes shall be located in the same memory without already specifying the memory section itself.
+        self.swAddrMethodRef: Optional[RefType] = None
+
+        # The attribute describes the intended alignment of the DataPrototype. If the attribute is not defined the alignment is determined by the swBaseType size and the memoryAllocationKeywordPolicy of the referenced SwAddrMethod.
+        self.swAlignment: Optional[AlignmentType] = None
+
+        # Base type associated with the containing data object.
+        self.baseTypeRef: Optional[RefType] = None
+
+        # Description of the binary representation in case of a bit variable.
+        self.swBitRepresentation: Optional[SwBitRepresentation] = None
+
+        # Specifies the read or write access by MCD tools for this data object.
+        self.swCalibrationAccess: Optional[SwCalibrationAccessEnum] = None
+
+        # This represents the size of a Value Block
+        self.swValueBlockSize: Optional[ARNumerical] = None
+
+        # This specifies the properties of the axes in case of a curve or map etc. This is mainly applicable to calibration parameters.
+        self.swCalprmAxisSet: Optional[SwCalprmAxisSet] = None
+
+        # the specific properties if the data object is a text object.
+        self.swTextProps: Optional[SwTextProps] = None
+
+        # This element is used to express that a data object is a comparison variable.
+        self.swComparisonVariables: List[SwVariableRefProxy] = []
+
+        # Compu method associated with the containing data object.
+        self.compuMethodRef: Optional[RefType] = None
+
+        # Data constraint associated with the containing data object.
+        self.dataConstrRef: Optional[RefType] = None
+
+        # This element describes the interdependencies of data objects, e.g. variables and parameters.
+        self.swDataDependency: Optional[SwDataDependency] = None
+
+        # This is a display format specifier for the display of values e.g. in documents or in measurement and calibration systems.
+        self.displayFormat: Optional[DisplayFormatString] = None
+
+        # This association denotes the ImplementationDataType of a data declaration via its aggregated SwDataDefProps.
+        self.implementationDataTypeRef: Optional[RefType] = None
+
+        # Proxy class for several kinds of references to a variable.
+        self.swHostVariable: Optional[SwVariableRefProxy] = None
+
+        # This indicates the intended implementation policy of the data object.
+        self.swImplPolicy: Optional[SwImplPolicyEnum] = None
+
+        # This string contains a native data declaration of a data type in a programming language. It is basically a string, but white-space shall be preserved.
+        self.additionalNativeTypeQualifier: Optional[NativeDeclarationString] = None
+
+        # This attribute can be used to specify the intended resolution of the data object.
+        self.swIntendedResolution: Optional[ARNumerical] = None
+
+        # This is the name of the interpolation method which is implemented by the referenced bswModuleEntry. It corresponds to swInterpolationMethod in SwDataDefProps.
+        self.swInterpolationMethod: Optional[Identifier] = None
+
+        # The value which indicates that the data object is invalid.
+        self.invalidValue: Optional[ValueSpecification] = None
+
+        # This element distinguishes virtual objects. Virtual objects do not appear in the memory, their derivation is much more dependent on other objects and hence they shall have a swDataDependency.
+        self.swIsVirtual: Optional[Boolean] = None
+
+        # Specifies that the containing data object is a pointer to another data object.
+        self.swPointerTargetProps: Optional[SwPointerTargetProps] = None
+
+        # Record layout for this data object.
+        self.swRecordLayoutRef: Optional[RefType] = None
+
+        # This element specifies the frequency in which the object involved shall be or is called or calculated.
+        self.swRefreshTiming: Optional[MultidimensionalTime] = None
+
+        # Physical unit associated with the semantics of this data object. This attribute applies if no compuMethod is specified.
+        self.unitRef: Optional[RefType] = None
+
+        # The referenced ApplicationPrimitiveDataType represents the primitive data type of the value axis within a compound primitive (e.g. curve, map). It supersedes CompuMethod, Unit, and BaseType.
+        self.valueAxisDataTypeRef: Optional[RefType] = None
+
+    def getDisplayPresentation(self) -> Optional[DisplayPresentationEnum]:
+        """
+        This attribute controls the presentation of the related data for measurement and calibration tools.
+        """
+        return self.displayPresentation
+
+    def setDisplayPresentation(self, value: Optional[DisplayPresentationEnum]) -> "SwDataDefProps":
+        """
+        This attribute controls the presentation of the related data for measurement and calibration tools. A None value is a no-op and does not overwrite an existing displayPresentation.
+        """
+        if value is not None:
+            self.displayPresentation = value
+        return self
+
+    def getStepSize(self) -> Optional[ARFloat]:
+        """
+        This attribute can be used to define a value which is added to or subtracted from the value of a DataPrototype when using up/down keys while calibrating.
+        """
+        return self.stepSize
+
+    def setStepSize(self, value: Optional[ARFloat]) -> "SwDataDefProps":
+        """
+        This attribute can be used to define a value which is added to or subtracted from the value of a DataPrototype when using up/down keys while calibrating. A None value is a no-op and does not overwrite an existing stepSize.
+        """
+        if value is not None:
+            self.stepSize = value
+        return self
+
+    def getSwValueBlockSizeMults(self) -> List[ARNumerical]:
+        """
+        This attribute is used to specify the dimensions of a value block (VAL_BLK) for the case that that value block has more than one dimension. The dimensions given in this attribute are ordered such that the first entry represents the first dimension, the second entry represents the second dimension, and so on. For one-dimensional value blocks the attribute swValueBlockSize shall be used and this attribute shall not exist.
+        """
+        return self.swValueBlockSizeMults
+
+    def addSwValueBlockSizeMult(self, value: Optional[ARNumerical]) -> "SwDataDefProps":
+        """
+        This attribute is used to specify the dimensions of a value block (VAL_BLK) for the case that that value block has more than one dimension. Appends a dimension to the ordered list. A None value is a no-op.
+        """
+        if value is not None:
+            self.swValueBlockSizeMults.append(value)
         return self
 
     def getAnnotations(self) -> List[Annotation]:
+        """
+        This aggregation allows to add annotations (yellow pads ...) related to the current data object.
+        """
         return self.annotations
 
-    def addAnnotation(self, annotation: Annotation):
-        self.annotations.append(annotation)
+    def addAnnotation(self, annotation: Annotation) -> "SwDataDefProps":
+        """
+        This aggregation allows to add annotations (yellow pads ...) related to the current data object. A None value is a no-op.
+        """
+        if annotation is not None:
+            self.annotations.append(annotation)
         return self
 
-    def getBaseTypeRef(self):
-        return self.baseTypeRef
-
-    def setBaseTypeRef(self, value):
-        self.baseTypeRef = value
-        return self
-
-    def getCompuMethodRef(self):
-        return self.compuMethodRef
-
-    def setCompuMethodRef(self, value):
-        self.compuMethodRef = value
-        return self
-
-    def getDataConstrRef(self):
-        return self.dataConstrRef
-
-    def setDataConstrRef(self, value):
-        self.dataConstrRef = value
-        return self
-
-    def getDisplayFormat(self):
-        return self.displayFormat
-
-    def setDisplayFormat(self, value):
-        self.displayFormat = value
-        return self
-
-    def getDisplayPresentation(self):
-        return self.displayPresentation
-
-    def setDisplayPresentation(self, value):
-        self.displayPresentation = value
-        return self
-
-    def getImplementationDataTypeRef(self):
-        return self.implementationDataTypeRef
-
-    def setImplementationDataTypeRef(self, value):
-        self.implementationDataTypeRef = value
-        return self
-
-    def getInvalidValue(self):
-        return self.invalidValue
-
-    def setInvalidValue(self, value):
-        self.invalidValue = value
-        return self
-
-    def getStepSize(self):
-        return self.stepSize
-
-    def setStepSize(self, value):
-        self.stepSize = value
-        return self
-
-    def getSwAddrMethodRef(self):
+    def getSwAddrMethodRef(self) -> Optional[RefType]:
+        """
+        Addressing method related to this data object. Via an association to the same SwAddrMethod it can be specified that several DataPrototypes shall be located in the same memory without already specifying the memory section itself.
+        """
         return self.swAddrMethodRef
 
-    def setSwAddrMethodRef(self, value):
-        self.swAddrMethodRef = value
+    def setSwAddrMethodRef(self, value: Optional[RefType]) -> "SwDataDefProps":
+        """
+        Addressing method related to this data object. Via an association to the same SwAddrMethod it can be specified that several DataPrototypes shall be located in the same memory without already specifying the memory section itself. A None value is a no-op and does not overwrite an existing swAddrMethodRef.
+        """
+        if value is not None:
+            self.swAddrMethodRef = value
         return self
 
-    def getSwAlignment(self):
+    def getSwAlignment(self) -> Optional[AlignmentType]:
+        """
+        The attribute describes the intended alignment of the DataPrototype. If the attribute is not defined the alignment is determined by the swBaseType size and the memoryAllocationKeywordPolicy of the referenced SwAddrMethod.
+        """
         return self.swAlignment
 
-    def setSwAlignment(self, value):
-        self.swAlignment = value
+    def setSwAlignment(self, value: Optional[AlignmentType]) -> "SwDataDefProps":
+        """
+        The attribute describes the intended alignment of the DataPrototype. If the attribute is not defined the alignment is determined by the swBaseType size and the memoryAllocationKeywordPolicy of the referenced SwAddrMethod. A None value is a no-op and does not overwrite an existing swAlignment.
+        """
+        if value is not None:
+            self.swAlignment = value
         return self
 
-    def getSwBitRepresentation(self):
+    def getBaseTypeRef(self) -> Optional[RefType]:
+        """
+        Base type associated with the containing data object.
+        """
+        return self.baseTypeRef
+
+    def setBaseTypeRef(self, value: Optional[RefType]) -> "SwDataDefProps":
+        """
+        Base type associated with the containing data object. A None value is a no-op and does not overwrite an existing baseTypeRef.
+        """
+        if value is not None:
+            self.baseTypeRef = value
+        return self
+
+    def getSwBitRepresentation(self) -> Optional[SwBitRepresentation]:
+        """
+        Description of the binary representation in case of a bit variable.
+        """
         return self.swBitRepresentation
 
-    def setSwBitRepresentation(self, value):
-        self.swBitRepresentation = value
+    def setSwBitRepresentation(self, value: Optional[SwBitRepresentation]) -> "SwDataDefProps":
+        """
+        Description of the binary representation in case of a bit variable. A None value is a no-op and does not overwrite an existing swBitRepresentation.
+        """
+        if value is not None:
+            self.swBitRepresentation = value
         return self
 
-    def getSwCalibrationAccess(self):
+    def getSwCalibrationAccess(self) -> Optional[SwCalibrationAccessEnum]:
+        """
+        Specifies the read or write access by MCD tools for this data object.
+        """
         return self.swCalibrationAccess
 
-    def setSwCalibrationAccess(self, value):
-        self.swCalibrationAccess = value
+    def setSwCalibrationAccess(self, value: Optional[SwCalibrationAccessEnum]) -> "SwDataDefProps":
+        """
+        Specifies the read or write access by MCD tools for this data object. A None value is a no-op and does not overwrite an existing swCalibrationAccess.
+        """
+        if value is not None:
+            self.swCalibrationAccess = value
         return self
 
-    def getSwCalprmAxisSet(self):
-        return self.swCalprmAxisSet
-
-    def setSwCalprmAxisSet(self, value):
-        self.swCalprmAxisSet = value
-        return self
-
-    def getSwComparisonVariables(self):
-        return self.swComparisonVariables
-
-    def setSwComparisonVariables(self, value):
-        self.swComparisonVariables = value
-        return self
-
-    def getSwDataDependency(self):
-        return self.swDataDependency
-
-    def setSwDataDependency(self, value):
-        self.swDataDependency = value
-        return self
-
-    def getSwHostVariable(self):
-        return self.swHostVariable
-
-    def setSwHostVariable(self, value):
-        self.swHostVariable = value
-        return self
-
-    def getSwImplPolicy(self):
-        return self.swImplPolicy
-
-    def setSwImplPolicy(self, value):
-        self.swImplPolicy = value
-        return self
-
-    def getSwIntendedResolution(self):
-        return self.swIntendedResolution
-
-    def setSwIntendedResolution(self, value):
-        self.swIntendedResolution = value
-        return self
-
-    def getSwInterpolationMethod(self):
-        return self.swInterpolationMethod
-
-    def setSwInterpolationMethod(self, value):
-        self.swInterpolationMethod = value
-        return self
-
-    def getSwIsVirtual(self):
-        return self.swIsVirtual
-
-    def setSwIsVirtual(self, value):
-        self.swIsVirtual = value
-        return self
-
-    def getSwPointerTargetProps(self):
-        return self.swPointerTargetProps
-
-    def setSwPointerTargetProps(self, value):
-        self.swPointerTargetProps = value
-        return self
-
-    def getSwRecordLayoutRef(self):
-        return self.swRecordLayoutRef
-
-    def setSwRecordLayoutRef(self, value):
-        self.swRecordLayoutRef = value
-        return self
-
-    def getSwRefreshTiming(self):
-        return self.swRefreshTiming
-
-    def setSwRefreshTiming(self, value):
-        self.swRefreshTiming = value
-        return self
-
-    def getSwTextProps(self):
-        return self.swTextProps
-
-    def setSwTextProps(self, value):
-        self.swTextProps = value
-        return self
-
-    def getSwValueBlockSize(self):
+    def getSwValueBlockSize(self) -> Optional[ARNumerical]:
+        """
+        This represents the size of a Value Block
+        """
         return self.swValueBlockSize
 
-    def setSwValueBlockSize(self, value):
-        self.swValueBlockSize = value
+    def setSwValueBlockSize(self, value: Optional[ARNumerical]) -> "SwDataDefProps":
+        """
+        This represents the size of a Value Block A None value is a no-op and does not overwrite an existing swValueBlockSize.
+        """
+        if value is not None:
+            self.swValueBlockSize = value
         return self
 
-    def getSwValueBlockSizeMults(self):
-        return self.swValueBlockSizeMults
+    def getSwCalprmAxisSet(self) -> Optional[SwCalprmAxisSet]:
+        """
+        This specifies the properties of the axes in case of a curve or map etc. This is mainly applicable to calibration parameters.
+        """
+        return self.swCalprmAxisSet
 
-    def setSwValueBlockSizeMults(self, value):
-        self.swValueBlockSizeMults = value
+    def setSwCalprmAxisSet(self, value: Optional[SwCalprmAxisSet]) -> "SwDataDefProps":
+        """
+        This specifies the properties of the axes in case of a curve or map etc. This is mainly applicable to calibration parameters. A None value is a no-op and does not overwrite an existing swCalprmAxisSet.
+        """
+        if value is not None:
+            self.swCalprmAxisSet = value
         return self
 
-    def getUnitRef(self):
+    def getSwTextProps(self) -> Optional[SwTextProps]:
+        """
+        the specific properties if the data object is a text object.
+        """
+        return self.swTextProps
+
+    def setSwTextProps(self, value: Optional[SwTextProps]) -> "SwDataDefProps":
+        """
+        the specific properties if the data object is a text object. A None value is a no-op and does not overwrite an existing swTextProps.
+        """
+        if value is not None:
+            self.swTextProps = value
+        return self
+
+    def getSwComparisonVariables(self) -> List[SwVariableRefProxy]:
+        """
+        This element is used to express that a data object is a comparison variable.
+        """
+        return self.swComparisonVariables
+
+    def addSwComparisonVariable(self, value: Optional[SwVariableRefProxy]) -> "SwDataDefProps":
+        """
+        This element is used to express that a data object is a comparison variable. Appends a comparison variable. A None value is a no-op.
+        """
+        if value is not None:
+            self.swComparisonVariables.append(value)
+        return self
+
+    def getCompuMethodRef(self) -> Optional[RefType]:
+        """
+        Compu method associated with the containing data object.
+        """
+        return self.compuMethodRef
+
+    def setCompuMethodRef(self, value: Optional[RefType]) -> "SwDataDefProps":
+        """
+        Compu method associated with the containing data object. A None value is a no-op and does not overwrite an existing compuMethodRef.
+        """
+        if value is not None:
+            self.compuMethodRef = value
+        return self
+
+    def getDataConstrRef(self) -> Optional[RefType]:
+        """
+        Data constraint associated with the containing data object.
+        """
+        return self.dataConstrRef
+
+    def setDataConstrRef(self, value: Optional[RefType]) -> "SwDataDefProps":
+        """
+        Data constraint associated with the containing data object. A None value is a no-op and does not overwrite an existing dataConstrRef.
+        """
+        if value is not None:
+            self.dataConstrRef = value
+        return self
+
+    def getSwDataDependency(self) -> Optional[SwDataDependency]:
+        """
+        This element describes the interdependencies of data objects, e.g. variables and parameters.
+        """
+        return self.swDataDependency
+
+    def setSwDataDependency(self, value: Optional[SwDataDependency]) -> "SwDataDefProps":
+        """
+        This element describes the interdependencies of data objects, e.g. variables and parameters. A None value is a no-op and does not overwrite an existing swDataDependency.
+        """
+        if value is not None:
+            self.swDataDependency = value
+        return self
+
+    def getDisplayFormat(self) -> Optional[DisplayFormatString]:
+        """
+        This is a display format specifier for the display of values e.g. in documents or in measurement and calibration systems.
+        """
+        return self.displayFormat
+
+    def setDisplayFormat(self, value: Optional[DisplayFormatString]) -> "SwDataDefProps":
+        """
+        This is a display format specifier for the display of values e.g. in documents or in measurement and calibration systems. A None value is a no-op and does not overwrite an existing displayFormat.
+        """
+        if value is not None:
+            self.displayFormat = value
+        return self
+
+    def getImplementationDataTypeRef(self) -> Optional[RefType]:
+        """
+        This association denotes the ImplementationDataType of a data declaration via its aggregated SwDataDefProps.
+        """
+        return self.implementationDataTypeRef
+
+    def setImplementationDataTypeRef(self, value: Optional[RefType]) -> "SwDataDefProps":
+        """
+        This association denotes the ImplementationDataType of a data declaration via its aggregated SwDataDefProps. A None value is a no-op and does not overwrite an existing implementationDataTypeRef.
+        """
+        if value is not None:
+            self.implementationDataTypeRef = value
+        return self
+
+    def getSwHostVariable(self) -> Optional[SwVariableRefProxy]:
+        """
+        Proxy class for several kinds of references to a variable.
+        """
+        return self.swHostVariable
+
+    def setSwHostVariable(self, value: Optional[SwVariableRefProxy]) -> "SwDataDefProps":
+        """
+        Proxy class for several kinds of references to a variable. A None value is a no-op and does not overwrite an existing swHostVariable.
+        """
+        if value is not None:
+            self.swHostVariable = value
+        return self
+
+    def getSwImplPolicy(self) -> Optional[SwImplPolicyEnum]:
+        """
+        This indicates the intended implementation policy of the data object.
+        """
+        return self.swImplPolicy
+
+    def setSwImplPolicy(self, value: Optional[SwImplPolicyEnum]) -> "SwDataDefProps":
+        """
+        This indicates the intended implementation policy of the data object. A None value is a no-op and does not overwrite an existing swImplPolicy.
+        """
+        if value is not None:
+            self.swImplPolicy = value
+        return self
+
+    def getAdditionalNativeTypeQualifier(self) -> Optional[NativeDeclarationString]:
+        """
+        This string contains a native data declaration of a data type in a programming language. It is basically a string, but white-space shall be preserved.
+        """
+        return self.additionalNativeTypeQualifier
+
+    def setAdditionalNativeTypeQualifier(self, value: Optional[NativeDeclarationString]) -> "SwDataDefProps":
+        """
+        This string contains a native data declaration of a data type in a programming language. It is basically a string, but white-space shall be preserved. A None value is a no-op and does not overwrite an existing additionalNativeTypeQualifier.
+        """
+        if value is not None:
+            self.additionalNativeTypeQualifier = value
+        return self
+
+    def getSwIntendedResolution(self) -> Optional[ARNumerical]:
+        """
+        This attribute can be used to specify the intended resolution of the data object.
+        """
+        return self.swIntendedResolution
+
+    def setSwIntendedResolution(self, value: Optional[ARNumerical]) -> "SwDataDefProps":
+        """
+        This attribute can be used to specify the intended resolution of the data object. A None value is a no-op and does not overwrite an existing swIntendedResolution.
+        """
+        if value is not None:
+            self.swIntendedResolution = value
+        return self
+
+    def getSwInterpolationMethod(self) -> Optional[Identifier]:
+        """
+        This is the name of the interpolation method which is implemented by the referenced bswModuleEntry. It corresponds to swInterpolationMethod in SwDataDefProps.
+        """
+        return self.swInterpolationMethod
+
+    def setSwInterpolationMethod(self, value: Optional[Identifier]) -> "SwDataDefProps":
+        """
+        This is the name of the interpolation method which is implemented by the referenced bswModuleEntry. It corresponds to swInterpolationMethod in SwDataDefProps. A None value is a no-op and does not overwrite an existing swInterpolationMethod.
+        """
+        if value is not None:
+            self.swInterpolationMethod = value
+        return self
+
+    def getInvalidValue(self) -> Optional[ValueSpecification]:
+        """
+        The value which indicates that the data object is invalid.
+        """
+        return self.invalidValue
+
+    def setInvalidValue(self, value: Optional[ValueSpecification]) -> "SwDataDefProps":
+        """
+        The value which indicates that the data object is invalid. A None value is a no-op and does not overwrite an existing invalidValue.
+        """
+        if value is not None:
+            self.invalidValue = value
+        return self
+
+    def getSwIsVirtual(self) -> Optional[Boolean]:
+        """
+        This element distinguishes virtual objects. Virtual objects do not appear in the memory, their derivation is much more dependent on other objects and hence they shall have a swDataDependency.
+        """
+        return self.swIsVirtual
+
+    def setSwIsVirtual(self, value: Optional[Boolean]) -> "SwDataDefProps":
+        """
+        This element distinguishes virtual objects. Virtual objects do not appear in the memory, their derivation is much more dependent on other objects and hence they shall have a swDataDependency. A None value is a no-op and does not overwrite an existing swIsVirtual.
+        """
+        if value is not None:
+            self.swIsVirtual = value
+        return self
+
+    def getSwPointerTargetProps(self) -> Optional[SwPointerTargetProps]:
+        """
+        Specifies that the containing data object is a pointer to another data object.
+        """
+        return self.swPointerTargetProps
+
+    def setSwPointerTargetProps(self, value: Optional[SwPointerTargetProps]) -> "SwDataDefProps":
+        """
+        Specifies that the containing data object is a pointer to another data object. A None value is a no-op and does not overwrite an existing swPointerTargetProps.
+        """
+        if value is not None:
+            self.swPointerTargetProps = value
+        return self
+
+    def getSwRecordLayoutRef(self) -> Optional[RefType]:
+        """
+        Record layout for this data object.
+        """
+        return self.swRecordLayoutRef
+
+    def setSwRecordLayoutRef(self, value: Optional[RefType]) -> "SwDataDefProps":
+        """
+        Record layout for this data object. A None value is a no-op and does not overwrite an existing swRecordLayoutRef.
+        """
+        if value is not None:
+            self.swRecordLayoutRef = value
+        return self
+
+    def getSwRefreshTiming(self) -> Optional[MultidimensionalTime]:
+        """
+        This element specifies the frequency in which the object involved shall be or is called or calculated.
+        """
+        return self.swRefreshTiming
+
+    def setSwRefreshTiming(self, value: Optional[MultidimensionalTime]) -> "SwDataDefProps":
+        """
+        This element specifies the frequency in which the object involved shall be or is called or calculated. A None value is a no-op and does not overwrite an existing swRefreshTiming.
+        """
+        if value is not None:
+            self.swRefreshTiming = value
+        return self
+
+    def getUnitRef(self) -> Optional[RefType]:
+        """
+        Physical unit associated with the semantics of this data object. This attribute applies if no compuMethod is specified.
+        """
         return self.unitRef
 
-    def setUnitRef(self, value):
-        self.unitRef = value
+    def setUnitRef(self, value: Optional[RefType]) -> "SwDataDefProps":
+        """
+        Physical unit associated with the semantics of this data object. This attribute applies if no compuMethod is specified. A None value is a no-op and does not overwrite an existing unitRef.
+        """
+        if value is not None:
+            self.unitRef = value
         return self
 
-    def getValueAxisDataTypeRef(self):
+    def getValueAxisDataTypeRef(self) -> Optional[RefType]:
+        """
+        The referenced ApplicationPrimitiveDataType represents the primitive data type of the value axis within a compound primitive (e.g. curve, map). It supersedes CompuMethod, Unit, and BaseType.
+        """
         return self.valueAxisDataTypeRef
 
-    def setValueAxisDataTypeRef(self, value):
-        self.valueAxisDataTypeRef = value
+    def setValueAxisDataTypeRef(self, value: Optional[RefType]) -> "SwDataDefProps":
+        """
+        The referenced ApplicationPrimitiveDataType represents the primitive data type of the value axis within a compound primitive (e.g. curve, map). It supersedes CompuMethod, Unit, and BaseType. A None value is a no-op and does not overwrite an existing valueAxisDataTypeRef.
+        """
+        if value is not None:
+            self.valueAxisDataTypeRef = value
         return self
 
 
 class SwPointerTargetProps(ARObject):
     """
-    Properties for pointer targets including function pointer signature and
-    target category.
+    Properties for pointer targets including function pointer signature and target category.
     """
 
     # SwPointerTargetProps method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getFunctionPointerSignatureRef [x] impl  [ ] docstring  [ ] test
-    # [ ] setFunctionPointerSignatureRef [x] impl  [ ] docstring  [ ] test
-    # [ ] getSwDataDefProps            [x] impl  [ ] docstring  [ ] test
-    # [ ] setSwDataDefProps            [x] impl  [ ] docstring  [ ] test
-    # [ ] getTargetCategory            [x] impl  [ ] docstring  [ ] test
-    # [ ] setTargetCategory            [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.19, p.287
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                       [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getFunctionPointerSignatureRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFunctionPointerSignatureRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwDataDefProps              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwDataDefProps              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTargetCategory              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTargetCategory              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.functionPointerSignatureRef = None  # type: RefType
-        self.swDataDefProps = None  # type: SwDataDefProps
-        self.targetCategory = None  # type: ARLiteral
+        # The signature of the function the pointer refers to.
+        self.functionPointerSignatureRef: Optional[RefType] = None
 
-    def getFunctionPointerSignatureRef(self):
+        # The properties of the data which is referenced by the pointer.
+        self.swDataDefProps: Optional[SwDataDefProps] = None
+
+        # Specifies the category of the target (the object the pointer points to).
+        self.targetCategory: Optional[Identifier] = None
+
+    def getFunctionPointerSignatureRef(self) -> Optional[RefType]:
+        """
+        The signature of the function the pointer refers to.
+        """
         return self.functionPointerSignatureRef
 
-    def setFunctionPointerSignatureRef(self, value):
-        self.functionPointerSignatureRef = value
+    def setFunctionPointerSignatureRef(self, value: Optional[RefType]) -> "SwPointerTargetProps":
+        """
+        The signature of the function the pointer refers to. A None value is a no-op and does not overwrite an existing functionPointerSignatureRef.
+        """
+        if value is not None:
+            self.functionPointerSignatureRef = value
         return self
 
-    def getSwDataDefProps(self):
+    def getSwDataDefProps(self) -> Optional[SwDataDefProps]:
+        """
+        The properties of the data which is referenced by the pointer.
+        """
         return self.swDataDefProps
 
-    def setSwDataDefProps(self, value):
-        self.swDataDefProps = value
+    def setSwDataDefProps(self, value: Optional[SwDataDefProps]) -> "SwPointerTargetProps":
+        """
+        The properties of the data which is referenced by the pointer. A None value is a no-op and does not overwrite an existing swDataDefProps.
+        """
+        if value is not None:
+            self.swDataDefProps = value
         return self
 
-    def getTargetCategory(self):
+    def getTargetCategory(self) -> Optional[Identifier]:
+        """
+        Specifies the category of the target (the object the pointer points to).
+        """
         return self.targetCategory
 
-    def setTargetCategory(self, value):
-        self.targetCategory = value
+    def setTargetCategory(self, value: Optional[Identifier]) -> "SwPointerTargetProps":
+        """
+        Specifies the category of the target (the object the pointer points to). A None value is a no-op and does not overwrite an existing targetCategory.
+        """
+        if value is not None:
+            self.targetCategory = value
         return self
 
 
@@ -424,29 +1075,30 @@ class ValueList(ARObject):
     """
 
     # ValueList method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getV                         [x] impl  [ ] docstring  [ ] test
-    # [ ] setV                         [x] impl  [ ] docstring  [ ] test
-    # [ ] addVf                        [x] impl  [ ] docstring  [ ] test
-    # [ ] getVfs                       [x] impl  [ ] docstring  [ ] test
+    # [ ] __init__                 [x] impl  [ ] docstring  [x] test  [—] reader  [—] writer
+    # [ ] getV                     [x] impl  [ ] docstring  [x] test  [—] reader  [x] writer
+    # [ ] setV                     [x] impl  [ ] docstring  [x] test  [x] reader  [—] writer
+    # [ ] addVf                    [x] impl  [ ] docstring  [x] test  [—] reader  [—] writer
+    # [ ] getVfs                   [x] impl  [ ] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.v = None  # type: ARFloat
-        self._vf = []  # type: List[ARLiteral]
+        self.v: Optional[ARNumerical] = None
+        self._vf: List[ARNumerical] = []
 
-    def getV(self):
+    def getV(self) -> Optional[ARNumerical]:
         return self.v
 
-    def setV(self, value):
-        self.v = value
+    def setV(self, value: Optional[ARNumerical]) -> "ValueList":
+        if value is not None:
+            self.v = value
         return self
 
-    def addVf(self, vf: ARLiteral):
+    def addVf(self, vf: ARNumerical):
         self._vf.append(vf)
 
-    def getVfs(self) -> List[ARLiteral]:
+    def getVfs(self) -> List[ARNumerical]:
         return sorted(self._vf)
 
 

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -2913,6 +2913,7 @@ class ARXMLParser(AbstractARXMLParser):
             props = SwPointerTargetProps()
             props.setTargetCategory(self.getChildElementOptionalLiteral(child_element, "TARGET-CATEGORY"))
             props.setSwDataDefProps(self.getSwDataDefProps(child_element, "SW-DATA-DEF-PROPS"))
+            props.setFunctionPointerSignatureRef(self.getChildElementOptionalRefType(child_element, "FUNCTION-POINTER-SIGNATURE-REF"))
         return props
 
     def readSwPointerTargetProps(self, element: ET.Element, parent: SwDataDefProps):
@@ -2921,6 +2922,7 @@ class ARXMLParser(AbstractARXMLParser):
             sw_pointer_target_props = SwPointerTargetProps()
             sw_pointer_target_props.setTargetCategory(self.getChildElementOptionalLiteral(child_element, "TARGET-CATEGORY"))
             sw_pointer_target_props.setSwDataDefProps(self.getSwDataDefProps(child_element, "SW-DATA-DEF-PROPS"))
+            sw_pointer_target_props.setFunctionPointerSignatureRef(self.getChildElementOptionalRefType(child_element, "FUNCTION-POINTER-SIGNATURE-REF"))
             parent.swPointerTargetProps = sw_pointer_target_props
 
     def getSwTextProps(self, element: ET.Element, key: str) -> SwTextProps:
@@ -5398,7 +5400,6 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readSecureCommunicationAuthenticationProps(self, element: ET.Element, props: SecureCommunicationAuthenticationProps):
         self.readIdentifiable(element, props)
-        props.setAuthAlgorithm(self.getChildElementOptionalLiteral(element, "AUTH-ALGORITHM"))
         props.setAuthInfoTxLength(self.getChildElementOptionalPositiveInteger(element, "AUTH-INFO-TX-LENGTH"))
 
     def readSecureCommunicationPropsSetAuthenticationProps(self, element: ET.Element, props_set: SecureCommunicationPropsSet):
@@ -5412,8 +5413,11 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readSecureCommunicationFreshnessProps(self, element: ET.Element, props: SecureCommunicationFreshnessProps):
         self.readIdentifiable(element, props)
-        props.setFreshnessValueLength(self.getChildElementOptionalLiteral(element, "FRESHNESS-VALUE-LENGTH"))
+        props.setFreshnessCounterSyncAttempts(self.getChildElementOptionalPositiveInteger(element, "FRESHNESS-COUNTER-SYNC-ATTEMPTS"))
+        props.setFreshnessTimestampTimePeriodFactor(self.getChildElementOptionalPositiveInteger(element, "FRESHNESS-TIMESTAMP-TIME-PERIOD-FACTOR"))
+        props.setFreshnessValueLength(self.getChildElementOptionalPositiveInteger(element, "FRESHNESS-VALUE-LENGTH"))
         props.setFreshnessValueTxLength(self.getChildElementOptionalPositiveInteger(element, "FRESHNESS-VALUE-TX-LENGTH"))
+        props.setUseFreshnessTimestamp(self.getChildElementOptionalBooleanValue(element, "USE-FRESHNESS-TIMESTAMP"))
 
     def readSecureCommunicationPropsSetFreshnessProps(self, element: ET.Element, props_set: SecureCommunicationPropsSet):
         for child_element in self.findall(element, "FRESHNESS-PROPSS/*"):
@@ -5582,13 +5586,15 @@ class ARXMLParser(AbstractARXMLParser):
             props = SecureCommunicationProps()
             props.setAuthDataFreshnessLength(self.getChildElementOptionalPositiveInteger(child_element, "AUTH-DATA-FRESHNESS-LENGTH"))
             props.setAuthDataFreshnessStartPosition(self.getChildElementOptionalPositiveInteger(child_element, "AUTH-DATA-FRESHNESS-START-POSITION"))
-            props.setAuthInfoTxLength(self.getChildElementOptionalPositiveInteger(child_element, "AUTH-INFO-TX-LENGTH"))
             props.setAuthenticationBuildAttempts(self.getChildElementOptionalPositiveInteger(child_element, "AUTHENTICATION-BUILD-ATTEMPTS"))
             props.setAuthenticationRetries(self.getChildElementOptionalPositiveInteger(child_element, "AUTHENTICATION-RETRIES"))
             props.setDataId(self.getChildElementOptionalPositiveInteger(child_element, "DATA-ID"))
             props.setFreshnessValueId(self.getChildElementOptionalPositiveInteger(child_element, "FRESHNESS-VALUE-ID"))
-            props.setFreshnessValueLength(self.getChildElementOptionalPositiveInteger(child_element, "FRESHNESS-VALUE-LENGTH"))
-            props.setFreshnessValueTxLength(self.getChildElementOptionalPositiveInteger(child_element, "FRESHNESS-VALUE-TX-LENGTH"))  # NOQA E501
+            props.setMessageLinkLength(self.getChildElementOptionalPositiveInteger(child_element, "MESSAGE-LINK-LENGTH"))
+            props.setMessageLinkPosition(self.getChildElementOptionalPositiveInteger(child_element, "MESSAGE-LINK-POSITION"))
+            props.setSecondaryFreshnessValueId(self.getChildElementOptionalPositiveInteger(child_element, "SECONDARY-FRESHNESS-VALUE-ID"))
+            props.setSecuredAreaLength(self.getChildElementOptionalPositiveInteger(child_element, "SECURED-AREA-LENGTH"))
+            props.setSecuredAreaOffset(self.getChildElementOptionalPositiveInteger(child_element, "SECURED-AREA-OFFSET"))
         return props
 
     def readSecuredIPdu(self, element: ET.Element, i_pdu: SecuredIPdu):

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -526,7 +526,18 @@ from armodel.models.M2.MSR.CalibrationData.CalibrationValue import SwValueCont, 
 from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod
 from armodel.models.M2.MSR.DataDictionary.Axis import SwAxisGrouped, SwAxisIndividual
 from armodel.models.M2.MSR.DataDictionary.CalibrationParameter import SwCalprmAxis, SwCalprmAxisSet
-from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps, SwPointerTargetProps, SwTextProps, ValueList
+from armodel.models.M2.MSR.DataDictionary.DataDefProperties import (
+    SwDataDefProps,
+    SwPointerTargetProps,
+    SwTextProps,
+    ValueList,
+    SwBitRepresentation,
+    SwVariableRefProxy,
+    SwCalprmRefProxy,
+    SwDataDependencyArgs,
+    CompuGenericMath,
+    SwDataDependency,
+)
 from armodel.models.M2.MSR.DataDictionary.RecordLayout import SwRecordLayout, SwRecordLayoutGroup, SwRecordLayoutGroupContent, SwRecordLayoutV
 from armodel.models.M2.MSR.DataDictionary.ServiceProcessTask import SwServiceArg
 from armodel.models.M2.MSR.DataDictionary.SystemConstant import SwSystemconst
@@ -3275,10 +3286,12 @@ class ARXMLParser(AbstractARXMLParser):
                 for annotation in self.getAnnotations(conditional_tag):
                     sw_data_def_props.addAnnotation(annotation)
 
+                sw_data_def_props.setDisplayPresentation(self.getChildElementOptionalLiteral(conditional_tag, "DISPLAY-PRESENTATION"))
                 sw_data_def_props.setBaseTypeRef(self.getChildElementOptionalRefType(conditional_tag, "BASE-TYPE-REF"))
                 sw_data_def_props.setDataConstrRef(self.getChildElementOptionalRefType(conditional_tag, "DATA-CONSTR-REF"))
                 sw_data_def_props.setCompuMethodRef(self.getChildElementOptionalRefType(conditional_tag, "COMPU-METHOD-REF"))
                 sw_data_def_props.setSwAddrMethodRef(self.getChildElementOptionalRefType(conditional_tag, "SW-ADDR-METHOD-REF"))
+                sw_data_def_props.setSwAlignment(self.getChildElementOptionalLiteral(conditional_tag, "SW-ALIGNMENT"))
                 sw_data_def_props.setSwImplPolicy(self.getChildElementOptionalLiteral(conditional_tag, "SW-IMPL-POLICY"))
                 sw_data_def_props.setSwIntendedResolution(self.getChildElementOptionalNumericalValue(conditional_tag, "SW-INTENDED-RESOLUTION"))
                 sw_data_def_props.setImplementationDataTypeRef(self.getChildElementOptionalRefType(conditional_tag, "IMPLEMENTATION-DATA-TYPE-REF"))
@@ -3290,10 +3303,84 @@ class ARXMLParser(AbstractARXMLParser):
                 sw_data_def_props.setSwRecordLayoutRef(self.getChildElementOptionalRefType(conditional_tag, "SW-RECORD-LAYOUT-REF"))
                 sw_data_def_props.setValueAxisDataTypeRef(self.getChildElementOptionalRefType(conditional_tag, "VALUE-AXIS-DATA-TYPE-REF"))
                 sw_data_def_props.setUnitRef(self.getChildElementOptionalRefType(conditional_tag, "UNIT-REF"))
+                sw_data_def_props.setDisplayFormat(self.getChildElementOptionalLiteral(conditional_tag, "DISPLAY-FORMAT"))
+                sw_data_def_props.setAdditionalNativeTypeQualifier(self.getChildElementOptionalLiteral(conditional_tag, "ADDITIONAL-NATIVE-TYPE-QUALIFIER"))
+                sw_data_def_props.setSwInterpolationMethod(self.getChildElementOptionalLiteral(conditional_tag, "SW-INTERPOLATION-METHOD"))
+                sw_data_def_props.setSwIsVirtual(self.getChildElementOptionalBooleanValue(conditional_tag, "SW-IS-VIRTUAL"))
                 self.readSwDataDefProsInvalidValue(conditional_tag, sw_data_def_props)
+                self.readSwDataDefPropsBits(conditional_tag, sw_data_def_props)
+                self.readSwComparisonVariables(conditional_tag, sw_data_def_props)
+                self.readSwDataDependency(conditional_tag, sw_data_def_props)
+                self.readSwHostVariable(conditional_tag, sw_data_def_props)
+                self.readSwRefTiming(conditional_tag, sw_data_def_props)
                 # self.readSwPointerTargetProps(conditional_tag, sw_data_def_props)
-                self.readARObjectAttributes(conditional_tag, sw_data_def_props.conditional)
         return sw_data_def_props
+
+    def readSwDataDefPropsBits(self, element: ET.Element, props: SwDataDefProps):
+        bit_representation_element = self.find(element, "SW-BIT-REPRESENTATION")
+        if bit_representation_element is not None:
+            bit_representation = SwBitRepresentation()
+            bit_representation.setBitPosition(self.getChildElementOptionalIntegerValue(bit_representation_element, "BIT-POSITION"))
+            bit_representation.setNumberOfBits(self.getChildElementOptionalIntegerValue(bit_representation_element, "NUMBER-OF-BITS"))
+            props.setSwBitRepresentation(bit_representation)
+        value_block_size = self.getChildElementOptionalNumericalValue(element, "SW-VALUE-BLOCK-SIZE")
+        props.setSwValueBlockSize(value_block_size)
+        for mult_element in self.findall(element, "SW-VALUE-BLOCK-SIZE-MULTS/NUMERICAL-VALUE-VARIATION-POINT"):
+            value = self.getChildElementOptionalNumericalValue(mult_element, "VALUE")
+            if value is None:
+                value = self.getChildElementOptionalNumericalValue(mult_element, "V")
+            props.addSwValueBlockSizeMult(value)
+
+    def readSwComparisonVariables(self, element: ET.Element, props: SwDataDefProps):
+        for proxy_element in self.findall(element, "SW-COMPARISON-VARIABLES/SW-VARIABLE-REF-PROXY"):
+            props.addSwComparisonVariable(self.readSwVariableRefProxy(proxy_element))
+
+    def readSwHostVariable(self, element: ET.Element, props: SwDataDefProps):
+        host_variable_element = self.find(element, "SW-HOST-VARIABLE")
+        if host_variable_element is not None:
+            props.setSwHostVariable(self.readSwVariableRefProxy(host_variable_element))
+
+    def readSwVariableRefProxy(self, element: ET.Element) -> SwVariableRefProxy:
+        proxy = SwVariableRefProxy()
+        proxy.setAutosarVariable(self.getAutosarVariableRef(element, "AUTOSAR-VARIABLE"))
+        proxy.setMcDataInstanceVarRef(self.getChildElementOptionalRefType(element, "MC-DATA-INSTANCE-VAR-REF"))
+        return proxy
+
+    def readSwDataDependency(self, element: ET.Element, props: SwDataDefProps):
+        dependency_element = self.find(element, "SW-DATA-DEPENDENCY")
+        if dependency_element is not None:
+            dependency = SwDataDependency()
+            formula_element = self.find(dependency_element, "SW-DATA-DEPENDENCY-FORMULA")
+            if formula_element is not None:
+                formula = CompuGenericMath()
+                level = formula_element.attrib.get("LEVEL")
+                if level is not None:
+                    formula.setLevel(ARLiteral().setValue(level))
+                dependency.setSwDataDependencyFormula(formula)
+            args_element = self.find(dependency_element, "SW-DATA-DEPENDENCY-ARGS")
+            if args_element is not None:
+                args = SwDataDependencyArgs()
+                calprm_element = self.find(args_element, "SW-CALPRM-REF-PROXY")
+                if calprm_element is not None:
+                    args.setSwCalprmRef(self.readSwCalprmRefProxy(calprm_element))
+                variable_element = self.find(args_element, "SW-VARIABLE-REF-PROXY")
+                if variable_element is not None:
+                    args.setSwVariable(self.readSwVariableRefProxy(variable_element))
+                dependency.setSwDataDependencyArgs(args)
+            props.setSwDataDependency(dependency)
+
+    def readSwCalprmRefProxy(self, element: ET.Element) -> SwCalprmRefProxy:
+        proxy = SwCalprmRefProxy()
+        proxy.setArParameter(self.getAutosarParameterRef(element, "AR-PARAMETER"))
+        proxy.setMcDataInstanceRef(self.getChildElementOptionalRefType(element, "MC-DATA-INSTANCE-REF"))
+        return proxy
+
+    def readSwRefTiming(self, element: ET.Element, props: SwDataDefProps):
+        refresh_timing_element = self.find(element, "SW-REFRESH-TIMING")
+        if refresh_timing_element is not None:
+            refresh_timing = MultidimensionalTime()
+            self.readMultidimensionalTime(refresh_timing_element, refresh_timing)
+            props.setSwRefreshTiming(refresh_timing)
 
     def readAutosarDataType(self, element: ET.Element, data_type: AutosarDataType):
         self.readIdentifiable(element, data_type)

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -527,16 +527,16 @@ from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod
 from armodel.models.M2.MSR.DataDictionary.Axis import SwAxisGrouped, SwAxisIndividual
 from armodel.models.M2.MSR.DataDictionary.CalibrationParameter import SwCalprmAxis, SwCalprmAxisSet
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import (
+    CompuGenericMath,
+    SwBitRepresentation,
+    SwCalprmRefProxy,
     SwDataDefProps,
+    SwDataDependency,
+    SwDataDependencyArgs,
     SwPointerTargetProps,
     SwTextProps,
-    ValueList,
-    SwBitRepresentation,
     SwVariableRefProxy,
-    SwCalprmRefProxy,
-    SwDataDependencyArgs,
-    CompuGenericMath,
-    SwDataDependency,
+    ValueList,
 )
 from armodel.models.M2.MSR.DataDictionary.RecordLayout import SwRecordLayout, SwRecordLayoutGroup, SwRecordLayoutGroupContent, SwRecordLayoutV
 from armodel.models.M2.MSR.DataDictionary.ServiceProcessTask import SwServiceArg

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -180,7 +180,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.EngineeringObject import AutosarEngineeringObject, EngineeringObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Describable, Identifiable, MultilanguageReferrable, Referrable, ShortNameFragment
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, Limit, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, Limit, RefType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import LifeCycleInfo, LifeCycleInfoSet, LifeCyclePeriod
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
     PredefinedVariant,
@@ -518,7 +518,18 @@ from armodel.models.M2.MSR.CalibrationData.CalibrationValue import SwValueCont, 
 from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod
 from armodel.models.M2.MSR.DataDictionary.Axis import SwAxisGrouped, SwAxisIndividual
 from armodel.models.M2.MSR.DataDictionary.CalibrationParameter import SwCalprmAxis, SwCalprmAxisSet
-from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps, SwPointerTargetProps, SwTextProps, ValueList
+from armodel.models.M2.MSR.DataDictionary.DataDefProperties import (
+    SwDataDefProps,
+    SwPointerTargetProps,
+    SwTextProps,
+    ValueList,
+    SwBitRepresentation,
+    SwVariableRefProxy,
+    SwCalprmRefProxy,
+    SwDataDependencyArgs,
+    CompuGenericMath,
+    SwDataDependency,
+)
 from armodel.models.M2.MSR.DataDictionary.RecordLayout import SwRecordLayout, SwRecordLayoutGroup, SwRecordLayoutV
 from armodel.models.M2.MSR.DataDictionary.ServiceProcessTask import SwServiceArg
 from armodel.models.M2.MSR.DataDictionary.SystemConstant import SwSystemconst
@@ -1551,10 +1562,11 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeARObjectAttributes(child_element, props)
             sw_data_def_props_variants_tag = ET.SubElement(child_element, "SW-DATA-DEF-PROPS-VARIANTS")
             conditional_tag = ET.SubElement(sw_data_def_props_variants_tag, "SW-DATA-DEF-PROPS-CONDITIONAL")
-            self.writeARObjectAttributes(conditional_tag, props.conditional)
             self.setAnnotations(conditional_tag, props.getAnnotations())
+            self.setChildElementOptionalLiteral(conditional_tag, "DISPLAY-PRESENTATION", props.getDisplayPresentation())
             self.setChildElementOptionalRefType(conditional_tag, "BASE-TYPE-REF", props.getBaseTypeRef())
             self.setChildElementOptionalRefType(conditional_tag, "SW-ADDR-METHOD-REF", props.getSwAddrMethodRef())
+            self.setChildElementOptionalLiteral(conditional_tag, "SW-ALIGNMENT", props.getSwAlignment())
             self.setChildElementOptionalLiteral(conditional_tag, "SW-CALIBRATION-ACCESS", props.getSwCalibrationAccess())
             self.setChildElementOptionalRefType(conditional_tag, "COMPU-METHOD-REF", props.getCompuMethodRef())
             self.setChildValueSpecification(conditional_tag, "INVALID-VALUE", props.getInvalidValue())
@@ -1562,13 +1574,79 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.setChildElementOptionalRefType(conditional_tag, "DATA-CONSTR-REF", props.getDataConstrRef())
             self.setChildElementOptionalRefType(conditional_tag, "IMPLEMENTATION-DATA-TYPE-REF", props.getImplementationDataTypeRef())
             self.setSwCalprmAxisSet(conditional_tag, "SW-CALPRM-AXIS-SET", props.getSwCalprmAxisSet())
+            self.setSwBitRepresentation(conditional_tag, props.getSwBitRepresentation())
+            self.setChildElementOptionalNumericalValue(conditional_tag, "SW-VALUE-BLOCK-SIZE", props.getSwValueBlockSize())
+            self.setSwValueBlockSizeMults(conditional_tag, props.getSwValueBlockSizeMults())
             self.setChildElementOptionalLiteral(conditional_tag, "SW-IMPL-POLICY", props.getSwImplPolicy())
             self.setChildElementOptionalNumericalValue(conditional_tag, "SW-INTENDED-RESOLUTION", props.getSwIntendedResolution())
             self.setSwPointerTargetProps(conditional_tag, "SW-POINTER-TARGET-PROPS", props.getSwPointerTargetProps())
             self.setSwTextProps(conditional_tag, props.getSwTextProps())
+            self.setSwComparisonVariables(conditional_tag, props.getSwComparisonVariables())
             self.setChildElementOptionalRefType(conditional_tag, "SW-RECORD-LAYOUT-REF", props.getSwRecordLayoutRef())
             self.setChildElementOptionalRefType(conditional_tag, "VALUE-AXIS-DATA-TYPE-REF", props.getValueAxisDataTypeRef())
             self.setChildElementOptionalRefType(conditional_tag, "UNIT-REF", props.getUnitRef())
+            self.setSwDataDependency(conditional_tag, props.getSwDataDependency())
+            self.setChildElementOptionalLiteral(conditional_tag, "DISPLAY-FORMAT", props.getDisplayFormat())
+            self.setChildElementOptionalLiteral(conditional_tag, "ADDITIONAL-NATIVE-TYPE-QUALIFIER", props.getAdditionalNativeTypeQualifier())
+            self.setChildElementOptionalLiteral(conditional_tag, "SW-INTERPOLATION-METHOD", props.getSwInterpolationMethod())
+            self.setChildElementOptionalBooleanValue(conditional_tag, "SW-IS-VIRTUAL", props.getSwIsVirtual())
+            self.setSwHostVariable(conditional_tag, props.getSwHostVariable())
+            self.setMultidimensionalTime(conditional_tag, "SW-REFRESH-TIMING", props.getSwRefreshTiming())
+
+    def setSwBitRepresentation(self, element: ET.Element, bit_representation: SwBitRepresentation):
+        if bit_representation is not None:
+            child_element = ET.SubElement(element, "SW-BIT-REPRESENTATION")
+            self.writeARObjectAttributes(child_element, bit_representation)
+            self.setChildElementOptionalIntegerValue(child_element, "BIT-POSITION", bit_representation.getBitPosition())
+            self.setChildElementOptionalIntegerValue(child_element, "NUMBER-OF-BITS", bit_representation.getNumberOfBits())
+
+    def setSwValueBlockSizeMults(self, element: ET.Element, mults: List[ARNumerical]):
+        if len(mults) > 0:
+            mults_element = ET.SubElement(element, "SW-VALUE-BLOCK-SIZE-MULTS")
+            for mult in mults:
+                value_element = ET.SubElement(mults_element, "NUMERICAL-VALUE-VARIATION-POINT")
+                self.setChildElementOptionalNumericalValue(value_element, "V", mult)
+
+    def setSwComparisonVariables(self, element: ET.Element, comparison_variables: List[SwVariableRefProxy]):
+        if len(comparison_variables) > 0:
+            comparison_variables_element = ET.SubElement(element, "SW-COMPARISON-VARIABLES")
+            for comparison_variable in comparison_variables:
+                self.setSwVariableRefProxy(comparison_variables_element, "SW-VARIABLE-REF-PROXY", comparison_variable)
+
+    def setSwHostVariable(self, element: ET.Element, host_variable: SwVariableRefProxy):
+        if host_variable is not None:
+            self.setSwVariableRefProxy(element, "SW-HOST-VARIABLE", host_variable)
+
+    def setSwVariableRefProxy(self, element: ET.Element, key: str, proxy: SwVariableRefProxy):
+        if proxy is not None:
+            child_element = ET.SubElement(element, key)
+            self.writeARObjectAttributes(child_element, proxy)
+            self.setAutosarVariableRef(child_element, "AUTOSAR-VARIABLE", proxy.getAutosarVariable())
+            self.setChildElementOptionalRefType(child_element, "MC-DATA-INSTANCE-VAR-REF", proxy.getMcDataInstanceVarRef())
+
+    def setSwCalprmRefProxy(self, element: ET.Element, key: str, proxy: SwCalprmRefProxy):
+        if proxy is not None:
+            child_element = ET.SubElement(element, key)
+            self.writeARObjectAttributes(child_element, proxy)
+            self.setAutosarParameterRef(child_element, "AR-PARAMETER", proxy.getArParameter())
+            self.setChildElementOptionalRefType(child_element, "MC-DATA-INSTANCE-REF", proxy.getMcDataInstanceRef())
+
+    def setSwDataDependency(self, element: ET.Element, dependency: SwDataDependency):
+        if dependency is not None:
+            dependency_element = ET.SubElement(element, "SW-DATA-DEPENDENCY")
+            self.writeARObjectAttributes(dependency_element, dependency)
+            formula = dependency.getSwDataDependencyFormula()
+            if formula is not None:
+                formula_element = ET.SubElement(dependency_element, "SW-DATA-DEPENDENCY-FORMULA")
+                self.writeARObjectAttributes(formula_element, formula)
+                if formula.getLevel() is not None:
+                    formula_element.set("LEVEL", formula.getLevel().value)
+            args = dependency.getSwDataDependencyArgs()
+            if args is not None:
+                args_element = ET.SubElement(dependency_element, "SW-DATA-DEPENDENCY-ARGS")
+                self.writeARObjectAttributes(args_element, args)
+                self.setSwCalprmRefProxy(args_element, "SW-CALPRM-REF-PROXY", args.getSwCalprmRef())
+                self.setSwVariableRefProxy(args_element, "SW-VARIABLE-REF-PROXY", args.getSwVariable())
 
     def setSwTextProps(self, element: ET.Element, props: SwTextProps):
         if props is not None:

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -1555,6 +1555,7 @@ class ARXMLWriter(AbstractARXMLWriter):
             child_element = ET.SubElement(element, key)
             self.setChildElementOptionalLiteral(child_element, "TARGET-CATEGORY", props.getTargetCategory())
             self.setSwDataDefProps(child_element, "SW-DATA-DEF-PROPS", props.getSwDataDefProps())
+            self.setChildElementOptionalRefType(child_element, "FUNCTION-POINTER-SIGNATURE-REF", props.getFunctionPointerSignatureRef())
 
     def setSwDataDefProps(self, element: ET.Element, key: str, props: SwDataDefProps):
         if props is not None:
@@ -4917,13 +4918,15 @@ class ARXMLWriter(AbstractARXMLWriter):
             child_element = ET.SubElement(element, key)
             self.setChildElementOptionalPositiveInteger(child_element, "AUTH-DATA-FRESHNESS-LENGTH", props.getAuthDataFreshnessLength())
             self.setChildElementOptionalPositiveInteger(child_element, "AUTH-DATA-FRESHNESS-START-POSITION", props.getAuthDataFreshnessStartPosition())  # noqa E501
-            self.setChildElementOptionalPositiveInteger(child_element, "AUTH-INFO-TX-LENGTH", props.getAuthInfoTxLength())
             self.setChildElementOptionalPositiveInteger(child_element, "AUTHENTICATION-BUILD-ATTEMPTS", props.getAuthenticationBuildAttempts())
             self.setChildElementOptionalPositiveInteger(child_element, "AUTHENTICATION-RETRIES", props.getAuthenticationRetries())
             self.setChildElementOptionalPositiveInteger(child_element, "DATA-ID", props.getDataId())
             self.setChildElementOptionalPositiveInteger(child_element, "FRESHNESS-VALUE-ID", props.getFreshnessValueId())
-            self.setChildElementOptionalPositiveInteger(child_element, "FRESHNESS-VALUE-LENGTH", props.getFreshnessValueLength())
-            self.setChildElementOptionalPositiveInteger(child_element, "FRESHNESS-VALUE-TX-LENGTH", props.getFreshnessValueTxLength())
+            self.setChildElementOptionalPositiveInteger(child_element, "MESSAGE-LINK-LENGTH", props.getMessageLinkLength())
+            self.setChildElementOptionalPositiveInteger(child_element, "MESSAGE-LINK-POSITION", props.getMessageLinkPosition())
+            self.setChildElementOptionalPositiveInteger(child_element, "SECONDARY-FRESHNESS-VALUE-ID", props.getSecondaryFreshnessValueId())
+            self.setChildElementOptionalPositiveInteger(child_element, "SECURED-AREA-LENGTH", props.getSecuredAreaLength())
+            self.setChildElementOptionalPositiveInteger(child_element, "SECURED-AREA-OFFSET", props.getSecuredAreaOffset())
 
     def writeSecuredIPdu(self, element: ET.Element, i_pdu: SecuredIPdu):
         self.logger.debug("Write SecuredIPdu <%s>" % i_pdu.getShortName())
@@ -7239,7 +7242,6 @@ class ARXMLWriter(AbstractARXMLWriter):
     def writeSecureCommunicationAuthenticationProps(self, element: ET.Element, props: SecureCommunicationAuthenticationProps):
         chile_element = ET.SubElement(element, "SECURE-COMMUNICATION-AUTHENTICATION-PROPS")
         self.writeIdentifiable(chile_element, props)
-        self.setChildElementOptionalLiteral(chile_element, "AUTH-ALGORITHM", props.getAuthAlgorithm())
         self.setChildElementOptionalPositiveInteger(chile_element, "AUTH-INFO-TX-LENGTH", props.getAuthInfoTxLength())
 
     def writeSecureCommunicationPropsSetAuthenticationProps(self, element: ET.Element, props_set: SecureCommunicationPropsSet):
@@ -7255,8 +7257,11 @@ class ARXMLWriter(AbstractARXMLWriter):
     def writeSecureCommunicationFreshnessProps(self, element: ET.Element, props: SecureCommunicationFreshnessProps):
         child_element = ET.SubElement(element, "SECURE-COMMUNICATION-FRESHNESS-PROPS")
         self.writeIdentifiable(child_element, props)
-        self.setChildElementOptionalLiteral(child_element, "FRESHNESS-VALUE-LENGTH", props.getFreshnessValueLength())
+        self.setChildElementOptionalPositiveInteger(child_element, "FRESHNESS-COUNTER-SYNC-ATTEMPTS", props.getFreshnessCounterSyncAttempts())
+        self.setChildElementOptionalPositiveInteger(child_element, "FRESHNESS-TIMESTAMP-TIME-PERIOD-FACTOR", props.getFreshnessTimestampTimePeriodFactor())
+        self.setChildElementOptionalPositiveInteger(child_element, "FRESHNESS-VALUE-LENGTH", props.getFreshnessValueLength())
         self.setChildElementOptionalPositiveInteger(child_element, "FRESHNESS-VALUE-TX-LENGTH", props.getFreshnessValueTxLength())
+        self.setChildElementOptionalBooleanValue(child_element, "USE-FRESHNESS-TIMESTAMP", props.getUseFreshnessTimestamp())
 
     def writeSecureCommunicationPropsSetFreshnessProps(self, element: ET.Element, props_set: SecureCommunicationPropsSet):
         propses = props_set.getFreshnessProps()

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -519,16 +519,14 @@ from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod
 from armodel.models.M2.MSR.DataDictionary.Axis import SwAxisGrouped, SwAxisIndividual
 from armodel.models.M2.MSR.DataDictionary.CalibrationParameter import SwCalprmAxis, SwCalprmAxisSet
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import (
+    SwBitRepresentation,
+    SwCalprmRefProxy,
     SwDataDefProps,
+    SwDataDependency,
     SwPointerTargetProps,
     SwTextProps,
-    ValueList,
-    SwBitRepresentation,
     SwVariableRefProxy,
-    SwCalprmRefProxy,
-    SwDataDependencyArgs,
-    CompuGenericMath,
-    SwDataDependency,
+    ValueList,
 )
 from armodel.models.M2.MSR.DataDictionary.RecordLayout import SwRecordLayout, SwRecordLayoutGroup, SwRecordLayoutV
 from armodel.models.M2.MSR.DataDictionary.ServiceProcessTask import SwServiceArg

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_PrimitiveTypes.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_PrimitiveTypes.py
@@ -20,6 +20,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     CseCodeType,
     DateTime,
     DiagRequirementIdString,
+    DisplayFormatString,
     Float,
     Identifier,
     Integer,
@@ -28,7 +29,9 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     Limit,
     MacAddressString,
     NameToken,
+    NativeDeclarationString,
     PositiveInteger,
+    PrimitiveIdentifier,
     ReferrableSubtypesEnum,
     RefType,
     RegularExpression,
@@ -408,6 +411,69 @@ class TestCseCodeType:
 
         cse_zero = CseCodeType().setValue("0")
         assert cse_zero.getValue() == "0"
+
+
+class TestDisplayFormatString:
+    """
+    Test class for DisplayFormatString functionality.
+    """
+
+    def test_initialization(self):
+        """
+        Test DisplayFormatString initialization.
+        """
+        display_format = DisplayFormatString()
+        assert display_format is not None
+        assert display_format._value is None
+
+    def test_set_value(self):
+        """
+        Test DisplayFormatString value assignment.
+        """
+        display_format = DisplayFormatString().setValue("%5.2f")
+        assert display_format.getValue() == "%5.2f"
+
+
+class TestNativeDeclarationString:
+    """
+    Test class for NativeDeclarationString functionality.
+    """
+
+    def test_initialization(self):
+        """
+        Test NativeDeclarationString initialization.
+        """
+        native_declaration = NativeDeclarationString()
+        assert native_declaration is not None
+        assert native_declaration._value is None
+
+    def test_set_value(self):
+        """
+        Test NativeDeclarationString value assignment.
+        """
+        native_declaration = NativeDeclarationString().setValue("volatile")
+        assert native_declaration.getValue() == "volatile"
+
+
+class TestPrimitiveIdentifier:
+    """
+    Test class for PrimitiveIdentifier functionality.
+    """
+
+    def test_initialization(self):
+        """
+        Test PrimitiveIdentifier initialization.
+        """
+        primitive_identifier = PrimitiveIdentifier()
+        assert primitive_identifier is not None
+        assert primitive_identifier._value is None
+
+    def test_set_value(self):
+        """
+        Test PrimitiveIdentifier value assignment.
+        """
+        primitive_identifier = PrimitiveIdentifier().setValue("INFORMAL")
+        assert primitive_identifier.getValue() == "INFORMAL"
 
 
 class TestReferrableSubtypesEnum:

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
@@ -298,84 +298,84 @@ class Test_FibexCoreCommunication:
         assert ipdu.getContainedIPduProps() == props
         assert ipdu == ipdu.setContainedIPduProps(props)  # Test method chaining
 
-    def test_SecureCommunicationProps(self):
-        """Test SecureCommunicationProps class functionality."""
+    def test_SecureCommunicationProps_initialization(self):
         props = SecureCommunicationProps()
 
         assert isinstance(props, ARObject)
 
-        # Test default values
         assert props.getAuthDataFreshnessLength() is None
         assert props.getAuthDataFreshnessStartPosition() is None
-        assert props.getAuthInfoTxLength() is None
         assert props.getAuthenticationBuildAttempts() is None
         assert props.getAuthenticationRetries() is None
         assert props.getDataId() is None
         assert props.getFreshnessValueId() is None
-        assert props.getFreshnessValueLength() is None
-        assert props.getFreshnessValueTxLength() is None
         assert props.getMessageLinkLength() is None
         assert props.getMessageLinkPosition() is None
         assert props.getSecondaryFreshnessValueId() is None
         assert props.getSecuredAreaLength() is None
         assert props.getSecuredAreaOffset() is None
 
-        # Test setter/getter methods with method chaining
+        assert not hasattr(props, "getAuthInfoTxLength")
+        assert not hasattr(props, "getFreshnessValueLength")
+        assert not hasattr(props, "getFreshnessValueTxLength")
+
+    def test_SecureCommunicationProps_set_get(self):
+        props = SecureCommunicationProps()
+
         props.setAuthDataFreshnessLength(10)
         assert props.getAuthDataFreshnessLength() == 10
-        assert props == props.setAuthDataFreshnessLength(10)  # Test method chaining
+        assert props == props.setAuthDataFreshnessLength(None)
+        assert props.getAuthDataFreshnessLength() == 10
 
         props.setAuthDataFreshnessStartPosition(20)
         assert props.getAuthDataFreshnessStartPosition() == 20
-        assert props == props.setAuthDataFreshnessStartPosition(20)  # Test method chaining
-
-        props.setAuthInfoTxLength(30)
-        assert props.getAuthInfoTxLength() == 30
-        assert props == props.setAuthInfoTxLength(30)  # Test method chaining
+        assert props == props.setAuthDataFreshnessStartPosition(None)
+        assert props.getAuthDataFreshnessStartPosition() == 20
 
         props.setAuthenticationBuildAttempts(5)
         assert props.getAuthenticationBuildAttempts() == 5
-        assert props == props.setAuthenticationBuildAttempts(5)  # Test method chaining
+        assert props == props.setAuthenticationBuildAttempts(None)
+        assert props.getAuthenticationBuildAttempts() == 5
 
         props.setAuthenticationRetries(3)
         assert props.getAuthenticationRetries() == 3
-        assert props == props.setAuthenticationRetries(3)  # Test method chaining
+        assert props == props.setAuthenticationRetries(None)
+        assert props.getAuthenticationRetries() == 3
 
         props.setDataId(42)
         assert props.getDataId() == 42
-        assert props == props.setDataId(42)  # Test method chaining
+        assert props == props.setDataId(None)
+        assert props.getDataId() == 42
 
         props.setFreshnessValueId(100)
         assert props.getFreshnessValueId() == 100
-        assert props == props.setFreshnessValueId(100)  # Test method chaining
-
-        props.setFreshnessValueLength(50)
-        assert props.getFreshnessValueLength() == 50
-        assert props == props.setFreshnessValueLength(50)  # Test method chaining
-
-        props.setFreshnessValueTxLength(60)
-        assert props.getFreshnessValueTxLength() == 60
-        assert props == props.setFreshnessValueTxLength(60)  # Test method chaining
+        assert props == props.setFreshnessValueId(None)
+        assert props.getFreshnessValueId() == 100
 
         props.setMessageLinkLength(70)
         assert props.getMessageLinkLength() == 70
-        assert props == props.setMessageLinkLength(70)  # Test method chaining
+        assert props == props.setMessageLinkLength(None)
+        assert props.getMessageLinkLength() == 70
 
         props.setMessageLinkPosition(80)
         assert props.getMessageLinkPosition() == 80
-        assert props == props.setMessageLinkPosition(80)  # Test method chaining
+        assert props == props.setMessageLinkPosition(None)
+        assert props.getMessageLinkPosition() == 80
 
         props.setSecondaryFreshnessValueId(200)
         assert props.getSecondaryFreshnessValueId() == 200
-        assert props == props.setSecondaryFreshnessValueId(200)  # Test method chaining
+        assert props == props.setSecondaryFreshnessValueId(None)
+        assert props.getSecondaryFreshnessValueId() == 200
 
         props.setSecuredAreaLength(90)
         assert props.getSecuredAreaLength() == 90
-        assert props == props.setSecuredAreaLength(90)  # Test method chaining
+        assert props == props.setSecuredAreaLength(None)
+        assert props.getSecuredAreaLength() == 90
 
         props.setSecuredAreaOffset(100)
         assert props.getSecuredAreaOffset() == 100
-        assert props == props.setSecuredAreaOffset(100)  # Test method chaining
+        assert props == props.setSecuredAreaOffset(None)
+        assert props.getSecuredAreaOffset() == 100
 
     def test_SecuredIPdu(self):
         """Test SecuredIPdu class functionality."""
@@ -955,15 +955,41 @@ class Test_FibexCoreCommunication:
 
         assert isinstance(ipdu, IPdu)
 
-    def test_SecureCommunicationPropsSet(self):
-        """Test SecureCommunicationPropsSet class functionality."""
+    def test_SecureCommunicationPropsSet_initialization(self):
         parent = MockParent()
         props_set = SecureCommunicationPropsSet(parent, "test_secure_com_props_set")
 
         assert isinstance(props_set, Identifiable)
 
-        # Test default values
-        assert props_set.secureComProps == []
+        assert props_set.getAuthenticationProps() == []
+        assert props_set.getFreshnessProps() == []
+        assert not hasattr(props_set, "secureComProps")
+
+    def test_SecureCommunicationPropsSet_create_authentication_props(self):
+        parent = MockParent()
+        props_set = SecureCommunicationPropsSet(parent, "test_secure_com_props_set")
+
+        props = props_set.createSecureCommunicationAuthenticationProps("authProps")
+        assert isinstance(props, SecureCommunicationAuthenticationProps)
+        assert props.getShortName() == "authProps"
+        assert props_set.getAuthenticationProps() == [props]
+
+        props_dup = props_set.createSecureCommunicationAuthenticationProps("authProps")
+        assert props_dup is props
+        assert len(props_set.getAuthenticationProps()) == 1
+
+    def test_SecureCommunicationPropsSet_create_freshness_props(self):
+        parent = MockParent()
+        props_set = SecureCommunicationPropsSet(parent, "test_secure_com_props_set")
+
+        props = props_set.createSecureCommunicationFreshnessProps("freshProps")
+        assert isinstance(props, SecureCommunicationFreshnessProps)
+        assert props.getShortName() == "freshProps"
+        assert props_set.getFreshnessProps() == [props]
+
+        props_dup = props_set.createSecureCommunicationFreshnessProps("freshProps")
+        assert props_dup is props
+        assert len(props_set.getFreshnessProps()) == 1
 
     def test_UserDefinedPdu(self):
         """Test UserDefinedPdu class functionality."""
@@ -979,77 +1005,69 @@ class Test_FibexCoreCommunication:
 
         assert isinstance(ipdu, IPdu)
 
-    def test_SecureCommunicationAuthenticationProps(self):
-        """Test SecureCommunicationAuthenticationProps class functionality."""
+    def test_SecureCommunicationAuthenticationProps_initialization(self):
         parent = MockParent()
         auth_props = SecureCommunicationAuthenticationProps(parent, "test_auth_props")
 
         assert isinstance(auth_props, Identifiable)
 
-        # Test default values
-        assert auth_props.getAuthenticationBuildAttempts() is None
-        assert auth_props.getAuthenticationRetries() is None
-        assert auth_props.getDataId() is None
-        assert auth_props.getSecuredComAuthenticationType() is None
+        assert auth_props.getAuthInfoTxLength() is None
+        assert not hasattr(auth_props, "getAuthenticationBuildAttempts")
+        assert not hasattr(auth_props, "getAuthenticationRetries")
+        assert not hasattr(auth_props, "getDataId")
+        assert not hasattr(auth_props, "getSecuredComAuthenticationType")
 
-        # Test setter/getter methods with method chaining (only when value is not None)
-        auth_props.setAuthenticationBuildAttempts(5)
-        assert auth_props.getAuthenticationBuildAttempts() == 5
-        assert auth_props == auth_props.setAuthenticationBuildAttempts(5)  # Test method chaining
+    def test_SecureCommunicationAuthenticationProps_set_get(self):
+        parent = MockParent()
+        auth_props = SecureCommunicationAuthenticationProps(parent, "test_auth_props")
 
-        auth_props.setAuthenticationRetries(3)
-        assert auth_props.getAuthenticationRetries() == 3
-        assert auth_props == auth_props.setAuthenticationRetries(3)  # Test method chaining
+        auth_props.setAuthInfoTxLength(4)
+        assert auth_props.getAuthInfoTxLength() == 4
+        assert auth_props == auth_props.setAuthInfoTxLength(None)
+        assert auth_props.getAuthInfoTxLength() == 4
 
-        auth_props.setDataId(42)
-        assert auth_props.getDataId() == 42
-        assert auth_props == auth_props.setDataId(42)  # Test method chaining
-
-        auth_props.setSecuredComAuthenticationType("HMAC_SHA256")
-        assert auth_props.getSecuredComAuthenticationType() == "HMAC_SHA256"
-        assert auth_props == auth_props.setSecuredComAuthenticationType("HMAC_SHA256")  # Test method chaining
-
-    def test_SecureCommunicationFreshnessProps(self):
-        """Test SecureCommunicationFreshnessProps class functionality."""
+    def test_SecureCommunicationFreshnessProps_initialization(self):
         parent = MockParent()
         freshness_props = SecureCommunicationFreshnessProps(parent, "test_freshness_props")
 
         assert isinstance(freshness_props, Identifiable)
 
-        # Test default values
-        assert freshness_props.getFreshnessValueId() is None
+        assert freshness_props.getFreshnessCounterSyncAttempts() is None
+        assert freshness_props.getFreshnessTimestampTimePeriodFactor() is None
         assert freshness_props.getFreshnessValueLength() is None
         assert freshness_props.getFreshnessValueTxLength() is None
-        assert freshness_props.getMessageLinkLength() is None
-        assert freshness_props.getMessageLinkPosition() is None
-        assert freshness_props.getSecondaryFreshnessValueId() is None
-        assert freshness_props.getSecuredComFreshnessType() is None
+        assert freshness_props.getUseFreshnessTimestamp() is None
+        assert not hasattr(freshness_props, "getFreshnessValueId")
+        assert not hasattr(freshness_props, "getMessageLinkLength")
+        assert not hasattr(freshness_props, "getMessageLinkPosition")
+        assert not hasattr(freshness_props, "getSecondaryFreshnessValueId")
+        assert not hasattr(freshness_props, "getSecuredComFreshnessType")
 
-        # Test setter/getter methods with method chaining (only when value is not None)
-        freshness_props.setFreshnessValueId(100)
-        assert freshness_props.getFreshnessValueId() == 100
-        assert freshness_props == freshness_props.setFreshnessValueId(100)  # Test method chaining
+    def test_SecureCommunicationFreshnessProps_set_get(self):
+        parent = MockParent()
+        freshness_props = SecureCommunicationFreshnessProps(parent, "test_freshness_props")
+
+        freshness_props.setFreshnessCounterSyncAttempts(3)
+        assert freshness_props.getFreshnessCounterSyncAttempts() == 3
+        assert freshness_props == freshness_props.setFreshnessCounterSyncAttempts(None)
+        assert freshness_props.getFreshnessCounterSyncAttempts() == 3
+
+        freshness_props.setFreshnessTimestampTimePeriodFactor(2)
+        assert freshness_props.getFreshnessTimestampTimePeriodFactor() == 2
+        assert freshness_props == freshness_props.setFreshnessTimestampTimePeriodFactor(None)
+        assert freshness_props.getFreshnessTimestampTimePeriodFactor() == 2
 
         freshness_props.setFreshnessValueLength(50)
         assert freshness_props.getFreshnessValueLength() == 50
-        assert freshness_props == freshness_props.setFreshnessValueLength(50)  # Test method chaining
+        assert freshness_props == freshness_props.setFreshnessValueLength(None)
+        assert freshness_props.getFreshnessValueLength() == 50
 
         freshness_props.setFreshnessValueTxLength(60)
         assert freshness_props.getFreshnessValueTxLength() == 60
-        assert freshness_props == freshness_props.setFreshnessValueTxLength(60)  # Test method chaining
+        assert freshness_props == freshness_props.setFreshnessValueTxLength(None)
+        assert freshness_props.getFreshnessValueTxLength() == 60
 
-        freshness_props.setMessageLinkLength(70)
-        assert freshness_props.getMessageLinkLength() == 70
-        assert freshness_props == freshness_props.setMessageLinkLength(70)  # Test method chaining
-
-        freshness_props.setMessageLinkPosition(80)
-        assert freshness_props.getMessageLinkPosition() == 80
-        assert freshness_props == freshness_props.setMessageLinkPosition(80)  # Test method chaining
-
-        freshness_props.setSecondaryFreshnessValueId(200)
-        assert freshness_props.getSecondaryFreshnessValueId() == 200
-        assert freshness_props == freshness_props.setSecondaryFreshnessValueId(200)  # Test method chaining
-
-        freshness_props.setSecuredComFreshnessType("COUNTER_BASED")
-        assert freshness_props.getSecuredComFreshnessType() == "COUNTER_BASED"
-        assert freshness_props == freshness_props.setSecuredComFreshnessType("COUNTER_BASED")  # Test method chaining
+        freshness_props.setUseFreshnessTimestamp(True)
+        assert freshness_props.getUseFreshnessTimestamp() is True
+        assert freshness_props == freshness_props.setUseFreshnessTimestamp(None)
+        assert freshness_props.getUseFreshnessTimestamp() is True

--- a/tests/test_armodel/models/M2/MSR/DataDictionary/test_DataDefProperties.py
+++ b/tests/test_armodel/models/M2/MSR/DataDictionary/test_DataDefProperties.py
@@ -4,10 +4,11 @@ This module contains tests for the DataDefProperties module in MSR.DataDictionar
 
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import NumericalValueSpecification
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes import ArraySizeSemanticsEnum
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    AlignmentType,
     ARFloat,
     ARNumerical,
-    AlignmentType,
     Boolean,
     DisplayFormatString,
     Identifier,
@@ -16,24 +17,23 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     PrimitiveIdentifier,
     RefType,
 )
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AutosarVariableRef import AutosarVariableRef
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.InstanceRefsUsage import AutosarParameterRef
 from armodel.models.M2.MSR.DataDictionary.CalibrationParameter import SwCalprmAxisSet
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import (
-    SwDataDefProps,
-    SwCalibrationAccessEnum,
-    SwImplPolicyEnum,
+    CompuGenericMath,
     DisplayPresentationEnum,
+    SwBitRepresentation,
+    SwCalibrationAccessEnum,
+    SwCalprmRefProxy,
+    SwDataDefProps,
+    SwDataDependency,
+    SwDataDependencyArgs,
+    SwImplPolicyEnum,
     SwPointerTargetProps,
     SwTextProps,
-    ValueList,
-    SwBitRepresentation,
     SwVariableRefProxy,
-    SwCalprmRefProxy,
-    SwDataDependencyArgs,
-    CompuGenericMath,
-    SwDataDependency,
+    ValueList,
 )
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation
 

--- a/tests/test_armodel/models/M2/MSR/DataDictionary/test_DataDefProperties.py
+++ b/tests/test_armodel/models/M2/MSR/DataDictionary/test_DataDefProperties.py
@@ -4,15 +4,36 @@ This module contains tests for the DataDefProperties module in MSR.DataDictionar
 
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import NumericalValueSpecification
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes import ArraySizeSemanticsEnum
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARFloat, ARLiteral, Integer, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    ARFloat,
+    ARNumerical,
+    AlignmentType,
+    Boolean,
+    DisplayFormatString,
+    Identifier,
+    Integer,
+    NativeDeclarationString,
+    PrimitiveIdentifier,
+    RefType,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AutosarVariableRef import AutosarVariableRef
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.InstanceRefsUsage import AutosarParameterRef
 from armodel.models.M2.MSR.DataDictionary.CalibrationParameter import SwCalprmAxisSet
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import (
     SwDataDefProps,
-    SwDataDefPropsConditional,
+    SwCalibrationAccessEnum,
     SwImplPolicyEnum,
+    DisplayPresentationEnum,
     SwPointerTargetProps,
     SwTextProps,
     ValueList,
+    SwBitRepresentation,
+    SwVariableRefProxy,
+    SwCalprmRefProxy,
+    SwDataDependencyArgs,
+    CompuGenericMath,
+    SwDataDependency,
 )
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation
 
@@ -21,9 +42,7 @@ class TestSwImplPolicyEnum:
     """Test class for SwImplPolicyEnum class."""
 
     def test_sw_impl_policy_enum_initialization(self):
-        """Test that SwImplPolicyEnum can be initialized with default values."""
         SwImplPolicyEnum()
-        # Since SwImplPolicyEnum inherits from AREnum, check that it has the expected values
         assert SwImplPolicyEnum.CONST == "const"
         assert SwImplPolicyEnum.FIXED == "fixed"
         assert SwImplPolicyEnum.MEASUREMENT_POINT == "measurementPoint"
@@ -31,7 +50,6 @@ class TestSwImplPolicyEnum:
         assert SwImplPolicyEnum.STANDARD == "standard"
 
     def test_sw_impl_policy_enum_values(self):
-        """Test that SwImplPolicyEnum has the expected values."""
         assert hasattr(SwImplPolicyEnum, "CONST")
         assert hasattr(SwImplPolicyEnum, "FIXED")
         assert hasattr(SwImplPolicyEnum, "MEASUREMENT_POINT")
@@ -44,20 +62,194 @@ class TestSwImplPolicyEnum:
         assert SwImplPolicyEnum.STANDARD == "standard"
 
 
-class TestSwDataDefPropsConditional:
-    """Test class for SwDataDefPropsConditional class."""
+class TestSwCalibrationAccessEnum:
+    """Test class for SwCalibrationAccessEnum class."""
 
-    def test_sw_data_def_props_conditional_initialization(self):
-        """Test that a SwDataDefPropsConditional object can be initialized."""
-        sw_data_def_props_conditional = SwDataDefPropsConditional()
-        assert sw_data_def_props_conditional is not None
+    def test_sw_calibration_access_enum_initialization(self):
+        SwCalibrationAccessEnum()
+        assert SwCalibrationAccessEnum.NOT_ACCESSIBLE == "notAccessible"
+        assert SwCalibrationAccessEnum.READ_ONLY == "readOnly"
+        assert SwCalibrationAccessEnum.READ_WRITE == "readWrite"
+
+    def test_sw_calibration_access_enum_values(self):
+        assert hasattr(SwCalibrationAccessEnum, "NOT_ACCESSIBLE")
+        assert hasattr(SwCalibrationAccessEnum, "READ_ONLY")
+        assert hasattr(SwCalibrationAccessEnum, "READ_WRITE")
+        assert SwCalibrationAccessEnum.NOT_ACCESSIBLE == "notAccessible"
+        assert SwCalibrationAccessEnum.READ_ONLY == "readOnly"
+        assert SwCalibrationAccessEnum.READ_WRITE == "readWrite"
+
+
+class TestDisplayPresentationEnum:
+    """Test class for DisplayPresentationEnum class."""
+
+    def test_display_presentation_enum_initialization(self):
+        DisplayPresentationEnum()
+        assert DisplayPresentationEnum.PRESENTATION_CONTINUOUS == "presentationContinuous"
+        assert DisplayPresentationEnum.PRESENTATION_DISCRETE == "presentationDiscrete"
+
+    def test_display_presentation_enum_values(self):
+        assert hasattr(DisplayPresentationEnum, "PRESENTATION_CONTINUOUS")
+        assert hasattr(DisplayPresentationEnum, "PRESENTATION_DISCRETE")
+        assert DisplayPresentationEnum.PRESENTATION_CONTINUOUS == "presentationContinuous"
+        assert DisplayPresentationEnum.PRESENTATION_DISCRETE == "presentationDiscrete"
+
+
+class TestSwBitRepresentation:
+    """Test class for SwBitRepresentation class."""
+
+    def test_sw_bit_representation_initialization(self):
+        sw_bit_representation = SwBitRepresentation()
+        assert sw_bit_representation.getBitPosition() is None
+        assert sw_bit_representation.getNumberOfBits() is None
+
+    def test_sw_bit_representation_methods(self):
+        sw_bit_representation = SwBitRepresentation()
+        bit_position = Integer().setValue("3")
+        number_of_bits = Integer().setValue("5")
+
+        assert sw_bit_representation.setBitPosition(bit_position) == sw_bit_representation
+        assert sw_bit_representation.getBitPosition() == bit_position
+        assert sw_bit_representation.setNumberOfBits(number_of_bits) == sw_bit_representation
+        assert sw_bit_representation.getNumberOfBits() == number_of_bits
+
+    def test_sw_bit_representation_none_noop(self):
+        sw_bit_representation = SwBitRepresentation()
+        sw_bit_representation.setBitPosition(Integer().setValue("3"))
+        sw_bit_representation.setBitPosition(None)
+        assert sw_bit_representation.getBitPosition().getValue() == 3
+
+
+class TestSwVariableRefProxy:
+    """Test class for SwVariableRefProxy class."""
+
+    def test_sw_variable_ref_proxy_initialization(self):
+        proxy = SwVariableRefProxy()
+        assert proxy.getAutosarVariable() is None
+        assert proxy.getMcDataInstanceVarRef() is None
+
+    def test_sw_variable_ref_proxy_methods(self):
+        proxy = SwVariableRefProxy()
+        autosar_variable = AutosarVariableRef().setLocalVariableRef(RefType().setDest("AUTOSAR/Variables/var"))
+        mc_data_instance_var = RefType().setDest("AUTOSAR/McDataInstances/inst")
+
+        assert proxy.setAutosarVariable(autosar_variable) == proxy
+        assert proxy.getAutosarVariable() == autosar_variable
+        assert proxy.setMcDataInstanceVarRef(mc_data_instance_var) == proxy
+        assert proxy.getMcDataInstanceVarRef() == mc_data_instance_var
+
+    def test_sw_variable_ref_proxy_none_noop(self):
+        proxy = SwVariableRefProxy()
+        autosar_variable = AutosarVariableRef().setLocalVariableRef(RefType().setDest("AUTOSAR/Variables/var"))
+        proxy.setAutosarVariable(autosar_variable)
+        proxy.setAutosarVariable(None)
+        assert proxy.getAutosarVariable() == autosar_variable
+
+
+class TestSwCalprmRefProxy:
+    """Test class for SwCalprmRefProxy class."""
+
+    def test_sw_calprm_ref_proxy_initialization(self):
+        proxy = SwCalprmRefProxy()
+        assert proxy.getArParameter() is None
+        assert proxy.getMcDataInstanceRef() is None
+
+    def test_sw_calprm_ref_proxy_methods(self):
+        proxy = SwCalprmRefProxy()
+        ar_parameter = AutosarParameterRef().setLocalParameterRef(RefType().setDest("AUTOSAR/Parameters/param"))
+        mc_data_instance = RefType().setDest("AUTOSAR/McDataInstances/inst")
+
+        assert proxy.setArParameter(ar_parameter) == proxy
+        assert proxy.getArParameter() == ar_parameter
+        assert proxy.setMcDataInstanceRef(mc_data_instance) == proxy
+        assert proxy.getMcDataInstanceRef() == mc_data_instance
+
+    def test_sw_calprm_ref_proxy_none_noop(self):
+        proxy = SwCalprmRefProxy()
+        ar_parameter = AutosarParameterRef().setLocalParameterRef(RefType().setDest("AUTOSAR/Parameters/param"))
+        proxy.setArParameter(ar_parameter)
+        proxy.setArParameter(None)
+        assert proxy.getArParameter() == ar_parameter
+
+
+class TestSwDataDependencyArgs:
+    """Test class for SwDataDependencyArgs class."""
+
+    def test_sw_data_dependency_args_initialization(self):
+        args = SwDataDependencyArgs()
+        assert args.getSwCalprmRef() is None
+        assert args.getSwVariable() is None
+
+    def test_sw_data_dependency_args_methods(self):
+        args = SwDataDependencyArgs()
+        sw_calprm_ref = SwCalprmRefProxy()
+        sw_variable = SwVariableRefProxy()
+
+        assert args.setSwCalprmRef(sw_calprm_ref) == args
+        assert args.getSwCalprmRef() == sw_calprm_ref
+        assert args.setSwVariable(sw_variable) == args
+        assert args.getSwVariable() == sw_variable
+
+    def test_sw_data_dependency_args_none_noop(self):
+        args = SwDataDependencyArgs()
+        sw_calprm_ref = SwCalprmRefProxy()
+        args.setSwCalprmRef(sw_calprm_ref)
+        args.setSwCalprmRef(None)
+        assert args.getSwCalprmRef() == sw_calprm_ref
+
+
+class TestCompuGenericMath:
+    """Test class for CompuGenericMath class."""
+
+    def test_compu_generic_math_initialization(self):
+        compu_generic_math = CompuGenericMath()
+        assert compu_generic_math.getLevel() is None
+
+    def test_compu_generic_math_methods(self):
+        compu_generic_math = CompuGenericMath()
+        level = PrimitiveIdentifier().setValue("INFORMAL")
+
+        assert compu_generic_math.setLevel(level) == compu_generic_math
+        assert compu_generic_math.getLevel() == level
+
+    def test_compu_generic_math_none_noop(self):
+        compu_generic_math = CompuGenericMath()
+        level = PrimitiveIdentifier().setValue("INFORMAL")
+        compu_generic_math.setLevel(level)
+        compu_generic_math.setLevel(None)
+        assert compu_generic_math.getLevel() == level
+
+
+class TestSwDataDependency:
+    """Test class for SwDataDependency class."""
+
+    def test_sw_data_dependency_initialization(self):
+        dependency = SwDataDependency()
+        assert dependency.getSwDataDependencyFormula() is None
+        assert dependency.getSwDataDependencyArgs() is None
+
+    def test_sw_data_dependency_methods(self):
+        dependency = SwDataDependency()
+        formula = CompuGenericMath()
+        args = SwDataDependencyArgs()
+
+        assert dependency.setSwDataDependencyFormula(formula) == dependency
+        assert dependency.getSwDataDependencyFormula() == formula
+        assert dependency.setSwDataDependencyArgs(args) == dependency
+        assert dependency.getSwDataDependencyArgs() == args
+
+    def test_sw_data_dependency_none_noop(self):
+        dependency = SwDataDependency()
+        formula = CompuGenericMath()
+        dependency.setSwDataDependencyFormula(formula)
+        dependency.setSwDataDependencyFormula(None)
+        assert dependency.getSwDataDependencyFormula() == formula
 
 
 class TestSwDataDefProps:
     """Test class for SwDataDefProps class."""
 
     def test_sw_data_def_props_initialization(self):
-        """Test that a SwDataDefProps object can be initialized with default values."""
         sw_data_def_props = SwDataDefProps()
         assert sw_data_def_props.additionalNativeTypeQualifier is None
         assert sw_data_def_props.annotations == []
@@ -89,276 +281,222 @@ class TestSwDataDefProps:
         assert sw_data_def_props.swValueBlockSizeMults == []
         assert sw_data_def_props.unitRef is None
         assert sw_data_def_props.valueAxisDataTypeRef is None
-        assert sw_data_def_props.conditional is not None
+
+    def test_sw_data_def_props_none_noop_chain(self):
+        sw_data_def_props = SwDataDefProps()
+        qualifier = NativeDeclarationString().setValue("const")
+        sw_data_def_props.setAdditionalNativeTypeQualifier(qualifier)
+        result = sw_data_def_props.setAdditionalNativeTypeQualifier(None)
+        assert sw_data_def_props.getAdditionalNativeTypeQualifier() == qualifier
+        assert result == sw_data_def_props
 
     def test_sw_data_def_props_additional_native_type_qualifier_methods(self):
-        """Test the additionalNativeTypeQualifier getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        qualifier = "const"
-
+        qualifier = NativeDeclarationString().setValue("const")
         result = sw_data_def_props.setAdditionalNativeTypeQualifier(qualifier)
         assert sw_data_def_props.getAdditionalNativeTypeQualifier() == qualifier
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_annotations_methods(self):
-        """Test adding annotations."""
         sw_data_def_props = SwDataDefProps()
         annotation = Annotation()
-
         result = sw_data_def_props.addAnnotation(annotation)
         annotations = sw_data_def_props.getAnnotations()
         assert annotation in annotations
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_base_type_ref_methods(self):
-        """Test the baseTypeRef getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        ref = RefType()
-
+        ref = RefType().setDest("AUTOSAR/BaseTypes/uint8")
         result = sw_data_def_props.setBaseTypeRef(ref)
         assert sw_data_def_props.getBaseTypeRef() == ref
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_compu_method_ref_methods(self):
-        """Test the compuMethodRef getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        ref = RefType()
-
+        ref = RefType().setDest("AUTOSAR/CompuMethods/cm")
         result = sw_data_def_props.setCompuMethodRef(ref)
         assert sw_data_def_props.getCompuMethodRef() == ref
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_data_constr_ref_methods(self):
-        """Test the dataConstrRef getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        ref = RefType()
-
+        ref = RefType().setDest("AUTOSAR/DataConstrs/dc")
         result = sw_data_def_props.setDataConstrRef(ref)
         assert sw_data_def_props.getDataConstrRef() == ref
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_display_format_methods(self):
-        """Test the displayFormat getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        format_str = ARLiteral()
-
+        format_str = DisplayFormatString().setValue("%5.2f")
         result = sw_data_def_props.setDisplayFormat(format_str)
         assert sw_data_def_props.getDisplayFormat() == format_str
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_display_presentation_methods(self):
-        """Test the displayPresentation getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        presentation = ARLiteral()
-
+        presentation = DisplayPresentationEnum().setValue(DisplayPresentationEnum.PRESENTATION_CONTINUOUS)
         result = sw_data_def_props.setDisplayPresentation(presentation)
         assert sw_data_def_props.getDisplayPresentation() == presentation
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_implementation_data_type_ref_methods(self):
-        """Test the implementationDataTypeRef getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        ref = RefType()
-
+        ref = RefType().setDest("AUTOSAR/ImplementationDataTypes/idt")
         result = sw_data_def_props.setImplementationDataTypeRef(ref)
         assert sw_data_def_props.getImplementationDataTypeRef() == ref
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_invalid_value_methods(self):
-        """Test the invalidValue getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        # Using a concrete implementation of ValueSpecification instead of abstract class
         invalid_val = NumericalValueSpecification()
-
         result = sw_data_def_props.setInvalidValue(invalid_val)
         assert sw_data_def_props.getInvalidValue() == invalid_val
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_step_size_methods(self):
-        """Test the stepSize getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        step_size = ARFloat()
-
+        step_size = ARFloat().setValue("0.5")
         result = sw_data_def_props.setStepSize(step_size)
         assert sw_data_def_props.getStepSize() == step_size
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_addr_method_ref_methods(self):
-        """Test the swAddrMethodRef getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        ref = RefType()
-
+        ref = RefType().setDest("AUTOSAR/SwAddrMethods/ram")
         result = sw_data_def_props.setSwAddrMethodRef(ref)
         assert sw_data_def_props.getSwAddrMethodRef() == ref
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_alignment_methods(self):
-        """Test the swAlignment getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        alignment = ARLiteral()
-
+        alignment = AlignmentType().setValue("4")
         result = sw_data_def_props.setSwAlignment(alignment)
         assert sw_data_def_props.getSwAlignment() == alignment
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_bit_representation_methods(self):
-        """Test the swBitRepresentation getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        bit_rep = ARLiteral()
-
+        bit_rep = SwBitRepresentation()
         result = sw_data_def_props.setSwBitRepresentation(bit_rep)
         assert sw_data_def_props.getSwBitRepresentation() == bit_rep
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_calibration_access_methods(self):
-        """Test the swCalibrationAccess getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        cal_access = ARLiteral()
-
+        cal_access = SwCalibrationAccessEnum().setValue(SwCalibrationAccessEnum.READ_WRITE)
         result = sw_data_def_props.setSwCalibrationAccess(cal_access)
         assert sw_data_def_props.getSwCalibrationAccess() == cal_access
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_calprm_axis_set_methods(self):
-        """Test the swCalprmAxisSet getter and setter."""
         sw_data_def_props = SwDataDefProps()
         calprm_axis_set = SwCalprmAxisSet()
-
         result = sw_data_def_props.setSwCalprmAxisSet(calprm_axis_set)
         assert sw_data_def_props.getSwCalprmAxisSet() == calprm_axis_set
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_comparison_variables_methods(self):
-        """Test the swComparisonVariables getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        comp_vars = ["var1", "var2"]
-
-        result = sw_data_def_props.setSwComparisonVariables(comp_vars)
-        assert sw_data_def_props.getSwComparisonVariables() == comp_vars
+        comp_var = SwVariableRefProxy()
+        result = sw_data_def_props.addSwComparisonVariable(comp_var)
+        assert comp_var in sw_data_def_props.getSwComparisonVariables()
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_data_dependency_methods(self):
-        """Test the swDataDependency getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        data_dep = "dependency"
-
+        data_dep = SwDataDependency()
         result = sw_data_def_props.setSwDataDependency(data_dep)
         assert sw_data_def_props.getSwDataDependency() == data_dep
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_host_variable_methods(self):
-        """Test the swHostVariable getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        host_var = "host"
-
+        host_var = SwVariableRefProxy()
         result = sw_data_def_props.setSwHostVariable(host_var)
         assert sw_data_def_props.getSwHostVariable() == host_var
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_impl_policy_methods(self):
-        """Test the swImplPolicy getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        impl_policy = ARLiteral()
-
+        impl_policy = SwImplPolicyEnum().setValue(SwImplPolicyEnum.STANDARD)
         result = sw_data_def_props.setSwImplPolicy(impl_policy)
         assert sw_data_def_props.getSwImplPolicy() == impl_policy
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_intended_resolution_methods(self):
-        """Test the swIntendedResolution getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        resolution = "resolution"
-
+        resolution = ARNumerical().setValue("0.01")
         result = sw_data_def_props.setSwIntendedResolution(resolution)
         assert sw_data_def_props.getSwIntendedResolution() == resolution
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_interpolation_method_methods(self):
-        """Test the swInterpolationMethod getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        interp_method = "linear"
-
+        interp_method = Identifier().setValue("linear")
         result = sw_data_def_props.setSwInterpolationMethod(interp_method)
         assert sw_data_def_props.getSwInterpolationMethod() == interp_method
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_is_virtual_methods(self):
-        """Test the swIsVirtual getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        is_virtual = True
-
+        is_virtual = Boolean().setValue("true")
         result = sw_data_def_props.setSwIsVirtual(is_virtual)
         assert sw_data_def_props.getSwIsVirtual() == is_virtual
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_pointer_target_props_methods(self):
-        """Test the swPointerTargetProps getter and setter."""
         sw_data_def_props = SwDataDefProps()
         ptr_target_props = SwPointerTargetProps()
-
         result = sw_data_def_props.setSwPointerTargetProps(ptr_target_props)
         assert sw_data_def_props.getSwPointerTargetProps() == ptr_target_props
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_record_layout_ref_methods(self):
-        """Test the swRecordLayoutRef getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        ref = RefType()
-
+        ref = RefType().setDest("AUTOSAR/RecordLayouts/rl")
         result = sw_data_def_props.setSwRecordLayoutRef(ref)
         assert sw_data_def_props.getSwRecordLayoutRef() == ref
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_refresh_timing_methods(self):
-        """Test the swRefreshTiming getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        refresh_timing = "timing"
-
+        refresh_timing = MultidimensionalTime()
         result = sw_data_def_props.setSwRefreshTiming(refresh_timing)
         assert sw_data_def_props.getSwRefreshTiming() == refresh_timing
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_text_props_methods(self):
-        """Test the swTextProps getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        text_props = "text_props"
-
+        text_props = SwTextProps()
         result = sw_data_def_props.setSwTextProps(text_props)
         assert sw_data_def_props.getSwTextProps() == text_props
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_value_block_size_methods(self):
-        """Test the swValueBlockSize getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        block_size = "size"
-
+        block_size = ARNumerical().setValue("10")
         result = sw_data_def_props.setSwValueBlockSize(block_size)
         assert sw_data_def_props.getSwValueBlockSize() == block_size
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_sw_value_block_size_mults_methods(self):
-        """Test the swValueBlockSizeMults getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        mults = ["mult1", "mult2"]
-
-        result = sw_data_def_props.setSwValueBlockSizeMults(mults)
-        assert sw_data_def_props.getSwValueBlockSizeMults() == mults
+        mult = ARNumerical().setValue("2")
+        result = sw_data_def_props.addSwValueBlockSizeMult(mult)
+        assert mult in sw_data_def_props.getSwValueBlockSizeMults()
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_unit_ref_methods(self):
-        """Test the unitRef getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        ref = RefType()
-
+        ref = RefType().setDest("AUTOSAR/Units/second")
         result = sw_data_def_props.setUnitRef(ref)
         assert sw_data_def_props.getUnitRef() == ref
         assert result == sw_data_def_props
 
     def test_sw_data_def_props_value_axis_data_type_ref_methods(self):
-        """Test the valueAxisDataTypeRef getter and setter."""
         sw_data_def_props = SwDataDefProps()
-        ref = RefType()
-
+        ref = RefType().setDest("AUTOSAR/ApplicationDataTypes/adt")
         result = sw_data_def_props.setValueAxisDataTypeRef(ref)
         assert sw_data_def_props.getValueAxisDataTypeRef() == ref
         assert result == sw_data_def_props
@@ -368,35 +506,28 @@ class TestSwPointerTargetProps:
     """Test class for SwPointerTargetProps class."""
 
     def test_sw_pointer_target_props_initialization(self):
-        """Test that a SwPointerTargetProps object can be initialized with default values."""
         sw_pointer_target_props = SwPointerTargetProps()
         assert sw_pointer_target_props.functionPointerSignatureRef is None
         assert sw_pointer_target_props.swDataDefProps is None
         assert sw_pointer_target_props.targetCategory is None
 
     def test_sw_pointer_target_props_function_pointer_signature_ref_methods(self):
-        """Test the functionPointerSignatureRef getter and setter."""
         sw_pointer_target_props = SwPointerTargetProps()
-        ref = RefType()
-
+        ref = RefType().setDest("AUTOSAR/FunctionPointerSignatures/fps")
         result = sw_pointer_target_props.setFunctionPointerSignatureRef(ref)
         assert sw_pointer_target_props.getFunctionPointerSignatureRef() == ref
         assert result == sw_pointer_target_props
 
     def test_sw_pointer_target_props_sw_data_def_props_methods(self):
-        """Test the swDataDefProps getter and setter."""
         sw_pointer_target_props = SwPointerTargetProps()
         data_def_props = SwDataDefProps()
-
         result = sw_pointer_target_props.setSwDataDefProps(data_def_props)
         assert sw_pointer_target_props.getSwDataDefProps() == data_def_props
         assert result == sw_pointer_target_props
 
     def test_sw_pointer_target_props_target_category_methods(self):
-        """Test the targetCategory getter and setter."""
         sw_pointer_target_props = SwPointerTargetProps()
-        category = ARLiteral()
-
+        category = Identifier().setValue("function-pointer")
         result = sw_pointer_target_props.setTargetCategory(category)
         assert sw_pointer_target_props.getTargetCategory() == category
         assert result == sw_pointer_target_props
@@ -406,25 +537,20 @@ class TestValueList:
     """Test class for ValueList class."""
 
     def test_value_list_initialization(self):
-        """Test that a ValueList object can be initialized with default values."""
         value_list = ValueList()
         assert value_list.v is None
         assert value_list._vf == []
 
     def test_value_list_v_methods(self):
-        """Test the v getter and setter."""
         value_list = ValueList()
-        value = ARFloat()
-
+        value = ARNumerical().setValue("1.5")
         result = value_list.setV(value)
         assert value_list.getV() == value
         assert result == value_list
 
     def test_value_list_vf_methods(self):
-        """Test adding and getting vf values."""
         value_list = ValueList()
-        vf = ARLiteral()
-
+        vf = ARNumerical().setValue("1.5")
         value_list.addVf(vf)
         vfs = value_list.getVfs()
         assert vf in vfs
@@ -435,7 +561,6 @@ class TestSwTextProps:
     """Test class for SwTextProps class."""
 
     def test_sw_text_props_initialization(self):
-        """Test that a SwTextProps object can be initialized with default values."""
         sw_text_props = SwTextProps()
         assert sw_text_props.arraySizeSemantics is None
         assert sw_text_props.baseTypeRef is None
@@ -443,49 +568,37 @@ class TestSwTextProps:
         assert sw_text_props.swMaxTextSize is None
 
     def test_sw_text_props_array_size_semantics_methods(self):
-        """Test the arraySizeSemantics getter and setter."""
         sw_text_props = SwTextProps()
         semantics = ArraySizeSemanticsEnum().setValue(ArraySizeSemanticsEnum.FIXED_SIZE)
-
         result = sw_text_props.setArraySizeSemantics(semantics)
         assert sw_text_props.getArraySizeSemantics() == semantics
         assert result == sw_text_props
-
         sw_text_props.setArraySizeSemantics(None)
         assert sw_text_props.getArraySizeSemantics() == semantics
 
     def test_sw_text_props_base_type_ref_methods(self):
-        """Test the baseTypeRef getter and setter."""
         sw_text_props = SwTextProps()
-        ref = RefType()
-
+        ref = RefType().setDest("AUTOSAR/BaseTypes/uint8")
         result = sw_text_props.setBaseTypeRef(ref)
         assert sw_text_props.getBaseTypeRef() == ref
         assert result == sw_text_props
-
         sw_text_props.setBaseTypeRef(None)
         assert sw_text_props.getBaseTypeRef() == ref
 
     def test_sw_text_props_sw_fill_character_methods(self):
-        """Test the swFillCharacter getter and setter."""
         sw_text_props = SwTextProps()
         fill_character = Integer().setValue("0")
-
         result = sw_text_props.setSwFillCharacter(fill_character)
         assert sw_text_props.getSwFillCharacter() == fill_character
         assert result == sw_text_props
-
         sw_text_props.setSwFillCharacter(None)
         assert sw_text_props.getSwFillCharacter() == fill_character
 
     def test_sw_text_props_sw_max_text_size_methods(self):
-        """Test the swMaxTextSize getter and setter."""
         sw_text_props = SwTextProps()
         max_text_size = Integer().setValue("200")
-
         result = sw_text_props.setSwMaxTextSize(max_text_size)
         assert sw_text_props.getSwMaxTextSize() == max_text_size
         assert result == sw_text_props
-
         sw_text_props.setSwMaxTextSize(None)
         assert sw_text_props.getSwMaxTextSize() == max_text_size

--- a/tests/test_armodel/parser/test_arxml_parser_multiplexed.py
+++ b/tests/test_armodel/parser/test_arxml_parser_multiplexed.py
@@ -326,11 +326,10 @@ class TestSecureCommunicationHandlers:
     def test_readSecureCommunicationAuthenticationProps_with_mock(self, parser):
         props = MagicMock()
         element = _snip(
-            "<SHORT-NAME>authProps</SHORT-NAME>" "<AUTH-ALGORITHM>AES-128</AUTH-ALGORITHM>" "<AUTH-INFO-TX-LENGTH>16</AUTH-INFO-TX-LENGTH>",
+            "<SHORT-NAME>authProps</SHORT-NAME>" "<AUTH-INFO-TX-LENGTH>16</AUTH-INFO-TX-LENGTH>",
             root_tag="SECURE-COMMUNICATION-AUTHENTICATION-PROPS",
         )
         parser.readSecureCommunicationAuthenticationProps(element, props)
-        assert props.setAuthAlgorithm.called
         assert props.setAuthInfoTxLength.called
 
     def test_readSecureCommunicationAuthenticationProps_empty_with_mock(self, parser):
@@ -340,19 +339,13 @@ class TestSecureCommunicationHandlers:
             root_tag="SECURE-COMMUNICATION-AUTHENTICATION-PROPS",
         )
         parser.readSecureCommunicationAuthenticationProps(element, props)
-        assert props.setAuthAlgorithm.called
         assert props.setAuthInfoTxLength.called
 
     def test_readSecureCommunicationPropsSetAuthenticationProps_with_props(self, parser):
         props_set = MagicMock()
         props_set.createSecureCommunicationAuthenticationProps.return_value = MagicMock()
         element = _snip(
-            "<AUTHENTICATION-PROPSS>"
-            "<SECURE-COMMUNICATION-AUTHENTICATION-PROPS>"
-            "<SHORT-NAME>authProps</SHORT-NAME>"
-            "<AUTH-ALGORITHM>AES-128</AUTH-ALGORITHM>"
-            "</SECURE-COMMUNICATION-AUTHENTICATION-PROPS>"
-            "</AUTHENTICATION-PROPSS>",
+            "<AUTHENTICATION-PROPSS>" "<SECURE-COMMUNICATION-AUTHENTICATION-PROPS>" "<SHORT-NAME>authProps</SHORT-NAME>" "</SECURE-COMMUNICATION-AUTHENTICATION-PROPS>" "</AUTHENTICATION-PROPSS>",
         )
         parser.readSecureCommunicationPropsSetAuthenticationProps(element, props_set)
         props_set.createSecureCommunicationAuthenticationProps.assert_called_once_with("authProps")
@@ -371,15 +364,26 @@ class TestSecureCommunicationHandlers:
 
         props = SecureCommunicationFreshnessProps(parent=_autosar_root(), short_name="freshProps")
         element = _snip(
-            "<SHORT-NAME>freshProps</SHORT-NAME>" "<FRESHNESS-VALUE-LENGTH>16</FRESHNESS-VALUE-LENGTH>" "<FRESHNESS-VALUE-TX-LENGTH>8</FRESHNESS-VALUE-TX-LENGTH>",
+            "<SHORT-NAME>freshProps</SHORT-NAME>"
+            "<FRESHNESS-COUNTER-SYNC-ATTEMPTS>3</FRESHNESS-COUNTER-SYNC-ATTEMPTS>"
+            "<FRESHNESS-TIMESTAMP-TIME-PERIOD-FACTOR>2</FRESHNESS-TIMESTAMP-TIME-PERIOD-FACTOR>"
+            "<FRESHNESS-VALUE-LENGTH>16</FRESHNESS-VALUE-LENGTH>"
+            "<FRESHNESS-VALUE-TX-LENGTH>8</FRESHNESS-VALUE-TX-LENGTH>"
+            "<USE-FRESHNESS-TIMESTAMP>true</USE-FRESHNESS-TIMESTAMP>",
             root_tag="SECURE-COMMUNICATION-FRESHNESS-PROPS",
         )
         parser.readSecureCommunicationFreshnessProps(element, props)
         assert props.getShortName() == "freshProps"
+        assert props.getFreshnessCounterSyncAttempts() is not None
+        assert props.getFreshnessCounterSyncAttempts().getValue() == 3
+        assert props.getFreshnessTimestampTimePeriodFactor() is not None
+        assert props.getFreshnessTimestampTimePeriodFactor().getValue() == 2
         assert props.getFreshnessValueLength() is not None
-        assert props.getFreshnessValueLength().getValue() == "16"
+        assert props.getFreshnessValueLength().getValue() == 16
         assert props.getFreshnessValueTxLength() is not None
         assert props.getFreshnessValueTxLength().getValue() == 8
+        assert props.getUseFreshnessTimestamp() is not None
+        assert props.getUseFreshnessTimestamp().getValue() is True
 
     def test_readSecureCommunicationFreshnessProps_empty(self, parser):
         from armodel.models import SecureCommunicationFreshnessProps
@@ -390,8 +394,11 @@ class TestSecureCommunicationHandlers:
             root_tag="SECURE-COMMUNICATION-FRESHNESS-PROPS",
         )
         parser.readSecureCommunicationFreshnessProps(element, props)
+        assert props.getFreshnessCounterSyncAttempts() is None
+        assert props.getFreshnessTimestampTimePeriodFactor() is None
         assert props.getFreshnessValueLength() is None
         assert props.getFreshnessValueTxLength() is None
+        assert props.getUseFreshnessTimestamp() is None
 
     def test_readSecureCommunicationPropsSetFreshnessProps_with_props(self, parser):
         props_set = MagicMock()
@@ -496,12 +503,13 @@ class TestPduAndSecureCommunication:
             "<SECURE-COMMUNICATION-PROPS>"
             "<AUTH-DATA-FRESHNESS-LENGTH>16</AUTH-DATA-FRESHNESS-LENGTH>"
             "<AUTH-DATA-FRESHNESS-START-POSITION>0</AUTH-DATA-FRESHNESS-START-POSITION>"
-            "<AUTH-INFO-TX-LENGTH>8</AUTH-INFO-TX-LENGTH>"
+            "<MESSAGE-LINK-LENGTH>8</MESSAGE-LINK-LENGTH>"
             "</SECURE-COMMUNICATION-PROPS>"
         )
         result = parser.getSecureCommunicationProps(element, "SECURE-COMMUNICATION-PROPS")
         assert result is not None
         assert result.getAuthDataFreshnessLength().getValue() == 16
+        assert result.getMessageLinkLength().getValue() == 8
 
 
 # ==================== NmConfig (L3981, L4072) ====================

--- a/tests/test_armodel/writer/test_writer_arpackage_dispatch.py
+++ b/tests/test_armodel/writer/test_writer_arpackage_dispatch.py
@@ -196,12 +196,14 @@ class TestWriteTriggerInterfaceDispatch:
 
 
 class TestWriteSecureCommunicationPropsSetDispatch:
-    @pytest.mark.skip(reason="Model method getAuthenticationProps not implemented")
     def test_secure_comm_props_set_dispatch(self, writer):
         pkg = _pkg()
         props = pkg.createSecureCommunicationPropsSet("Props")
         parent = _parent()
         writer.writeARPackageElement(parent, props)
+        child = parent.find("SECURE-COMMUNICATION-PROPS-SET")
+        assert child is not None
+        assert child.find("SHORT-NAME").text == "Props"
 
 
 class TestWriteReferenceBases:

--- a/tests/test_armodel/writer/test_writer_pdu_secure_soad.py
+++ b/tests/test_armodel/writer/test_writer_pdu_secure_soad.py
@@ -408,8 +408,6 @@ class TestWriteGeneralPurposeIPdu:
 class TestWriteSecureCommunicationAuthenticationProps:
     def test_with_mock(self, writer):
         props = SecureCommunicationAuthenticationProps(_pkg(), "authProps")
-        auth_algo = MagicMock()
-        props.getAuthAlgorithm = MagicMock(return_value=auth_algo)
         tx_len = MagicMock()
         props.getAuthInfoTxLength = MagicMock(return_value=tx_len)
         parent = _parent()
@@ -430,8 +428,6 @@ class TestWriteSecureCommunicationPropsSetAuthenticationProps:
         props_set = MagicMock()
         pkg = _pkg()
         props = SecureCommunicationAuthenticationProps(pkg, "authProps")
-        auth_algo = MagicMock()
-        props.getAuthAlgorithm = MagicMock(return_value=auth_algo)
         tx_len = MagicMock()
         props.getAuthInfoTxLength = MagicMock(return_value=tx_len)
         props_set.getAuthenticationProps.return_value = [props]
@@ -448,15 +444,21 @@ class TestWriteSecureCommunicationFreshnessProps:
     def test_with_real_props(self, writer):
         pkg = _pkg()
         props = SecureCommunicationFreshnessProps(pkg, "freshProps")
+        props.setFreshnessCounterSyncAttempts(_pos_int("3"))
+        props.setFreshnessTimestampTimePeriodFactor(_pos_int("2"))
         props.setFreshnessValueLength(_pos_int("16"))
         props.setFreshnessValueTxLength(_pos_int("8"))
+        props.setUseFreshnessTimestamp(_bool("true"))
         parent = _parent()
         writer.writeSecureCommunicationFreshnessProps(parent, props)
         child = parent.find("SECURE-COMMUNICATION-FRESHNESS-PROPS")
         assert child is not None
         assert child.find("SHORT-NAME").text == "freshProps"
-        assert child.find("FRESHNESS-VALUE-LENGTH") is not None
-        assert child.find("FRESHNESS-VALUE-TX-LENGTH") is not None
+        assert child.find("FRESHNESS-COUNTER-SYNC-ATTEMPTS").text == "3"
+        assert child.find("FRESHNESS-TIMESTAMP-TIME-PERIOD-FACTOR").text == "2"
+        assert child.find("FRESHNESS-VALUE-LENGTH").text == "16"
+        assert child.find("FRESHNESS-VALUE-TX-LENGTH").text == "8"
+        assert child.find("USE-FRESHNESS-TIMESTAMP").text == "true"
 
 
 class TestWriteSecureCommunicationPropsSetFreshnessProps:

--- a/tests/test_armodel/writer/test_writer_pdu_tp.py
+++ b/tests/test_armodel/writer/test_writer_pdu_tp.py
@@ -203,13 +203,15 @@ class TestSetSecureCommunicationProps:
         props = SecureCommunicationProps()
         props.setAuthDataFreshnessLength(_pos_int("8"))
         props.setAuthDataFreshnessStartPosition(_pos_int("0"))
-        props.setAuthInfoTxLength(_pos_int("4"))
         props.setAuthenticationBuildAttempts(_pos_int("2"))
         props.setAuthenticationRetries(_pos_int("3"))
         props.setDataId(_pos_int("1"))
         props.setFreshnessValueId(_pos_int("5"))
-        props.setFreshnessValueLength(_pos_int("6"))
-        props.setFreshnessValueTxLength(_pos_int("7"))
+        props.setMessageLinkLength(_pos_int("6"))
+        props.setMessageLinkPosition(_pos_int("7"))
+        props.setSecondaryFreshnessValueId(_pos_int("9"))
+        props.setSecuredAreaLength(_pos_int("10"))
+        props.setSecuredAreaOffset(_pos_int("11"))
         parent = _parent()
         writer.setSecureCommunicationProps(parent, "SECURE-PROPS", props)
         assert len(parent) == 1
@@ -217,7 +219,8 @@ class TestSetSecureCommunicationProps:
         assert child.tag == "SECURE-PROPS"
         assert child.find("AUTH-DATA-FRESHNESS-LENGTH").text == "8"
         assert child.find("DATA-ID").text == "1"
-        assert child.find("FRESHNESS-VALUE-TX-LENGTH").text == "7"
+        assert child.find("MESSAGE-LINK-LENGTH").text == "6"
+        assert child.find("SECURED-AREA-OFFSET").text == "11"
 
 
 class TestWriteSecuredIPdu:

--- a/tests/test_armodel/writer/test_writer_sw_data_def_props.py
+++ b/tests/test_armodel/writer/test_writer_sw_data_def_props.py
@@ -1,0 +1,165 @@
+"""Reader/writer round-trip tests for the SwDataDefProps meta-class (Table 5.39)."""
+
+import os
+import tempfile
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    ARFloat,
+    ARNumerical,
+    AlignmentType,
+    Boolean,
+    CseCodeType,
+    DisplayFormatString,
+    Identifier,
+    Integer,
+    NativeDeclarationString,
+    PrimitiveIdentifier,
+    RefType,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AutosarVariableRef import AutosarVariableRef
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.InstanceRefsUsage import AutosarParameterRef
+from armodel.models.M2.MSR.DataDictionary.DataDefProperties import (
+    CompuGenericMath,
+    DisplayPresentationEnum,
+    SwBitRepresentation,
+    SwCalibrationAccessEnum,
+    SwDataDefProps,
+    SwDataDependency,
+    SwDataDependencyArgs,
+    SwImplPolicyEnum,
+    SwVariableRefProxy,
+)
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+class TestSwDataDefPropsRoundTrip:
+    def _build(self, document):
+        pkg = document.createARPackage("AUTOSAR")
+        data_type = pkg.createApplicationPrimitiveDataType("MyType")
+
+        props = SwDataDefProps()
+        props.setDisplayPresentation(DisplayPresentationEnum().setValue(DisplayPresentationEnum.PRESENTATION_CONTINUOUS))
+        props.setSwAlignment(AlignmentType().setValue("4"))
+        props.setSwCalibrationAccess(SwCalibrationAccessEnum().setValue(SwCalibrationAccessEnum.READ_WRITE))
+        props.setDisplayFormat(DisplayFormatString().setValue("%5.2f"))
+        props.setAdditionalNativeTypeQualifier(NativeDeclarationString().setValue("volatile"))
+        props.setSwInterpolationMethod(Identifier().setValue("linear"))
+        props.setSwImplPolicy(SwImplPolicyEnum().setValue(SwImplPolicyEnum.STANDARD))
+        props.setStepSize(ARFloat().setValue("0.5"))
+        props.setSwIntendedResolution(ARNumerical().setValue("0.01"))
+        props.setSwValueBlockSize(ARNumerical().setValue("10"))
+        props.addSwValueBlockSizeMult(ARNumerical().setValue("2"))
+        props.addSwValueBlockSizeMult(ARNumerical().setValue("3"))
+        props.setSwIsVirtual(Boolean().setValue("true"))
+        props.setBaseTypeRef(RefType().setDest("AUTOSAR/BaseTypes/uint8"))
+        props.setSwAddrMethodRef(RefType().setDest("AUTOSAR/SwAddrMethods/ram"))
+        props.setCompuMethodRef(RefType().setDest("AUTOSAR/CompuMethods/cm"))
+        props.setDataConstrRef(RefType().setDest("AUTOSAR/DataConstrs/dc"))
+        props.setImplementationDataTypeRef(RefType().setDest("AUTOSAR/ImplementationDataTypes/idt"))
+        props.setSwRecordLayoutRef(RefType().setDest("AUTOSAR/RecordLayouts/rl"))
+        props.setUnitRef(RefType().setDest("AUTOSAR/Units/second"))
+        props.setValueAxisDataTypeRef(RefType().setDest("AUTOSAR/ApplicationDataTypes/adt"))
+
+        bit_representation = SwBitRepresentation()
+        bit_representation.setBitPosition(Integer().setValue("3"))
+        bit_representation.setNumberOfBits(Integer().setValue("5"))
+        props.setSwBitRepresentation(bit_representation)
+
+        comparison_variable = SwVariableRefProxy()
+        comparison_variable.setAutosarVariable(AutosarVariableRef().setLocalVariableRef(RefType().setDest("AUTOSAR/Variables/var1")))
+        props.addSwComparisonVariable(comparison_variable)
+
+        host_variable = SwVariableRefProxy()
+        host_variable.setAutosarVariable(AutosarVariableRef().setLocalVariableRef(RefType().setDest("AUTOSAR/Variables/host")))
+        props.setSwHostVariable(host_variable)
+
+        dependency = SwDataDependency()
+        formula = CompuGenericMath()
+        formula.setLevel(PrimitiveIdentifier().setValue("INFORMAL"))
+        dependency.setSwDataDependencyFormula(formula)
+        args = SwDataDependencyArgs()
+        args.setSwVariable(SwVariableRefProxy())
+        dependency.setSwDataDependencyArgs(args)
+        props.setSwDataDependency(dependency)
+
+        refresh_timing = MultidimensionalTime()
+        refresh_timing.setCseCode(CseCodeType().setValue("100ms"))
+        refresh_timing.setCseCodeFactor(Integer().setValue("1"))
+        props.setSwRefreshTiming(refresh_timing)
+
+        data_type.setSwDataDefProps(props)
+        return data_type
+
+    def test_round_trip(self):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        document = AUTOSAR.getInstance()
+        document.clear()
+        self._build(document)
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, document)
+
+            document_2 = AUTOSAR.getInstance()
+            document_2.clear()
+            ARXMLParser().load(file_path, document_2)
+
+            data_type_2 = document_2.getARPackages()[0].getApplicationPrimitiveDataTypes()[0]
+            props = data_type_2.getSwDataDefProps()
+            assert props is not None
+            assert props.getDisplayPresentation().getValue() == "presentationContinuous"
+            assert props.getSwAlignment().getValue() == "4"
+            assert props.getSwCalibrationAccess().getValue() == "readWrite"
+            assert props.getDisplayFormat().getValue() == "%5.2f"
+            assert props.getAdditionalNativeTypeQualifier().getValue() == "volatile"
+            assert props.getSwInterpolationMethod().getValue() == "linear"
+            assert props.getSwImplPolicy().getValue() == "standard"
+            assert props.getStepSize().getValue() == 0.5
+            assert props.getSwIntendedResolution().getValue() == 0.01
+            assert props.getSwValueBlockSize().getValue() == 10
+            assert [m.getValue() for m in props.getSwValueBlockSizeMults()] == [2, 3]
+            assert props.getSwIsVirtual().getValue() is True
+            assert props.getBaseTypeRef().getDest() == "AUTOSAR/BaseTypes/uint8"
+            assert props.getSwAddrMethodRef().getDest() == "AUTOSAR/SwAddrMethods/ram"
+            assert props.getCompuMethodRef().getDest() == "AUTOSAR/CompuMethods/cm"
+            assert props.getDataConstrRef().getDest() == "AUTOSAR/DataConstrs/dc"
+            assert props.getImplementationDataTypeRef().getDest() == "AUTOSAR/ImplementationDataTypes/idt"
+            assert props.getSwRecordLayoutRef().getDest() == "AUTOSAR/RecordLayouts/rl"
+            assert props.getUnitRef().getDest() == "AUTOSAR/Units/second"
+            assert props.getValueAxisDataTypeRef().getDest() == "AUTOSAR/ApplicationDataTypes/adt"
+            assert props.getSwBitRepresentation().getBitPosition().getValue() == 3
+            assert props.getSwBitRepresentation().getNumberOfBits().getValue() == 5
+            assert len(props.getSwComparisonVariables()) == 1
+            assert props.getSwComparisonVariables()[0].getAutosarVariable().getLocalVariableRef().getDest() == "AUTOSAR/Variables/var1"
+            assert props.getSwHostVariable().getAutosarVariable().getLocalVariableRef().getDest() == "AUTOSAR/Variables/host"
+            assert props.getSwDataDependency().getSwDataDependencyFormula().getLevel().getValue() == "INFORMAL"
+            assert props.getSwDataDependency().getSwDataDependencyArgs() is not None
+            assert props.getSwRefreshTiming().getCseCode().getValue() == "100ms"
+            assert props.getSwRefreshTiming().getCseCodeFactor().getValue() == 1
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+    def test_round_trip_no_sw_data_def_props(self):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        document = AUTOSAR.getInstance()
+        document.clear()
+        pkg = document.createARPackage("AUTOSAR")
+        pkg.createApplicationPrimitiveDataType("MyType")
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, document)
+
+            document_2 = AUTOSAR.getInstance()
+            document_2.clear()
+            ARXMLParser().load(file_path, document_2)
+
+            data_type_2 = document_2.getARPackages()[0].getApplicationPrimitiveDataTypes()[0]
+            assert data_type_2.getSwDataDefProps() is None
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)

--- a/tests/test_armodel/writer/test_writer_sw_data_def_props.py
+++ b/tests/test_armodel/writer/test_writer_sw_data_def_props.py
@@ -4,10 +4,11 @@ import os
 import tempfile
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    AlignmentType,
     ARFloat,
     ARNumerical,
-    AlignmentType,
     Boolean,
     CseCodeType,
     DisplayFormatString,
@@ -17,9 +18,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     PrimitiveIdentifier,
     RefType,
 )
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AutosarVariableRef import AutosarVariableRef
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.InstanceRefsUsage import AutosarParameterRef
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import (
     CompuGenericMath,
     DisplayPresentationEnum,


### PR DESCRIPTION
## Related Issue
Closes #572

## Description
Completes the `SwDataDefProps` sync to AUTOSAR R23-11 and aligns additional model/writer classes.

### SwDataDefProps sync (Table 5.39, p.332)
- 30 attributes typed with `Optional[T]` / `List[T]`, verbatim spec docstrings, and a 5-column method parity checklist carrying `# Spec verified: R23-11`.
- Referenced classes implemented and marked:
  - `SwBitRepresentation` (Table 5.41)
  - `SwVariableRefProxy`, `SwCalprmRefProxy` (proxy classes)
  - `SwDataDependencyArgs` (Table 5.59), `CompuGenericMath` (Table 5.60), `SwDataDependency` (Table 5.58)
  - `SwImplPolicyEnum` (Table 5.45) — marker completed
  - `MultidimensionalTime` reused for `swRefreshTiming`
- Reader (`arxml_parser.py`) and writer (`arxml_writer.py`) extended so every attribute survives a lossless parse → write → re-parse round-trip.

### Additional changes (same branch)
- Fibex `CoreCommunication` model sync and PDU/SoAd writer alignment to spec.
- `run_tests.py` pytest summary parser fix for comma-separated counts.

## Verification
- 5838 unit/integration tests pass (`python -m pytest tests/`)
- `flake8` (E9/F63/F7/F82) clean
- `black --check` clean
- New round-trip tests assert every `SwDataDefProps` attribute round-trips.

## Test Plan
- [x] CI lint + test suite green
- [x] Checklist markers carry `# Spec verified: R23-11`