### PR TITLE
feat(model): sync PortInterface and ServiceProviderEnum to R23-11

### DIFF
--- a/.agents/skills/sync-autosar-class/SKILL.md
+++ b/.agents/skills/sync-autosar-class/SKILL.md
@@ -73,6 +73,9 @@ class turns out to be missing mid-sync (Rule 0001.10).
 4. **Build the sync queue**: parents first (deepest ancestor first → input class
    last), member types in spec-row order. Skip classes already stamped
    `# Spec verified: R<YY>-<MM>` unless extending or drift (Rule 0012.3).
+   **"Exists" is not a stamp** — a member type that exists but is a stub (no marker,
+   or fields/literals don't match its own table) is queued for the same pass like a
+   missing class (Rule 0001.10 / 0016.4).
 
 **Output:** a sync map (kept in the conversation) listing each closure class,
 its source, its parent, and whether it enters the 9-step queue.
@@ -137,7 +140,7 @@ before its failing test.
 - **1** — Extract `Note`/`Base`/`Attribute` rows in displayed order; confirm Class-vs-Enumeration header. *Rule 0015* arbitrates XSD-vs-PDF/markdown attribute conflicts (the PDF/markdown table wins — model nothing the PDF lacks).
 - **2** — `test_initialization` (defaults), `test_get_set_*` (round-trip + **None no-op**), `create*`/`add*` (append, duplicate returns existing). Abstract class → test `__init__` + base accessors via a concrete subclass.
 - **3** — Most-derived base from the `Base` chain; dedicated typed-list fields for `*` `aggr` (never registry filters); `createXxx` only for `Referrable` children; collect referenced missing classes and report in Step 8 (don't block). Enum (`AREnum`) → literals, not accessors.
-- **4** — Copy the spec `Note` **verbatim from the markdown** into the class docstring, `__init__` comments, and getter/setter docstrings (PDF opened only for the `p.NN` page); guarded setters append the None-no-op sentence.
+- **4** — Copy the spec `Note` **verbatim from the markdown** into the **class docstring** (the class-level `Note` — **not** into `__init__`, which has no docstring), inline `__init__` **comments**, and getter/setter docstrings (PDF opened only for the `p.NN` page); guarded setters append the None-no-op sentence.
 - **5** — Reader/writer tests live in **their own folders** (`tests/test_armodel/parser/`, `.../writer/`, both `class Test*`), not the per-class mirror. Assert **field values**, not just `len(...) == n`; add an empty-wrapper-list case.
 - **6** — Reader populates via mutators (`readXxx`→`set/create/addXxx`), writer reads via getters (`writeXxx`→`getXxx`); cover wrapper lists + polymorphic five-place dispatch; **no chained mutator calls**.
 - **7** — One row per method, source order, all `[x]`, 5-column format below.
@@ -200,6 +203,9 @@ detail: *Rule 0002*.
   base-class table* named in `Base`. Model that base class and relocate the members there;
   reduce the subclass to its own attributes (*Rule 0001.3*). A fully-`[x]` checklist + clean
   round-trip **will not** catch this — the field-to-spec cross-check is the gate.
+- **Class `Note` written into the `__init__` docstring** — the class-level `Note` belongs
+  in the **class docstring** only; `__init__` carries inline per-attribute comments and
+  **no docstring** (Rule 0012.2.3 / 0012.2.4.2).
 
 | Rationalization | Reality |
 |---|---|

--- a/.agents/skills/sync-autosar-class/rules.md
+++ b/.agents/skills/sync-autosar-class/rules.md
@@ -313,7 +313,8 @@ the checklist title cites the spec table, then the version marker:
   for members with no XML element: `__init__`, `atpDerived` attributes, read-only
   convenience properties. The split matches how coverage is verified (grep the reader
   for the mutator call, the writer for the getter call) and closes the Rule 0001.7
-  blind spot.
+  blind spot. The `__init__` row's `docstring` column marks the **class docstring** (the
+  class-level `Note`) — `__init__` itself has no docstring (Rule 0012.2.3).
 - The checklist covers every method 1:1 (no missing/extra); a `@property` counts as a
   method (needs a row + test). A commented-out member block is dead code — remove it.
 - Every row fully `[x]` (impl **and** docstring **and** test **and** reader/writer as
@@ -617,9 +618,11 @@ string values (`MEMBER = "member_value"`).
 
 ## Rule 0012 — Docstring & Comment Sync *(formerly Rule 13)*
 
-Class docstrings, inline `__init__` comments, and getter/setter docstrings copy the spec
-`Note` **verbatim from the markdown table** (`autosar/markdown/*.md`) — never summarize,
-paraphrase, or rephrase the wording — and stay synced across AUTOSAR upgrades. The PDF
+The class-level `Note` lives in the **class docstring**; per-attribute `Note`s live in
+inline `__init__` **comments** and getter/setter docstrings — all copied **verbatim from
+the markdown table** (`autosar/markdown/*.md`), never summarized, paraphrased, or
+rephrased, and staying synced across AUTOSAR upgrades. **`__init__` has no docstring** —
+do not write the class `Note` into an `__init__` docstring (0012.2.3, 0012.2.4.2). The PDF
 (`autosar/pdf/*.pdf`) is opened **only to read the page number** for the `p.NN` citation;
 all `Note`/`Attribute`/`Base` text (and the `Table N.M` id) comes from the markdown. This
 is one ordered procedure per class (Rule 0006's mechanical check only confirms the marker
@@ -658,13 +661,15 @@ is one ordered procedure per class (Rule 0006's mechanical check only confirms t
 3. **Class docstring** = the spec `Note` **copied verbatim from the markdown table** (no
    invented recap prose, no `Base` chain summary); append class-level `constr_*` rows
    (including ones targeting inherited attributes). For a terse citation Note, append the
-   XSD complexType doc as an elaboration (also verbatim).
+   XSD complexType doc as an elaboration (also verbatim). The class `Note` lives **only**
+   here — **do not** also write it into an `__init__` docstring; `__init__` carries no
+   docstring (step 4.2's inline comments hold the per-attribute `Note`).
 4. **Per-attribute loop** (all five, per attribute, before the next):
    1. Referenced type must exist and be synced before typing (Rule 0010/0011); its
       `# Spec:` cites its **own** table, independent of the owning class.
-   2. Inline `__init__` comment: the attribute's `Note` (markdown) semantic sentence,
-      copied verbatim (drop `Stereotypes:`/`Tags:` tail); append any `constr_*` wording
-      + id.
+   2. Inline `__init__` **comment** (not a docstring — `__init__` has no docstring): the
+      attribute's `Note` (markdown) semantic sentence, copied verbatim (drop
+      `Stereotypes:`/`Tags:` tail); append any `constr_*` wording + id.
    3. Getter docstring: the spec `Note` **copied verbatim from the markdown** + constraint
       — never summarize or rephrase into "Gets the value of X"; for an `iref`, name the
       concrete `<name>InstanceRef` class.
@@ -890,6 +895,14 @@ Order the closure for syncing:
 Skip classes that already carry `# Spec verified: R<YY>-<MM>` **unless** the spec
 changed (Rule 0012.3 drift) or the class is being extended — those re-enter the
 queue at Step 1.
+
+An un-stamped member type is **not** skipped — it is queued. A member type that
+**exists but is a stub** (no `# Spec verified:` marker, or its fields/literals don't
+match its own table) counts as missing and is queued for the same pass exactly like an
+absent class (Rule 0001.10) — e.g. an enum member type whose `Literal` rows don't match
+its `Enumeration` table, or a class whose `Attribute` rows are missing/fabricated.
+"Exists in the codebase" is not a stamp; verify the marker before treating a member
+type as already-synced.
 
 A class marked Skip in 16.3 stays out of the queue; a class marked XSD-derived
 enters the queue with the XSD-only flag.

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py
@@ -3653,22 +3653,113 @@ class SecureOnBoardCommunicationNeeds(ServiceNeeds):
 
 class ServiceProviderEnum(AREnum):
     """
-    Enumeration for service provider types.
+    This represents a list of possible service providers
     """
 
     # ServiceProviderEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 3.20, p.90
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
 
-    BSW = "bsw"
-    RTE = "rte"
-    SWC = "swc"
+    # This value means that the specific nature is either unknown or it is not important for the given purpose.
+    # This is also the default value for any attribute of type ServiceProviderEnum. Tags: atp.EnumerationLiteralIndex=0
+    ANY_STANDARDIZED = "anyStandardized"
+
+    # The service relates to the Basic Software Mode Manager (BswM). Tags: atp.EnumerationLiteralIndex=1
+    BASIC_SOFTWARE_MODE_MANAGER = "basicSoftwareModeManager"
+
+    # The service relates to the COM Manager (ComM). Tags: atp.EnumerationLiteralIndex=2
+    COM_MANAGER = "comManager"
+
+    # The service relates to the Key Manager (KeyM). Tags: atp.EnumerationLiteralIndex=23
+    CRYPTO_KEY_MANAGEMENT = "cryptoKeyManagement"
+
+    # The service relates to the Crypto Service Manager (CsM). Tags: atp.EnumerationLiteralIndex=3
+    CRYPTO_SERVICE_MANAGER = "cryptoServiceManager"
+
+    # The service relates to the Default Error Tracer (DET). Tags: atp.EnumerationLiteralIndex=4
+    DEFAULT_ERROR_TRACER = "defaultErrorTracer"
+
+    # The service relates to the Diagnostic Communication Manager (DCM). Tags: atp.EnumerationLiteralIndex=6
+    DIAGNOSTIC_COMMUNICATION_MANAGER = "diagnosticCommunicationManager"
+
+    # The service relates to the Diagnostic Event Manager (DEM). Tags: atp.EnumerationLiteralIndex=7
+    DIAGNOSTIC_EVENT_MANAGER = "diagnosticEventManager"
+
+    # The service relates to the Diagnostic Log and Trace (DLT). Tags: atp.EnumerationLiteralIndex=8
+    DIAGNOSTIC_LOG_AND_TRACE = "diagnosticLogAndTrace"
+
+    # The service relates to the ECU Manager (EcuM). Tags: atp.EnumerationLiteralIndex=9
+    ECU_MANAGER = "ecuManager"
+
+    # This service relates to the error tracer. Tags: atp.EnumerationLiteralIndex=18
+    ERROR_TRACER = "errorTracer"
+
+    # The service relates to the Function Inhibition Manager (FIM). Tags: atp.EnumerationLiteralIndex=10
+    FUNCTION_INHIBITION_MANAGER = "functionInhibitionManager"
+
+    # This service relates to the hardware test manager. Tags: atp.EnumerationLiteralIndex=19
+    HARDWARE_TEST_MANAGER = "hardwareTestManager"
+
+    # The service relates to the intrusion detection security management (IdsM). Tags: atp.EnumerationLiteralIndex=24
+    INTRUSION_DETECTION_SECURITY_MANAGEMENT = "intrusionDetectionSecurityManagement"
+
+    # This service relates to the J1939 Dcm. Tags: atp.EnumerationLiteralIndex=22
+    J1939_DCM = "j1939Dcm"
+
+    # The service relates to the J1939Rm. Tags: atp.EnumerationLiteralIndex=11
+    J1939_REQUEST_MANAGER = "j1939RequestManager"
+
+    # The service relates to the Non-Volatile RAM Manager (NvM). Tags: atp.EnumerationLiteralIndex=12
+    NON_VOLATILE_RAM_MANAGER = "nonVolatileRamManager"
+
+    # The service relates to the Operating System (OS). Tags: atp.EnumerationLiteralIndex=13
+    OPERATING_SYSTEM = "operatingSystem"
+
+    # The service relates to the SecOc module. Tags: atp.EnumerationLiteralIndex=14
+    SECURE_ON_BOARD_COMMUNICATION = "secureOnBoardCommunication"
+
+    # The service relates to the Sync Time Base Manager (StbM). Tags: atp.EnumerationLiteralIndex=15
+    SYNC_BASE_TIME_MANAGER = "syncBaseTimeManager"
+
+    # This service relates to the Vehicle to X facilities. Tags: atp.EnumerationLiteralIndex=20
+    V2X_FACILITIES = "v2xFacilities"
+
+    # This service relates to the Vehicle to X management. Tags: atp.EnumerationLiteralIndex=21
+    V2X_MANAGEMENT = "v2xManagement"
+
+    # This value denotes a vendor-specific service. Tags: atp.EnumerationLiteralIndex=16
+    VENDOR_SPECIFIC = "vendorSpecific"
 
     def __init__(self):
+        """
+        Initializes a ServiceProviderEnum instance with the spec-defined literals.
+        """
         super().__init__(
             (
-                ServiceProviderEnum.BSW,
-                ServiceProviderEnum.RTE,
-                ServiceProviderEnum.SWC,
+                ServiceProviderEnum.ANY_STANDARDIZED,
+                ServiceProviderEnum.BASIC_SOFTWARE_MODE_MANAGER,
+                ServiceProviderEnum.COM_MANAGER,
+                ServiceProviderEnum.CRYPTO_KEY_MANAGEMENT,
+                ServiceProviderEnum.CRYPTO_SERVICE_MANAGER,
+                ServiceProviderEnum.DEFAULT_ERROR_TRACER,
+                ServiceProviderEnum.DIAGNOSTIC_COMMUNICATION_MANAGER,
+                ServiceProviderEnum.DIAGNOSTIC_EVENT_MANAGER,
+                ServiceProviderEnum.DIAGNOSTIC_LOG_AND_TRACE,
+                ServiceProviderEnum.ECU_MANAGER,
+                ServiceProviderEnum.ERROR_TRACER,
+                ServiceProviderEnum.FUNCTION_INHIBITION_MANAGER,
+                ServiceProviderEnum.HARDWARE_TEST_MANAGER,
+                ServiceProviderEnum.INTRUSION_DETECTION_SECURITY_MANAGEMENT,
+                ServiceProviderEnum.J1939_DCM,
+                ServiceProviderEnum.J1939_REQUEST_MANAGER,
+                ServiceProviderEnum.NON_VOLATILE_RAM_MANAGER,
+                ServiceProviderEnum.OPERATING_SYSTEM,
+                ServiceProviderEnum.SECURE_ON_BOARD_COMMUNICATION,
+                ServiceProviderEnum.SYNC_BASE_TIME_MANAGER,
+                ServiceProviderEnum.V2X_FACILITIES,
+                ServiceProviderEnum.V2X_MANAGEMENT,
+                ServiceProviderEnum.VENDOR_SPECIFIC,
             )
         )
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/__init__.py
@@ -6,16 +6,18 @@ parameter interfaces, as well as mapping classes for interface mappings.
 """
 
 from abc import ABC
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import TextValueSpecification
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import ModeDeclarationGroupPrototype, ModeDeclarationGroupPrototypeMapping
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.TriggerDeclaration import Trigger, TriggerMapping
+
+if TYPE_CHECKING:
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import ServiceProviderEnum
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpBlueprintable, AtpStructureElement, AtpType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
-    ARBoolean,
     AREnum,
     ArgumentDirectionEnum,
     ARLiteral,
@@ -28,33 +30,92 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.DataPrototy
 
 
 class PortInterface(AtpType, ABC):
+    """Abstract base class for an interface that is either provided or required by a port of a software component."""
+
     # PortInterface method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getIsService                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setIsService                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getServiceKind               [x] impl  [ ] docstring  [ ] test
-    # [ ] setServiceKind               [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 3.18, p.87
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__       [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getIsService   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIsService   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getServiceKind [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setServiceKind [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         if type(self) is PortInterface:
             raise TypeError("PortInterface is an abstract class.")
         super().__init__(parent, short_name)
 
-        self.isService: ARBoolean = None
-        self.serviceKind: ARLiteral = None
+        # This flag is set if the PortInterface is to be used for communication between an
+        # ApplicationSwComponentType or ServiceProxySwComponentType or SensorActuatorSwComponentType or
+        # ComplexDeviceDriverSwComponentType or ServiceSwComponentType or EcuAbstractionSwComponentType and a
+        # ServiceSwComponentType (namely an AUTOSAR Service) located on the same ECU. Otherwise the flag is not set.
+        self.isService: Optional[Boolean] = None
 
-    def getIsService(self):
+        # This attribute provides further details about the nature of the applied service.
+        self.serviceKind: Optional["ServiceProviderEnum"] = None
+
+    def getIsService(self) -> Optional[Boolean]:
+        """
+        Gets the isService flag of this PortInterface.
+
+        This flag is set if the PortInterface is to be used for communication between an ApplicationSwComponentType or
+        ServiceProxySwComponentType or SensorActuatorSwComponentType or ComplexDeviceDriverSwComponentType or
+        ServiceSwComponentType or EcuAbstractionSwComponentType and a ServiceSwComponentType (namely an AUTOSAR Service)
+        located on the same ECU. Otherwise the flag is not set.
+
+        Returns:
+            Optional[Boolean]: The isService flag, or None if not set
+        """
         return self.isService
 
-    def setIsService(self, value):
-        self.isService = value
+    def setIsService(self, value: Optional[Boolean]) -> "PortInterface":
+        """
+        Sets the isService flag of this PortInterface.
+
+        This flag is set if the PortInterface is to be used for communication between an ApplicationSwComponentType or
+        ServiceProxySwComponentType or SensorActuatorSwComponentType or ComplexDeviceDriverSwComponentType or
+        ServiceSwComponentType or EcuAbstractionSwComponentType and a ServiceSwComponentType (namely an AUTOSAR Service)
+        located on the same ECU. Otherwise the flag is not set.
+        A None value is a no-op and does not overwrite an existing isService.
+
+        Args:
+            value: The isService flag to set
+
+        Returns:
+            PortInterface: self for method chaining
+        """
+        if value is not None:
+            self.isService = value
         return self
 
-    def getServiceKind(self):
+    def getServiceKind(self) -> Optional["ServiceProviderEnum"]:
+        """
+        Gets the serviceKind of this PortInterface.
+
+        This attribute provides further details about the nature of the applied service.
+
+        Returns:
+            Optional[ServiceProviderEnum]: The serviceKind, or None if not set
+        """
         return self.serviceKind
 
-    def setServiceKind(self, value):
-        self.serviceKind = value
+    def setServiceKind(self, value: Optional["ServiceProviderEnum"]) -> "PortInterface":
+        """
+        Sets the serviceKind of this PortInterface.
+
+        This attribute provides further details about the nature of the applied service.
+        A None value is a no-op and does not overwrite an existing serviceKind.
+
+        Args:
+            value: The serviceKind to set
+
+        Returns:
+            PortInterface: self for method chaining
+        """
+        if value is not None:
+            self.serviceKind = value
         return self
 
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_ServiceNeeds.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_ServiceNeeds.py
@@ -63,6 +63,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import (
     ServiceDependency,
     ServiceDiagnosticRelevanceEnum,
     ServiceNeeds,
+    ServiceProviderEnum,
     StorageConditionStatusEnum,
     SupervisedEntityNeeds,
     TracedFailure,
@@ -155,6 +156,68 @@ class TestRamBlockStatusControlEnum:
         """Test enum values"""
         assert RamBlockStatusControlEnum.API == "api"
         assert RamBlockStatusControlEnum.NV_RAM_MANAGER == "nvRamManager"
+
+
+class TestServiceProviderEnum:
+    def test_initialization(self):
+        """Test ServiceProviderEnum initialization matches the spec Literal rows in order"""
+        enum = ServiceProviderEnum()
+        assert enum.enumValues == (
+            "anyStandardized",
+            "basicSoftwareModeManager",
+            "comManager",
+            "cryptoKeyManagement",
+            "cryptoServiceManager",
+            "defaultErrorTracer",
+            "diagnosticCommunicationManager",
+            "diagnosticEventManager",
+            "diagnosticLogAndTrace",
+            "ecuManager",
+            "errorTracer",
+            "functionInhibitionManager",
+            "hardwareTestManager",
+            "intrusionDetectionSecurityManagement",
+            "j1939Dcm",
+            "j1939RequestManager",
+            "nonVolatileRamManager",
+            "operatingSystem",
+            "secureOnBoardCommunication",
+            "syncBaseTimeManager",
+            "v2xFacilities",
+            "v2xManagement",
+            "vendorSpecific",
+        )
+
+    def test_values(self):
+        """Test enum member values match the spec literals"""
+        assert ServiceProviderEnum.ANY_STANDARDIZED == "anyStandardized"
+        assert ServiceProviderEnum.BASIC_SOFTWARE_MODE_MANAGER == "basicSoftwareModeManager"
+        assert ServiceProviderEnum.COM_MANAGER == "comManager"
+        assert ServiceProviderEnum.CRYPTO_KEY_MANAGEMENT == "cryptoKeyManagement"
+        assert ServiceProviderEnum.CRYPTO_SERVICE_MANAGER == "cryptoServiceManager"
+        assert ServiceProviderEnum.DEFAULT_ERROR_TRACER == "defaultErrorTracer"
+        assert ServiceProviderEnum.DIAGNOSTIC_COMMUNICATION_MANAGER == "diagnosticCommunicationManager"
+        assert ServiceProviderEnum.DIAGNOSTIC_EVENT_MANAGER == "diagnosticEventManager"
+        assert ServiceProviderEnum.DIAGNOSTIC_LOG_AND_TRACE == "diagnosticLogAndTrace"
+        assert ServiceProviderEnum.ECU_MANAGER == "ecuManager"
+        assert ServiceProviderEnum.ERROR_TRACER == "errorTracer"
+        assert ServiceProviderEnum.FUNCTION_INHIBITION_MANAGER == "functionInhibitionManager"
+        assert ServiceProviderEnum.HARDWARE_TEST_MANAGER == "hardwareTestManager"
+        assert ServiceProviderEnum.INTRUSION_DETECTION_SECURITY_MANAGEMENT == "intrusionDetectionSecurityManagement"
+        assert ServiceProviderEnum.J1939_DCM == "j1939Dcm"
+        assert ServiceProviderEnum.J1939_REQUEST_MANAGER == "j1939RequestManager"
+        assert ServiceProviderEnum.NON_VOLATILE_RAM_MANAGER == "nonVolatileRamManager"
+        assert ServiceProviderEnum.OPERATING_SYSTEM == "operatingSystem"
+        assert ServiceProviderEnum.SECURE_ON_BOARD_COMMUNICATION == "secureOnBoardCommunication"
+        assert ServiceProviderEnum.SYNC_BASE_TIME_MANAGER == "syncBaseTimeManager"
+        assert ServiceProviderEnum.V2X_FACILITIES == "v2xFacilities"
+        assert ServiceProviderEnum.V2X_MANAGEMENT == "v2xManagement"
+        assert ServiceProviderEnum.VENDOR_SPECIFIC == "vendorSpecific"
+
+    def test_instantiation(self):
+        """Test ServiceProviderEnum is instantiable and settable"""
+        enum = ServiceProviderEnum().setValue(ServiceProviderEnum.COM_MANAGER)
+        assert enum.getValue() == "comManager"
 
 
 class TestNvBlockNeedsReliabilityEnum:

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/test_PortInterface.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/test_PortInterface.py
@@ -1,6 +1,7 @@
 import pytest
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import ServiceProviderEnum
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpBlueprintable, AtpType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, MultilanguageReferrable, Referrable
@@ -207,30 +208,46 @@ class Test_M2_AUTOSARTemplates_SWComponentTemplate_PortInterface:
         element2 = cs_if.getPossibleErrors()[0]
         assert element == element2
 
-    def test_NvDataInterface_serviceKind(self):
-        """Test NvDataInterface getServiceKind method to cover line 42 in PortInterface/__init__.py"""
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import NvDataInterface
-
+    def test_PortInterface_isService(self):
+        """PortInterface.isService: default None, setter chains, value round-trips, None no-op."""
         document = AUTOSAR.getInstance()
         ar_root = document.createARPackage("AUTOSAR")
-        nv_data_if = NvDataInterface(ar_root, "NvDataInterface")
+        pi = NvDataInterface(ar_root, "NvDataInterface")
 
-        # Test getServiceKind - this should return self.serviceKind
-        _service_kind = nv_data_if.getServiceKind()
-        # NvDataInterface inherits from PortInterface, so it should have serviceKind attribute
-        # This test covers line 42 in PortInterface/__init__.py
+        assert pi.getIsService() is None
 
-        # Test setServiceKind to cover lines 45-46
-        ar_literal = ARLiteral()
-        nv_data_if.setServiceKind(ar_literal)
-        assert nv_data_if.getServiceKind() == ar_literal
-        assert nv_data_if == nv_data_if.setServiceKind(ar_literal)  # Test method chaining
+        is_service = Boolean()
+        is_service.setValue("true")
+        assert pi.setIsService(is_service) is pi
+        assert pi.getIsService() is is_service
+        assert pi.getIsService().getValue() is True
 
-        # Test setIsService and getIsService to cover lines 35, 38-39
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean
+        # None is a no-op: existing value is preserved
+        pi.setIsService(None)
+        assert pi.getIsService() is is_service
 
-        ar_bool = ARBoolean()
-        nv_data_if.setIsService(ar_bool)
-        assert nv_data_if.getIsService() == ar_bool
-        assert nv_data_if == nv_data_if.setIsService(ar_bool)  # Test method chaining
+        is_service_false = Boolean()
+        is_service_false.setValue("false")
+        pi.setIsService(is_service_false)
+        assert pi.getIsService() is is_service_false
+
+    def test_PortInterface_serviceKind(self):
+        """PortInterface.serviceKind: default None, setter chains, value round-trips, None no-op."""
+        document = AUTOSAR.getInstance()
+        ar_root = document.createARPackage("AUTOSAR")
+        pi = NvDataInterface(ar_root, "NvDataInterface")
+
+        assert pi.getServiceKind() is None
+
+        service_kind = ServiceProviderEnum().setValue(ServiceProviderEnum.COM_MANAGER)
+        assert pi.setServiceKind(service_kind) is pi
+        assert pi.getServiceKind() is service_kind
+        assert pi.getServiceKind().getValue() == "comManager"
+
+        # None is a no-op: existing value is preserved
+        pi.setServiceKind(None)
+        assert pi.getServiceKind() is service_kind
+
+        service_kind2 = ServiceProviderEnum().setValue(ServiceProviderEnum.DEFAULT_ERROR_TRACER)
+        pi.setServiceKind(service_kind2)
+        assert pi.getServiceKind() is service_kind2

--- a/tests/test_armodel/writer/test_writer_port_interface_service.py
+++ b/tests/test_armodel/writer/test_writer_port_interface_service.py
@@ -1,0 +1,80 @@
+"""Round-trip tests for PortInterface.isService and PortInterface.serviceKind (Table 3.18)."""
+
+import os
+import tempfile
+import xml.etree.cElementTree as ET
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import ServiceProviderEnum
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+class TestPortInterfaceServiceAttributesRoundTrip:
+    def test_round_trip_is_service_and_service_kind(self):
+        AUTOSAR.getInstance().new()
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        autosar = AUTOSAR.getInstance()
+        pkg = autosar.createARPackage("PortInterfaces")
+        cs = pkg.createClientServerInterface("CSInterface")
+        cs.createOperation("Op")
+
+        is_service = Boolean()
+        is_service.setValue("true")
+        cs.setIsService(is_service)
+
+        service_kind = ServiceProviderEnum().setValue(ServiceProviderEnum.COM_MANAGER)
+        cs.setServiceKind(service_kind)
+
+        with tempfile.NamedTemporaryFile(suffix=".arxml", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            ARXMLWriter().save(tmp_path, autosar)
+
+            document_2 = AUTOSAR.getInstance()
+            document_2.clear()
+            ARXMLParser().load(tmp_path, document_2)
+
+            cs_2 = document_2.getARPackages()[0].getClientServerInterfaces()[0]
+            assert cs_2.getShortName() == "CSInterface"
+
+            # isService round-trips as a Boolean
+            assert cs_2.getIsService() is not None
+            assert cs_2.getIsService().getValue() is True
+
+            # serviceKind round-trips as the literal text "comManager"
+            assert cs_2.getServiceKind() is not None
+            assert cs_2.getServiceKind().getText() == "comManager"
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+    def test_round_trip_optional_absent(self):
+        AUTOSAR.getInstance().new()
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        autosar = AUTOSAR.getInstance()
+        pkg = autosar.createARPackage("PortInterfaces")
+        cs = pkg.createClientServerInterface("CSInterface")
+        cs.createOperation("Op")
+
+        with tempfile.NamedTemporaryFile(suffix=".arxml", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            ARXMLWriter().save(tmp_path, autosar)
+
+            tree = ET.parse(tmp_path)
+            root = tree.getroot()
+            local_tags = [el.tag.split("}")[-1] for el in root.iter()]
+            assert "IS-SERVICE" not in local_tags
+            assert "SERVICE-KIND" not in local_tags
+
+            document_2 = AUTOSAR.getInstance()
+            document_2.clear()
+            ARXMLParser().load(tmp_path, document_2)
+            cs_2 = document_2.getARPackages()[0].getClientServerInterfaces()[0]
+            assert cs_2.getIsService() is None
+            assert cs_2.getServiceKind() is None
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)


### PR DESCRIPTION
## Summary
Syncs `PortInterface` and `ServiceProviderEnum` to the AUTOSAR R23-11 meta-model (SoftwareComponentTemplate Tables 3.18 / 3.20). Closes #582.

## Changes
- **ServiceProviderEnum**: replaced placeholder literals (`bsw`/`rte`/`swc`) with the full spec-defined enumeration (23 literals, `atp.EnumerationLiteralIndex` preserved).
- **PortInterface**: typed `isService` as `Optional[Boolean]` and `serviceKind` as `Optional[ServiceProviderEnum]`; setters are now `None`-safe no-ops; added spec docstrings + method-parity checklist annotations.
- Added unit and writer round-trip tests.

## Test plan
- `pytest` on the changed test files: 223 passed.
- Round-trip parse → write → re-parse integrity preserved.