### PR TITLE
feat(model): sync SwcServiceDependency to AUTOSAR R23-11 spec (Table 7.56)

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ServiceMapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ServiceMapping.py
@@ -3,7 +3,7 @@ This module contains classes for representing AUTOSAR service mapping elements
 in software component internal behavior templates.
 """
 
-from typing import List
+from typing import List, Optional
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import (
     ComMgrUserNeeds,
     CryptoServiceNeeds,
@@ -103,56 +103,74 @@ class RoleBasedPortAssignment(ARObject):
 
 class SwcServiceDependency(Identifiable, ServiceDependency):
     """
-    A service dependency for an atomic software component that defines the
-    required services and their assignments.
+    Specialization of ServiceDependency in the context of an SwcInternalBehavior. It allows to associate ports, port groups and (in special cases) data defined for an atomic software component to a given ServiceNeeds element.
     """
 
     # SwcServiceDependency method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] AddAssignedData              [x] impl  [x] docstring  [ ] test
-    # [ ] getAssignedData              [x] impl  [x] docstring  [ ] test
-    # [ ] AddAssignedPort              [x] impl  [x] docstring  [ ] test
-    # [ ] getAssignedPorts             [x] impl  [x] docstring  [ ] test
-    # [ ] createNvBlockNeeds           [x] impl  [x] docstring  [ ] test
-    # [ ] createDiagnosticCommunicationManagerNeeds [x] impl  [x] docstring  [ ] test
-    # [ ] createDiagnosticRoutineNeeds [x] impl  [x] docstring  [ ] test
-    # [ ] createDiagnosticValueNeeds   [x] impl  [x] docstring  [ ] test
-    # [ ] createDiagnosticEventNeeds   [x] impl  [x] docstring  [ ] test
-    # [ ] createDiagnosticEventInfoNeeds [x] impl  [x] docstring  [ ] test
-    # [ ] createCryptoServiceNeeds     [x] impl  [x] docstring  [ ] test
-    # [ ] createEcuStateMgrUserNeeds   [x] impl  [x] docstring  [ ] test
-    # [ ] createDtcStatusChangeNotificationNeeds [x] impl  [x] docstring  [ ] test
-    # [ ] createDiagnosticIoControlNeeds [x] impl  [x] docstring  [x] test
-    # [ ] createDltUserNeeds           [x] impl  [x] docstring  [ ] test
-    # [ ] createComMgrUserNeeds        [x] impl  [x] docstring  [x] test
-    # [ ] createErrorTracerNeeds       [x] impl  [x] docstring  [ ] test
-    # [ ] getNvBlockNeeds              [x] impl  [x] docstring  [ ] test
-    # [ ] getDiagnosticCommunicationManagerNeeds [x] impl  [x] docstring  [ ] test
-    # [ ] getDiagnosticRoutineNeeds    [x] impl  [x] docstring  [ ] test
-    # [ ] getDiagnosticValueNeeds      [x] impl  [x] docstring  [ ] test
-    # [ ] getDiagnosticEventNeeds      [x] impl  [x] docstring  [ ] test
-    # [ ] getDiagnosticEventInfoNeeds  [x] impl  [x] docstring  [ ] test
-    # [ ] getCryptoServiceNeeds        [x] impl  [x] docstring  [ ] test
-    # [ ] getEcuStateMgrUserNeeds      [x] impl  [x] docstring  [ ] test
-    # [ ] getDtcStatusChangeNotificationNeeds [x] impl  [x] docstring  [ ] test
-    # [ ] getDiagnosticIoControlNeeds  [x] impl  [x] docstring  [x] test
-    # [ ] getDltUserNeeds              [x] impl  [x] docstring  [ ] test
-    # [ ] getComMgrUserNeeds           [x] impl  [x] docstring  [x] test
-    # [ ] getErrorTracerNeeds          [x] impl  [x] docstring  [ ] test
-    # [ ] createObdInfoServiceNeeds    [x] impl  [x] docstring  [x] test
-    # [ ] createObdMonitorServiceNeeds [x] impl  [x] docstring  [x] test
-    # [ ] createObdPidServiceNeeds     [x] impl  [x] docstring  [x] test
-    # [ ] getObdInfoServiceNeeds       [x] impl  [x] docstring  [x] test
-    # [ ] getObdMonitorServiceNeeds    [x] impl  [x] docstring  [x] test
-    # [ ] getObdPidServiceNeeds        [x] impl  [x] docstring  [x] test
-    # [ ] getServiceNeeds              [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 7.56, p.608
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] AddAssignedData              [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getAssignedData              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] AddAssignedPort              [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getAssignedPorts             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createNvBlockNeeds           [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createDiagnosticCommunicationManagerNeeds [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createDiagnosticRoutineNeeds [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createDiagnosticValueNeeds   [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createDiagnosticEventNeeds   [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createDiagnosticEventInfoNeeds [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createCryptoServiceNeeds     [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createEcuStateMgrUserNeeds   [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createDtcStatusChangeNotificationNeeds [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createDiagnosticIoControlNeeds [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createDltUserNeeds           [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createComMgrUserNeeds        [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createErrorTracerNeeds       [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createDiagnosticEnableConditionNeeds [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createDiagnosticOperationCycleNeeds [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createDiagnosticStorageConditionNeeds [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createFunctionInhibitionAvailabilityNeeds [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createIndicatorStatusNeeds   [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getNvBlockNeeds              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getDiagnosticCommunicationManagerNeeds [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getDiagnosticRoutineNeeds    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getDiagnosticValueNeeds      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getDiagnosticEventNeeds      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getDiagnosticEventInfoNeeds  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getCryptoServiceNeeds        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getEcuStateMgrUserNeeds      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getDtcStatusChangeNotificationNeeds [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getDiagnosticIoControlNeeds  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getDltUserNeeds              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getComMgrUserNeeds           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getErrorTracerNeeds          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createObdInfoServiceNeeds    [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createObdMonitorServiceNeeds [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] createObdPidServiceNeeds     [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getObdInfoServiceNeeds       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getObdMonitorServiceNeeds    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getObdPidServiceNeeds        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setRepresentedPortGroup      [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getRepresentedPortGroup      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getServiceNeeds              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         ServiceDependency.__init__(self)
         Identifiable.__init__(self, parent, short_name)
 
-        self._assigned_data: List["RoleBasedDataAssignment"] = []
-        self._assigned_ports: List["RoleBasedPortAssignment"] = []
+        # Defines the role of an associated data object of the same component.
+        self.assignedData: List["RoleBasedDataAssignment"] = []
+
+        # Defines the role of an associated port of the same component.
+        self.assignedPort: List["RoleBasedPortAssignment"] = []
+
+        # This reference specifies an association between the ServiceNeeeds and a PortGroup, for example to request a communication mode which applies for communication via these ports. The referred PortGroup shall be local to this atomic SWC, but via the links between the Port Groups, a tool can evaluate this information such that all the ports linked via this port group on the same ECU can be found.
+        self.representedPortGroup: Optional["RefType"] = None
+
+        # The associated ServiceNeeds.
+        self.serviceNeeds: Optional["ServiceNeeds"] = None
 
     def AddAssignedData(self, data: RoleBasedDataAssignment):
         """
