### PR TITLE
feat(model): sync Chapter and SWC documentation classes

### DIFF
--- a/docs/examples/method_deviation_by_class.md
+++ b/docs/examples/method_deviation_by_class.md
@@ -668,6 +668,60 @@ Table 13.6, p.711): member values corrected from `"full-communication"` etc. to
 the spec literals `full`/`none`/`silent` and member names to `FULL`/`NONE`/
 `SILENT`.
 
+## `ChapterContent`
+- **PDF:** `AUTOSAR_FO_TPS_GenericStructureTemplate.pdf`  | **page:** 330
+- **Package:** `M2::MSR::Documentation::Chapters`
+- **Source:** `src/armodel/models/M2/MSR/Documentation/Chapters.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| `topicContent` | `Optional[TopicContentOrMsrQuery]` | `topicContent` | `TopicContentOrMsrQuery` | aggr | synced via the `TopicContentOrMsrQuery` pass; `prms` member (Table 9.60) still pending its own pass |
+
+## `TopicContentOrMsrQuery`
+- **PDF:** `AUTOSAR_FO_TPS_GenericStructureTemplate.pdf`  | **page:** 342
+- **Package:** `M2::MSR::Documentation::Chapters`
+- **Source:** `src/armodel/models/M2/MSR/Documentation/Chapters.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| `msrQueryP1` | `Optional[MsrQueryP1]` | `msrQueryP1` | `MsrQueryP1` | aggr | referenced class `MsrQueryP1` (Table 9.82) deferred to a 2nd-level placeholder; `# Spec:` line kept without the `# Spec verified:` stamp until resolved |
+| `topicContent` | `Optional[TopicContent]` | `topicContent` | `TopicContent` | aggr | synced via the `TopicContent` pass |
+
+## `TopicContent`
+- **PDF:** `AUTOSAR_FO_TPS_GenericStructureTemplate.pdf`  | **page:** 478
+- **Package:** `M2::MSR::Documentation::Chapters`
+- **Source:** `src/armodel/models/M2/MSR/Documentation/Chapters.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| `blockLevelContent` | `Optional[DocumentationBlock]` | `blockLevelContent` | `DocumentationBlock` | aggr | synced; XSD group holds DOCUMENTATION-BLOCK (unbounded) while the spec table E.81 lists mult. 1 |
+| — *(missing)* | `—` | `table` | `Table` | — | missing |
+| — *(missing)* | `—` | `traceableTable` | `TraceableTable` | — | missing |
+
+## `MsrQueryChapter`
+- **PDF:** `AUTOSAR_FO_TPS_GenericStructureTemplate.pdf`  | **page:** 343
+- **Package:** `M2::MSR::Documentation::Chapters`
+- **Source:** `src/armodel/models/M2/MSR/Documentation/Chapters.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| `msrQueryProps` | `Optional[MsrQueryProps]` | `msrQueryProps` | `MsrQueryProps` | aggr | synced via the `MsrQueryProps` pass |
+| — *(missing)* | `—` | `msrQueryResultChapter` | `MsrQueryResultChapter` | — | missing |
+
+Base deviation: spec Base is `ARObject , DocumentViewSelectable , Paginateable`; implemented as `ARObject` (matches the sibling `MsrQueryP2`). `# Spec:` line kept without the `# Spec verified:` stamp until `msrQueryResultChapter` lands.
+
+## `MsrQueryTopic1`
+- **PDF:** `AUTOSAR_FO_TPS_GenericStructureTemplate.pdf`  | **page:** 343
+- **Package:** `M2::MSR::Documentation::Chapters`
+- **Source:** `src/armodel/models/M2/MSR/Documentation/Chapters.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| `msrQueryProps` | `Optional[MsrQueryProps]` | `msrQueryProps` | `MsrQueryProps` | aggr | synced via the `MsrQueryProps` pass |
+| — *(missing)* | `—` | `msrQueryResultTopic1` | `MsrQueryResultTopic1` | — | missing |
+
+Base deviation: spec Base is `ARObject , DocumentViewSelectable , Paginateable`; implemented as `ARObject` (matches the sibling `MsrQueryP2`). `# Spec:` line kept without the `# Spec verified:` stamp until `msrQueryResultTopic1` lands.
+
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
 | `maxCommMode` | `Optional[MaxCommModeEnum]` | `maxCommMode` | `MaxCommModeEnum` | attr | — |
@@ -1189,16 +1243,27 @@ The previous `dataTransformation` "type (spec many vs py single)" row was stale 
 | — *(missing)* | `—` | `namespace` | `SymbolProps` | — | missing |
 
 ## `SwComponentType`
-- **PDF:** `AUTOSAR_CP_TPS_DiagnosticExtractTemplate.pdf`  | **page:** 330
+- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 65
 - **Package:** `M2::AUTOSARTemplates::SWComponentTemplate::Components`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwComponentType.py`
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — *(missing)* | `—` | `consistencyNeeds` | `ConsistencyNeeds` | — | missing |
-| — *(missing)* | `—` | `swComponentDocumentation` | `SwComponentDocumentation` | — | missing |
-| — *(missing)* | `—` | `swcMappingConstraintRefs` | `Ref (SwComponentMappingConstraints)` | Refs | missing |
-| — *(missing)* | `—` | `unitGroupRefs` | `Ref (UnitGroup)` | Refs | missing |
+| `consistencyNeeds` | `List[ARObject]` | `consistencyNeeds` | `ConsistencyNeeds` | aggr | Table 4.99 class not yet implemented — ARObject placeholder; reader/writer pending |
+| `swcMappingConstraintsRefs` | `List[RefType]` | `swcMappingConstraintRefs` | `Ref (SwComponentMappingConstraints)` | Refs | class not in markdown/PDF — skipped per user; RefType placeholder |
+| `unitGroupRefs` | `List[RefType]` | `unitGroupRefs` | `Ref (UnitGroup)` | Refs | `UnitGroup` not yet synced (stub); RefType placeholder |
+
+## `SwComponentDocumentation`
+- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 698
+- **Package:** `M2::AUTOSARTemplates::SWComponentTemplate::SoftwareComponentDocumentation`
+- **Source:** `src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SoftwareComponentDocumentation.py`
+
+Model aligned (Table 12.1, p.698): `chapter` (*, aggr) and the seven predefined
+0..1 chapters (`swCalibrationNotes`, `swCarbDoc`, `swDiagnosticsNotes`,
+`swFeatureDef`, `swFeatureDesc`, `swMaintenanceNotes`, `swTestDesc`) implemented
+as `List[Chapter]` / `Optional[Chapter]` with `createXXX`/`getXXX` accessors,
+tests, and reader/writer coverage. The aggregated Chapter family lives in
+`M2::MSR::Documentation::Chapters`. `# Spec verified: R23-11` stamped.
 
 ## `EcucDefinitionCollection`
 - **PDF:** `AUTOSAR_CP_TPS_ECUConfiguration.pdf`  | **page:** 25

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SoftwareComponentDocumentation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SoftwareComponentDocumentation.py
@@ -1,228 +1,273 @@
 """
-This module contains classes for representing AUTOSAR software component documentation
-elements in software component templates.
+This module contains the SwComponentDocumentation class for AUTOSAR software
+component templates (spec M2::AUTOSARTemplates::SWComponentTemplate::SoftwareComponentDocumentation).
+
+The Chapter family it aggregates (Chapter, ChapterModel, ChapterContent,
+ChapterOrMsrQuery, TopicOrMsrQuery) lives in its own package
+M2::MSR::Documentation::Chapters (see src/armodel/models/M2/MSR/Documentation/Chapters.py).
 """
 
+from __future__ import annotations
+
+from typing import List, Optional
+
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+from armodel.models.M2.MSR.Documentation.Chapters import Chapter
 
 
 class SwComponentDocumentation(ARObject):
     """
-    Documentation for a software component including chapters, calibration
-    notes, diagnostics notes, feature descriptions, and test descriptions.
+    This class specifies the ability to write dedicated documentation to a component type according to ASAM FSX.
     """
 
     # SwComponentDocumentation method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getChapters                  [x] impl  [x] docstring  [ ] test
