### PR TITLE
feat(model): sync BaseTypes to R23-11 and add ObdControlServiceNeeds

### DIFF
--- a/docs/examples/method_deviation_by_class.md
+++ b/docs/examples/method_deviation_by_class.md
@@ -7,8 +7,8 @@ the member name and is recognised in matching, so e.g. a spec attr `type` of
 kind `TRef` is correctly implemented by `typeTRef`. `variationPoint`/
 `shortLabel` are excluded as framework-level.
 
-- Classes with deviations: **292**
-- Missing accessors: **665**
+- Classes with deviations: **293**
+- Missing accessors: **664**
 - Naming deviations: **11**
 - Type deviations (list/single multiplicity): **60**
 
@@ -1094,13 +1094,22 @@ Aligned to `class_check_rules.md` on 2026-08-07. PDF-synced (Rule 1):
 | — *(missing)* | `—` | `testId` | `PositiveInteger` | — | missing |
 
 ## `BaseTypeDirectDefinition`
-- **PDF:** `AUTOSAR_CP_TPS_DiagnosticExtractTemplate.pdf`  | **page:** 302
+- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 290
 - **Package:** `M2::MSR::AsamHdo::BaseTypes`
 - **Source:** `src/armodel/models/M2/MSR/AsamHdo/BaseTypes.py`
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — *(missing)* | `—` | `maxBaseTypeSize` | `PositiveInteger` | — | missing |
+| — *(missing)* | `—` | `maxBaseTypeSize` | `PositiveInteger` | — | deprecated (atp.Status=removed), not implemented |
+
+## `BaseType`
+- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 291
+- **Package:** `M2::MSR::AsamHdo::BaseTypes`
+- **Source:** `src/armodel/models/M2/MSR/AsamHdo/BaseTypes.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| `baseTypeDefinition` | `BaseTypeDirectDefinition` | `baseTypeDefinition` | `BaseTypeDefinition` | aggr | type (PDF abstract BaseTypeDefinition vs py BaseTypeDirectDefinition; the abstract aggregated type is instantiated as the concrete subtype) |
 
 ## `CompositionSwComponentType`
 - **PDF:** `AUTOSAR_CP_TPS_DiagnosticExtractTemplate.pdf`  | **page:** 307

--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -1,1 +1,1 @@
-Let us update the `ExecutableEntityActivationReason` class follow @docs\development\class_check_rules.md and collect the change feedback and update @docs\development\class_check_rules.md to make rule more general
+Let us update the `BaseTypeDirectDefinition` class follow @docs\development\class_check_rules.md and collect the change feedback and update @docs\development\class_check_rules.md to make rule more general

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py
@@ -3322,13 +3322,15 @@ class MaxCommModeEnum(AREnum):
         )
 
 
-class ObdControlServiceNeeds(ServiceNeeds):
+class ObdControlServiceNeeds(DiagnosticCapabilityElement):
     """
     Specifies the abstract needs of a component or module on the configuration of OBD Service 08 (request control of on-board system) in relation to a particular test-Identifier (TID) supported by this component or module.
     """
 
     # ObdControlServiceNeeds method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 13.45, p.796
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
 
     def __init__(self, parent: ARObject, short_name: str):
         """

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
@@ -438,6 +438,25 @@ class NativeDeclarationString(ARLiteral):
         super().__init__()
 
 
+class BaseTypeEncodingString(ARLiteral):
+    """
+    This is the string denotion of a BaseType encoding. It may be refined by specific use-cases. Tags: xml.xsd.customType=BASE-TYPE-ENCODING-STRING xml.xsd.type=string
+
+    Tags:
+        * xml.xsd.customType=BASE-TYPE-ENCODING-STRING
+        * xml.xsd.type=string
+    """
+
+    # BaseTypeEncodingString method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.25, p.291
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+
 class PrimitiveIdentifier(ARLiteral):
     """
     This meta-class has the ability to contain a string. Please note that this meta-class has only been introduced to fix an issue with the generation of attributes on primitives in context with [TPS_XMLSPR_00024].
@@ -1107,14 +1126,31 @@ class CategoryString(ARLiteral):
 
 class ByteOrderEnum(AREnum):
     """
-    Enumeration for byte order in AUTOSAR models.
+    When more than one byte is stored in the memory the order of those bytes may differ depending on the architecture of the processing unit. If the least significant byte is stored at the lowest address, this architecture is called little endian and otherwise it is called big endian. ByteOrder is very important in case of communication between different PUs or ECUs.
     """
 
     # ByteOrderEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [x] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.27, p.297
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
+
+    # Most significant byte shall come at the lowest address (also known as BigEndian or as Motorola-Format) Tags: atp.EnumerationLiteralIndex=0
+    MOST_SIGNIFICANT_BYTE_FIRST = "mostSignificantByteFirst"
+
+    # Most significant byte shall come highest address (also known as LittleEndian or as Intel-Format) Tags: atp.EnumerationLiteralIndex=1
+    MOST_SIGNIFICANT_BYTE_LAST = "mostSignificantByteLast"
+
+    # For opaque data endianness conversion has to be configured to Opaque. See AUTOSAR COM Specification for more details. Tags: atp.EnumerationLiteralIndex=2
+    OPAQUE = "opaque"
 
     def __init__(self):
-        super().__init__([])
+        super().__init__(
+            (
+                ByteOrderEnum.MOST_SIGNIFICANT_BYTE_FIRST,
+                ByteOrderEnum.MOST_SIGNIFICANT_BYTE_LAST,
+                ByteOrderEnum.OPAQUE,
+            )
+        )
 
 
 class DateTime(ARLiteral):

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ServiceMapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ServiceMapping.py
@@ -27,6 +27,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import (
     FunctionInhibitionAvailabilityNeeds,
     IndicatorStatusNeeds,
     NvBlockNeeds,
+    ObdControlServiceNeeds,
     ObdInfoServiceNeeds,
     ObdMonitorServiceNeeds,
     ObdPidServiceNeeds,
@@ -546,6 +547,22 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
             self.serviceNeeds = needs
         return self.getElement(short_name)
 
+    def createObdControlServiceNeeds(self, short_name: str) -> ObdControlServiceNeeds:
+        """
+        Creates or retrieves an ObdControlServiceNeeds element.
+
+        Args:
+            short_name: The short name for the needs element
+
+        Returns:
+            ObdControlServiceNeeds: The created or existing needs element
+        """
+        if not self.IsElementExists(short_name):
+            needs = ObdControlServiceNeeds(self, short_name)
+            self.addElement(needs)
+            self.serviceNeeds = needs
+        return self.getElement(short_name)
+
     def getNvBlockNeeds(self) -> List[NvBlockNeeds]:
         """
         Gets sorted NvBlockNeeds elements.
@@ -694,6 +711,15 @@ class SwcServiceDependency(Identifiable, ServiceDependency):
             List[ObdPidServiceNeeds]: Sorted list of ObdPidServiceNeeds
         """
         return sorted(filter(lambda c: isinstance(c, ObdPidServiceNeeds), self.elements), key=lambda e: e.short_name)
+
+    def getObdControlServiceNeeds(self) -> List[ObdControlServiceNeeds]:
+        """
+        Gets sorted ObdControlServiceNeeds elements.
+
+        Returns:
+            List[ObdControlServiceNeeds]: Sorted list of ObdControlServiceNeeds
+        """
+        return sorted(filter(lambda c: isinstance(c, ObdControlServiceNeeds), self.elements), key=lambda e: e.short_name)
 
     def getServiceNeeds(self) -> List[ServiceNeeds]:
         """

--- a/src/armodel/models/M2/MSR/AsamHdo/BaseTypes.py
+++ b/src/armodel/models/M2/MSR/AsamHdo/BaseTypes.py
@@ -1,17 +1,26 @@
 from abc import ABC
+from typing import Optional
+
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARNumerical, ByteOrderEnum
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    BaseTypeEncodingString,
+    ByteOrderEnum,
+    NativeDeclarationString,
+    PositiveInteger,
+)
 
 
 class BaseTypeDefinition(ARObject, ABC):
     """
-    Abstract base class for base type definitions.
-    Base: ARObject
+    This meta-class represents the ability to define a basetype.
     """
 
     # BaseTypeDefinition method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.23, p.290
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self):
         if type(self) is BaseTypeDefinition:
@@ -21,78 +30,136 @@ class BaseTypeDefinition(ARObject, ABC):
 
 class BaseTypeDirectDefinition(BaseTypeDefinition):
     """
-    Direct definition of a base type with encoding, size, and memory alignment specifications.
-    Base: BaseTypeDefinition
+    This BaseType is defined directly (as opposite to a derived BaseType)
     """
 
     # BaseTypeDirectDefinition method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getBaseTypeEncoding          [x] impl  [ ] docstring  [ ] test
-    # [ ] setBaseTypeEncoding          [x] impl  [ ] docstring  [ ] test
-    # [ ] getBaseTypeSize              [x] impl  [ ] docstring  [ ] test
-    # [ ] setBaseTypeSize              [x] impl  [ ] docstring  [ ] test
-    # [ ] getByteOrder                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setByteOrder                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getMemAlignment              [x] impl  [ ] docstring  [ ] test
-    # [ ] setMemAlignment              [x] impl  [ ] docstring  [ ] test
-    # [ ] getNativeDeclaration         [x] impl  [ ] docstring  [ ] test
-    # [ ] setNativeDeclaration         [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.24, p.290
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBaseTypeEncoding       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBaseTypeEncoding       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getBaseTypeSize           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBaseTypeSize           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getByteOrder              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setByteOrder              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMemAlignment           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMemAlignment           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getNativeDeclaration      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setNativeDeclaration      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.baseTypeEncoding: str = None
-        self.baseTypeSize: ARNumerical = None
-        self.byteOrder: ByteOrderEnum = None
-        self.memAlignment: ARNumerical = None
-        self.nativeDeclaration: str = None
+        # This specifies, how an object of the current BaseType is encoded, e.g. in an ECU within a message sequence.
+        self.baseTypeEncoding: Optional[BaseTypeEncodingString] = None
 
-    def getBaseTypeEncoding(self):
+        # Describes the length of the data type specified in the container in bits.
+        self.baseTypeSize: Optional[PositiveInteger] = None
+
+        # This attribute specifies the byte order of the base type.
+        self.byteOrder: Optional[ByteOrderEnum] = None
+
+        # This attribute describes the alignment of the memory object in bits. E.g. "8" specifies, that the object in question is aligned to a byte while "32" specifies that it is aligned four byte. If the value is set to "0" the meaning shall be interpreted as "unspecified".
+        self.memAlignment: Optional[PositiveInteger] = None
+
+        # This attribute describes the declaration of such a base type in the native programming language, primarily in the Programming language C. This can then be used by a code generator to include the necessary declarations into a header file.
+        self.nativeDeclaration: Optional[NativeDeclarationString] = None
+
+    def getBaseTypeEncoding(self) -> Optional[BaseTypeEncodingString]:
+        """
+        This specifies, how an object of the current BaseType is encoded, e.g. in an ECU within a message sequence.
+        """
         return self.baseTypeEncoding
 
-    def setBaseTypeEncoding(self, value):
-        self.baseTypeEncoding = value
+    def setBaseTypeEncoding(self, value: Optional[BaseTypeEncodingString]) -> "BaseTypeDirectDefinition":
+        """
+        This specifies, how an object of the current BaseType is encoded, e.g. in an ECU within a message sequence.
+
+        A None value is a no-op and does not overwrite an existing baseTypeEncoding.
+        """
+        if value is not None:
+            self.baseTypeEncoding = value
         return self
 
-    def getBaseTypeSize(self):
+    def getBaseTypeSize(self) -> Optional[PositiveInteger]:
+        """
+        Describes the length of the data type specified in the container in bits.
+        """
         return self.baseTypeSize
 
-    def setBaseTypeSize(self, value):
-        self.baseTypeSize = value
+    def setBaseTypeSize(self, value: Optional[PositiveInteger]) -> "BaseTypeDirectDefinition":
+        """
+        Describes the length of the data type specified in the container in bits.
+
+        A None value is a no-op and does not overwrite an existing baseTypeSize.
+        """
+        if value is not None:
+            self.baseTypeSize = value
         return self
 
-    def getByteOrder(self):
+    def getByteOrder(self) -> Optional[ByteOrderEnum]:
+        """
+        This attribute specifies the byte order of the base type.
+        """
         return self.byteOrder
 
-    def setByteOrder(self, value):
-        self.byteOrder = value
+    def setByteOrder(self, value: Optional[ByteOrderEnum]) -> "BaseTypeDirectDefinition":
+        """
+        This attribute specifies the byte order of the base type.
+
+        A None value is a no-op and does not overwrite an existing byteOrder.
+        """
+        if value is not None:
+            self.byteOrder = value
         return self
 
-    def getMemAlignment(self):
+    def getMemAlignment(self) -> Optional[PositiveInteger]:
+        """
+        This attribute describes the alignment of the memory object in bits. E.g. "8" specifies, that the object in question is aligned to a byte while "32" specifies that it is aligned four byte. If the value is set to "0" the meaning shall be interpreted as "unspecified".
+        """
         return self.memAlignment
 
-    def setMemAlignment(self, value):
-        self.memAlignment = value
+    def setMemAlignment(self, value: Optional[PositiveInteger]) -> "BaseTypeDirectDefinition":
+        """
+        This attribute describes the alignment of the memory object in bits. E.g. "8" specifies, that the object in question is aligned to a byte while "32" specifies that it is aligned four byte. If the value is set to "0" the meaning shall be interpreted as "unspecified".
+
+        A None value is a no-op and does not overwrite an existing memAlignment.
+        """
+        if value is not None:
+            self.memAlignment = value
         return self
 
-    def getNativeDeclaration(self):
+    def getNativeDeclaration(self) -> Optional[NativeDeclarationString]:
+        """
+        This attribute describes the declaration of such a base type in the native programming language, primarily in the Programming language C. This can then be used by a code generator to include the necessary declarations into a header file. For example BaseType with shortName: "MyUnsignedInt" native Declaration: "unsigned short" Results in typedef unsigned short MyUnsignedInt; If the attribute is not defined the referring Implementation DataTypes will not be generated as a typedef by RTE. If a nativeDeclaration type is given it shall fulfill the characteristic given by basetypeEncoding and baseType Size. This is required to ensure the consistent handling and interpretation by software components, RTE, COM and MCM systems.
+        """
         return self.nativeDeclaration
 
-    def setNativeDeclaration(self, value):
-        self.nativeDeclaration = value
+    def setNativeDeclaration(self, value: Optional[NativeDeclarationString]) -> "BaseTypeDirectDefinition":
+        """
+        This attribute describes the declaration of such a base type in the native programming language, primarily in the Programming language C. This can then be used by a code generator to include the necessary declarations into a header file. For example BaseType with shortName: "MyUnsignedInt" native Declaration: "unsigned short" Results in typedef unsigned short MyUnsignedInt; If the attribute is not defined the referring Implementation DataTypes will not be generated as a typedef by RTE. If a nativeDeclaration type is given it shall fulfill the characteristic given by basetypeEncoding and baseType Size. This is required to ensure the consistent handling and interpretation by software components, RTE, COM and MCM systems.
+
+        A None value is a no-op and does not overwrite an existing nativeDeclaration.
+        """
+        if value is not None:
+            self.nativeDeclaration = value
         return self
 
 
 class BaseType(ARElement, ABC):
     """
-    Abstract base class for base types.
-    Base: ARElement
+    This abstract meta-class represents the ability to specify a platform dependent base type.
     """
 
     # BaseType method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getBaseTypeDefinition        [x] impl  [ ] docstring  [ ] test
-    # [ ] setBaseTypeDefinition        [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.26, p.291
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBaseTypeDefinition     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBaseTypeDefinition     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         if type(self) is BaseType:
@@ -100,24 +167,36 @@ class BaseType(ARElement, ABC):
 
         super().__init__(parent, short_name)
 
+        # This is the actual definition of the base type.
         self.baseTypeDefinition: BaseTypeDirectDefinition = BaseTypeDirectDefinition()
 
     def getBaseTypeDefinition(self) -> BaseTypeDirectDefinition:
+        """
+        This is the actual definition of the base type.
+        """
         return self.baseTypeDefinition
 
-    def setBaseTypeDefinition(self, value: BaseTypeDirectDefinition):
-        self.baseTypeDefinition = value
+    def setBaseTypeDefinition(self, value: Optional[BaseTypeDirectDefinition]) -> "BaseType":
+        """
+        This is the actual definition of the base type.
+
+        A None value is a no-op and does not overwrite an existing baseTypeDefinition.
+        """
+        if value is not None:
+            self.baseTypeDefinition = value
         return self
 
 
 class SwBaseType(BaseType):
     """
-    Software base type representing primitive data types in software.
-    Base: BaseType
+    This meta-class represents a base type used within ECU software.
     """
 
     # SwBaseType method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.22, p.290
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -118,6 +118,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import (
     FunctionInhibitionAvailabilityNeeds,
     IndicatorStatusNeeds,
     NvBlockNeeds,
+    ObdControlServiceNeeds,
     ObdInfoServiceNeeds,
     ObdMonitorServiceNeeds,
     ObdPidServiceNeeds,
@@ -1172,6 +1173,10 @@ class ARXMLParser(AbstractARXMLParser):
                 short_name = self.getShortName(child_element)
                 needs = ObdPidServiceNeeds(dependency, short_name)
                 self.readObdPidServiceNeeds(child_element, needs)
+            elif tag_name == "OBD-CONTROL-SERVICE-NEEDS":
+                short_name = self.getShortName(child_element)
+                needs = ObdControlServiceNeeds(dependency, short_name)
+                self.readObdControlServiceNeeds(child_element, needs)
             else:
                 self.notImplemented("Unsupported service needs <%s>" % tag_name)
                 continue
@@ -1250,6 +1255,9 @@ class ARXMLParser(AbstractARXMLParser):
         needs.setUpdateKind(self.getChildElementOptionalLiteral(element, "UPDATE-KIND"))
 
     def readObdPidServiceNeeds(self, element: ET.Element, needs: ObdPidServiceNeeds):
+        self.readDiagnosticCapabilityElement(element, needs)
+
+    def readObdControlServiceNeeds(self, element: ET.Element, needs: ObdControlServiceNeeds):
         self.readDiagnosticCapabilityElement(element, needs)
 
     def readDiagnosticCommunicationManagerNeeds(self, element: ET.Element, needs: DiagnosticCommunicationManagerNeeds):
@@ -1488,6 +1496,9 @@ class ARXMLParser(AbstractARXMLParser):
             elif tag_name == "OBD-PID-SERVICE-NEEDS":
                 needs = parent.createObdPidServiceNeeds(self.getShortName(child_element))
                 self.readObdPidServiceNeeds(child_element, needs)
+            elif tag_name == "OBD-CONTROL-SERVICE-NEEDS":
+                needs = parent.createObdControlServiceNeeds(self.getShortName(child_element))
+                self.readObdControlServiceNeeds(child_element, needs)
             else:
                 self.notImplemented("Unsupported service needs <%s>" % tag_name)
 
@@ -3443,10 +3454,10 @@ class ARXMLParser(AbstractARXMLParser):
         data_type.setTypeEmitter(self.getChildElementOptionalLiteral(element, "TYPE-EMITTER"))
 
     def readBaseTypeDirectDefinition(self, element: ET.Element, definition: BaseTypeDirectDefinition):
-        definition.setBaseTypeSize(self.getChildElementOptionalNumericalValue(element, "BASE-TYPE-SIZE"))
+        definition.setBaseTypeSize(self.getChildElementOptionalPositiveInteger(element, "BASE-TYPE-SIZE"))
         definition.setBaseTypeEncoding(self.getChildElementOptionalLiteral(element, "BASE-TYPE-ENCODING"))
+        definition.setMemAlignment(self.getChildElementOptionalPositiveInteger(element, "MEM-ALIGNMENT"))
         definition.setByteOrder(self.getChildElementOptionalLiteral(element, "BYTE-ORDER"))
-        definition.setMemAlignment(self.getChildElementOptionalNumericalValue(element, "MEM-ALIGNMENT"))
         definition.setNativeDeclaration(self.getChildElementOptionalLiteral(element, "NATIVE-DECLARATION"))
 
     def readSwBaseType(self, element: ET.Element, data_type: SwBaseType):

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -111,6 +111,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import (
     FunctionInhibitionAvailabilityNeeds,
     IndicatorStatusNeeds,
     NvBlockNeeds,
+    ObdControlServiceNeeds,
     ObdInfoServiceNeeds,
     ObdMonitorServiceNeeds,
     ObdPidServiceNeeds,
@@ -1708,10 +1709,10 @@ class ARXMLWriter(AbstractARXMLWriter):
                 self.notImplemented("Unsupported ApplicationDataType <%s>" % type(data_type))
 
     def setBaseTypeDirectDefinition(self, element: ET.Element, base_type_definition: BaseTypeDirectDefinition):
-        self.setChildElementOptionalNumericalValue(element, "BASE-TYPE-SIZE", base_type_definition.getBaseTypeSize())
+        self.setChildElementOptionalPositiveInteger(element, "BASE-TYPE-SIZE", base_type_definition.getBaseTypeSize())
         self.setChildElementOptionalLiteral(element, "BASE-TYPE-ENCODING", base_type_definition.getBaseTypeEncoding())
+        self.setChildElementOptionalPositiveInteger(element, "MEM-ALIGNMENT", base_type_definition.getMemAlignment())
         self.setChildElementOptionalLiteral(element, "BYTE-ORDER", base_type_definition.getByteOrder())
-        self.setChildElementOptionalNumericalValue(element, "MEM-ALIGNMENT", base_type_definition.getMemAlignment())
         self.setChildElementOptionalLiteral(element, "NATIVE-DECLARATION", base_type_definition.getNativeDeclaration())
 
     def writeSwBaseType(self, element: ET.Element, base_type: SwBaseType):
@@ -2562,6 +2563,8 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeObdMonitorServiceNeeds(child_element, needs)
         elif isinstance(needs, ObdPidServiceNeeds):
             self.writeObdPidServiceNeeds(child_element, needs)
+        elif isinstance(needs, ObdControlServiceNeeds):
+            self.writeObdControlServiceNeeds(child_element, needs)
         else:
             self.notImplemented("Unsupported service needs <%s>" % type(needs))
 
@@ -2694,6 +2697,11 @@ class ARXMLWriter(AbstractARXMLWriter):
     def writeObdPidServiceNeeds(self, element: ET.Element, needs: ObdPidServiceNeeds):
         child_element = ET.SubElement(element, "OBD-PID-SERVICE-NEEDS")
         self.logger.debug("write ObdPidServiceNeeds %s" % needs.getShortName())
+        self.writeDiagnosticCapabilityElement(child_element, needs)
+
+    def writeObdControlServiceNeeds(self, element: ET.Element, needs: ObdControlServiceNeeds):
+        child_element = ET.SubElement(element, "OBD-CONTROL-SERVICE-NEEDS")
+        self.logger.debug("write ObdControlServiceNeeds %s" % needs.getShortName())
         self.writeDiagnosticCapabilityElement(child_element, needs)
 
     def setDiagEventDebounceCounterBased(self, element: ET.Element, algorithm: DiagEventDebounceCounterBased):
@@ -2920,6 +2928,8 @@ class ARXMLWriter(AbstractARXMLWriter):
                     self.writeObdMonitorServiceNeeds(child_element, needs)
                 elif isinstance(needs, ObdPidServiceNeeds):
                     self.writeObdPidServiceNeeds(child_element, needs)
+                elif isinstance(needs, ObdControlServiceNeeds):
+                    self.writeObdControlServiceNeeds(child_element, needs)
                 else:
                     self.notImplemented("Unsupported service needs <%s>" % type(needs))
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_ServiceNeeds.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_ServiceNeeds.py
@@ -50,6 +50,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import (
     NvBlockNeeds,
     NvBlockNeedsReliabilityEnum,
     NvBlockNeedsWritingPriorityEnum,
+    ObdControlServiceNeeds,
     ObdInfoServiceNeeds,
     ObdMonitorServiceNeeds,
     ObdPidServiceNeeds,
@@ -2770,6 +2771,74 @@ class TestObdPidServiceNeedsRoundTrip:
             needs_2 = behavior_2.getServiceDependencies()[0].getServiceNeeds()
             assert needs_2.getShortName() == "ObdPidNeeds"
             assert isinstance(needs_2, ObdPidServiceNeeds)
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+
+class TestObdControlServiceNeeds:
+    def test_initialization(self):
+        """Test ObdControlServiceNeeds initialization defaults."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        needs = ObdControlServiceNeeds(ar_root, "TestObdControlServiceNeeds")
+
+        assert needs is not None
+        assert needs.getShortName() == "TestObdControlServiceNeeds"
+        assert needs.audiences == []
+        assert needs.diagRequirement is None
+        assert needs.securityAccessLevel is None
+
+
+class TestObdControlServiceNeedsRoundTrip:
+    def test_round_trip_bsw_attributes(self):
+        """Test parse -> write -> re-parse preserves ObdControlServiceNeeds (attribute-less, BSW path)."""
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        document = AUTOSAR.getInstance()
+        document.clear()
+        ar_root = document.createARPackage("AUTOSAR")
+        desc = ar_root.createBswModuleDescription("BswMd")
+        behavior = desc.createBswInternalBehavior("Beh")
+        dependency = BswServiceDependency()
+        needs = ObdControlServiceNeeds(dependency, "ObdControlNeeds")
+        dependency.setServiceNeeds(needs)
+        behavior.addServiceDependency(dependency)
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, document)
+            document_2 = AUTOSAR.getInstance()
+            document_2.clear()
+            ARXMLParser().load(file_path, document_2)
+            behavior_2 = document_2.getARPackages()[0].getBswModuleDescriptions()[0].getInternalBehaviors()[0]
+            needs_2 = behavior_2.getServiceDependencies()[0].getServiceNeeds()
+            assert needs_2.getShortName() == "ObdControlNeeds"
+            assert isinstance(needs_2, ObdControlServiceNeeds)
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+    def test_round_trip_swc_attributes(self):
+        """Test parse -> write -> re-parse preserves ObdControlServiceNeeds (attribute-less, SWC path)."""
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        document = AUTOSAR.getInstance()
+        document.clear()
+        ar_root = document.createARPackage("AUTOSAR")
+        swc = ar_root.createApplicationSwComponentType("Swc")
+        behavior = swc.createSwcInternalBehavior("Beh")
+        dependency = behavior.createSwcServiceDependency("Dep")
+        dependency.createObdControlServiceNeeds("ObdControlNeeds")
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, document)
+            document_2 = AUTOSAR.getInstance()
+            document_2.clear()
+            ARXMLParser().load(file_path, document_2)
+            behavior_2 = document_2.getARPackages()[0].getElement("Swc", ApplicationSwComponentType).getInternalBehavior()
+            needs_2 = behavior_2.getSwcServiceDependencies()[0].getObdControlServiceNeeds()[0]
+            assert needs_2.getShortName() == "ObdControlNeeds"
+            assert isinstance(needs_2, ObdControlServiceNeeds)
         finally:
             if os.path.exists(file_path):
                 os.remove(file_path)

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_PrimitiveTypes.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_PrimitiveTypes.py
@@ -854,7 +854,27 @@ class TestByteOrderEnum:
 
         # Verify basic properties
         assert enum is not None
-        assert enum.getEnumValues() == []
+        assert enum.getEnumValues() == (
+            "mostSignificantByteFirst",
+            "mostSignificantByteLast",
+            "opaque",
+        )
+
+    def test_enum_values(self):
+        """
+        Test ByteOrderEnum values.
+        """
+        enum = ByteOrderEnum()
+
+        assert ByteOrderEnum.MOST_SIGNIFICANT_BYTE_FIRST == "mostSignificantByteFirst"
+        assert ByteOrderEnum.MOST_SIGNIFICANT_BYTE_LAST == "mostSignificantByteLast"
+        assert ByteOrderEnum.OPAQUE == "opaque"
+
+        # Test validation
+        assert enum.validateEnumValue("mostSignificantByteFirst") is True
+        assert enum.validateEnumValue("mostSignificantByteLast") is True
+        assert enum.validateEnumValue("opaque") is True
+        assert enum.validateEnumValue("invalid") is False
 
 
 class TestCIdentifier:

--- a/tests/test_armodel/models/M2/MSR/AsamHdo/test_BaseTypes.py
+++ b/tests/test_armodel/models/M2/MSR/AsamHdo/test_BaseTypes.py
@@ -5,7 +5,12 @@ This module contains tests for the BaseTypes module in MSR.AsamHdo.
 import pytest
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARNumerical, ByteOrderEnum
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    BaseTypeEncodingString,
+    ByteOrderEnum,
+    NativeDeclarationString,
+    PositiveInteger,
+)
 from armodel.models.M2.MSR.AsamHdo.BaseTypes import (
     BaseType,
     BaseTypeDefinition,
@@ -41,41 +46,95 @@ class TestBaseTypeDirectDefinition:
         assert base_type_direct_def.memAlignment is None
         assert base_type_direct_def.nativeDeclaration is None
 
+    def test_base_type_direct_definition_base_type_encoding(self):
+        """Test get/set of baseTypeEncoding owned by BaseTypeDirectDefinition (Table 5.24)."""
+        base_type_direct_def = BaseTypeDirectDefinition()
+
+        assert base_type_direct_def.getBaseTypeEncoding() is None
+
+        encoding = BaseTypeEncodingString().setValue("IEEE754")
+        result = base_type_direct_def.setBaseTypeEncoding(encoding)
+        assert base_type_direct_def.getBaseTypeEncoding() == encoding
+        assert isinstance(base_type_direct_def.getBaseTypeEncoding(), BaseTypeEncodingString)
+        assert result == base_type_direct_def
+
+    def test_base_type_direct_definition_base_type_encoding_none_noop(self):
+        """A None value must not overwrite an existing baseTypeEncoding."""
+        base_type_direct_def = BaseTypeDirectDefinition()
+        encoding = BaseTypeEncodingString().setValue("IEEE754")
+        base_type_direct_def.setBaseTypeEncoding(encoding)
+
+        result = base_type_direct_def.setBaseTypeEncoding(None)
+        assert base_type_direct_def.getBaseTypeEncoding() == encoding
+        assert result == base_type_direct_def
+
     def test_base_type_direct_definition_setters_and_getters(self):
         """Test the setters and getters for BaseTypeDirectDefinition class."""
         base_type_direct_def = BaseTypeDirectDefinition()
 
-        # Create test objects
-        encoding = "some_encoding"
-        size = ARNumerical()
-        byte_order = ByteOrderEnum()
-        alignment = ARNumerical()
-        native_decl = "native_declaration"
-
-        # Test setBaseTypeEncoding and getBaseTypeEncoding
-        result = base_type_direct_def.setBaseTypeEncoding(encoding)
-        assert base_type_direct_def.getBaseTypeEncoding() == encoding
-        assert result == base_type_direct_def
+        # Create test objects using spec-accurate primitive types
+        size = PositiveInteger().setValue("32")
+        encoding = BaseTypeEncodingString().setValue("IEEE754")
+        byte_order = ByteOrderEnum().setValue("MOST-SIGNIFICANT-BYTE-FIRST")
+        alignment = PositiveInteger().setValue("8")
+        native_decl = NativeDeclarationString().setValue("unsigned int")
 
         # Test setBaseTypeSize and getBaseTypeSize
         result = base_type_direct_def.setBaseTypeSize(size)
         assert base_type_direct_def.getBaseTypeSize() == size
+        assert isinstance(base_type_direct_def.getBaseTypeSize(), PositiveInteger)
+        assert result == base_type_direct_def
+
+        # Test setBaseTypeEncoding and getBaseTypeEncoding
+        result = base_type_direct_def.setBaseTypeEncoding(encoding)
+        assert base_type_direct_def.getBaseTypeEncoding() == encoding
+        assert isinstance(base_type_direct_def.getBaseTypeEncoding(), BaseTypeEncodingString)
         assert result == base_type_direct_def
 
         # Test setByteOrder and getByteOrder
         result = base_type_direct_def.setByteOrder(byte_order)
         assert base_type_direct_def.getByteOrder() == byte_order
+        assert isinstance(base_type_direct_def.getByteOrder(), ByteOrderEnum)
         assert result == base_type_direct_def
 
         # Test setMemAlignment and getMemAlignment
         result = base_type_direct_def.setMemAlignment(alignment)
         assert base_type_direct_def.getMemAlignment() == alignment
+        assert isinstance(base_type_direct_def.getMemAlignment(), PositiveInteger)
         assert result == base_type_direct_def
 
         # Test setNativeDeclaration and getNativeDeclaration
         result = base_type_direct_def.setNativeDeclaration(native_decl)
         assert base_type_direct_def.getNativeDeclaration() == native_decl
+        assert isinstance(base_type_direct_def.getNativeDeclaration(), NativeDeclarationString)
         assert result == base_type_direct_def
+
+    def test_base_type_direct_definition_setters_none_noop(self):
+        """None values must not overwrite existing attributes."""
+        base_type_direct_def = BaseTypeDirectDefinition()
+        size = PositiveInteger().setValue("32")
+        encoding = BaseTypeEncodingString().setValue("IEEE754")
+        byte_order = ByteOrderEnum().setValue("MOST-SIGNIFICANT-BYTE-FIRST")
+        alignment = PositiveInteger().setValue("8")
+        native_decl = NativeDeclarationString().setValue("unsigned int")
+
+        base_type_direct_def.setBaseTypeSize(size)
+        base_type_direct_def.setBaseTypeEncoding(encoding)
+        base_type_direct_def.setByteOrder(byte_order)
+        base_type_direct_def.setMemAlignment(alignment)
+        base_type_direct_def.setNativeDeclaration(native_decl)
+
+        base_type_direct_def.setBaseTypeSize(None)
+        base_type_direct_def.setBaseTypeEncoding(None)
+        base_type_direct_def.setByteOrder(None)
+        base_type_direct_def.setMemAlignment(None)
+        base_type_direct_def.setNativeDeclaration(None)
+
+        assert base_type_direct_def.getBaseTypeSize() == size
+        assert base_type_direct_def.getBaseTypeEncoding() == encoding
+        assert base_type_direct_def.getByteOrder() == byte_order
+        assert base_type_direct_def.getMemAlignment() == alignment
+        assert base_type_direct_def.getNativeDeclaration() == native_decl
 
 
 class TestBaseType:
@@ -105,6 +164,21 @@ class TestBaseType:
         new_def = BaseTypeDirectDefinition()
         result = concrete_type.setBaseTypeDefinition(new_def)
         assert concrete_type.getBaseTypeDefinition() == new_def
+        assert result == concrete_type
+
+    def test_base_type_definition_none_noop(self):
+        """A None value must not overwrite an existing baseTypeDefinition."""
+
+        class ConcreteBaseType(BaseType):
+            def __init__(self, parent, short_name):
+                super().__init__(parent, short_name)
+
+        parent_obj = ARPackage(None, "parent_test")
+        concrete_type = ConcreteBaseType(parent_obj, "test_type")
+        existing = concrete_type.getBaseTypeDefinition()
+
+        result = concrete_type.setBaseTypeDefinition(None)
+        assert concrete_type.getBaseTypeDefinition() == existing
         assert result == concrete_type
 
 

--- a/tests/test_armodel/parser/test_arxml_parser_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_handlers.py
@@ -370,6 +370,7 @@ class TestDataTypeAndValueSpecHandlers:
         parser.readSwBaseType(element, bt)
         definition = bt.getBaseTypeDefinition()
         assert definition.getBaseTypeSize().getValue() == 32
+        assert definition.getBaseTypeEncoding().getValue() == "IEEE754"
         assert definition.getNativeDeclaration().getValue() == "float"
         assert definition.getByteOrder().getValue() == "BIG-ENDIAN"
 

--- a/tests/test_armodel/writer/test_writer_data_types.py
+++ b/tests/test_armodel/writer/test_writer_data_types.py
@@ -511,6 +511,15 @@ class TestBaseTypeDirectDefinitionWriter:
         assert parent.find("MEM-ALIGNMENT").text == "4"
         assert parent.find("NATIVE-DECLARATION").text == "float"
 
+        # Elements are emitted in XSD sequenceOffset order (70, 90, 100, 110, 120)
+        assert [child.tag for child in parent] == [
+            "BASE-TYPE-SIZE",
+            "BASE-TYPE-ENCODING",
+            "MEM-ALIGNMENT",
+            "BYTE-ORDER",
+            "NATIVE-DECLARATION",
+        ]
+
     def test_set_base_type_direct_definition_empty(self, writer):
         btd = BaseTypeDirectDefinition()
         parent = _parent()


### PR DESCRIPTION
## Summary

Combined feature branch delivering two related model changes:

### 1. BaseTypes re-verification against AUTOSAR R23-11 (closes #575)
- Re-verified all 4 classes in `BaseTypes.py` (`BaseTypeDefinition`, `BaseTypeDirectDefinition`, `BaseType`, `SwBaseType`) against the spec; each now carries `# Spec verified: R23-11` with a fully `[x]` method-parity checklist.
- Reordered `BaseTypeDirectDefinition` fields to XSD `sequenceOffset` order (BASE-TYPE-SIZE, BASE-TYPE-ENCODING, MEM-ALIGNMENT, BYTE-ORDER, NATIVE-DECLARATION) in both `arxml_parser.py` and `arxml_writer.py`.
- Synced referenced `ByteOrderEnum` (`PrimitiveTypes.py`, Table 5.27) to `mostSignificantByteFirst` / `mostSignificantByteLast` / `opaque`.
- Removed invented docstring recap lines, used verbatim spec Notes, corrected citation pages, and updated the deviation tracker.

### 2. ObdControlServiceNeeds support (closes #576)
- Added `ObdControlServiceNeeds` to `ServiceNeeds.py`/`ServiceMapping.py` with parser/writer handlers (`OBD-CONTROL-SERVICE-NEEDS`) delegating to the shared `DiagnosticCapabilityElement` read/write, plus tests.

## Verification
- `flake8` and `black --check`: clean.
- Targeted tests on changed modules: 539 passed, 0 failed.
- Full suite (unit + integration round-trip) previously green at 5852 passed in this exact state.

## Test plan
- [x] Review spec markers and method-parity checklists in `BaseTypes.py` / `PrimitiveTypes.py`
- [x] Confirm XML element order for `BASE-TYPE-DIRECT-DEFINITION` round-trips
- [x] Confirm `OBD-CONTROL-SERVICE-NEEDS` parse/write round-trips

Closes #575
Closes #576