@@ -161,7 +179,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         Args:
             data: The role-based data assignment to add
         """
-        self._assigned_data.append(data)
+        self.assignedData.append(data)
 
     def getAssignedData(self) -> List[RoleBasedDataAssignment]:
         """
@@ -170,7 +188,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         Returns:
             List[RoleBasedDataAssignment]: The assigned data list
         """
-        return self._assigned_data
+        return self.assignedData
 
     def AddAssignedPort(self, data: RoleBasedPortAssignment):
         """
@@ -179,7 +197,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         Args:
             data: The role-based port assignment to add
         """
-        self._assigned_ports.append(data)
+        self.assignedPort.append(data)
 
     def getAssignedPorts(self) -> List[RoleBasedPortAssignment]:
         """
@@ -188,7 +206,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         Returns:
             List[RoleBasedPortAssignment]: The assigned ports list
         """
-        return self._assigned_ports
+        return self.assignedPort
 
     def createNvBlockNeeds(self, short_name: str) -> NvBlockNeeds:
         """
@@ -203,6 +221,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = NvBlockNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createDiagnosticCommunicationManagerNeeds(self, short_name: str) -> DiagnosticCommunicationManagerNeeds:
@@ -219,6 +238,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = DiagnosticCommunicationManagerNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createDiagnosticRoutineNeeds(self, short_name: str) -> DiagnosticRoutineNeeds:
@@ -234,6 +254,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = DiagnosticRoutineNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createDiagnosticValueNeeds(self, short_name: str) -> DiagnosticValueNeeds:
@@ -249,6 +270,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = DiagnosticValueNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createDiagnosticEventNeeds(self, short_name: str) -> DiagnosticEventNeeds:
@@ -264,6 +286,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = DiagnosticEventNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createDiagnosticEventInfoNeeds(self, short_name: str) -> DiagnosticEventInfoNeeds:
@@ -279,6 +302,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = DiagnosticEventInfoNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createCryptoServiceNeeds(self, short_name: str) -> CryptoServiceNeeds:
@@ -294,6 +318,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = CryptoServiceNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createEcuStateMgrUserNeeds(self, short_name: str) -> EcuStateMgrUserNeeds:
@@ -309,6 +334,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = EcuStateMgrUserNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createDtcStatusChangeNotificationNeeds(self, short_name: str) -> DtcStatusChangeNotificationNeeds:
@@ -325,6 +351,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = DtcStatusChangeNotificationNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createDiagnosticIoControlNeeds(self, short_name: str) -> DiagnosticIoControlNeeds:
@@ -340,6 +367,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = DiagnosticIoControlNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createDiagnosticEnableConditionNeeds(self, short_name: str) -> DiagnosticEnableConditionNeeds:
@@ -355,6 +383,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = DiagnosticEnableConditionNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createDiagnosticOperationCycleNeeds(self, short_name: str) -> DiagnosticOperationCycleNeeds:
@@ -370,6 +399,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = DiagnosticOperationCycleNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createDiagnosticStorageConditionNeeds(self, short_name: str) -> DiagnosticStorageConditionNeeds:
@@ -385,6 +415,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = DiagnosticStorageConditionNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createFunctionInhibitionAvailabilityNeeds(self, short_name: str) -> FunctionInhibitionAvailabilityNeeds:
@@ -400,6 +431,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = FunctionInhibitionAvailabilityNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createIndicatorStatusNeeds(self, short_name: str) -> IndicatorStatusNeeds:
@@ -415,6 +447,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = IndicatorStatusNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createDltUserNeeds(self, short_name: str) -> DltUserNeeds:
@@ -430,6 +463,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = DltUserNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createComMgrUserNeeds(self, short_name: str) -> ComMgrUserNeeds:
@@ -445,6 +479,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = ComMgrUserNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createErrorTracerNeeds(self, short_name: str) -> ErrorTracerNeeds:
@@ -460,6 +495,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = ErrorTracerNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createObdInfoServiceNeeds(self, short_name: str) -> ObdInfoServiceNeeds:
@@ -475,6 +511,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = ObdInfoServiceNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createObdMonitorServiceNeeds(self, short_name: str) -> ObdMonitorServiceNeeds:
@@ -490,6 +527,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = ObdMonitorServiceNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def createObdPidServiceNeeds(self, short_name: str) -> ObdPidServiceNeeds:
@@ -505,6 +543,7 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
         if not self.IsElementExists(short_name):
             needs = ObdPidServiceNeeds(self, short_name)
             self.addElement(needs)