-    # [ ] addChapter                   [x] impl  [x] docstring  [ ] test
-    # [ ] getSwCalibrationNotes        [x] impl  [x] docstring  [ ] test
-    # [ ] setSwCalibrationNotes        [x] impl  [x] docstring  [ ] test
-    # [ ] getSwCarbDoc                 [x] impl  [x] docstring  [ ] test
-    # [ ] setSwCarbDoc                 [x] impl  [x] docstring  [ ] test
-    # [ ] getSwDiagnosticsNotes        [x] impl  [x] docstring  [ ] test
-    # [ ] setSwDiagnosticsNotes        [x] impl  [x] docstring  [ ] test
-    # [ ] getSwFeatureDef              [x] impl  [x] docstring  [ ] test
-    # [ ] setSwFeatureDef              [x] impl  [x] docstring  [ ] test
-    # [ ] getSwFeatureDesc             [x] impl  [x] docstring  [ ] test
-    # [ ] setSwFeatureDesc             [x] impl  [x] docstring  [ ] test
-    # [ ] getSwMaintenanceNotes        [x] impl  [x] docstring  [ ] test
-    # [ ] setSwMaintenanceNotes        [x] impl  [x] docstring  [ ] test
-    # [ ] getSwTestDesc                [x] impl  [x] docstring  [ ] test
-    # [ ] setSwTestDesc                [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 12.1, p.698
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                 [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] createChapter            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getChapters              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createSwCalibrationNotes [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwCalibrationNotes    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createSwCarbDoc          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwCarbDoc             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createSwDiagnosticsNotes [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwDiagnosticsNotes    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createSwFeatureDef       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwFeatureDef          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createSwFeatureDesc      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwFeatureDesc         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createSwMaintenanceNotes [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwMaintenanceNotes    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createSwTestDesc         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwTestDesc            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self):
         super().__init__()
 
-        self.chapters = []
-        self.swCalibrationNotes = None
-        self.swCarbDoc = None
-        self.swDiagnosticsNotes = None
-        self.swFeatureDef = None
-        self.swFeatureDesc = None
-        self.swMaintenanceNotes = None
-        self.swTestDesc = None
+        # These chapters provide additional information about the software component that do not fit in the other chapters. Note that this is subject to variation because Chapter aggregations in the role chapter are variant within the documentation in general.
+        self.chapters: List[Chapter] = []
 
-    def getChapters(self):
+        # This element contains calibration instructions and hints for a calibration engineer.
+        self.swCalibrationNotes: Optional[Chapter] = None
+
+        # This element records the documentation requested by CARB.
+        self.swCarbDoc: Optional[Chapter] = None
+
+        # This element contains general information about diagnostics issues within the component.
+        self.swDiagnosticsNotes: Optional[Chapter] = None
+
+        # This element contains the definition of the physical functionality of this software component. This definition is more or less formal and is intended to be delivered from modeling tools.
+        self.swFeatureDef: Optional[Chapter] = None
+
+        # This element contains the textual description of the software functionality of this software component. Expert should write this description.
+        self.swFeatureDesc: Optional[Chapter] = None
+
+        # This element contains information regarding the software maintenance of the component.
+        self.swMaintenanceNotes: Optional[Chapter] = None
+
+        # This element contains suggestions and hints for the test of the software functionality of this software component.
+        self.swTestDesc: Optional[Chapter] = None
+
+    def createChapter(self, short_name: str) -> Chapter:
         """
-        Gets the list of documentation chapters.
+        These chapters provide additional information about the software component that do not fit in the other chapters. Note that this is subject to variation because Chapter aggregations in the role chapter are variant within the documentation in general.
+
+        Creates a new Chapter for the chapter attribute with the given short name, or returns the existing one if it already exists.
+
+        Args:
+            short_name: The short name for the new Chapter
 
         Returns:
-            The list of chapters
+            The created (or existing) Chapter
+        """
+        for chapter in self.chapters:
+            if chapter.getShortName() == short_name:
+                return chapter
+        chapter = Chapter(self, short_name)
+        self.chapters.append(chapter)
+        return chapter
+
+    def getChapters(self) -> List[Chapter]:
+        """
+        These chapters provide additional information about the software component that do not fit in the other chapters. Note that this is subject to variation because Chapter aggregations in the role chapter are variant within the documentation in general.
+
+        Returns:
+            List of Chapter instances
         """
         return self.chapters
 
-    def addChapter(self, value):
+    def createSwCalibrationNotes(self, short_name: str) -> Chapter:
         """
-        Adds a documentation chapter.
+        This element contains calibration instructions and hints for a calibration engineer.
+
+        Creates a new Chapter for the swCalibrationNotes attribute with the given short name, or returns the existing one if already set.
 
         Args:
-            value: The chapter to add
+            short_name: The short name for the new Chapter
 
         Returns:
-            self for method chaining
+            The created (or existing) Chapter
         """
-        if value is not None:
-            self.chapters.append(value)
-        return self
+        if self.swCalibrationNotes is None:
+            self.swCalibrationNotes = Chapter(self, short_name)
+        return self.swCalibrationNotes
 
-    def getSwCalibrationNotes(self):
+    def getSwCalibrationNotes(self) -> Optional[Chapter]:
         """
-        Gets the software calibration notes.
+        This element contains calibration instructions and hints for a calibration engineer.
 
         Returns:
-            The software calibration notes
+            Chapter, or None if not set
         """
         return self.swCalibrationNotes
 
-    def setSwCalibrationNotes(self, value):
+    def createSwCarbDoc(self, short_name: str) -> Chapter:
         """
-        Sets the software calibration notes.
+        This element records the documentation requested by CARB.
+
+        Creates a new Chapter for the swCarbDoc attribute with the given short name, or returns the existing one if already set.
 
         Args:
-            value: The calibration notes to set
+            short_name: The short name for the new Chapter
 
         Returns:
-            self for method chaining
+            The created (or existing) Chapter
         """
-        if value is not None:
-            self.swCalibrationNotes = value
-        return self
+        if self.swCarbDoc is None:
+            self.swCarbDoc = Chapter(self, short_name)
+        return self.swCarbDoc
 
-    def getSwCarbDoc(self):
+    def getSwCarbDoc(self) -> Optional[Chapter]:
         """
-        Gets the software carbon documentation.
+        This element records the documentation requested by CARB.
 
         Returns:
-            The software carbon documentation
+            Chapter, or None if not set
         """
         return self.swCarbDoc
 
-    def setSwCarbDoc(self, value):
+    def createSwDiagnosticsNotes(self, short_name: str) -> Chapter:
         """
-        Sets the software carbon documentation.
+        This element contains general information about diagnostics issues within the component.
+
+        Creates a new Chapter for the swDiagnosticsNotes attribute with the given short name, or returns the existing one if already set.
 
         Args:
-            value: The carbon documentation to set
+            short_name: The short name for the new Chapter
 
         Returns:
-            self for method chaining
+            The created (or existing) Chapter
         """
-        if value is not None:
-            self.swCarbDoc = value
-        return self
+        if self.swDiagnosticsNotes is None:
+            self.swDiagnosticsNotes = Chapter(self, short_name)
+        return self.swDiagnosticsNotes
 
-    def getSwDiagnosticsNotes(self):
+    def getSwDiagnosticsNotes(self) -> Optional[Chapter]:
         """
-        Gets the software diagnostics notes.
+        This element contains general information about diagnostics issues within the component.
 
         Returns:
-            The software diagnostics notes
+            Chapter, or None if not set
         """
         return self.swDiagnosticsNotes
 
-    def setSwDiagnosticsNotes(self, value):
+    def createSwFeatureDef(self, short_name: str) -> Chapter:
         """
-        Sets the software diagnostics notes.
+        This element contains the definition of the physical functionality of this software component. This definition is more or less formal and is intended to be delivered from modeling tools.
+
+        Creates a new Chapter for the swFeatureDef attribute with the given short name, or returns the existing one if already set.
 
         Args:
-            value: The diagnostics notes to set
+            short_name: The short name for the new Chapter
 
         Returns:
-            self for method chaining
+            The created (or existing) Chapter
         """
-        if value is not None:
-            self.swDiagnosticsNotes = value
-        return self
+        if self.swFeatureDef is None:
+            self.swFeatureDef = Chapter(self, short_name)
+        return self.swFeatureDef
 
-    def getSwFeatureDef(self):
+    def getSwFeatureDef(self) -> Optional[Chapter]:
         """
-        Gets the software feature definition.
+        This element contains the definition of the physical functionality of this software component. This definition is more or less formal and is intended to be delivered from modeling tools.
 
         Returns:
-            The software feature definition
+            Chapter, or None if not set
         """
         return self.swFeatureDef
 
-    def setSwFeatureDef(self, value):
+    def createSwFeatureDesc(self, short_name: str) -> Chapter:
         """
-        Sets the software feature definition.
+        This element contains the textual description of the software functionality of this software component. Expert should write this description.
+
+        Creates a new Chapter for the swFeatureDesc attribute with the given short name, or returns the existing one if already set.
 
         Args:
-            value: The feature definition to set
+            short_name: The short name for the new Chapter
 
         Returns:
-            self for method chaining
+            The created (or existing) Chapter
         """
-        if value is not None:
-            self.swFeatureDef = value
-        return self
+        if self.swFeatureDesc is None:
+            self.swFeatureDesc = Chapter(self, short_name)
+        return self.swFeatureDesc
 
-    def getSwFeatureDesc(self):
+    def getSwFeatureDesc(self) -> Optional[Chapter]:
         """
-        Gets the software feature description.
+        This element contains the textual description of the software functionality of this software component. Expert should write this description.
 
         Returns:
-            The software feature description
+            Chapter, or None if not set
         """
         return self.swFeatureDesc
 
-    def setSwFeatureDesc(self, value):
+    def createSwMaintenanceNotes(self, short_name: str) -> Chapter:
         """
-        Sets the software feature description.
+        This element contains information regarding the software maintenance of the component.
+
+        Creates a new Chapter for the swMaintenanceNotes attribute with the given short name, or returns the existing one if already set.
 
         Args:
-            value: The feature description to set
+            short_name: The short name for the new Chapter
 
         Returns:
-            self for method chaining
+            The created (or existing) Chapter
         """
-        if value is not None:
-            self.swFeatureDesc = value
-        return self
+        if self.swMaintenanceNotes is None:
+            self.swMaintenanceNotes = Chapter(self, short_name)
+        return self.swMaintenanceNotes
 
-    def getSwMaintenanceNotes(self):
+    def getSwMaintenanceNotes(self) -> Optional[Chapter]:
         """
-        Gets the software maintenance notes.
+        This element contains information regarding the software maintenance of the component.
 
         Returns:
-            The software maintenance notes
+            Chapter, or None if not set
         """
         return self.swMaintenanceNotes
 
-    def setSwMaintenanceNotes(self, value):
+    def createSwTestDesc(self, short_name: str) -> Chapter:
         """
-        Sets the software maintenance notes.
+        This element contains suggestions and hints for the test of the software functionality of this software component.
+
+        Creates a new Chapter for the swTestDesc attribute with the given short name, or returns the existing one if already set.
 
         Args:
-            value: The maintenance notes to set
+            short_name: The short name for the new Chapter
 
         Returns:
-            self for method chaining
+            The created (or existing) Chapter
         """
-        if value is not None:
-            self.swMaintenanceNotes = value
-        return self
-
-    def getSwTestDesc(self):
-        """
-        Gets the software test description.
-
-        Returns:
-            The software test description
-        """
+        if self.swTestDesc is None:
+            self.swTestDesc = Chapter(self, short_name)
         return self.swTestDesc
 
-    def setSwTestDesc(self, value):
+    def getSwTestDesc(self) -> Optional[Chapter]:
         """
-        Sets the software test description.
-
-        Args:
-            value: The test description to set
+        This element contains suggestions and hints for the test of the software functionality of this software component.
 
         Returns:
-            self for method chaining
+            Chapter, or None if not set
         """
-        if value is not None:
-            self.swTestDesc = value
-        return self
+        return self.swTestDesc

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwComponentType.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwComponentType.py
@@ -2,148 +2,279 @@
 This module contains the SwComponentType base class for AUTOSAR software components.
 """
 
+from __future__ import annotations
+
 from abc import ABC
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional
+
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
 
 if TYPE_CHECKING:
-    from ....M2.AUTOSARTemplates.SWComponentTemplate.Components import PPortPrototype, RPortPrototype, PRPortPrototype, PortPrototype, PortGroup
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import (
+        PPortPrototype,
+        PortGroup,
+        PortPrototype,
+        PRPortPrototype,
+        RPortPrototype,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SoftwareComponentDocumentation import (
+        SwComponentDocumentation,
+    )
 
 
 class SwComponentType(AtpType, ABC):
     """
-    Abstract base class for all software component types in AUTOSAR.
-    Provides port and port group management.
+    Base class for AUTOSAR software components.
     """
 
     # SwComponentType method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [x] test
-    # [ ] getPorts                     [x] impl  [x] docstring  [ ] test
-    # [ ] createPPortPrototype         [x] impl  [x] docstring  [ ] test
-    # [ ] createRPortPrototype         [x] impl  [x] docstring  [ ] test
-    # [ ] createPRPortPrototype        [x] impl  [x] docstring  [ ] test
-    # [ ] getPPortPrototypes           [x] impl  [ ] docstring  [ ] test
-    # [ ] getRPortPrototypes           [x] impl  [ ] docstring  [ ] test
-    # [ ] getPRPortPrototypes          [x] impl  [ ] docstring  [ ] test
-    # [ ] getPortPrototypes            [x] impl  [ ] docstring  [ ] test
-    # [ ] getPortGroups                [x] impl  [x] docstring  [ ] test
-    # [ ] createPortGroup              [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 3.1, p.64
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] createPPortPrototype         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] createRPortPrototype         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] createPRPortPrototype        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPorts                     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getPPortPrototypes           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getRPortPrototypes           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getPRPortPrototypes          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getPortPrototypes            [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] createPortGroup              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPortGroups                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addSwcMappingConstraintRef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwcMappingConstraintsRefs  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getSwComponentDocumentation   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwComponentDocumentation   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] addUnitGroupRef               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getUnitGroupRefs              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         if type(self) is SwComponentType:
             raise TypeError("SwComponentType is an abstract class.")
         super().__init__(parent, short_name)
 
-        self.ports = []
-        self.portGroups = []
+        # The PortPrototypes through which this SwComponent Type can communicate. The aggregation of PortPrototype is subject to variability with the purpose to support the conditional existence of PortPrototypes.
+        self.ports: List[PortPrototype] = []
 
-    def getPorts(self):
+        # A port group being part of this component.
+        self.portGroups: List[PortGroup] = []
+
+        # Reference to constraints that are valid for this SwComponentType.
+        self.swcMappingConstraintsRefs: List[RefType] = []
+
+        # This adds a documentation to the SwComponentType.
+        self.swComponentDocumentation: Optional[SwComponentDocumentation] = None
+
+        # This allows for the specification of which UnitGroups are relevant in the context of referencing SwComponentType.
+        self.unitGroupRefs: List[RefType] = []
+
+    def createPPortPrototype(self, short_name: str) -> PPortPrototype:
         """
-        Gets the list of all ports.
+        Creates a PPortPrototype of this SwComponentType. The aggregation of PortPrototype is subject to variability with the purpose to support the conditional existence of PortPrototypes.
+        Returns the existing PPortPrototype when the short name already exists.
+
+        Args:
+            short_name: The short name of the PPortPrototype
 
         Returns:
-            The list of ports
+            The created or existing PPortPrototype
+        """
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import PPortPrototype
+
+        if not self.IsElementExists(short_name, PPortPrototype):
+            prototype = PPortPrototype(self, short_name)
+            self.addElement(prototype)
+            self.ports.append(prototype)
+        return self.getElement(short_name, PPortPrototype)
+
+    def createRPortPrototype(self, short_name: str) -> RPortPrototype:
+        """
+        Creates an RPortPrototype of this SwComponentType. The aggregation of PortPrototype is subject to variability with the purpose to support the conditional existence of PortPrototypes.
+        Returns the existing RPortPrototype when the short name already exists.
+
+        Args:
+            short_name: The short name of the RPortPrototype
+
+        Returns:
+            The created or existing RPortPrototype
+        """
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import RPortPrototype
+
+        if not self.IsElementExists(short_name, RPortPrototype):
+            prototype = RPortPrototype(self, short_name)
+            self.addElement(prototype)
+            self.ports.append(prototype)
+        return self.getElement(short_name, RPortPrototype)
+
+    def createPRPortPrototype(self, short_name: str) -> PRPortPrototype:
+        """
+        Creates a PRPortPrototype of this SwComponentType. The aggregation of PortPrototype is subject to variability with the purpose to support the conditional existence of PortPrototypes.
+        Returns the existing PRPortPrototype when the short name already exists.
+
+        Args:
+            short_name: The short name of the PRPortPrototype
+
+        Returns:
+            The created or existing PRPortPrototype
+        """
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import PRPortPrototype
+
+        if not self.IsElementExists(short_name, PRPortPrototype):
+            prototype = PRPortPrototype(self, short_name)
+            self.addElement(prototype)
+            self.ports.append(prototype)
+        return self.getElement(short_name, PRPortPrototype)
+
+    def getPorts(self) -> List[PortPrototype]:
+        """
+        Gets the PortPrototypes through which this SwComponentType can communicate. The aggregation of PortPrototype is subject to variability with the purpose to support the conditional existence of PortPrototypes.
+
+        Returns:
+            List of PortPrototype instances
         """
         return self.ports
 
-    def createPPortPrototype(self, short_name: str):
+    def getPPortPrototypes(self) -> List[PPortPrototype]:
         """
-        Creates and adds a PPortPrototype.
-
-        Args:
-            short_name: The short name for the port prototype
+        Convenience getter for the PPortPrototype instances aggregated by this SwComponentType.
 
         Returns:
-            PPortPrototype: The created port prototype
+            List of PPortPrototype instances
         """
-        # Import here to avoid circular dependency
-        from ....M2.AUTOSARTemplates.SWComponentTemplate.Components import PPortPrototype
-
-        prototype = PPortPrototype(self, short_name)
-        self.addElement(prototype)
-        self.ports.append(prototype)
-        return prototype
-
-    def createRPortPrototype(self, short_name):
-        """
-        Creates and adds an RPortPrototype.
-
-        Args:
-            short_name: The short name for the port prototype
-
-        Returns:
-            RPortPrototype: The created port prototype
-        """
-        # Import here to avoid circular dependency
-        from ....M2.AUTOSARTemplates.SWComponentTemplate.Components import RPortPrototype
-
-        prototype = RPortPrototype(self, short_name)
-        self.addElement(prototype)
-        self.ports.append(prototype)
-        return prototype
-
-    def createPRPortPrototype(self, short_name):
-        """
-        Creates and adds a PRPortPrototype.
-
-        Args:
-            short_name: The short name for the port prototype
-
-        Returns:
-            PRPortPrototype: The created port prototype
-        """
-        # Import here to avoid circular dependency
-        from ....M2.AUTOSARTemplates.SWComponentTemplate.Components import PRPortPrototype
-
-        prototype = PRPortPrototype(self, short_name)
-        self.addElement(prototype)
-        self.ports.append(prototype)
-        return prototype
-
-    def getPPortPrototypes(self) -> List["PPortPrototype"]:
-        from ....M2.AUTOSARTemplates.SWComponentTemplate.Components import PPortPrototype
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import PPortPrototype
 
         return list(sorted(filter(lambda c: isinstance(c, PPortPrototype), self.ports), key=lambda o: o.short_name))
 
-    def getRPortPrototypes(self) -> List["RPortPrototype"]:
-        from ....M2.AUTOSARTemplates.SWComponentTemplate.Components import RPortPrototype
+    def getRPortPrototypes(self) -> List[RPortPrototype]:
+        """
+        Convenience getter for the RPortPrototype instances aggregated by this SwComponentType.
+
+        Returns:
+            List of RPortPrototype instances
+        """
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import RPortPrototype
 
         return list(sorted(filter(lambda c: isinstance(c, RPortPrototype), self.ports), key=lambda o: o.short_name))
 
-    def getPRPortPrototypes(self) -> List["PRPortPrototype"]:
-        from ....M2.AUTOSARTemplates.SWComponentTemplate.Components import PRPortPrototype
+    def getPRPortPrototypes(self) -> List[PRPortPrototype]:
+        """
+        Convenience getter for the PRPortPrototype instances aggregated by this SwComponentType.
+
+        Returns:
+            List of PRPortPrototype instances
+        """
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import PRPortPrototype
 
         return list(sorted(filter(lambda c: isinstance(c, PRPortPrototype), self.ports), key=lambda o: o.short_name))
 
-    def getPortPrototypes(self) -> List["PortPrototype"]:
-        from ....M2.AUTOSARTemplates.SWComponentTemplate.Components import PortPrototype
+    def getPortPrototypes(self) -> List[PortPrototype]:
+        """
+        Convenience getter for all PortPrototype instances aggregated by this SwComponentType.
+
+        Returns:
+            List of PortPrototype instances
+        """
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import PortPrototype
 
         return list(sorted(filter(lambda c: isinstance(c, PortPrototype), self.ports), key=lambda o: o.short_name))
 
-    def getPortGroups(self) -> List["PortGroup"]:
+    def createPortGroup(self, short_name: str) -> PortGroup:
         """
-        Gets the list of port groups.
+        Creates a PortGroup being part of this component.
+        Returns the existing PortGroup when the short name already exists.
+
+        Args:
+            short_name: The short name of the PortGroup
 
         Returns:
-            List[PortGroup]: The list of port groups
+            The created or existing PortGroup
+        """
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import PortGroup
+
+        if not self.IsElementExists(short_name, PortGroup):
+            port_group = PortGroup(self, short_name)
+            self.addElement(port_group)
+            self.portGroups.append(port_group)
+        return self.getElement(short_name, PortGroup)
+
+    def getPortGroups(self) -> List[PortGroup]:
+        """
+        Gets the PortGroups being part of this component.
+
+        Returns:
+            List of PortGroup instances
         """
         return self.portGroups
 
-    def createPortGroup(self, short_name):
+    def addSwcMappingConstraintRef(self, value: Optional[RefType]) -> "SwComponentType":
         """
-        Creates and adds a PortGroup.
+        Adds a reference to constraints that are valid for this SwComponentType.
+        A None value is a no-op and does not append anything.
 
         Args:
-            short_name: The short name for the port group
+            value: The SwComponentMappingConstraints reference to add
 
         Returns:
-            PortGroup: The created port group
+            self for method chaining
         """
-        # Import here to avoid circular dependency
-        from ....M2.AUTOSARTemplates.SWComponentTemplate.Components import PortGroup
+        if value is not None:
+            self.swcMappingConstraintsRefs.append(value)
+        return self
 
-        port_group = PortGroup(self, short_name)
-        self.addElement(port_group)
-        self.portGroups.append(port_group)
-        return port_group
+    def getSwcMappingConstraintsRefs(self) -> List[RefType]:
+        """
+        Gets the references to constraints that are valid for this SwComponentType.
+
+        Returns:
+            List of RefType instances
+        """
+        return self.swcMappingConstraintsRefs
+
+    def getSwComponentDocumentation(self) -> Optional[SwComponentDocumentation]:
+        """
+        Gets the documentation that is added to the SwComponentType.
+
+        Returns:
+            SwComponentDocumentation, or None if not set
+        """
+        return self.swComponentDocumentation
+
+    def setSwComponentDocumentation(self, value: Optional[SwComponentDocumentation]) -> "SwComponentType":
+        """
+        Sets the documentation that is added to the SwComponentType.
+        A None value is a no-op and does not overwrite an existing documentation.
+
+        Args:
+            value: The SwComponentDocumentation to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.swComponentDocumentation = value
+        return self
+
+    def addUnitGroupRef(self, value: Optional[RefType]) -> "SwComponentType":
+        """
+        Adds a reference which allows for the specification of which UnitGroups are relevant in the context of referencing SwComponentType.
+        A None value is a no-op and does not append anything.
+
+        Args:
+            value: The UnitGroup reference to add
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.unitGroupRefs.append(value)
+        return self
+
+    def getUnitGroupRefs(self) -> List[RefType]:
+        """
+        Gets the references which allow for the specification of which UnitGroups are relevant in the context of referencing SwComponentType.
+
+        Returns:
+            List of RefType instances
+        """
+        return self.unitGroupRefs

--- a/src/armodel/models/M2/MSR/Documentation/Chapters.py
+++ b/src/armodel/models/M2/MSR/Documentation/Chapters.py
@@ -1,0 +1,662 @@
+"""
+This module contains the Chapter family of AUTOSAR model classes from the
+MSR Documentation::Chapters package (spec M2::MSR::Documentation::Chapters).
+
+These classes are referenced by SwComponentDocumentation
+(M2::AUTOSARTemplates::SWComponentTemplate::SoftwareComponentDocumentation) but
+live in their own package per the AUTOSAR meta-model.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import String
+from armodel.models.M2.MSR.Documentation.TextModel.MsrQuery import MsrQueryP1, MsrQueryProps
+
+if TYPE_CHECKING:
+    from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
+
+
+class Chapter(Identifiable):
+    """
+    This meta-class represents a chapter of a document. Chapters are the primary structuring element in documentation.
+    """
+
+    # Chapter method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 9.58, p.329
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__            [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setChapterModel     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getChapterModel     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setHelpEntry        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHelpEntry        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+
+    def __init__(self, parent: ARObject, short_name: str):
+        super().__init__(parent, short_name)
+
+        # This represents the overall contents of the chapter.
+        self.chapterModel: Optional[ChapterModel] = None
+
+        # This specifies an entry point in an online help system to be linked with the parent class. The syntax shall be defined by the applied help system respectively help system generator. Maybe it is a concatenated Identifier, but as of now we leave it as an arbitrary string.
+        self.helpEntry: Optional[String] = None
+
+    def setHelpEntry(self, value: Optional[String]) -> "Chapter":
+        """
+        This specifies an entry point in an online help system to be linked with the parent class. The syntax shall be defined by the applied help system respectively help system generator. Maybe it is a concatenated Identifier, but as of now we leave it as an arbitrary string.
+
+        A None value is a no-op and does not overwrite an existing helpEntry.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.helpEntry = value
+        return self
+
+    def getHelpEntry(self) -> Optional[String]:
+        """
+        This specifies an entry point in an online help system to be linked with the parent class. The syntax shall be defined by the applied help system respectively help system generator. Maybe it is a concatenated Identifier, but as of now we leave it as an arbitrary string.
+
+        Returns:
+            The entry point in an online help system to be linked with the parent class
+        """
+        return self.helpEntry
+
+    def setChapterModel(self, value: Optional[ChapterModel]) -> "Chapter":
+        """
+        This represents the overall contents of the chapter.
+
+        A None value is a no-op and does not overwrite an existing chapterModel.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.chapterModel = value
+        return self
+
+    def getChapterModel(self) -> Optional[ChapterModel]:
+        """
+        This represents the overall contents of the chapter.
+
+        Returns:
+            The overall contents of the chapter
+        """
+        return self.chapterModel
+
+
+class ChapterModel(ARObject):
+    """
+    This is the basic content model of a chapter except the Chapter title. This can be utilized in general chapters as well as in predefined chapters.
+
+    A chapter has content on three levels:
+
+    1. chapter content
+
+    2. topics
+
+    3. subchapters
+    """
+
+    # ChapterModel method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 9.59, p.330
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setChapter         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getChapter         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setChapterContent  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getChapterContent  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTopic1          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTopic1          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This is a particular subchapter.
+        self.chapter: Optional[ChapterOrMsrQuery] = None
+
+        # This is the chapter content which is not a topic or a subchapter. It is the content which is directly in the chapter.
+        self.chapterContent: Optional[ChapterContent] = None
+
+        # This is a topic within the chapter.
+        self.topic1: Optional[TopicOrMsrQuery] = None
+
+    def setChapterContent(self, value: Optional[ChapterContent]) -> "ChapterModel":
+        """
+        This is the chapter content which is not a topic or a subchapter. It is the content which is directly in the chapter.
+
+        A None value is a no-op and does not overwrite an existing chapterContent.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.chapterContent = value
+        return self
+
+    def getChapterContent(self) -> Optional[ChapterContent]:
+        """
+        This is the chapter content which is not a topic or a subchapter. It is the content which is directly in the chapter.
+
+        Returns:
+            The chapter content which is not a topic or a subchapter
+        """
+        return self.chapterContent
+
+    def setTopic1(self, value: Optional[TopicOrMsrQuery]) -> "ChapterModel":
+        """
+        This is a topic within the chapter.
+
+        A None value is a no-op and does not overwrite an existing topic1.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.topic1 = value
+        return self
+
+    def getTopic1(self) -> Optional[TopicOrMsrQuery]:
+        """
+        This is a topic within the chapter.
+
+        Returns:
+            A topic within the chapter
+        """
+        return self.topic1
+
+    def setChapter(self, value: Optional[ChapterOrMsrQuery]) -> "ChapterModel":
+        """
+        This is a particular subchapter.
+
+        A None value is a no-op and does not overwrite an existing chapter.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.chapter = value
+        return self
+
+    def getChapter(self) -> Optional[ChapterOrMsrQuery]:
+        """
+        This is a particular subchapter.
+
+        Returns:
+            A particular subchapter
+        """
+        return self.chapter
+
+
+class ChapterContent(ARObject):
+    """
+    This class represents the content which is directly in a chapter. It is basically the same as the one in a Topic but might have additional complex structures (e.g. Synopsis)
+    """
+
+    # ChapterContent method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 9.60, p.330
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__               [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setTopicContent        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTopicContent        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [ ] setPrms                [x] impl  [ ] docstring  [ ] test  [ ] reader  [ ] writer
+    # [ ] getPrms                [x] impl  [ ] docstring  [ ] test  [ ] reader  [ ] writer
+    #
+    # NOTE: prms (Prms, 1, aggr) is not modeled yet — the Prms class is a deferred
+    # placeholder (Rule 0001.10); the stamp is omitted until the real type lands.
+
+    def __init__(self):
+        super().__init__()
+
+        # This is that part of a chapter content which may appear in a chapter as well as in a topic.
+        self.topicContent: Optional[TopicContentOrMsrQuery] = None
+
+    def setTopicContent(self, value: Optional[TopicContentOrMsrQuery]) -> "ChapterContent":
+        """
+        This is that part of a chapter content which may appear in a chapter as well as in a topic.
+
+        A None value is a no-op and does not overwrite an existing topicContent.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.topicContent = value
+        return self
+
+    def getTopicContent(self) -> Optional[TopicContentOrMsrQuery]:
+        """
+        This is that part of a chapter content which may appear in a chapter as well as in a topic.
+
+        Returns:
+            The chapter content which may appear in a chapter as well as in a topic
+        """
+        return self.topicContent
+
+
+class ChapterOrMsrQuery(ARObject):
+    """
+    This meta-class represents the ability to denote a particular chapter or a query returning a chapter.
+    """
+
+    # ChapterOrMsrQuery method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 9.81, p.342
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__            [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addChapter          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getChapters         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMsrQueryChapter  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMsrQueryChapter  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This establishes a subschapter.
+        self.chapters: List[Chapter] = []
+
+        # This represents automatically contributed chapters provided by an msrquery.
+        self.msrQueryChapter: Optional[MsrQueryChapter] = None
+
+    def addChapter(self, value: Optional[Chapter]) -> "ChapterOrMsrQuery":
+        """
+        This establishes a subschapter.
+
+        A None value is a no-op and does not append anything.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.chapters.append(value)
+        return self
+
+    def getChapters(self) -> List[Chapter]:
+        """
+        This establishes a subschapter.
+
+        Returns:
+            The established subschapters
+        """
+        return self.chapters
+
+    def setMsrQueryChapter(self, value: Optional[MsrQueryChapter]) -> "ChapterOrMsrQuery":
+        """
+        This represents automatically contributed chapters provided by an msrquery.
+
+        A None value is a no-op and does not overwrite an existing msrQueryChapter.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.msrQueryChapter = value
+        return self
+
+    def getMsrQueryChapter(self) -> Optional[MsrQueryChapter]:
+        """
+        This represents automatically contributed chapters provided by an msrquery.
+
+        Returns:
+            The automatically contributed chapters provided by an msrquery
+        """
+        return self.msrQueryChapter
+
+
+class TopicOrMsrQuery(ARObject):
+    """
+    This class provides the alternative of a Topic with an MsrQuery which delivers a topic.
+    """
+
+    # TopicOrMsrQuery method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 9.80, p.342
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__             [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addTopic1           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTopic1s          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMsrQueryTopic1   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMsrQueryTopic1   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This represents automatically contributed topics provided by an msrquery.
+        self.msrQueryTopic1: Optional[MsrQueryTopic1] = None
+
+        # This is used to create particular topics within a chapter. A topic is similar to a subchapter, but cannot be nested and will not appear in the table of contents of the document.
+        self.topic1: List[Topic1] = []
+
+    def addTopic1(self, value: Optional[Topic1]) -> "TopicOrMsrQuery":
+        """
+        This is used to create particular topics within a chapter. A topic is similar to a subchapter, but cannot be nested and will not appear in the table of contents of the document.
+
+        A None value is a no-op and does not append anything.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.topic1.append(value)
+        return self
+
+    def getTopic1s(self) -> List[Topic1]:
+        """
+        This is used to create particular topics within a chapter. A topic is similar to a subchapter, but cannot be nested and will not appear in the table of contents of the document.
+
+        Returns:
+            The created particular topics within a chapter
+        """
+        return self.topic1
+
+    def setMsrQueryTopic1(self, value: Optional[MsrQueryTopic1]) -> "TopicOrMsrQuery":
+        """
+        This represents automatically contributed topics provided by an msrquery.
+
+        A None value is a no-op and does not overwrite an existing msrQueryTopic1.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.msrQueryTopic1 = value
+        return self
+
+    def getMsrQueryTopic1(self) -> Optional[MsrQueryTopic1]:
+        """
+        This represents automatically contributed topics provided by an msrquery.
+
+        Returns:
+            The automatically contributed topics provided by an msrquery
+        """
+        return self.msrQueryTopic1
+
+
+class Topic1(Identifiable):
+    """
+    This meta-class represents a topic of a documentation. Topics are similar to chapters but they cannot be nested.
+
+    They also do not appear in the table of content. Topics can be used to produce intermediate headlines thus structuring a chapter internally.
+    """
+
+    # Topic1 method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 9.73, p.338
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__               [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setHelpEntry           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHelpEntry           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTopicContent        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTopicContent        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+
+    def __init__(self, parent: ARObject, short_name: str):
+        super().__init__(parent, short_name)
+
+        # This specifies an entry point in an online help system to be linked with the parent class. The syntax shall be defined by the applied help system respectively help system generator.
+        self.helpEntry: Optional[String] = None
+
+        # This is the content of the topic.
+        self.topicContent: Optional[TopicContentOrMsrQuery] = None
+
+    def setHelpEntry(self, value: Optional[String]) -> "Topic1":
+        """
+        This specifies an entry point in an online help system to be linked with the parent class. The syntax shall be defined by the applied help system respectively help system generator.
+
+        A None value is a no-op and does not overwrite an existing helpEntry.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.helpEntry = value
+        return self
+
+    def getHelpEntry(self) -> Optional[String]:
+        """
+        This specifies an entry point in an online help system to be linked with the parent class. The syntax shall be defined by the applied help system respectively help system generator.
+
+        Returns:
+            The entry point in an online help system to be linked with the parent class
+        """
+        return self.helpEntry
+
+    def setTopicContent(self, value: Optional[TopicContentOrMsrQuery]) -> "Topic1":
+        """
+        This is the content of the topic.
+
+        A None value is a no-op and does not overwrite an existing topicContent.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.topicContent = value
+        return self
+
+    def getTopicContent(self) -> Optional[TopicContentOrMsrQuery]:
+        """
+        This is the content of the topic.
+
+        Returns:
+            The content of the topic
+        """
+        return self.topicContent
+
+
+class MsrQueryChapter(ARObject):
+    """
+    This meta-class represents the ability to express a query which yields a set of chapters as a result.
+    """
+
+    # MsrQueryChapter method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 9.84, p.343
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__               [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setMsrQueryProps       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMsrQueryProps       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [ ] setMsrQueryResultChapter  [x] impl  [ ] docstring  [ ] test  [ ] reader  [ ] writer
+    # [ ] getMsrQueryResultChapter  [x] impl  [ ] docstring  [ ] test  [ ] reader  [ ] writer
+    #
+    # NOTE: msrQueryResultChapter (MsrQueryResultChapter, 0..1, aggr) is not modeled
+    # yet — the MsrQueryResultChapter class is a deferred placeholder (Rule 0001.10);
+    # the stamp is omitted until the real type lands.
+
+    def __init__(self):
+        super().__init__()
+
+        # This is argument and properties of the chapter query.
+        self.msrQueryProps: Optional[MsrQueryProps] = None
+
+    def setMsrQueryProps(self, value: Optional[MsrQueryProps]) -> "MsrQueryChapter":
+        """
+        This is argument and properties of the chapter query.
+
+        A None value is a no-op and does not overwrite an existing msrQueryProps.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.msrQueryProps = value
+        return self
+
+    def getMsrQueryProps(self) -> Optional[MsrQueryProps]:
+        """
+        This is argument and properties of the chapter query.
+
+        Returns:
+            The argument and properties of the chapter query
+        """
+        return self.msrQueryProps
+
+
+class MsrQueryTopic1(ARObject):
+    """
+    This meta-class represents the ability to specify a query which yields a set of topics as a result.
+    """
+
+    # MsrQueryTopic1 method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 9.83, p.343
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__               [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setMsrQueryProps       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMsrQueryProps       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [ ] setMsrQueryResultTopic1  [x] impl  [ ] docstring  [ ] test  [ ] reader  [ ] writer
+    # [ ] getMsrQueryResultTopic1  [x] impl  [ ] docstring  [ ] test  [ ] reader  [ ] writer
+    #
+    # NOTE: msrQueryResultTopic1 (MsrQueryResultTopic1, 0..1, aggr) is not modeled
+    # yet — the MsrQueryResultTopic1 class is a deferred placeholder (Rule 0001.10);
+    # the stamp is omitted until the real type lands.
+
+    def __init__(self):
+        super().__init__()
+
+        # This is argument and properties of the topic query.
+        self.msrQueryProps: Optional[MsrQueryProps] = None
+
+    def setMsrQueryProps(self, value: Optional[MsrQueryProps]) -> "MsrQueryTopic1":
+        """
+        This is argument and properties of the topic query.
+
+        A None value is a no-op and does not overwrite an existing msrQueryProps.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.msrQueryProps = value
+        return self
+
+    def getMsrQueryProps(self) -> Optional[MsrQueryProps]:
+        """
+        This is argument and properties of the topic query.
+
+        Returns:
+            The argument and properties of the topic query
+        """
+        return self.msrQueryProps
+
+
+class TopicContent(ARObject):
+    """
+    This meta-class represents the content of a topic. It is mainly a documentation block, but can also be a table.
+    """
+
+    # TopicContent method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table E.81, p.478
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setBlockLevelContent        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getBlockLevelContent        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [ ] setTable                    [ ] impl  [ ] docstring  [ ] test  [ ] reader  [ ] writer
+    # [ ] getTable                    [ ] impl  [ ] docstring  [ ] test  [ ] reader  [ ] writer
+    # [ ] setTraceableTable           [ ] impl  [ ] docstring  [ ] test  [ ] reader  [ ] writer
+    # [ ] getTraceableTable           [ ] impl  [ ] docstring  [ ] test  [ ] reader  [ ] writer
+    #
+    # NOTE: table (Table, 0..1, aggr) and traceableTable (TraceableTable, 1, aggr) are
+    # not modeled yet — the Table and TraceableTable classes are deferred placeholders
+    # (Rule 0001.10); the stamp is omitted until the real types land.
+
+    def __init__(self):
+        super().__init__()
+
+        # This is that part of the content which may also occur in a table cell.
+        self.blockLevelContent: Optional["DocumentationBlock"] = None
+
+    def setBlockLevelContent(self, value: Optional["DocumentationBlock"]) -> "TopicContent":
+        """
+        This is that part of the content which may also occur in a table cell.
+
+        A None value is a no-op and does not overwrite an existing blockLevelContent.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.blockLevelContent = value
+        return self
+
+    def getBlockLevelContent(self) -> Optional["DocumentationBlock"]:
+        """
+        This is that part of the content which may also occur in a table cell.
+
+        Returns:
+            The part of the content which may also occur in a table cell
+        """
+        return self.blockLevelContent
+
+
+class TopicContentOrMsrQuery(ARObject):
+    """
+    This meta-class represents a topic or a topic content which is generated using queries.
+    """
+
+    # TopicContentOrMsrQuery method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 9.79, p.342
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__               [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setMsrQueryP1          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMsrQueryP1          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTopicContent        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTopicContent        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    #
+    # NOTE: msrQueryP1 references the MsrQueryP1 stub (Rule 0001.10) which is a deferred
+    # placeholder; the stamp is omitted until the real type lands.
+
+    def __init__(self):
+        super().__init__()
+
+        # This represents automatically contributed contents provided by an msrquery.
+        self.msrQueryP1: Optional[MsrQueryP1] = None
+
+        # This is the content of a topic.
+        self.topicContent: Optional[TopicContent] = None
+
+    def setMsrQueryP1(self, value: Optional[MsrQueryP1]) -> "TopicContentOrMsrQuery":
+        """
+        This represents automatically contributed contents provided by an msrquery.
+
+        A None value is a no-op and does not overwrite an existing msrQueryP1.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.msrQueryP1 = value
+        return self
+
+    def getMsrQueryP1(self) -> Optional[MsrQueryP1]:
+        """
+        This represents automatically contributed contents provided by an msrquery.
+
+        Returns:
+            The automatically contributed contents provided by an msrquery
+        """
+        return self.msrQueryP1
+
+    def setTopicContent(self, value: Optional[TopicContent]) -> "TopicContentOrMsrQuery":
+        """
+        This is the content of a topic.
+
+        A None value is a no-op and does not overwrite an existing topicContent.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.topicContent = value
+        return self
+
+    def getTopicContent(self) -> Optional[TopicContent]:
+        """
+        This is the content of a topic.
+
+        Returns:
+            The content of a topic
+        """
+        return self.topicContent

--- a/src/armodel/models/M2/MSR/Documentation/TextModel/MsrQuery.py
+++ b/src/armodel/models/M2/MSR/Documentation/TextModel/MsrQuery.py
@@ -227,3 +227,20 @@ class MsrQueryP2(ARObject):
         if value is not None:
             self.msrQueryResultP2 = value
         return self
+
+
+class MsrQueryP1(ARObject):
+    """
+    This meta-class represents the ability to express a query which yields the content of a topic as a result.
+
+    NOTE: stub placeholder for the MSR::Documentation::MsrQuery MsrQueryP1 type
+    (Table 9.82); the full content model is not yet synced. Referred to by
+    TopicContentOrMsrQuery.msrQueryP1.
+    """
+
+    # MsrQueryP1 method parity checklist (stub):
+    # Spec: not synced (MSR Documentation subtree)
+    # (no methods)
+
+    def __init__(self):
+        super().__init__()

--- a/src/armodel/models/__init__.py
+++ b/src/armodel/models/__init__.py
@@ -102,6 +102,7 @@ from armodel.models.M2.MSR.DataDictionary.SystemConstant import *  # noqa: F403
 from armodel.models.M2.MSR.Documentation.BlockElements import *  # noqa: F403
 from armodel.models.M2.MSR.Documentation.BlockElements.Figure import *  # noqa: F403
 from armodel.models.M2.MSR.Documentation.BlockElements.Formula import *  # noqa: F403
+from armodel.models.M2.MSR.Documentation.Chapters import *  # noqa: F403
 
 # Additional CommonStructure imports
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.AbstractBlueprintStructure.AtpBlueprint import *  # noqa: F403

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -184,6 +184,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwDescriptionEntity, HwElement, HwPinGroup
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwAttributeDef, HwCategory, HwType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import AnyInstanceRef
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage, ReferenceBase
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import Collection
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.EngineeringObject import AutosarEngineeringObject, EngineeringObject
@@ -323,6 +324,9 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface.InstanceRefs import ApplicationCompositeElementInPortInterfaceInstanceRef
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.RPTScenario import RptExecutableEntityProperties, RptImplPolicy
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SoftwareComponentDocumentation import (
+    SwComponentDocumentation,
+)
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation import SwcImplementation
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior import ExternalTriggeringPoint, RunnableEntity, RunnableEntityArgument, SwcExclusiveAreaPolicy, SwcInternalBehavior
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AccessCount import AccessCount, AccessCountSet
@@ -556,6 +560,18 @@ from armodel.models.M2.MSR.Documentation.Annotation import Annotation, GeneralAn
 from armodel.models.M2.MSR.Documentation.BlockElements.Figure import Graphic, LGraphic, MlFigure
 from armodel.models.M2.MSR.Documentation.BlockElements.Formula import MlFormula
 from armodel.models.M2.MSR.Documentation.BlockElements.OasisExchangeTable import FloatEnum, PgwideEnum
+from armodel.models.M2.MSR.Documentation.Chapters import (
+    Chapter,
+    ChapterContent,
+    ChapterModel,
+    ChapterOrMsrQuery,
+    MsrQueryChapter,
+    MsrQueryTopic1,
+    Topic1,
+    TopicContent,
+    TopicContentOrMsrQuery,
+    TopicOrMsrQuery,
+)
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements.ListElements import ARList, DefItem, DefList, IndentSample, ItemLabelPosEnum, LabeledItem, LabeledList
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements.Note import Note, NoteTypeEnum
@@ -563,7 +579,7 @@ from armodel.models.M2.MSR.Documentation.TextModel.BlockElements.PaginationAndVi
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements.RequirementsTracing import StructuredReq, TraceableText
 from armodel.models.M2.MSR.Documentation.TextModel.InlineTextElements import EmphasisText, IndexEntry, Superscript, Tt
 from armodel.models.M2.MSR.Documentation.TextModel.LanguageDataModel import LanguageSpecific, LLongName, LOverviewParagraph, LParagraph, LVerbatim
-from armodel.models.M2.MSR.Documentation.TextModel.MsrQuery import MsrQueryArg, MsrQueryP2, MsrQueryProps
+from armodel.models.M2.MSR.Documentation.TextModel.MsrQuery import MsrQueryArg, MsrQueryP1, MsrQueryP2, MsrQueryProps
 from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultilanguageLongName, MultiLanguageOverviewParagraph, MultiLanguageParagraph, MultiLanguagePlainText, MultiLanguageVerbatim
 from armodel.parser.abstract_arxml_parser import AbstractARXMLParser
 
@@ -3837,10 +3853,141 @@ class ARXMLParser(AbstractARXMLParser):
             else:
                 self.raiseError("Unsupported Port Group type: %s" % tag_name)
 
+    def readSwComponentTypeSwcMappingConstraints(self, element: ET.Element, parent: SwComponentType):
+        for ref in self.getChildElementRefTypeList(element, "SWC-MAPPING-CONSTRAINT-REFS/SWC-MAPPING-CONSTRAINT-REF"):
+            parent.addSwcMappingConstraintRef(ref)
+
+    def readSwComponentTypeUnitGroups(self, element: ET.Element, parent: SwComponentType):
+        for ref in self.getChildElementRefTypeList(element, "UNIT-GROUP-REFS/UNIT-GROUP-REF"):
+            parent.addUnitGroupRef(ref)
+
+    def readSwComponentTypeSwComponentDocumentation(self, element: ET.Element, parent: SwComponentType):
+        child_element = self.find(element, "SW-COMPONENT-DOCUMENTATION")
+        if child_element is None:
+            return
+        documentation = SwComponentDocumentation()
+        predefined_chapter_map = [
+            ("SW-FEATURE-DEF", documentation.createSwFeatureDef),
+            ("SW-FEATURE-DESC", documentation.createSwFeatureDesc),
+            ("SW-TEST-DESC", documentation.createSwTestDesc),
+            ("SW-CALIBRATION-NOTES", documentation.createSwCalibrationNotes),
+            ("SW-MAINTENANCE-NOTES", documentation.createSwMaintenanceNotes),
+            ("SW-DIAGNOSTICS-NOTES", documentation.createSwDiagnosticsNotes),
+            ("SW-CARB-DOC", documentation.createSwCarbDoc),
+        ]
+        for tag_name, creator in predefined_chapter_map:
+            chapter_element = self.find(child_element, tag_name)
+            if chapter_element is not None:
+                chapter = creator(self.getShortName(chapter_element))
+                self.readChapterBody(chapter_element, chapter)
+        for chapter_element in self.findall(child_element, "CHAPTER"):
+            chapter = documentation.createChapter(self.getShortName(chapter_element))
+            self.readChapterBody(chapter_element, chapter)
+        parent.setSwComponentDocumentation(documentation)
+
+    def readChapter(self, element: ET.Element, parent: ARObject) -> Chapter:
+        chapter = Chapter(parent, self.getShortName(element))
+        self.readChapterBody(element, chapter)
+        return chapter
+
+    def readChapterBody(self, element: ET.Element, chapter: Chapter):
+        self.readIdentifiable(element, chapter)
+        help_entry = element.get("HELP-ENTRY")
+        if help_entry is not None:
+            chapter.setHelpEntry(String().setValue(help_entry))
+        chapter_model_element = self.find(element, "CHAPTER-MODEL")
+        if chapter_model_element is not None:
+            chapter.setChapterModel(self.readChapterModel(chapter_model_element, chapter))
+
+    def readChapterModel(self, element: ET.Element, parent: Chapter) -> ChapterModel:
+        chapter_model = ChapterModel()
+        chapter_content_element = self.find(element, "CHAPTER-CONTENT")
+        if chapter_content_element is not None:
+            chapter_model.setChapterContent(self.readChapterContent(chapter_content_element, parent))
+        topic_elements = self.findall(element, "TOPIC-1")
+        msr_query_topic1_element = self.find(element, "MSR-QUERY-TOPIC-1")
+        if len(topic_elements) > 0 or msr_query_topic1_element is not None:
+            topic_or_msr_query = TopicOrMsrQuery()
+            for topic_element in topic_elements:
+                topic_or_msr_query.addTopic1(self.readTopic1(topic_element, parent))
+            if msr_query_topic1_element is not None:
+                topic_or_msr_query.setMsrQueryTopic1(self.readMsrQueryTopic1(msr_query_topic1_element, parent))
+            chapter_model.setTopic1(topic_or_msr_query)
+        chapter_elements = self.findall(element, "CHAPTER")
+        msr_query_chapter_element = self.find(element, "MSR-QUERY-CHAPTER")
+        if len(chapter_elements) > 0 or msr_query_chapter_element is not None:
+            chapter_or_msr_query = ChapterOrMsrQuery()
+            for chapter_element in chapter_elements:
+                chapter_or_msr_query.addChapter(self.readChapter(chapter_element, parent))
+            if msr_query_chapter_element is not None:
+                chapter_or_msr_query.setMsrQueryChapter(self.readMsrQueryChapter(msr_query_chapter_element, parent))
+            chapter_model.setChapter(chapter_or_msr_query)
+        return chapter_model
+
+    def readChapterContent(self, element: ET.Element, parent: Chapter) -> ChapterContent:
+        chapter_content = ChapterContent()
+        topic_content_or_msr_query = self.readTopicContentOrMsrQuery(element, chapter_content)
+        if topic_content_or_msr_query is not None:
+            chapter_content.setTopicContent(topic_content_or_msr_query)
+        return chapter_content
+
+    def readTopicContentOrMsrQuery(self, element: ET.Element, parent: ARObject) -> "TopicContentOrMsrQuery":
+        result = None
+        msr_query_p1_element = self.find(element, "MSR-QUERY-P1")
+        topic_content_element = self.find(element, "TOPIC-CONTENT")
+        if msr_query_p1_element is not None or topic_content_element is not None:
+            result = TopicContentOrMsrQuery()
+            if msr_query_p1_element is not None:
+                result.setMsrQueryP1(self.readMsrQueryP1(msr_query_p1_element, parent))
+            if topic_content_element is not None:
+                result.setTopicContent(self.readTopicContent(topic_content_element, parent))
+        return result
+
+    def readMsrQueryP1(self, element: ET.Element, parent: ARObject) -> MsrQueryP1:
+        return MsrQueryP1()
+
+    def readTopicContent(self, element: ET.Element, parent: ARObject) -> TopicContent:
+        topic_content = TopicContent()
+        self.readARObjectAttributes(element, topic_content)
+        block_level_content = self.getDocumentationBlock(element, "DOCUMENTATION-BLOCK")
+        if block_level_content is not None:
+            topic_content.setBlockLevelContent(block_level_content)
+        return topic_content
+
+    def readTopic1(self, element: ET.Element, parent: Chapter) -> Topic1:
+        topic1 = Topic1(parent, self.getShortName(element))
+        self.readIdentifiable(element, topic1)
+        help_entry = element.get("HELP-ENTRY")
+        if help_entry is not None:
+            topic1.setHelpEntry(String().setValue(help_entry))
+        topic_content_or_msr_query = self.readTopicContentOrMsrQuery(element, topic1)
+        if topic_content_or_msr_query is not None:
+            topic1.setTopicContent(topic_content_or_msr_query)
+        return topic1
+
+    def readMsrQueryTopic1(self, element: ET.Element, parent: Chapter) -> MsrQueryTopic1:
+        msr_query_topic1 = MsrQueryTopic1()
+        self.readARObjectAttributes(element, msr_query_topic1)
+        msr_query_props = self.find(element, "MSR-QUERY-PROPS")
+        if msr_query_props is not None:
+            msr_query_topic1.setMsrQueryProps(self.getMsrQueryProps(msr_query_props))
+        return msr_query_topic1
+
+    def readMsrQueryChapter(self, element: ET.Element, parent: Chapter) -> MsrQueryChapter:
+        msr_query_chapter = MsrQueryChapter()
+        self.readARObjectAttributes(element, msr_query_chapter)
+        msr_query_props = self.find(element, "MSR-QUERY-PROPS")
+        if msr_query_props is not None:
+            msr_query_chapter.setMsrQueryProps(self.getMsrQueryProps(msr_query_props))
+        return msr_query_chapter
+
     def readSwComponentType(self, element: ET.Element, parent: SwComponentType):
         self.readIdentifiable(element, parent)
         self.readSwComponentTypePorts(element, parent)
         self.readSwComponentTypePortGroups(element, parent)
+        self.readSwComponentTypeSwcMappingConstraints(element, parent)
+        self.readSwComponentTypeUnitGroups(element, parent)
+        self.readSwComponentTypeSwComponentDocumentation(element, parent)
 
     def readAtomicSwComponentTypeSymbolProps(self, element: ET.Element, sw_component: AtomicSwComponentType):
         child_element = self.find(element, "SYMBOL-PROPS")

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -544,6 +544,18 @@ from armodel.models.M2.MSR.DataDictionary.SystemConstant import SwSystemconst
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation
 from armodel.models.M2.MSR.Documentation.BlockElements.Figure import Graphic, MlFigure
 from armodel.models.M2.MSR.Documentation.BlockElements.Formula import MlFormula
+from armodel.models.M2.MSR.Documentation.Chapters import (
+    Chapter,
+    ChapterContent,
+    ChapterModel,
+    ChapterOrMsrQuery,
+    MsrQueryChapter,
+    MsrQueryTopic1,
+    Topic1,
+    TopicContent,
+    TopicContentOrMsrQuery,
+    TopicOrMsrQuery,
+)
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements.ListElements import ARList, DefItem, DefList, IndentSample, LabeledItem, LabeledList
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements.Note import Note
@@ -551,7 +563,7 @@ from armodel.models.M2.MSR.Documentation.TextModel.BlockElements.PaginationAndVi
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements.RequirementsTracing import StructuredReq, TraceableText
 from armodel.models.M2.MSR.Documentation.TextModel.InlineTextElements import EmphasisText, IndexEntry, Tt
 from armodel.models.M2.MSR.Documentation.TextModel.LanguageDataModel import LanguageSpecific, LLongName, LPlainText, LVerbatim
-from armodel.models.M2.MSR.Documentation.TextModel.MsrQuery import MsrQueryArg, MsrQueryP2, MsrQueryProps
+from armodel.models.M2.MSR.Documentation.TextModel.MsrQuery import MsrQueryArg, MsrQueryP1, MsrQueryP2, MsrQueryProps
 from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultilanguageLongName, MultiLanguageOverviewParagraph, MultiLanguageParagraph, MultiLanguagePlainText, MultiLanguageVerbatim
 from armodel.writer.abstract_arxml_writer import AbstractARXMLWriter
 
@@ -1217,10 +1229,114 @@ class ARXMLWriter(AbstractARXMLWriter):
             for port_group in port_groups:
                 self.writePortGroup(child_element, port_group)
 
+    def writeSwComponentTypeSwcMappingConstraints(self, element: ET.Element, parent: SwComponentType):
+        refs = parent.getSwcMappingConstraintsRefs()
+        if len(refs) > 0:
+            child_element = ET.SubElement(element, "SWC-MAPPING-CONSTRAINT-REFS")
+            for ref in refs:
+                self.setChildElementOptionalRefType(child_element, "SWC-MAPPING-CONSTRAINT-REF", ref)
+
+    def writeSwComponentTypeSwComponentDocumentation(self, element: ET.Element, parent: SwComponentType):
+        documentation = parent.getSwComponentDocumentation()
+        if documentation is None:
+            return
+        child_element = ET.SubElement(element, "SW-COMPONENT-DOCUMENTATION")
+        predefined_chapters = [
+            (documentation.getSwFeatureDef(), "SW-FEATURE-DEF"),
+            (documentation.getSwFeatureDesc(), "SW-FEATURE-DESC"),
+            (documentation.getSwTestDesc(), "SW-TEST-DESC"),
+            (documentation.getSwCalibrationNotes(), "SW-CALIBRATION-NOTES"),
+            (documentation.getSwMaintenanceNotes(), "SW-MAINTENANCE-NOTES"),
+            (documentation.getSwDiagnosticsNotes(), "SW-DIAGNOSTICS-NOTES"),
+            (documentation.getSwCarbDoc(), "SW-CARB-DOC"),
+        ]
+        for chapter, tag_name in predefined_chapters:
+            if chapter is not None:
+                self.writeChapter(child_element, chapter, tag_name)
+        for chapter in documentation.getChapters():
+            self.writeChapter(child_element, chapter, "CHAPTER")
+
+    def writeChapter(self, element: ET.Element, chapter: Chapter, tag_name: str):
+        child_element = ET.SubElement(element, tag_name)
+        self.writeIdentifiable(child_element, chapter)
+        if chapter.getHelpEntry() is not None:
+            child_element.set("HELP-ENTRY", chapter.getHelpEntry().getValue())
+        chapter_model = chapter.getChapterModel()
+        if chapter_model is not None:
+            self.writeChapterModel(child_element, chapter_model)
+
+    def writeChapterModel(self, element: ET.Element, chapter_model: ChapterModel):
+        child_element = ET.SubElement(element, "CHAPTER-MODEL")
+        chapter_content = chapter_model.getChapterContent()
+        if chapter_content is not None:
+            self.writeChapterContent(child_element, chapter_content)
+        topic1 = chapter_model.getTopic1()
+        if topic1 is not None:
+            for topic in topic1.getTopic1s():
+                self.writeTopic1(child_element, topic)
+            if topic1.getMsrQueryTopic1() is not None:
+                self.writeMsrQueryTopic1(child_element, topic1.getMsrQueryTopic1())
+        chapter = chapter_model.getChapter()
+        if chapter is not None:
+            for chapter_item in chapter.getChapters():
+                self.writeChapter(child_element, chapter_item, "CHAPTER")
+            if chapter.getMsrQueryChapter() is not None:
+                self.writeMsrQueryChapter(child_element, chapter.getMsrQueryChapter())
+
+    def writeChapterContent(self, element: ET.Element, chapter_content: ChapterContent):
+        child_element = ET.SubElement(element, "CHAPTER-CONTENT")
+        self.writeTopicContentOrMsrQuery(child_element, chapter_content.getTopicContent())
+
+    def writeTopicContentOrMsrQuery(self, element: ET.Element, topic_content_or_msr_query: TopicContentOrMsrQuery):
+        if topic_content_or_msr_query is None:
+            return
+        if topic_content_or_msr_query.getMsrQueryP1() is not None:
+            self.writeMsrQueryP1(element, topic_content_or_msr_query.getMsrQueryP1())
+        if topic_content_or_msr_query.getTopicContent() is not None:
+            self.writeTopicContent(element, topic_content_or_msr_query.getTopicContent())
+
+    def writeMsrQueryP1(self, element: ET.Element, msr_query_p1: MsrQueryP1):
+        child_element = ET.SubElement(element, "MSR-QUERY-P1")
+        self.writeARObjectAttributes(child_element, msr_query_p1)
+
+    def writeTopicContent(self, element: ET.Element, topic_content: TopicContent):
+        child_element = ET.SubElement(element, "TOPIC-CONTENT")
+        self.writeARObjectAttributes(child_element, topic_content)
+        self.writeDocumentationBlock(child_element, "DOCUMENTATION-BLOCK", topic_content.getBlockLevelContent())
+
+    def writeTopic1(self, element: ET.Element, topic1: Topic1):
+        child_element = ET.SubElement(element, "TOPIC-1")
+        self.writeIdentifiable(child_element, topic1)
+        if topic1.getHelpEntry() is not None:
+            child_element.set("HELP-ENTRY", topic1.getHelpEntry().getValue())
+        self.writeTopicContentOrMsrQuery(child_element, topic1.getTopicContent())
+
+    def writeMsrQueryTopic1(self, element: ET.Element, msr_query_topic1: MsrQueryTopic1):
+        child_element = ET.SubElement(element, "MSR-QUERY-TOPIC-1")
+        self.writeARObjectAttributes(child_element, msr_query_topic1)
+        if msr_query_topic1.getMsrQueryProps() is not None:
+            self.setMsrQueryProps(child_element, msr_query_topic1.getMsrQueryProps())
+
+    def writeMsrQueryChapter(self, element: ET.Element, msr_query_chapter: MsrQueryChapter):
+        child_element = ET.SubElement(element, "MSR-QUERY-CHAPTER")
+        self.writeARObjectAttributes(child_element, msr_query_chapter)
+        if msr_query_chapter.getMsrQueryProps() is not None:
+            self.setMsrQueryProps(child_element, msr_query_chapter.getMsrQueryProps())
+
+    def writeSwComponentTypeUnitGroups(self, element: ET.Element, parent: SwComponentType):
+        refs = parent.getUnitGroupRefs()
+        if len(refs) > 0:
+            child_element = ET.SubElement(element, "UNIT-GROUP-REFS")
+            for ref in refs:
+                self.setChildElementOptionalRefType(child_element, "UNIT-GROUP-REF", ref)
+
     def writeSwComponentType(self, element: ET.Element, sw_component: SwComponentType):
         self.writeIdentifiable(element, sw_component)
         self.writeSwComponentTypePorts(element, sw_component)
         self.writeSwComponentTypePortGroups(element, sw_component)
+        self.writeSwComponentTypeSwcMappingConstraints(element, sw_component)
+        self.writeSwComponentTypeUnitGroups(element, sw_component)
+        self.writeSwComponentTypeSwComponentDocumentation(element, sw_component)
 
     def writeSwComponentPrototype(self, element: ET.Element, prototype: SwComponentPrototype):
         prototype_tag = ET.SubElement(element, "SW-COMPONENT-PROTOTYPE")

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -548,13 +548,11 @@ from armodel.models.M2.MSR.Documentation.Chapters import (
     Chapter,
     ChapterContent,
     ChapterModel,
-    ChapterOrMsrQuery,
     MsrQueryChapter,
     MsrQueryTopic1,
     Topic1,
     TopicContent,
     TopicContentOrMsrQuery,
-    TopicOrMsrQuery,
 )
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements.ListElements import ARList, DefItem, DefList, IndentSample, LabeledItem, LabeledList

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_SoftwareComponentDocumentation.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_SoftwareComponentDocumentation.py
@@ -1,63 +1,69 @@
 """
-This module contains comprehensive tests for the SoftwareComponentDocumentation module in SWComponentTemplate.
-Tests cover all classes and methods in the SoftwareComponentDocumentation.py file to achieve 100% test coverage.
+This module contains tests for the SoftwareComponentDocumentation module in SWComponentTemplate.
 """
 
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SoftwareComponentDocumentation import SwComponentDocumentation
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SoftwareComponentDocumentation import (
+    SwComponentDocumentation,
+)
 
 
 class TestSwComponentDocumentation:
     """Test class for SwComponentDocumentation class."""
 
     def test_sw_component_documentation_initialization(self):
-        """Test SwComponentDocumentation initialization and methods."""
+        doc = SwComponentDocumentation()
+        assert doc.getChapters() == []
+        assert doc.getSwCalibrationNotes() is None
+        assert doc.getSwCarbDoc() is None
+        assert doc.getSwDiagnosticsNotes() is None
+        assert doc.getSwFeatureDef() is None
+        assert doc.getSwFeatureDesc() is None
+        assert doc.getSwMaintenanceNotes() is None
+        assert doc.getSwTestDesc() is None
+
+    def test_create_get_predefined_chapters(self):
         doc = SwComponentDocumentation()
 
-        assert doc.chapters == []
-        assert doc.swCalibrationNotes is None
-        assert doc.swCarbDoc is None
-        assert doc.swDiagnosticsNotes is None
-        assert doc.swFeatureDef is None
-        assert doc.swFeatureDesc is None
-        assert doc.swMaintenanceNotes is None
-        assert doc.swTestDesc is None
+        feature_def = doc.createSwFeatureDef("FeatureDef")
+        assert feature_def.getShortName() == "FeatureDef"
+        assert doc.getSwFeatureDef() is feature_def
+        assert doc.createSwFeatureDef("FeatureDef") is feature_def
 
-        # Test chapters methods
-        chapter = "Test Chapter"
-        doc.addChapter(chapter)
-        assert chapter in doc.getChapters()
+        feature_desc = doc.createSwFeatureDesc("FeatureDesc")
+        assert feature_desc.getShortName() == "FeatureDesc"
+        assert doc.getSwFeatureDesc() is feature_desc
+        assert doc.createSwFeatureDesc("FeatureDesc") is feature_desc
 
-        # Test swCalibrationNotes methods
-        calibration_notes = "Calibration notes"
-        doc.setSwCalibrationNotes(calibration_notes)
-        assert doc.getSwCalibrationNotes() == calibration_notes
+        test_desc = doc.createSwTestDesc("TestDesc")
+        assert test_desc.getShortName() == "TestDesc"
+        assert doc.getSwTestDesc() is test_desc
+        assert doc.createSwTestDesc("TestDesc") is test_desc
 
-        # Test swCarbDoc methods
-        carb_doc = "CARB document"
-        doc.setSwCarbDoc(carb_doc)
-        assert doc.getSwCarbDoc() == carb_doc
+        calibration_notes = doc.createSwCalibrationNotes("CalibrationNotes")
+        assert calibration_notes.getShortName() == "CalibrationNotes"
+        assert doc.getSwCalibrationNotes() is calibration_notes
+        assert doc.createSwCalibrationNotes("CalibrationNotes") is calibration_notes
 
-        # Test swDiagnosticsNotes methods
-        diag_notes = "Diagnostic notes"
-        doc.setSwDiagnosticsNotes(diag_notes)
-        assert doc.getSwDiagnosticsNotes() == diag_notes
+        maintenance_notes = doc.createSwMaintenanceNotes("MaintenanceNotes")
+        assert maintenance_notes.getShortName() == "MaintenanceNotes"
+        assert doc.getSwMaintenanceNotes() is maintenance_notes
+        assert doc.createSwMaintenanceNotes("MaintenanceNotes") is maintenance_notes
 
-        # Test swFeatureDef methods
-        feature_def = "Feature definition"
-        doc.setSwFeatureDef(feature_def)
-        assert doc.getSwFeatureDef() == feature_def
+        diagnostics_notes = doc.createSwDiagnosticsNotes("DiagnosticsNotes")
+        assert diagnostics_notes.getShortName() == "DiagnosticsNotes"
+        assert doc.getSwDiagnosticsNotes() is diagnostics_notes
+        assert doc.createSwDiagnosticsNotes("DiagnosticsNotes") is diagnostics_notes
 
-        # Test swFeatureDesc methods
-        feature_desc = "Feature description"
-        doc.setSwFeatureDesc(feature_desc)
-        assert doc.getSwFeatureDesc() == feature_desc
+        carb_doc = doc.createSwCarbDoc("CarbDoc")
+        assert carb_doc.getShortName() == "CarbDoc"
+        assert doc.getSwCarbDoc() is carb_doc
+        assert doc.createSwCarbDoc("CarbDoc") is carb_doc
 
-        # Test swMaintenanceNotes methods
-        maintenance_notes = "Maintenance notes"
-        doc.setSwMaintenanceNotes(maintenance_notes)
-        assert doc.getSwMaintenanceNotes() == maintenance_notes
-
-        # Test swTestDesc methods
-        test_desc = "Test description"
-        doc.setSwTestDesc(test_desc)
-        assert doc.getSwTestDesc() == test_desc
+    def test_create_get_chapters(self):
+        doc = SwComponentDocumentation()
+        chapter_a = doc.createChapter("ChapterA")
+        assert chapter_a.getShortName() == "ChapterA"
+        chapter_b = doc.createChapter("ChapterB")
+        assert doc.getChapters() == [chapter_a, chapter_b]
+        assert doc.createChapter("ChapterA") is chapter_a
+        assert doc.getChapters() == [chapter_a, chapter_b]

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_SwComponentType.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_SwComponentType.py
@@ -4,6 +4,16 @@ AUTOSAR SWComponentTemplate module.
 """
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import (
+    PortGroup,
+    PPortPrototype,
+    PRPortPrototype,
+    RPortPrototype,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SoftwareComponentDocumentation import (
+    SwComponentDocumentation,
+)
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwComponentType import (
     SwComponentType,
 )
@@ -14,6 +24,16 @@ class TestSwComponentType:
     Test class for SwComponentType functionality.
     """
 
+    def _create_concrete(self):
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+
+        class ConcreteSwComponentType(SwComponentType):
+            def __init__(self, parent, short_name):
+                super().__init__(parent, short_name)
+
+        return ConcreteSwComponentType(ar_root, "TestSwComponentType")
+
     def test_abstract_initialization(self):
         parent = AUTOSAR.getInstance()
         ar_root = parent.createARPackage("AUTOSAR")
@@ -23,13 +43,78 @@ class TestSwComponentType:
         except TypeError:
             pass
 
-    def test_concrete_subclass_initialization(self):
-        parent = AUTOSAR.getInstance()
-        ar_root = parent.createARPackage("AUTOSAR")
+    def test_initialization(self):
+        obj = self._create_concrete()
+        assert obj.getShortName() == "TestSwComponentType"
+        assert obj.getPorts() == []
+        assert obj.getPortGroups() == []
+        assert obj.getSwcMappingConstraintsRefs() == []
+        assert obj.getSwComponentDocumentation() is None
+        assert obj.getUnitGroupRefs() == []
 
-        class ConcreteSwComponentType(SwComponentType):
-            def __init__(self, parent, short_name):
-                super().__init__(parent, short_name)
+    def test_get_set_swComponentDocumentation(self):
+        obj = self._create_concrete()
+        documentation = SwComponentDocumentation()
+        assert obj.setSwComponentDocumentation(documentation) is obj
+        assert obj.getSwComponentDocumentation() == documentation
+        obj.setSwComponentDocumentation(None)
+        assert obj.getSwComponentDocumentation() == documentation
 
-        obj = ConcreteSwComponentType(ar_root, "TestName")
-        assert obj.getShortName() == "TestName"
+    def test_create_PPortPrototype(self):
+        obj = self._create_concrete()
+        port = obj.createPPortPrototype("PPort")
+        assert isinstance(port, PPortPrototype)
+        assert port in obj.getPorts()
+        assert port in obj.getPPortPrototypes()
+        assert obj.createPPortPrototype("PPort") == port
+
+    def test_create_RPortPrototype(self):
+        obj = self._create_concrete()
+        port = obj.createRPortPrototype("RPort")
+        assert isinstance(port, RPortPrototype)
+        assert port in obj.getPorts()
+        assert port in obj.getRPortPrototypes()
+        assert obj.createRPortPrototype("RPort") == port
+
+    def test_create_PRPortPrototype(self):
+        obj = self._create_concrete()
+        port = obj.createPRPortPrototype("PRPort")
+        assert isinstance(port, PRPortPrototype)
+        assert port in obj.getPorts()
+        assert port in obj.getPRPortPrototypes()
+        assert obj.createPRPortPrototype("PRPort") == port
+
+    def test_get_port_prototypes(self):
+        obj = self._create_concrete()
+        obj.createPPortPrototype("PPort")
+        obj.createRPortPrototype("RPort")
+        obj.createPRPortPrototype("PRPort")
+        assert len(obj.getPortPrototypes()) == 3
+        assert len(obj.getPPortPrototypes()) == 1
+        assert len(obj.getRPortPrototypes()) == 1
+        assert len(obj.getPRPortPrototypes()) == 1
+
+    def test_create_PortGroup(self):
+        obj = self._create_concrete()
+        port_group = obj.createPortGroup("PortGroup")
+        assert isinstance(port_group, PortGroup)
+        assert port_group in obj.getPortGroups()
+        assert obj.createPortGroup("PortGroup") == port_group
+
+    def test_add_get_swcMappingConstraintRefs(self):
+        obj = self._create_concrete()
+        ref = RefType()
+        ref.setValue("/SwComponentMappingConstraints")
+        assert obj.addSwcMappingConstraintRef(ref) is obj
+        assert ref in obj.getSwcMappingConstraintsRefs()
+        obj.addSwcMappingConstraintRef(None)
+        assert len(obj.getSwcMappingConstraintsRefs()) == 1
+
+    def test_add_get_unitGroupRefs(self):
+        obj = self._create_concrete()
+        ref = RefType()
+        ref.setValue("/UnitGroup")
+        assert obj.addUnitGroupRef(ref) is obj
+        assert ref in obj.getUnitGroupRefs()
+        obj.addUnitGroupRef(None)
+        assert len(obj.getUnitGroupRefs()) == 1

--- a/tests/test_armodel/models/M2/MSR/Documentation/test_Chapters.py
+++ b/tests/test_armodel/models/M2/MSR/Documentation/test_Chapters.py
@@ -1,0 +1,133 @@
+"""
+This module contains tests for the Chapter family of classes in the
+MSR Documentation::Chapters package (Chapter, ChapterModel, ChapterContent,
+ChapterOrMsrQuery, TopicOrMsrQuery and the MSR query stub types).
+"""
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import String
+from armodel.models.M2.MSR.Documentation.Chapters import (
+    Chapter,
+    ChapterContent,
+    ChapterModel,
+    ChapterOrMsrQuery,
+    MsrQueryChapter,
+    MsrQueryTopic1,
+    Topic1,
+    TopicContent,
+    TopicContentOrMsrQuery,
+    TopicOrMsrQuery,
+)
+from armodel.models.M2.MSR.Documentation.TextModel.MsrQuery import MsrQueryP1
+
+
+class TestChapter:
+    """Test class for Chapter class."""
+
+    def _parent(self):
+        document = AUTOSAR.getInstance()
+        return document.createARPackage("AUTOSAR")
+
+    def test_chapter_initialization(self):
+        parent = self._parent()
+        chapter = Chapter(parent, "MyChapter")
+        assert chapter.getShortName() == "MyChapter"
+        assert chapter.getHelpEntry() is None
+        assert chapter.getChapterModel() is None
+
+    def test_set_get_help_entry(self):
+        parent = self._parent()
+        chapter = Chapter(parent, "MyChapter")
+        help_entry = String().setValue("help.entry")
+        assert chapter.setHelpEntry(help_entry) is chapter
+        assert chapter.getHelpEntry() is help_entry
+        chapter.setHelpEntry(None)
+        assert chapter.getHelpEntry() is help_entry
+
+    def test_set_get_chapter_model(self):
+        parent = self._parent()
+        chapter = Chapter(parent, "MyChapter")
+        chapter_model = ChapterModel()
+        assert chapter.setChapterModel(chapter_model) is chapter
+        assert chapter.getChapterModel() is chapter_model
+        chapter.setChapterModel(None)
+        assert chapter.getChapterModel() is chapter_model
+
+
+class TestDocumentationLeafClasses:
+    """Test classes for the empty/leaf documentation container classes."""
+
+    def _parent(self):
+        document = AUTOSAR.getInstance()
+        return document.createARPackage("AUTOSAR")
+
+    def test_chapter_content_and_topic_or_msr_query(self):
+        content = ChapterContent()
+        query = TopicOrMsrQuery()
+        assert isinstance(content, object)
+        assert isinstance(query, object)
+
+    def test_chapter_or_msr_query_add_get_chapters(self):
+        parent = self._parent()
+        query = ChapterOrMsrQuery()
+        chapter_a = Chapter(parent, "NestedA")
+        chapter_b = Chapter(parent, "NestedB")
+        assert query.addChapter(chapter_a) is query
+        query.addChapter(None)
+        query.addChapter(chapter_b)
+        assert query.getChapters() == [chapter_a, chapter_b]
+
+    def test_chapter_or_msr_query_msr_query_chapter(self):
+        query = ChapterOrMsrQuery()
+        msr_chapter = MsrQueryChapter()
+        assert query.setMsrQueryChapter(msr_chapter) is query
+        assert query.getMsrQueryChapter() is msr_chapter
+        query.setMsrQueryChapter(None)
+        assert query.getMsrQueryChapter() is msr_chapter
+
+    def test_topic_or_msr_query_add_get_topic1_and_msr_query_topic1(self):
+        parent = self._parent()
+        query = TopicOrMsrQuery()
+        topic_a = Topic1(parent, "TopicA")
+        topic_b = Topic1(parent, "TopicB")
+        assert query.addTopic1(topic_a) is query
+        query.addTopic1(None)
+        query.addTopic1(topic_b)
+        assert query.getTopic1s() == [topic_a, topic_b]
+        msr_topic = MsrQueryTopic1()
+        assert query.setMsrQueryTopic1(msr_topic) is query
+        assert query.getMsrQueryTopic1() is msr_topic
+        query.setMsrQueryTopic1(None)
+        assert query.getMsrQueryTopic1() is msr_topic
+
+    def test_msr_query_stub_classes_instantiable(self):
+        parent = self._parent()
+        assert isinstance(Topic1(parent, "T"), object)
+        assert isinstance(MsrQueryChapter(), object)
+        assert isinstance(MsrQueryTopic1(), object)
+
+
+class TestTopicContentOrMsrQuery:
+    """Test class for TopicContentOrMsrQuery class."""
+
+    def test_initialization(self):
+        content = TopicContentOrMsrQuery()
+        assert isinstance(content, object)
+        assert content.getMsrQueryP1() is None
+        assert content.getTopicContent() is None
+
+    def test_set_get_msr_query_p1(self):
+        content = TopicContentOrMsrQuery()
+        msr_query_p1 = MsrQueryP1()
+        assert content.setMsrQueryP1(msr_query_p1) is content
+        assert content.getMsrQueryP1() is msr_query_p1
+        content.setMsrQueryP1(None)
+        assert content.getMsrQueryP1() is msr_query_p1
+
+    def test_set_get_topic_content(self):
+        content = TopicContentOrMsrQuery()
+        topic_content = TopicContent()
+        assert content.setTopicContent(topic_content) is content
+        assert content.getTopicContent() is topic_content
+        content.setTopicContent(None)
+        assert content.getTopicContent() is topic_content

--- a/tests/test_armodel/parser/test_arxml_parser_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_handlers.py
@@ -677,6 +677,29 @@ class TestSwComponentAndConnectorHandlers:
             warning_parser.readSwComponentTypePorts(element, composition)
         assert any("Unsupported Port Prototype" in r.getMessage() for r in caplog.records)
 
+    def test_readSwComponentTypeSwcMappingConstraints(self, parser, composition):
+        element = _snip(
+            "<SWC-MAPPING-CONSTRAINT-REFS>"
+            "<SWC-MAPPING-CONSTRAINT-REF DEST='SWC-MAPPING-CONSTRAINTS'>/Mapping/Const1</SWC-MAPPING-CONSTRAINT-REF>"
+            "<SWC-MAPPING-CONSTRAINT-REF DEST='SWC-MAPPING-CONSTRAINTS'>/Mapping/Const2</SWC-MAPPING-CONSTRAINT-REF>"
+            "</SWC-MAPPING-CONSTRAINT-REFS>",
+            root_tag="COMP",
+        )
+        parser.readSwComponentTypeSwcMappingConstraints(element, composition)
+        refs = composition.getSwcMappingConstraintsRefs()
+        assert [ref.getValue() for ref in refs] == ["/Mapping/Const1", "/Mapping/Const2"]
+        assert refs[0].getDest() == "SWC-MAPPING-CONSTRAINTS"
+
+    def test_readSwComponentTypeUnitGroups(self, parser, composition):
+        element = _snip(
+            "<UNIT-GROUP-REFS>" "<UNIT-GROUP-REF DEST='UNIT-GROUP'>/Units/Group1</UNIT-GROUP-REF>" "</UNIT-GROUP-REFS>",
+            root_tag="COMP",
+        )
+        parser.readSwComponentTypeUnitGroups(element, composition)
+        refs = composition.getUnitGroupRefs()
+        assert [ref.getValue() for ref in refs] == ["/Units/Group1"]
+        assert refs[0].getDest() == "UNIT-GROUP"
+
     def test_readSwComponentPrototype_sets_typeTRef(self, parser, composition):
         prototype = composition.createSwComponentPrototype("cp1")
         element = _snip(

--- a/tests/test_armodel/writer/test_writer_sw_component.py
+++ b/tests/test_armodel/writer/test_writer_sw_component.py
@@ -22,6 +22,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     ARNumerical,
     ARPositiveInteger,
     RefType,
+    String,
     TimeValue,
     TRefType,
 )
@@ -58,6 +59,9 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition.Instance
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface.InstanceRefs import (  # noqa: E501
     ApplicationCompositeElementInPortInterfaceInstanceRef,
 )
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SoftwareComponentDocumentation import (
+    SwComponentDocumentation,
+)
 from armodel.models.M2.MSR.CalibrationData.CalibrationValue import (
     SwValueCont,
     SwValues,
@@ -69,6 +73,19 @@ from armodel.models.M2.MSR.DataDictionary.DataDefProperties import (
     SwDataDefProps,
     ValueList,
 )
+from armodel.models.M2.MSR.Documentation.Chapters import (
+    ChapterContent,
+    ChapterModel,
+    ChapterOrMsrQuery,
+    MsrQueryChapter,
+    MsrQueryTopic1,
+    Topic1,
+    TopicContent,
+    TopicContentOrMsrQuery,
+    TopicOrMsrQuery,
+)
+from armodel.models.M2.MSR.Documentation.TextModel.MsrQuery import MsrQueryP1
+from armodel.parser.arxml_parser import ARXMLParser
 from armodel.writer.arxml_writer import ARXMLWriter
 
 
@@ -724,6 +741,232 @@ class TestWriteSwComponentType:
         assert parent.find("SHORT-NAME") is not None
         assert parent.find("PORTS") is not None
         assert parent.find("PORT-GROUPS") is not None
+
+    def test_write_sw_component_type_swc_mapping_constraints_empty(self, writer):
+        app = self._app()
+        parent = _parent()
+        writer.writeSwComponentTypeSwcMappingConstraints(parent, app)
+        assert parent.find("SWC-MAPPING-CONSTRAINT-REFS") is None
+
+    def test_write_sw_component_type_swc_mapping_constraints(self, writer):
+        app = self._app()
+        app.addSwcMappingConstraintRef(_ref("/Mapping/Const1"))
+        app.addSwcMappingConstraintRef(_ref("/Mapping/Const2"))
+        parent = _parent()
+        writer.writeSwComponentTypeSwcMappingConstraints(parent, app)
+        refs = parent.find("SWC-MAPPING-CONSTRAINT-REFS")
+        assert refs is not None
+        assert len(refs) == 2
+        assert [r.text for r in refs] == ["/Mapping/Const1", "/Mapping/Const2"]
+
+    def test_write_sw_component_type_unit_groups_empty(self, writer):
+        app = self._app()
+        parent = _parent()
+        writer.writeSwComponentTypeUnitGroups(parent, app)
+        assert parent.find("UNIT-GROUP-REFS") is None
+
+    def test_write_sw_component_type_unit_groups(self, writer):
+        app = self._app()
+        app.addUnitGroupRef(_ref("/Units/Group1"))
+        parent = _parent()
+        writer.writeSwComponentTypeUnitGroups(parent, app)
+        refs = parent.find("UNIT-GROUP-REFS")
+        assert refs is not None
+        assert len(refs) == 1
+        assert refs[0].text == "/Units/Group1"
+
+
+class TestSwComponentTypeRoundTrip:
+    def test_round_trip(self, tmp_path):
+        document = AUTOSAR.getInstance()
+        document.clear()
+        document.setARRelease("R23-11")
+        pkg = document.createARPackage("Swcs")
+        app = pkg.createApplicationSwComponentType("App")
+        app.createPPortPrototype("PPort")
+        app.createRPortPrototype("RPort")
+        app.createPRPortPrototype("PRPort")
+        app.createPortGroup("PG")
+        app.addSwcMappingConstraintRef(_ref("/Mapping/Const1"))
+        app.addSwcMappingConstraintRef(_ref("/Mapping/Const2"))
+        app.addUnitGroupRef(_ref("/Units/Group1"))
+
+        out_file = tmp_path / "sw_component_type_out.arxml"
+        ARXMLWriter().save(str(out_file), document)
+
+        reloaded = AUTOSAR.getInstance()
+        reloaded.clear()
+        reloaded.setARRelease("R23-11")
+        ARXMLParser().load(str(out_file), reloaded)
+
+        swc = reloaded.find("/Swcs/App")
+        assert swc is not None
+        assert swc.getShortName() == "App"
+        assert len(swc.getPorts()) == 3
+        assert len(swc.getPPortPrototypes()) == 1
+        assert len(swc.getRPortPrototypes()) == 1
+        assert len(swc.getPRPortPrototypes()) == 1
+        assert len(swc.getPortGroups()) == 1
+        assert [r.getValue() for r in swc.getSwcMappingConstraintsRefs()] == ["/Mapping/Const1", "/Mapping/Const2"]
+        assert [r.getValue() for r in swc.getUnitGroupRefs()] == ["/Units/Group1"]
+
+    def test_round_trip_empty_refs(self, tmp_path):
+        document = AUTOSAR.getInstance()
+        document.clear()
+        document.setARRelease("R23-11")
+        pkg = document.createARPackage("Swcs")
+        pkg.createApplicationSwComponentType("App")
+
+        out_file = tmp_path / "sw_component_type_empty_out.arxml"
+        ARXMLWriter().save(str(out_file), document)
+
+        reloaded = AUTOSAR.getInstance()
+        reloaded.clear()
+        reloaded.setARRelease("R23-11")
+        ARXMLParser().load(str(out_file), reloaded)
+
+        swc = reloaded.find("/Swcs/App")
+        assert swc is not None
+        assert swc.getSwcMappingConstraintsRefs() == []
+        assert swc.getUnitGroupRefs() == []
+        assert swc.getSwComponentDocumentation() is None
+
+
+class TestSwComponentTypeDocumentationRoundTrip:
+    def _build(self, pkg):
+        app = pkg.createApplicationSwComponentType("App")
+        documentation = SwComponentDocumentation()
+        documentation.createSwFeatureDef("FeatureDef")
+        general_chapter = documentation.createChapter("GeneralChapter")
+        general_chapter.setHelpEntry(String().setValue("help.general"))
+        chapter_model = ChapterModel()
+        chapter_model.setChapterContent(ChapterContent())
+        general_chapter.setChapterModel(chapter_model)
+        app.setSwComponentDocumentation(documentation)
+        return app
+
+    def test_round_trip_with_documentation(self, tmp_path):
+        document = AUTOSAR.getInstance()
+        document.clear()
+        document.setARRelease("R23-11")
+        pkg = document.createARPackage("Swcs")
+        self._build(pkg)
+
+        out_file = tmp_path / "sw_component_documentation_out.arxml"
+        ARXMLWriter().save(str(out_file), document)
+
+        reloaded = AUTOSAR.getInstance()
+        reloaded.clear()
+        reloaded.setARRelease("R23-11")
+        ARXMLParser().load(str(out_file), reloaded)
+
+        swc = reloaded.find("/Swcs/App")
+        assert swc is not None
+        documentation = swc.getSwComponentDocumentation()
+        assert documentation is not None
+        assert documentation.getSwFeatureDef() is not None
+        assert documentation.getSwFeatureDef().getShortName() == "FeatureDef"
+        assert len(documentation.getChapters()) == 1
+        general_chapter = documentation.getChapters()[0]
+        assert general_chapter.getShortName() == "GeneralChapter"
+        assert general_chapter.getHelpEntry().getValue() == "help.general"
+        assert general_chapter.getChapterModel() is not None
+        assert general_chapter.getChapterModel().getChapterContent() is not None
+
+    def test_round_trip_with_msr_query_members(self, tmp_path):
+        document = AUTOSAR.getInstance()
+        document.clear()
+        document.setARRelease("R23-11")
+        pkg = document.createARPackage("Swcs")
+        app = pkg.createApplicationSwComponentType("App")
+        documentation = SwComponentDocumentation()
+        chapter = documentation.createChapter("ChapterWithMsr")
+        chapter_model = ChapterModel()
+        topic_query = TopicOrMsrQuery()
+        topic_query.addTopic1(Topic1(chapter, "TopicA"))
+        topic_query.setMsrQueryTopic1(MsrQueryTopic1())
+        chapter_model.setTopic1(topic_query)
+        subchapter_query = ChapterOrMsrQuery()
+        subchapter_query.setMsrQueryChapter(MsrQueryChapter())
+        chapter_model.setChapter(subchapter_query)
+        chapter.setChapterModel(chapter_model)
+        app.setSwComponentDocumentation(documentation)
+
+        out_file = tmp_path / "sw_component_msr_query_out.arxml"
+        ARXMLWriter().save(str(out_file), document)
+
+        reloaded = AUTOSAR.getInstance()
+        reloaded.clear()
+        reloaded.setARRelease("R23-11")
+        ARXMLParser().load(str(out_file), reloaded)
+
+        swc = reloaded.find("/Swcs/App")
+        documentation = swc.getSwComponentDocumentation()
+        assert documentation is not None
+        reloaded_chapter = documentation.getChapters()[0]
+        reloaded_model = reloaded_chapter.getChapterModel()
+        assert reloaded_model is not None
+        assert reloaded_model.getTopic1() is not None
+        assert len(reloaded_model.getTopic1().getTopic1s()) == 1
+        assert reloaded_model.getTopic1().getMsrQueryTopic1() is not None
+        assert reloaded_model.getChapter() is not None
+        assert reloaded_model.getChapter().getMsrQueryChapter() is not None
+
+    def test_round_trip_with_topic_content_or_msr_query(self, tmp_path):
+        document = AUTOSAR.getInstance()
+        document.clear()
+        document.setARRelease("R23-11")
+        pkg = document.createARPackage("Swcs")
+        app = pkg.createApplicationSwComponentType("App")
+        documentation = SwComponentDocumentation()
+        chapter = documentation.createChapter("ChapterWithTopicContent")
+        chapter_model = ChapterModel()
+        chapter_content = ChapterContent()
+        topic_content_query = TopicContentOrMsrQuery()
+        topic_content_query.setMsrQueryP1(MsrQueryP1())
+        topic_content_query.setTopicContent(TopicContent())
+        chapter_content.setTopicContent(topic_content_query)
+        chapter_model.setChapterContent(chapter_content)
+        chapter.setChapterModel(chapter_model)
+        app.setSwComponentDocumentation(documentation)
+
+        out_file = tmp_path / "sw_component_topic_content_out.arxml"
+        ARXMLWriter().save(str(out_file), document)
+
+        reloaded = AUTOSAR.getInstance()
+        reloaded.clear()
+        reloaded.setARRelease("R23-11")
+        ARXMLParser().load(str(out_file), reloaded)
+
+        swc = reloaded.find("/Swcs/App")
+        documentation = swc.getSwComponentDocumentation()
+        assert documentation is not None
+        reloaded_chapter = documentation.getChapters()[0]
+        reloaded_content = reloaded_chapter.getChapterModel().getChapterContent()
+        assert reloaded_content is not None
+        reloaded_topic_content = reloaded_content.getTopicContent()
+        assert reloaded_topic_content is not None
+        assert reloaded_topic_content.getMsrQueryP1() is not None
+        assert reloaded_topic_content.getTopicContent() is not None
+
+    def test_round_trip_without_documentation(self, tmp_path):
+        document = AUTOSAR.getInstance()
+        document.clear()
+        document.setARRelease("R23-11")
+        pkg = document.createARPackage("Swcs")
+        pkg.createApplicationSwComponentType("App")
+
+        out_file = tmp_path / "sw_component_no_documentation_out.arxml"
+        ARXMLWriter().save(str(out_file), document)
+
+        reloaded = AUTOSAR.getInstance()
+        reloaded.clear()
+        reloaded.setARRelease("R23-11")
+        ARXMLParser().load(str(out_file), reloaded)
+
+        swc = reloaded.find("/Swcs/App")
+        assert swc is not None
+        assert swc.getSwComponentDocumentation() is None
 
 
 class TestWriteSwComponentPrototype:


### PR DESCRIPTION
## Summary
- Sync the Chapter documentation model family to AUTOSAR R23-11.
- Sync SwComponentDocumentation and SwComponentType model coverage.
- Rename Topic to Topic1 and align member ordering/checklists.
- Fix flat Chapter XML reader/writer structure and add round-trip coverage.
- Record deferred member-type deviations.

## Verification
- 5961 unit tests passed.
- Integration round-trip passed.
- flake8 passed.
- Black passed on changed files.

Closes #586