+            self.serviceNeeds = needs
         return self.getElement(short_name)
 
     def getNvBlockNeeds(self) -> List[NvBlockNeeds]:
@@ -664,3 +703,27 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
             List[ServiceNeeds]: Sorted list of ServiceNeeds
         """
         return sorted(filter(lambda c: isinstance(c, ServiceNeeds), self.elements), key=lambda e: e.short_name)
+
+    def setRepresentedPortGroup(self, value: Optional["RefType"]) -> "SwcServiceDependency":
+        """
+        This reference specifies an association between the ServiceNeeeds and a PortGroup, for example to request a communication mode which applies for communication via these ports. The referred PortGroup shall be local to this atomic SWC, but via the links between the Port Groups, a tool can evaluate this information such that all the ports linked via this port group on the same ECU can be found.
+        A None value is a no-op and does not overwrite an existing representedPortGroup.
+
+        Args:
+            value: The represented port group reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.representedPortGroup = value
+        return self
+
+    def getRepresentedPortGroup(self) -> Optional["RefType"]:
+        """
+        This reference specifies an association between the ServiceNeeeds and a PortGroup, for example to request a communication mode which applies for communication via these ports. The referred PortGroup shall be local to this atomic SWC, but via the links between the Port Groups, a tool can evaluate this information such that all the ports linked via this port group on the same ECU can be found.
+
+        Returns:
+            RefType: The represented port group reference
+        """
+        return self.representedPortGroup

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -1491,6 +1491,11 @@ class ARXMLParser(AbstractARXMLParser):
             else:
                 self.notImplemented("Unsupported service needs <%s>" % tag_name)
 
+    def readSwcServiceDependencyRepresentedPortGroup(self, element: ET.Element, dependency: SwcServiceDependency):
+        ref = self.getChildElementOptionalRefType(element, "REPRESENTED-PORT-GROUP-REF")
+        if ref is not None:
+            dependency.setRepresentedPortGroup(ref)
+
     def readSwcServiceDependency(self, element: ET.Element, parent: SwcInternalBehavior):
         short_name = self.getShortName(element)
         dependency = parent.createSwcServiceDependency(short_name)
@@ -1499,6 +1504,7 @@ class ARXMLParser(AbstractARXMLParser):
         self.readSwcServiceDependencyAssignedData(element, dependency)
         self.readSwcServiceDependencyAssignedPorts(element, dependency)
         self.readSwcServiceDependencyServiceNeeds(element, dependency)
+        self.readSwcServiceDependencyRepresentedPortGroup(element, dependency)
 
     def readSwcInternalBehaviorServiceDependencies(self, element: ET.Element, parent: SwcInternalBehavior):
         for child_element in self.findall(element, "SERVICE-DEPENDENCYS/*"):

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -2923,12 +2923,16 @@ class ARXMLWriter(AbstractARXMLWriter):
                 else:
                     self.notImplemented("Unsupported service needs <%s>" % type(needs))
 
+    def writeSwcServiceDependencyRepresentedPortGroup(self, element: ET.Element, dependency: SwcServiceDependency):
+        self.setChildElementOptionalRefType(element, "REPRESENTED-PORT-GROUP-REF", dependency.getRepresentedPortGroup())
+
     def writeSwcServiceDependency(self, element: ET.Element, dependency: SwcServiceDependency):
         child_element = ET.SubElement(element, "SWC-SERVICE-DEPENDENCY")
         self.writeServiceDependency(child_element, dependency)
         self.writeSwcServiceDependencyAssignedData(child_element, dependency)
         self.writeSwcServiceDependencyAssignedPorts(child_element, dependency)
         self.writeSwcServiceDependencyServiceNeeds(child_element, dependency)
+        self.writeSwcServiceDependencyRepresentedPortGroup(child_element, dependency)
 
     def writeSwcInternalBehaviorServiceDependencies(self, element: ET.Element, behavior: SwcInternalBehavior):
         dependencies = behavior.getSwcServiceDependencies()

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/test_ServiceMapping.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/test_ServiceMapping.py
@@ -57,8 +57,9 @@ class TestSwcServiceDependency:
 
         assert service_dep.parent == ar_root
         assert service_dep.short_name == "TestSwcServiceDependency"
-        assert service_dep._assigned_data == []
-        assert service_dep._assigned_ports == []
+        assert service_dep.assignedData == []
+        assert service_dep.assignedPort == []
+        assert service_dep.serviceNeeds is None
 
         # Test assigned data methods
         from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import RoleBasedDataAssignment
@@ -158,9 +159,43 @@ class TestSwcServiceDependency:
         assert fim_availability_needs.short_name == "TestFimAvailabilityNeeds"
         assert fim_availability_needs in service_dep.getServiceNeeds()
 
+        # Test remaining create/get service needs methods
+        error_tracer_needs = service_dep.createErrorTracerNeeds("TestErrorTracerNeeds")
+        assert error_tracer_needs is not None
+        assert error_tracer_needs in service_dep.getErrorTracerNeeds()
+
+        obd_info_needs = service_dep.createObdInfoServiceNeeds("TestObdInfoNeeds")
+        assert obd_info_needs is not None
+        assert obd_info_needs in service_dep.getObdInfoServiceNeeds()
+
+        obd_monitor_needs = service_dep.createObdMonitorServiceNeeds("TestObdMonitorNeeds")
+        assert obd_monitor_needs is not None
+        assert obd_monitor_needs in service_dep.getObdMonitorServiceNeeds()
+
+        obd_pid_needs = service_dep.createObdPidServiceNeeds("TestObdPidNeeds")
+        assert obd_pid_needs is not None
+        assert obd_pid_needs in service_dep.getObdPidServiceNeeds()
+
         # Test getting all service needs
         all_service_needs = service_dep.getServiceNeeds()
-        assert len(all_service_needs) == 17  # All the ones we created above
+        assert len(all_service_needs) == 21  # All the ones we created above
+
+    def test_get_set_represented_port_group(self):
+        """Test representedPortGroup getter/setter round-trip with None no-op."""
+        document = AUTOSAR.getInstance()
+        ar_root = document.createARPackage("AUTOSAR")
+        service_dep = SwcServiceDependency(ar_root, "TestSwcServiceDependency")
+
+        assert service_dep.getRepresentedPortGroup() is None
+
+        port_group_ref = RefType()
+        port_group_ref.setValue("/PortGroup/Ref")
+        service_dep.setRepresentedPortGroup(port_group_ref)
+        assert service_dep.getRepresentedPortGroup().getValue() == "/PortGroup/Ref"
+
+        # None is a no-op and must not overwrite an existing value
+        service_dep.setRepresentedPortGroup(None)
+        assert service_dep.getRepresentedPortGroup().getValue() == "/PortGroup/Ref"
 
 
 class TestSwcServiceDependencyRoundTrip:
@@ -210,6 +245,35 @@ class TestSwcServiceDependencyRoundTrip:
             assert needs_2["StorageNeeds"].getInitialStatus().getValue() == "eventStorageEnabled"
             assert needs_2["IndicatorNeeds"].getType().getValue() == "malfunction"
             assert needs_2["FimNeeds"].getControlledFidRef().getValue() == "/Fim/Ref"
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+    def test_swc_service_dependency_represented_port_group_round_trip(self):
+        """Verify representedPortGroup (REPRESENTED-PORT-GROUP-REF) survives an SWC round-trip."""
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        document = AUTOSAR.getInstance()
+        document.clear()
+        ar_root = document.createARPackage("AUTOSAR")
+        swc = ar_root.createApplicationSwComponentType("MySwc")
+        behavior = swc.createSwcInternalBehavior("Beh")
+        dependency = behavior.createSwcServiceDependency("Dep")
+
+        port_group_ref = RefType()
+        port_group_ref.setValue("/PortGroup/Ref")
+        dependency.setRepresentedPortGroup(port_group_ref)
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, document)
+            document_2 = AUTOSAR.getInstance()
+            document_2.clear()
+            ARXMLParser().load(file_path, document_2)
+
+            swc_2 = document_2.getARPackages()[0].getSwComponentTypes()[0]
+            behavior_2 = swc_2.getInternalBehavior()
+            dependency_2 = behavior_2.getSwcServiceDependencies()[0]
+            assert dependency_2.getRepresentedPortGroup().getValue() == "/PortGroup/Ref"
         finally:
             if os.path.exists(file_path):
                 os.remove(file_path)

--- a/tests/test_armodel/parser/test_arxml_parser_orchestrators.py
+++ b/tests/test_armodel/parser/test_arxml_parser_orchestrators.py
@@ -2941,6 +2941,24 @@ class TestSwcServiceDependencyAssigned:
         assert any("Unsupported Service Dependencies" in r.getMessage() for r in caplog.records)
 
 
+class TestSwcServiceDependencyRepresentedPortGroup:
+    def test_readRepresentedPortGroup(self, parser):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        dep = _make_service_dependency()
+        element = _snip('<REPRESENTED-PORT-GROUP-REF DEST="PORT-GROUP">/PortGroup/Ref</REPRESENTED-PORT-GROUP-REF>')
+        parser.readSwcServiceDependencyRepresentedPortGroup(element, dep)
+        ref = dep.getRepresentedPortGroup()
+        assert ref is not None
+        assert ref.getValue() == "/PortGroup/Ref"
+
+    def test_readRepresentedPortGroup_absent_is_none(self, parser):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        dep = _make_service_dependency()
+        element = _snip("<SWC-SERVICE-DEPENDENCY/>")
+        parser.readSwcServiceDependencyRepresentedPortGroup(element, dep)
+        assert dep.getRepresentedPortGroup() is None
+
+
 # ==================== SwcInternalBehavior IncludedModeDeclarationGroupSet (L813, L840, L845-848) ====================
 
 

--- a/tests/test_armodel/writer/test_writer_swc_behavior.py
+++ b/tests/test_armodel/writer/test_writer_swc_behavior.py
@@ -1395,6 +1395,27 @@ class TestWriterSwcServiceDependencyServiceNeeds:
         assert parent.find("SERVICE-NEEDS") is None
 
 
+class TestWriterSwcServiceDependencyRepresentedPortGroup:
+    def test_writeRepresentedPortGroup(self, writer):
+        behavior = _make_behavior()
+        dep = behavior.createSwcServiceDependency("dep1")
+        ref = RefType()
+        ref.setValue("/PortGroup/Ref")
+        dep.setRepresentedPortGroup(ref)
+        parent = _parent()
+        writer.writeSwcServiceDependencyRepresentedPortGroup(parent, dep)
+        ref_tag = parent.find("REPRESENTED-PORT-GROUP-REF")
+        assert ref_tag is not None
+        assert ref_tag.text == "/PortGroup/Ref"
+
+    def test_writeRepresentedPortGroup_none_no_tag(self, writer):
+        behavior = _make_behavior()
+        dep = behavior.createSwcServiceDependency("dep1")
+        parent = _parent()
+        writer.writeSwcServiceDependencyRepresentedPortGroup(parent, dep)
+        assert parent.find("REPRESENTED-PORT-GROUP-REF") is None
+
+
 # ==================== SwcInternalBehavior hub & helpers ====================
 
 


### PR DESCRIPTION
## Summary
Sync `SwcServiceDependency` (SoftwareComponentTemplate, Table 7.56, p.608) to the AUTOSAR R23-11 spec. Closes #573.

## Spec attributes (modeled in markdown order)
- `assignedData` (RoleBasedDataAssignment, *, aggr)
- `assignedPort` (RoleBasedPortAssignment, *, aggr)
- `representedPortGroup` (PortGroup, 0..1, ref) — **previously missing**
- `serviceNeeds` (ServiceNeeds, 0..1, aggr)

## Changes
- First-class, underscore-free members matching the markdown attribute order.
- Added `representedPortGroup` with `setRepresentedPortGroup` / `getRepresentedPortGroup` (None no-op guard).
- Added a dedicated `serviceNeeds` typed field maintained by all `create*` helpers.
- Reader/writer: parse and serialize `REPRESENTED-PORT-GROUP-REF`.
- Verbatim docstrings, synced 5-column checklist, and `# Spec verified: R23-11` marker.
- Test restructure: dedicated `test_get_set_represented_port_group` plus parser/writer unit tests for the new reader/writer methods.

## Test plan
- [x] Model / parser / writer tests pass
- [x] Integration lossless round-trip (29 ARXML fixtures) PASS
- [x] `ruff-check` and `black-check` clean; checklist↔methods 1:1

## Linked issue
Closes #573