### PR TITLE
feat(model): sync InstanceRefs and DataPrototypeGroup to R23-11

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
@@ -21,6 +21,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import 
 )
 
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SensorActuatorSwComponentType
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import DataPrototypeGroup
 from armodel.models.M2.MSR.AsamHdo.BaseTypes import SwBaseType
 from armodel.models.M2.MSR.AsamHdo.Units import PhysicalDimension, Unit
 from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import DataConstr
@@ -1011,6 +1012,12 @@ class ARPackage(CollectableElement):
             trigger_interface = TriggerInterface(self, short_name)
             self.addElement(trigger_interface)
         return self.getElement(short_name, TriggerInterface)
+
+    def createDataPrototypeGroup(self, short_name: str) -> DataPrototypeGroup:
+        if not self.IsElementExists(short_name, DataPrototypeGroup):
+            data_group = DataPrototypeGroup(self, short_name)
+            self.addElement(data_group)
+        return self.getElement(short_name, DataPrototypeGroup)
 
     def createModeDeclarationGroup(self, short_name: str) -> ModeDeclarationGroup:
         if not self.IsElementExists(short_name, ModeDeclarationGroup):

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/InstanceRefs.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/InstanceRefs.py
@@ -1,0 +1,465 @@
+"""
+This module contains classes for representing AUTOSAR instance references
+in the SWComponentTemplate.ImplicitCommunicationBehavior module. These
+classes are used for referencing nested DataPrototypeGroups,
+RunnableEntityGroups, RunnableEntitys and VariableDataPrototypes in the
+context of a CompositionSwComponentType.
+"""
+
+from typing import List, Optional
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpInstanceRef
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+
+
+class InnerDataPrototypeGroupInCompositionInstanceRef(AtpInstanceRef):
+    """
+    This meta-class represents the ability to define an InstanceRef to a
+    nested DataPrototypeGroup
+    """
+
+    # InnerDataPrototypeGroupInCompositionInstanceRef method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table D.19, p.955
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer
+    # [x] __init__                             [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBaseRef                           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setBaseRef                           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getContextSwComponentPrototypeRefs   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addContextSwComponentPrototypeRef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTargetDataPrototypeGroupRef       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTargetDataPrototypeGroupRef       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        """
+        Initializes the InnerDataPrototypeGroupInCompositionInstanceRef with
+        default values.
+        """
+        super().__init__()
+
+        # This represents the base of the instanceRef.
+        self.baseRef: Optional[RefType] = None
+
+        # This represents the nested structure of SwComponent Prototypes.
+        self.contextSwComponentPrototypeRefs: List[RefType] = []
+
+        # This represents the target of the InstanceRef.
+        self.targetDataPrototypeGroupRef: Optional[RefType] = None
+
+    def getBaseRef(self) -> Optional[RefType]:
+        """
+        This represents the base of the instanceRef.
+
+        Returns:
+            Optional[RefType]: The base reference, or None if not set
+        """
+        return self.baseRef
+
+    def setBaseRef(self, value: Optional[RefType]) -> "InnerDataPrototypeGroupInCompositionInstanceRef":
+        """
+        This represents the base of the instanceRef. Only sets the value if it
+        is not None, and returns self for method chaining.
+
+        Args:
+            value: The base reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.baseRef = value
+        return self
+
+    def getContextSwComponentPrototypeRefs(self) -> List[RefType]:
+        """
+        This represents the nested structure of SwComponent Prototypes.
+
+        Returns:
+            List of RefType instances representing the context SwComponentPrototypes
+        """
+        return self.contextSwComponentPrototypeRefs
+
+    def addContextSwComponentPrototypeRef(self, value: RefType) -> "InnerDataPrototypeGroupInCompositionInstanceRef":
+        """
+        This represents the nested structure of SwComponent Prototypes. Returns
+        self for method chaining.
+
+        Args:
+            value: The context SwComponentPrototype reference to add
+
+        Returns:
+            self for method chaining
+        """
+        self.contextSwComponentPrototypeRefs.append(value)
+        return self
+
+    def getTargetDataPrototypeGroupRef(self) -> Optional[RefType]:
+        """
+        This represents the target of the InstanceRef.
+
+        Returns:
+            Optional[RefType]: The target DataPrototypeGroup reference, or None if not set
+        """
+        return self.targetDataPrototypeGroupRef
+
+    def setTargetDataPrototypeGroupRef(self, value: Optional[RefType]) -> "InnerDataPrototypeGroupInCompositionInstanceRef":
+        """
+        This represents the target of the InstanceRef. Only sets the value if it
+        is not None, and returns self for method chaining.
+
+        Args:
+            value: The target DataPrototypeGroup reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.targetDataPrototypeGroupRef = value
+        return self
+
+
+class InnerRunnableEntityGroupInCompositionInstanceRef(AtpInstanceRef):
+    """
+    This meta-class represents the ability to define an InstanceRef to a
+    nested RunnableEntityGroup.
+    """
+
+    # InnerRunnableEntityGroupInCompositionInstanceRef method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table D.20, p.956
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer
+    # [x] __init__                             [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBaseRef                           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setBaseRef                           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getContextSwComponentPrototypeRefs   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addContextSwComponentPrototypeRef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTargetRunnableEntityGroupRef      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTargetRunnableEntityGroupRef      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        """
+        Initializes the InnerRunnableEntityGroupInCompositionInstanceRef with
+        default values.
+        """
+        super().__init__()
+
+        # This represents the base of the InstanceRef.
+        self.baseRef: Optional[RefType] = None
+
+        # This represents the nested structure of SwComponent Prototypes.
+        self.contextSwComponentPrototypeRefs: List[RefType] = []
+
+        # This represents the target association of the InstanceRef.
+        self.targetRunnableEntityGroupRef: Optional[RefType] = None
+
+    def getBaseRef(self) -> Optional[RefType]:
+        """
+        This represents the base of the InstanceRef.
+
+        Returns:
+            Optional[RefType]: The base reference, or None if not set
+        """
+        return self.baseRef
+
+    def setBaseRef(self, value: Optional[RefType]) -> "InnerRunnableEntityGroupInCompositionInstanceRef":
+        """
+        This represents the base of the InstanceRef. Only sets the value if it
+        is not None, and returns self for method chaining.
+
+        Args:
+            value: The base reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.baseRef = value
+        return self
+
+    def getContextSwComponentPrototypeRefs(self) -> List[RefType]:
+        """
+        This represents the nested structure of SwComponent Prototypes.
+
+        Returns:
+            List of RefType instances representing the context SwComponentPrototypes
+        """
+        return self.contextSwComponentPrototypeRefs
+
+    def addContextSwComponentPrototypeRef(self, value: RefType) -> "InnerRunnableEntityGroupInCompositionInstanceRef":
+        """
+        This represents the nested structure of SwComponent Prototypes. Returns
+        self for method chaining.
+
+        Args:
+            value: The context SwComponentPrototype reference to add
+
+        Returns:
+            self for method chaining
+        """
+        self.contextSwComponentPrototypeRefs.append(value)
+        return self
+
+    def getTargetRunnableEntityGroupRef(self) -> Optional[RefType]:
+        """
+        This represents the target association of the InstanceRef.
+
+        Returns:
+            Optional[RefType]: The target RunnableEntityGroup reference, or None if not set
+        """
+        return self.targetRunnableEntityGroupRef
+
+    def setTargetRunnableEntityGroupRef(self, value: Optional[RefType]) -> "InnerRunnableEntityGroupInCompositionInstanceRef":
+        """
+        This represents the target association of the InstanceRef. Only sets the
+        value if it is not None, and returns self for method chaining.
+
+        Args:
+            value: The target RunnableEntityGroup reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.targetRunnableEntityGroupRef = value
+        return self
+
+
+class RunnableEntityInCompositionInstanceRef(AtpInstanceRef):
+    """
+    This meta-class represents the ability to define an InstanceRef to a
+    RunnableEntity in the context of a CompositionSwComponentType.
+    """
+
+    # RunnableEntityInCompositionInstanceRef method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table D.21, p.956
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer
+    # [x] __init__                             [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBaseRef                           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setBaseRef                           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getContextSwComponentPrototypeRefs   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addContextSwComponentPrototypeRef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTargetRunnableEntityRef           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTargetRunnableEntityRef           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        """
+        Initializes the RunnableEntityInCompositionInstanceRef with default
+        values.
+        """
+        super().__init__()
+
+        # This represents the base of the InstanceRef.
+        self.baseRef: Optional[RefType] = None
+
+        # This represents the nested structure of SwComponent Prototypes.
+        self.contextSwComponentPrototypeRefs: List[RefType] = []
+
+        # This represents the target RunnableEntity.
+        self.targetRunnableEntityRef: Optional[RefType] = None
+
+    def getBaseRef(self) -> Optional[RefType]:
+        """
+        This represents the base of the InstanceRef.
+
+        Returns:
+            Optional[RefType]: The base reference, or None if not set
+        """
+        return self.baseRef
+
+    def setBaseRef(self, value: Optional[RefType]) -> "RunnableEntityInCompositionInstanceRef":
+        """
+        This represents the base of the InstanceRef. Only sets the value if it
+        is not None, and returns self for method chaining.
+
+        Args:
+            value: The base reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.baseRef = value
+        return self
+
+    def getContextSwComponentPrototypeRefs(self) -> List[RefType]:
+        """
+        This represents the nested structure of SwComponent Prototypes.
+
+        Returns:
+            List of RefType instances representing the context SwComponentPrototypes
+        """
+        return self.contextSwComponentPrototypeRefs
+
+    def addContextSwComponentPrototypeRef(self, value: RefType) -> "RunnableEntityInCompositionInstanceRef":
+        """
+        This represents the nested structure of SwComponent Prototypes. Returns
+        self for method chaining.
+
+        Args:
+            value: The context SwComponentPrototype reference to add
+
+        Returns:
+            self for method chaining
+        """
+        self.contextSwComponentPrototypeRefs.append(value)
+        return self
+
+    def getTargetRunnableEntityRef(self) -> Optional[RefType]:
+        """
+        This represents the target RunnableEntity.
+
+        Returns:
+            Optional[RefType]: The target RunnableEntity reference, or None if not set
+        """
+        return self.targetRunnableEntityRef
+
+    def setTargetRunnableEntityRef(self, value: Optional[RefType]) -> "RunnableEntityInCompositionInstanceRef":
+        """
+        This represents the target RunnableEntity. Only sets the value if it is
+        not None, and returns self for method chaining.
+
+        Args:
+            value: The target RunnableEntity reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.targetRunnableEntityRef = value
+        return self
+
+
+class VariableDataPrototypeInCompositionInstanceRef(AtpInstanceRef):
+    """
+    This meta-class represents the ability to define an InstanceRef to a
+    VariableDataPrototype in the context of a CompositionSwComponentType.
+    """
+
+    # VariableDataPrototypeInCompositionInstanceRef method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table D.22, p.959
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer
+    # [x] __init__                             [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBaseRef                           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setBaseRef                           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getContextPortPrototypeRef           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setContextPortPrototypeRef           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getContextSwComponentPrototypeRefs   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addContextSwComponentPrototypeRef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTargetVariableDataPrototypeRef    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTargetVariableDataPrototypeRef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        """
+        Initializes the VariableDataPrototypeInCompositionInstanceRef with
+        default values.
+        """
+        super().__init__()
+
+        # This represents the base of the InstanceRef.
+        self.baseRef: Optional[RefType] = None
+
+        # This represents a reference to a context PortPrototype.
+        self.contextPortPrototypeRef: Optional[RefType] = None
+
+        # This represents the nested structure of Sw Component Prototypes.
+        self.contextSwComponentPrototypeRefs: List[RefType] = []
+
+        # This represents the target VariableDataPrototype.
+        self.targetVariableDataPrototypeRef: Optional[RefType] = None
+
+    def getBaseRef(self) -> Optional[RefType]:
+        """
+        This represents the base of the InstanceRef.
+
+        Returns:
+            Optional[RefType]: The base reference, or None if not set
+        """
+        return self.baseRef
+
+    def setBaseRef(self, value: Optional[RefType]) -> "VariableDataPrototypeInCompositionInstanceRef":
+        """
+        This represents the base of the InstanceRef. Only sets the value if it
+        is not None, and returns self for method chaining.
+
+        Args:
+            value: The base reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.baseRef = value
+        return self
+
+    def getContextPortPrototypeRef(self) -> Optional[RefType]:
+        """
+        This represents a reference to a context PortPrototype.
+
+        Returns:
+            Optional[RefType]: The context PortPrototype reference, or None if not set
+        """
+        return self.contextPortPrototypeRef
+
+    def setContextPortPrototypeRef(self, value: Optional[RefType]) -> "VariableDataPrototypeInCompositionInstanceRef":
+        """
+        This represents a reference to a context PortPrototype. Only sets the
+        value if it is not None, and returns self for method chaining.
+
+        Args:
+            value: The context PortPrototype reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.contextPortPrototypeRef = value
+        return self
+
+    def getContextSwComponentPrototypeRefs(self) -> List[RefType]:
+        """
+        This represents the nested structure of Sw Component Prototypes.
+
+        Returns:
+            List of RefType instances representing the context SwComponentPrototypes
+        """
+        return self.contextSwComponentPrototypeRefs
+
+    def addContextSwComponentPrototypeRef(self, value: RefType) -> "VariableDataPrototypeInCompositionInstanceRef":
+        """
+        This represents the nested structure of Sw Component Prototypes.
+        Returns self for method chaining.
+
+        Args:
+            value: The context SwComponentPrototype reference to add
+
+        Returns:
+            self for method chaining
+        """
+        self.contextSwComponentPrototypeRefs.append(value)
+        return self
+
+    def getTargetVariableDataPrototypeRef(self) -> Optional[RefType]:
+        """
+        This represents the target VariableDataPrototype.
+
+        Returns:
+            Optional[RefType]: The target VariableDataPrototype reference, or None if not set
+        """
+        return self.targetVariableDataPrototypeRef
+
+    def setTargetVariableDataPrototypeRef(self, value: Optional[RefType]) -> "VariableDataPrototypeInCompositionInstanceRef":
+        """
+        This represents the target VariableDataPrototype. Only sets the value
+        if it is not None, and returns self for method chaining.
+
+        Args:
+            value: The target VariableDataPrototype reference to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.targetVariableDataPrototypeRef = value
+        return self

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/__init__.py
@@ -1,0 +1,101 @@
+"""
+This module contains the classes of the ImplicitCommunicationBehavior
+sub-package of the SWComponentTemplate module, together with its
+InstanceRefs sub-module.
+"""
+
+from typing import List, Optional
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpStructureElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import *  # noqa: F401,F403
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
+    InnerDataPrototypeGroupInCompositionInstanceRef,
+    VariableDataPrototypeInCompositionInstanceRef,
+)
+
+
+class DataPrototypeGroup(AtpStructureElement):
+    """
+    This meta-class represents the ability to define a collection of
+    DataPrototypes that are subject to the formal definition of implicit
+    communication behavior. The definition of the collection can be nested.
+    """
+
+    # DataPrototypeGroup method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.101, p.223
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addDataPrototypeGroupIRef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDataPrototypeGroupIRefs   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addImplicitDataAccessIRef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getImplicitDataAccessIRefs   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+
+    def __init__(self, parent: ARObject, short_name: str):
+        """
+        Initializes the DataPrototypeGroup with default values.
+        """
+        super().__init__(parent, short_name)
+
+        # This represents the ability to define nested groups of
+        # VariableDataPrototypes.
+        self.dataPrototypeGroupIRefs: List[InnerDataPrototypeGroupInCompositionInstanceRef] = []
+
+        # This represents a collection of VariableDataPrototypes that belong to
+        # the enclosing DataPrototypeGroup
+        self.implicitDataAccessIRefs: List[VariableDataPrototypeInCompositionInstanceRef] = []
+
+    def addDataPrototypeGroupIRef(self, value: Optional[InnerDataPrototypeGroupInCompositionInstanceRef]) -> "DataPrototypeGroup":
+        """
+        This represents the ability to define nested groups of
+        VariableDataPrototypes. A None value is a no-op and does not append to
+        dataPrototypeGroupIRefs.
+
+        Args:
+            value: The InnerDataPrototypeGroupInCompositionInstanceRef to add
+
+        Returns:
+            DataPrototypeGroup: self for method chaining
+        """
+        if value is not None:
+            self.dataPrototypeGroupIRefs.append(value)
+        return self
+
+    def getDataPrototypeGroupIRefs(self) -> List[InnerDataPrototypeGroupInCompositionInstanceRef]:
+        """
+        This represents the ability to define nested groups of
+        VariableDataPrototypes.
+
+        Returns:
+            List[InnerDataPrototypeGroupInCompositionInstanceRef]: The list of
+            dataPrototypeGroup instance references
+        """
+        return self.dataPrototypeGroupIRefs
+
+    def addImplicitDataAccessIRef(self, value: Optional[VariableDataPrototypeInCompositionInstanceRef]) -> "DataPrototypeGroup":
+        """
+        This represents a collection of VariableDataPrototypes that belong to
+        the enclosing DataPrototypeGroup A None value is a no-op and does not
+        append to implicitDataAccessIRefs.
+
+        Args:
+            value: The VariableDataPrototypeInCompositionInstanceRef to add
+
+        Returns:
+            DataPrototypeGroup: self for method chaining
+        """
+        if value is not None:
+            self.implicitDataAccessIRefs.append(value)
+        return self
+
+    def getImplicitDataAccessIRefs(self) -> List[VariableDataPrototypeInCompositionInstanceRef]:
+        """
+        This represents a collection of VariableDataPrototypes that belong to
+        the enclosing DataPrototypeGroup
+
+        Returns:
+            List[VariableDataPrototypeInCompositionInstanceRef]: The list of
+            implicitDataAccess instance references
+        """
+        return self.implicitDataAccessIRefs

--- a/src/armodel/models/__init__.py
+++ b/src/armodel/models/__init__.py
@@ -141,6 +141,8 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition.Instance
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype import *  # noqa: F403
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.DataPrototypes import *  # noqa: F403
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import *  # noqa: F403
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import *  # noqa: F403
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import *  # noqa: F403
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import *  # noqa: F403
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface.InstanceRefs import *  # noqa: F403
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SoftwareComponentDocumentation import *  # noqa: F403

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -301,6 +301,13 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection i
     EndToEndProtectionSet,
     EndToEndProtectionVariablePrototype,
 )
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import DataPrototypeGroup
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
+    InnerDataPrototypeGroupInCompositionInstanceRef,
+    InnerRunnableEntityGroupInCompositionInstanceRef,
+    RunnableEntityInCompositionInstanceRef,
+    VariableDataPrototypeInCompositionInstanceRef,
+)
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import (
     ArgumentDataPrototype,
     ClientServerInterface,
@@ -2678,6 +2685,45 @@ class ARXMLParser(AbstractARXMLParser):
     def readPTriggerInAtomicSwcTypeInstanceRef(self, element: ET.Element, instance_ref: PTriggerInAtomicSwcTypeInstanceRef):
         instance_ref.setContextPPortRef(self.getChildElementOptionalRefType(element, "CONTEXT-P-PORT-REF"))
         instance_ref.setTargetTriggerRef(self.getChildElementOptionalRefType(element, "TARGET-TRIGGER-REF"))
+
+    def readInnerDataPrototypeGroupInCompositionInstanceRef(self, element: ET.Element, instance_ref: InnerDataPrototypeGroupInCompositionInstanceRef):
+        for ref in self.getChildElementRefTypeList(element, "CONTEXT-SW-COMPONENT-PROTOTYPE-REF"):
+            instance_ref.addContextSwComponentPrototypeRef(ref)
+        instance_ref.setTargetDataPrototypeGroupRef(self.getChildElementOptionalRefType(element, "TARGET-DATA-PROTOTYPE-GROUP-REF"))
+
+    def readInnerRunnableEntityGroupInCompositionInstanceRef(self, element: ET.Element, instance_ref: InnerRunnableEntityGroupInCompositionInstanceRef):
+        for ref in self.getChildElementRefTypeList(element, "CONTEXT-SW-COMPONENT-PROTOTYPE-REF"):
+            instance_ref.addContextSwComponentPrototypeRef(ref)
+        instance_ref.setTargetRunnableEntityGroupRef(self.getChildElementOptionalRefType(element, "TARGET-RUNNABLE-ENTITY-GROUP-REF"))
+
+    def readRunnableEntityInCompositionInstanceRef(self, element: ET.Element, instance_ref: RunnableEntityInCompositionInstanceRef):
+        for ref in self.getChildElementRefTypeList(element, "CONTEXT-SW-COMPONENT-PROTOTYPE-REF"):
+            instance_ref.addContextSwComponentPrototypeRef(ref)
+        instance_ref.setTargetRunnableEntityRef(self.getChildElementOptionalRefType(element, "TARGET-RUNNABLE-ENTITY-REF"))
+
+    def readVariableDataPrototypeInCompositionInstanceRef(self, element: ET.Element, instance_ref: VariableDataPrototypeInCompositionInstanceRef):
+        for ref in self.getChildElementRefTypeList(element, "CONTEXT-SW-COMPONENT-PROTOTYPE-REF"):
+            instance_ref.addContextSwComponentPrototypeRef(ref)
+        instance_ref.setContextPortPrototypeRef(self.getChildElementOptionalRefType(element, "CONTEXT-PORT-PROTOTYPE-REF"))
+        instance_ref.setTargetVariableDataPrototypeRef(self.getChildElementOptionalRefType(element, "TARGET-VARIABLE-DATA-PROTOTYPE-REF"))
+
+    def readDataPrototypeGroupDataPrototypeGroupIRefs(self, element: ET.Element, parent: DataPrototypeGroup):
+        for child_element in self.findall(element, "DATA-PROTOTYPE-GROUP-IREFS/DATA-PROTOTYPE-GROUP-IREF"):
+            instance_ref = InnerDataPrototypeGroupInCompositionInstanceRef()
+            self.readInnerDataPrototypeGroupInCompositionInstanceRef(child_element, instance_ref)
+            parent.addDataPrototypeGroupIRef(instance_ref)
+
+    def readDataPrototypeGroupImplicitDataAccessIRefs(self, element: ET.Element, parent: DataPrototypeGroup):
+        for child_element in self.findall(element, "IMPLICIT-DATA-ACCESS-IREFS/IMPLICIT-DATA-ACCESS-IREF"):
+            instance_ref = VariableDataPrototypeInCompositionInstanceRef()
+            self.readVariableDataPrototypeInCompositionInstanceRef(child_element, instance_ref)
+            parent.addImplicitDataAccessIRef(instance_ref)
+
+    def readDataPrototypeGroup(self, element: ET.Element, data_group: DataPrototypeGroup):
+        self.logger.debug("readDataPrototypeGroup %s" % data_group.getShortName())
+        self.readIdentifiable(element, data_group)
+        self.readDataPrototypeGroupDataPrototypeGroupIRefs(element, data_group)
+        self.readDataPrototypeGroupImplicitDataAccessIRefs(element, data_group)
 
     def getModeGroupIRef(self, element: ET.Element, key: str) -> ModeGroupInAtomicSwcInstanceRef:
         instance_ref = None
@@ -7631,6 +7677,9 @@ class ARXMLParser(AbstractARXMLParser):
             if tag_name == "COMPOSITION-SW-COMPONENT-TYPE":
                 type = parent.createCompositionSwComponentType(self.getShortName(child_element))
                 self.readCompositionSwComponentType(child_element, type)
+            elif tag_name == "DATA-PROTOTYPE-GROUP":
+                data_group = parent.createDataPrototypeGroup(self.getShortName(child_element))
+                self.readDataPrototypeGroup(child_element, data_group)
             elif tag_name == "COMPLEX-DEVICE-DRIVER-SW-COMPONENT-TYPE":
                 type = parent.createComplexDeviceDriverSwComponentType(self.getShortName(child_element))
                 self.readComplexDeviceDriverSwComponentType(child_element, type)

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -286,6 +286,13 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection i
     EndToEndProtectionSet,
     EndToEndProtectionVariablePrototype,
 )
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import DataPrototypeGroup
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
+    InnerDataPrototypeGroupInCompositionInstanceRef,
+    InnerRunnableEntityGroupInCompositionInstanceRef,
+    RunnableEntityInCompositionInstanceRef,
+    VariableDataPrototypeInCompositionInstanceRef,
+)
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import (
     ApplicationError,
     ArgumentDataPrototype,
@@ -2417,6 +2424,56 @@ class ARXMLWriter(AbstractARXMLWriter):
             child_element = ET.SubElement(element, key)
             self.setChildElementOptionalRefType(child_element, "CONTEXT-P-PORT-REF", instance_ref.getContextPPortRef())
             self.setChildElementOptionalRefType(child_element, "TARGET-TRIGGER-REF", instance_ref.getTargetTriggerRef())
+
+    def writeInnerDataPrototypeGroupInCompositionInstanceRef(self, element: ET.Element, key: str, instance_ref: InnerDataPrototypeGroupInCompositionInstanceRef):
+        if instance_ref is not None:
+            child_element = ET.SubElement(element, key)
+            for ref in instance_ref.getContextSwComponentPrototypeRefs():
+                self.setChildElementOptionalRefType(child_element, "CONTEXT-SW-COMPONENT-PROTOTYPE-REF", ref)
+            self.setChildElementOptionalRefType(child_element, "TARGET-DATA-PROTOTYPE-GROUP-REF", instance_ref.getTargetDataPrototypeGroupRef())
+
+    def writeInnerRunnableEntityGroupInCompositionInstanceRef(self, element: ET.Element, key: str, instance_ref: InnerRunnableEntityGroupInCompositionInstanceRef):
+        if instance_ref is not None:
+            child_element = ET.SubElement(element, key)
+            for ref in instance_ref.getContextSwComponentPrototypeRefs():
+                self.setChildElementOptionalRefType(child_element, "CONTEXT-SW-COMPONENT-PROTOTYPE-REF", ref)
+            self.setChildElementOptionalRefType(child_element, "TARGET-RUNNABLE-ENTITY-GROUP-REF", instance_ref.getTargetRunnableEntityGroupRef())
+
+    def writeRunnableEntityInCompositionInstanceRef(self, element: ET.Element, key: str, instance_ref: RunnableEntityInCompositionInstanceRef):
+        if instance_ref is not None:
+            child_element = ET.SubElement(element, key)
+            for ref in instance_ref.getContextSwComponentPrototypeRefs():
+                self.setChildElementOptionalRefType(child_element, "CONTEXT-SW-COMPONENT-PROTOTYPE-REF", ref)
+            self.setChildElementOptionalRefType(child_element, "TARGET-RUNNABLE-ENTITY-REF", instance_ref.getTargetRunnableEntityRef())
+
+    def writeVariableDataPrototypeInCompositionInstanceRef(self, element: ET.Element, key: str, instance_ref: VariableDataPrototypeInCompositionInstanceRef):
+        if instance_ref is not None:
+            child_element = ET.SubElement(element, key)
+            for ref in instance_ref.getContextSwComponentPrototypeRefs():
+                self.setChildElementOptionalRefType(child_element, "CONTEXT-SW-COMPONENT-PROTOTYPE-REF", ref)
+            self.setChildElementOptionalRefType(child_element, "CONTEXT-PORT-PROTOTYPE-REF", instance_ref.getContextPortPrototypeRef())
+            self.setChildElementOptionalRefType(child_element, "TARGET-VARIABLE-DATA-PROTOTYPE-REF", instance_ref.getTargetVariableDataPrototypeRef())
+
+    def writeDataPrototypeGroupDataPrototypeGroupIRefs(self, element: ET.Element, data_group: DataPrototypeGroup):
+        irefs = data_group.getDataPrototypeGroupIRefs()
+        if len(irefs) > 0:
+            child_element = ET.SubElement(element, "DATA-PROTOTYPE-GROUP-IREFS")
+            for iref in irefs:
+                self.writeInnerDataPrototypeGroupInCompositionInstanceRef(child_element, "DATA-PROTOTYPE-GROUP-IREF", iref)
+
+    def writeDataPrototypeGroupImplicitDataAccessIRefs(self, element: ET.Element, data_group: DataPrototypeGroup):
+        irefs = data_group.getImplicitDataAccessIRefs()
+        if len(irefs) > 0:
+            child_element = ET.SubElement(element, "IMPLICIT-DATA-ACCESS-IREFS")
+            for iref in irefs:
+                self.writeVariableDataPrototypeInCompositionInstanceRef(child_element, "IMPLICIT-DATA-ACCESS-IREF", iref)
+
+    def writeDataPrototypeGroup(self, element: ET.Element, data_group: DataPrototypeGroup):
+        self.logger.debug("writeDataPrototypeGroup %s" % data_group.getShortName())
+        child_element = ET.SubElement(element, "DATA-PROTOTYPE-GROUP")
+        self.writeIdentifiable(child_element, data_group)
+        self.writeDataPrototypeGroupDataPrototypeGroupIRefs(child_element, data_group)
+        self.writeDataPrototypeGroupImplicitDataAccessIRefs(child_element, data_group)
 
     def setPModeGroupInAtomicSwcInstanceRef(self, element: ET.Element, key: str, instance_ref: PModeGroupInAtomicSwcInstanceRef):
         if instance_ref is not None:
@@ -8033,6 +8090,8 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeMcFunction(element, ar_element)
         elif isinstance(ar_element, McGroup):
             self.writeMcGroup(element, ar_element)
+        elif isinstance(ar_element, DataPrototypeGroup):
+            self.writeDataPrototypeGroup(element, ar_element)
         else:
             self.notImplemented("Unsupported Elements of ARPackage <%s>" % type(ar_element))
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/test_DataPrototypeGroup.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/test_DataPrototypeGroup.py
@@ -1,0 +1,88 @@
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpStructureElement
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import DataPrototypeGroup
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
+    InnerDataPrototypeGroupInCompositionInstanceRef,
+    VariableDataPrototypeInCompositionInstanceRef,
+)
+
+
+class TestDataPrototypeGroupInitialization:
+    def test_initialization(self):
+        """Test DataPrototypeGroup __init__ defaults"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        data_group = DataPrototypeGroup(ar_root, "Group")
+
+        assert data_group is not None
+        assert isinstance(data_group, DataPrototypeGroup)
+        assert isinstance(data_group, AtpStructureElement)
+        assert data_group.getShortName() == "Group"
+        assert data_group.dataPrototypeGroupIRefs == []
+        assert data_group.implicitDataAccessIRefs == []
+
+
+class TestDataPrototypeGroupDataPrototypeGroup:
+    def test_add_get_data_prototype_group_iref(self):
+        """Test addDataPrototypeGroupIRef appends and returns self"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        data_group = DataPrototypeGroup(ar_root, "Group")
+
+        iref = InnerDataPrototypeGroupInCompositionInstanceRef()
+        result = data_group.addDataPrototypeGroupIRef(iref)
+        assert result is data_group
+        assert data_group.getDataPrototypeGroupIRefs() == [iref]
+
+    def test_add_data_prototype_group_iref_none_is_noop(self):
+        """Test adding a None dataPrototypeGroup iref is a no-op"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        data_group = DataPrototypeGroup(ar_root, "Group")
+
+        data_group.addDataPrototypeGroupIRef(None)
+        assert data_group.getDataPrototypeGroupIRefs() == []
+
+    def test_add_multiple_data_prototype_group_irefs(self):
+        """Test adding multiple dataPrototypeGroup irefs"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        data_group = DataPrototypeGroup(ar_root, "Group")
+
+        iref1 = InnerDataPrototypeGroupInCompositionInstanceRef()
+        iref2 = InnerDataPrototypeGroupInCompositionInstanceRef()
+        data_group.addDataPrototypeGroupIRef(iref1).addDataPrototypeGroupIRef(iref2)
+        assert data_group.getDataPrototypeGroupIRefs() == [iref1, iref2]
+
+
+class TestDataPrototypeGroupImplicitDataAccess:
+    def test_add_get_implicit_data_access_iref(self):
+        """Test addImplicitDataAccessIRef appends and returns self"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        data_group = DataPrototypeGroup(ar_root, "Group")
+
+        iref = VariableDataPrototypeInCompositionInstanceRef()
+        result = data_group.addImplicitDataAccessIRef(iref)
+        assert result is data_group
+        assert data_group.getImplicitDataAccessIRefs() == [iref]
+
+    def test_add_implicit_data_access_iref_none_is_noop(self):
+        """Test adding a None implicitDataAccess iref is a no-op"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        data_group = DataPrototypeGroup(ar_root, "Group")
+
+        data_group.addImplicitDataAccessIRef(None)
+        assert data_group.getImplicitDataAccessIRefs() == []
+
+    def test_add_multiple_implicit_data_access_irefs(self):
+        """Test adding multiple implicitDataAccess irefs"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        data_group = DataPrototypeGroup(ar_root, "Group")
+
+        iref1 = VariableDataPrototypeInCompositionInstanceRef()
+        iref2 = VariableDataPrototypeInCompositionInstanceRef()
+        data_group.addImplicitDataAccessIRef(iref1).addImplicitDataAccessIRef(iref2)
+        assert data_group.getImplicitDataAccessIRefs() == [iref1, iref2]

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/test_InstanceRefs.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/test_InstanceRefs.py
@@ -1,0 +1,220 @@
+"""
+This module contains comprehensive tests for the InstanceRefs module in
+SWComponentTemplate.ImplicitCommunicationBehavior.
+Tests cover all classes and methods in the InstanceRefs.py file to achieve
+100% test coverage.
+"""
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
+    InnerDataPrototypeGroupInCompositionInstanceRef,
+    InnerRunnableEntityGroupInCompositionInstanceRef,
+    RunnableEntityInCompositionInstanceRef,
+    VariableDataPrototypeInCompositionInstanceRef,
+)
+
+
+class TestInnerDataPrototypeGroupInCompositionInstanceRef:
+    """Test class for InnerDataPrototypeGroupInCompositionInstanceRef class."""
+
+    def test_initialization(self):
+        """Test InnerDataPrototypeGroupInCompositionInstanceRef initialization."""
+        instance_ref = InnerDataPrototypeGroupInCompositionInstanceRef()
+
+        assert instance_ref.baseRef is None
+        assert instance_ref.contextSwComponentPrototypeRefs == []
+        assert instance_ref.targetDataPrototypeGroupRef is None
+
+    def test_base_ref(self):
+        """Test baseRef getter/setter with round-trip and None no-op."""
+        instance_ref = InnerDataPrototypeGroupInCompositionInstanceRef()
+
+        base_ref = RefType()
+        base_ref.setValue("/Base/Ref")
+        result = instance_ref.setBaseRef(base_ref)
+        assert result is instance_ref
+        assert instance_ref.getBaseRef() == base_ref
+
+        instance_ref.setBaseRef(None)
+        assert instance_ref.getBaseRef() == base_ref
+
+    def test_context_sw_component_prototype_refs(self):
+        """Test contextSwComponentPrototypeRefs add/get."""
+        instance_ref = InnerDataPrototypeGroupInCompositionInstanceRef()
+
+        context_ref = RefType()
+        context_ref.setValue("/Context/Component")
+        result = instance_ref.addContextSwComponentPrototypeRef(context_ref)
+        assert result is instance_ref
+        assert context_ref in instance_ref.getContextSwComponentPrototypeRefs()
+
+    def test_target_data_prototype_group_ref(self):
+        """Test targetDataPrototypeGroupRef getter/setter with None no-op."""
+        instance_ref = InnerDataPrototypeGroupInCompositionInstanceRef()
+
+        target_ref = RefType()
+        target_ref.setValue("/Target/DataPrototypeGroup")
+        result = instance_ref.setTargetDataPrototypeGroupRef(target_ref)
+        assert result is instance_ref
+        assert instance_ref.getTargetDataPrototypeGroupRef() == target_ref
+
+        instance_ref.setTargetDataPrototypeGroupRef(None)
+        assert instance_ref.getTargetDataPrototypeGroupRef() == target_ref
+
+
+class TestInnerRunnableEntityGroupInCompositionInstanceRef:
+    """Test class for InnerRunnableEntityGroupInCompositionInstanceRef class."""
+
+    def test_initialization(self):
+        """Test InnerRunnableEntityGroupInCompositionInstanceRef initialization."""
+        instance_ref = InnerRunnableEntityGroupInCompositionInstanceRef()
+
+        assert instance_ref.baseRef is None
+        assert instance_ref.contextSwComponentPrototypeRefs == []
+        assert instance_ref.targetRunnableEntityGroupRef is None
+
+    def test_base_ref(self):
+        """Test baseRef getter/setter with round-trip and None no-op."""
+        instance_ref = InnerRunnableEntityGroupInCompositionInstanceRef()
+
+        base_ref = RefType()
+        base_ref.setValue("/Base/Ref")
+        result = instance_ref.setBaseRef(base_ref)
+        assert result is instance_ref
+        assert instance_ref.getBaseRef() == base_ref
+
+        instance_ref.setBaseRef(None)
+        assert instance_ref.getBaseRef() == base_ref
+
+    def test_context_sw_component_prototype_refs(self):
+        """Test contextSwComponentPrototypeRefs add/get."""
+        instance_ref = InnerRunnableEntityGroupInCompositionInstanceRef()
+
+        context_ref = RefType()
+        context_ref.setValue("/Context/Component")
+        result = instance_ref.addContextSwComponentPrototypeRef(context_ref)
+        assert result is instance_ref
+        assert context_ref in instance_ref.getContextSwComponentPrototypeRefs()
+
+    def test_target_runnable_entity_group_ref(self):
+        """Test targetRunnableEntityGroupRef getter/setter with None no-op."""
+        instance_ref = InnerRunnableEntityGroupInCompositionInstanceRef()
+
+        target_ref = RefType()
+        target_ref.setValue("/Target/RunnableEntityGroup")
+        result = instance_ref.setTargetRunnableEntityGroupRef(target_ref)
+        assert result is instance_ref
+        assert instance_ref.getTargetRunnableEntityGroupRef() == target_ref
+
+        instance_ref.setTargetRunnableEntityGroupRef(None)
+        assert instance_ref.getTargetRunnableEntityGroupRef() == target_ref
+
+
+class TestRunnableEntityInCompositionInstanceRef:
+    """Test class for RunnableEntityInCompositionInstanceRef class."""
+
+    def test_initialization(self):
+        """Test RunnableEntityInCompositionInstanceRef initialization."""
+        instance_ref = RunnableEntityInCompositionInstanceRef()
+
+        assert instance_ref.baseRef is None
+        assert instance_ref.contextSwComponentPrototypeRefs == []
+        assert instance_ref.targetRunnableEntityRef is None
+
+    def test_base_ref(self):
+        """Test baseRef getter/setter with round-trip and None no-op."""
+        instance_ref = RunnableEntityInCompositionInstanceRef()
+
+        base_ref = RefType()
+        base_ref.setValue("/Base/Ref")
+        result = instance_ref.setBaseRef(base_ref)
+        assert result is instance_ref
+        assert instance_ref.getBaseRef() == base_ref
+
+        instance_ref.setBaseRef(None)
+        assert instance_ref.getBaseRef() == base_ref
+
+    def test_context_sw_component_prototype_refs(self):
+        """Test contextSwComponentPrototypeRefs add/get."""
+        instance_ref = RunnableEntityInCompositionInstanceRef()
+
+        context_ref = RefType()
+        context_ref.setValue("/Context/Component")
+        result = instance_ref.addContextSwComponentPrototypeRef(context_ref)
+        assert result is instance_ref
+        assert context_ref in instance_ref.getContextSwComponentPrototypeRefs()
+
+    def test_target_runnable_entity_ref(self):
+        """Test targetRunnableEntityRef getter/setter with None no-op."""
+        instance_ref = RunnableEntityInCompositionInstanceRef()
+
+        target_ref = RefType()
+        target_ref.setValue("/Target/RunnableEntity")
+        result = instance_ref.setTargetRunnableEntityRef(target_ref)
+        assert result is instance_ref
+        assert instance_ref.getTargetRunnableEntityRef() == target_ref
+
+        instance_ref.setTargetRunnableEntityRef(None)
+        assert instance_ref.getTargetRunnableEntityRef() == target_ref
+
+
+class TestVariableDataPrototypeInCompositionInstanceRef:
+    """Test class for VariableDataPrototypeInCompositionInstanceRef class."""
+
+    def test_initialization(self):
+        """Test VariableDataPrototypeInCompositionInstanceRef initialization."""
+        instance_ref = VariableDataPrototypeInCompositionInstanceRef()
+
+        assert instance_ref.baseRef is None
+        assert instance_ref.contextPortPrototypeRef is None
+        assert instance_ref.contextSwComponentPrototypeRefs == []
+        assert instance_ref.targetVariableDataPrototypeRef is None
+
+    def test_base_ref(self):
+        """Test baseRef getter/setter with round-trip and None no-op."""
+        instance_ref = VariableDataPrototypeInCompositionInstanceRef()
+
+        base_ref = RefType()
+        base_ref.setValue("/Base/Ref")
+        result = instance_ref.setBaseRef(base_ref)
+        assert result is instance_ref
+        assert instance_ref.getBaseRef() == base_ref
+
+        instance_ref.setBaseRef(None)
+        assert instance_ref.getBaseRef() == base_ref
+
+    def test_context_port_prototype_ref(self):
+        """Test contextPortPrototypeRef getter/setter with None no-op."""
+        instance_ref = VariableDataPrototypeInCompositionInstanceRef()
+
+        context_port_ref = RefType()
+        context_port_ref.setValue("/Context/Port")
+        result = instance_ref.setContextPortPrototypeRef(context_port_ref)
+        assert result is instance_ref
+        assert instance_ref.getContextPortPrototypeRef() == context_port_ref
+
+        instance_ref.setContextPortPrototypeRef(None)
+        assert instance_ref.getContextPortPrototypeRef() == context_port_ref
+
+    def test_context_sw_component_prototype_refs(self):
+        """Test contextSwComponentPrototypeRefs add/get."""
+        instance_ref = VariableDataPrototypeInCompositionInstanceRef()
+
+        context_ref = RefType()
+        context_ref.setValue("/Context/Component")
+        result = instance_ref.addContextSwComponentPrototypeRef(context_ref)
+        assert result is instance_ref
+        assert context_ref in instance_ref.getContextSwComponentPrototypeRefs()
+
+    def test_target_variable_data_prototype_ref(self):
+        """Test targetVariableDataPrototypeRef getter/setter with None no-op."""
+        instance_ref = VariableDataPrototypeInCompositionInstanceRef()
+
+        target_ref = RefType()
+        target_ref.setValue("/Target/VariableDataPrototype")
+        result = instance_ref.setTargetVariableDataPrototypeRef(target_ref)
+        assert result is instance_ref
+        assert instance_ref.getTargetVariableDataPrototypeRef() == target_ref
+
+        instance_ref.setTargetVariableDataPrototypeRef(None)
+        assert instance_ref.getTargetVariableDataPrototypeRef() == target_ref

--- a/tests/test_armodel/writer/test_writer_data_prototype_group.py
+++ b/tests/test_armodel/writer/test_writer_data_prototype_group.py
@@ -1,0 +1,98 @@
+"""Tests for reading and writing DataPrototypeGroup elements."""
+
+import os
+import tempfile
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import DataPrototypeGroup
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
+    InnerDataPrototypeGroupInCompositionInstanceRef,
+    VariableDataPrototypeInCompositionInstanceRef,
+)
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+def make_ref(value: str, dest: str = "DATA-PROTOTYPE-GROUP") -> RefType:
+    ref = RefType()
+    ref.setValue(value)
+    ref.setDest(dest)
+    return ref
+
+
+def _build_document(group: DataPrototypeGroup):
+    AUTOSAR.getInstance().setARRelease("R23-11")
+    document = AUTOSAR.getInstance()
+    document.clear()
+    ar_root = document.createARPackage("AUTOSAR")
+    ar_root.addElement(group)
+    return document
+
+
+def _reload(file_path):
+    document_2 = AUTOSAR.getInstance()
+    document_2.clear()
+    ARXMLParser().load(file_path, document_2)
+    package = document_2.getARPackages()[0]
+    return next(element for element in package.elements if isinstance(element, DataPrototypeGroup))
+
+
+class TestWriteDataPrototypeGroup:
+    def test_round_trip_populated(self):
+        """Test parse -> write -> re-parse of populated dataPrototypeGroupIRefs and implicitDataAccessIRefs."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        group = DataPrototypeGroup(ar_root, "ImplicitDataGroup")
+
+        inner_iref = InnerDataPrototypeGroupInCompositionInstanceRef()
+        inner_iref.addContextSwComponentPrototypeRef(make_ref("/Comp/A", "SW-COMPONENT-PROTOTYPE"))
+        inner_iref.addContextSwComponentPrototypeRef(make_ref("/Comp/B", "SW-COMPONENT-PROTOTYPE"))
+        inner_iref.setTargetDataPrototypeGroupRef(make_ref("/Comp/A/Group"))
+        group.addDataPrototypeGroupIRef(inner_iref)
+
+        implicit_iref = VariableDataPrototypeInCompositionInstanceRef()
+        implicit_iref.addContextSwComponentPrototypeRef(make_ref("/Comp/A", "SW-COMPONENT-PROTOTYPE"))
+        implicit_iref.setContextPortPrototypeRef(make_ref("/Comp/A/PPort", "P-PORT-PROTOTYPE"))
+        implicit_iref.setTargetVariableDataPrototypeRef(make_ref("/Comp/A/PPort/Data", "VARIABLE-DATA-PROTOTYPE"))
+        group.addImplicitDataAccessIRef(implicit_iref)
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, _build_document(group))
+            group_2 = _reload(file_path)
+            assert group_2.getShortName() == "ImplicitDataGroup"
+            inner_refs = group_2.getDataPrototypeGroupIRefs()
+            assert len(inner_refs) == 1
+            assert [r.getValue() for r in inner_refs[0].getContextSwComponentPrototypeRefs()] == ["/Comp/A", "/Comp/B"]
+            assert inner_refs[0].getTargetDataPrototypeGroupRef().getValue() == "/Comp/A/Group"
+            implicit_refs = group_2.getImplicitDataAccessIRefs()
+            assert len(implicit_refs) == 1
+            assert [r.getValue() for r in implicit_refs[0].getContextSwComponentPrototypeRefs()] == ["/Comp/A"]
+            assert implicit_refs[0].getContextPortPrototypeRef().getValue() == "/Comp/A/PPort"
+            assert implicit_refs[0].getTargetVariableDataPrototypeRef().getValue() == "/Comp/A/PPort/Data"
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+    def test_round_trip_unset_emits_no_wrappers(self):
+        """Test empty iref lists round-trip to no wrapper elements."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        group = DataPrototypeGroup(ar_root, "ImplicitDataGroup")
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, _build_document(group))
+            with open(file_path, "r", encoding="utf-8") as file_handle:
+                content = file_handle.read()
+            assert "DATA-PROTOTYPE-GROUP-IREFS" not in content
+            assert "IMPLICIT-DATA-ACCESS-IREFS" not in content
+
+            group_2 = _reload(file_path)
+            assert group_2.getShortName() == "ImplicitDataGroup"
+            assert group_2.getDataPrototypeGroupIRefs() == []
+            assert group_2.getImplicitDataAccessIRefs() == []
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)

--- a/tests/test_armodel/writer/test_writer_instance_refs.py
+++ b/tests/test_armodel/writer/test_writer_instance_refs.py
@@ -1,0 +1,185 @@
+"""Tests for writing ImplicitCommunicationBehavior instance-reference elements."""
+
+import xml.etree.cElementTree as ET
+
+import pytest
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
+    InnerDataPrototypeGroupInCompositionInstanceRef,
+    InnerRunnableEntityGroupInCompositionInstanceRef,
+    RunnableEntityInCompositionInstanceRef,
+    VariableDataPrototypeInCompositionInstanceRef,
+)
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+@pytest.fixture
+def parser():
+    AUTOSAR.getInstance().new()
+    return ARXMLParser()
+
+
+def _parent():
+    return ET.Element("PARENT")
+
+
+def _ref(value="/Pkg/Elem", dest="DATA-PROTOTYPE-GROUP"):
+    r = RefType()
+    r.setValue(value)
+    r.setDest(dest)
+    return r
+
+
+NS = "http://autosar.org/schema/r4.0"
+
+
+def _parse_element(xml: str, tag: str) -> ET.Element:
+    return ET.fromstring(f"<{tag} xmlns='{NS}'>{xml}</{tag}>")
+
+
+def _serialize_and_wrap(parent: ET.Element) -> ET.Element:
+    inner = ET.tostring(parent).decode("utf-8")
+    root = _parse_element(inner, "AUTOSAR")
+    return root[0][0]
+
+
+class TestWriteInnerDataPrototypeGroupInCompositionInstanceRef:
+    def test_write_none(self, writer):
+        parent = _parent()
+        writer.writeInnerDataPrototypeGroupInCompositionInstanceRef(parent, "DATA-PROTOTYPE-GROUP-IN-COMPOSITION-INSTANCE-REF", None)
+        assert len(parent) == 0
+
+    def test_write_iref_with_context_and_target(self, writer):
+        iref = InnerDataPrototypeGroupInCompositionInstanceRef()
+        iref.setBaseRef(_ref("/Swc"))
+        iref.addContextSwComponentPrototypeRef(_ref("/Comp/Prototype", "SW-COMPONENT-PROTOTYPE"))
+        iref.setTargetDataPrototypeGroupRef(_ref("/Comp/Prototype/Group", "DATA-PROTOTYPE-GROUP"))
+
+        parent = _parent()
+        writer.writeInnerDataPrototypeGroupInCompositionInstanceRef(parent, "INNER-DATA-PROTOTYPE-GROUP-IN-COMPOSITION-INSTANCE-REF", iref)
+        child = parent[0]
+        assert child.tag == "INNER-DATA-PROTOTYPE-GROUP-IN-COMPOSITION-INSTANCE-REF"
+        assert child.find("CONTEXT-SW-COMPONENT-PROTOTYPE-REF") is not None
+        assert child.find("CONTEXT-SW-COMPONENT-PROTOTYPE-REF").text == "/Comp/Prototype"
+        assert child.find("TARGET-DATA-PROTOTYPE-GROUP-REF") is not None
+        assert child.find("TARGET-DATA-PROTOTYPE-GROUP-REF").text == "/Comp/Prototype/Group"
+
+    def test_round_trip(self, writer, parser):
+        iref = InnerDataPrototypeGroupInCompositionInstanceRef()
+        iref.addContextSwComponentPrototypeRef(_ref("/Comp/A", "SW-COMPONENT-PROTOTYPE"))
+        iref.addContextSwComponentPrototypeRef(_ref("/Comp/B", "SW-COMPONENT-PROTOTYPE"))
+        iref.setTargetDataPrototypeGroupRef(_ref("/Comp/A/Group", "DATA-PROTOTYPE-GROUP"))
+
+        parent = _parent()
+        writer.writeInnerDataPrototypeGroupInCompositionInstanceRef(parent, "INNER-DATA-PROTOTYPE-GROUP-IN-COMPOSITION-INSTANCE-REF", iref)
+        element = _serialize_and_wrap(parent)
+        recovered = InnerDataPrototypeGroupInCompositionInstanceRef()
+        parser.readInnerDataPrototypeGroupInCompositionInstanceRef(element, recovered)
+        assert [r.getValue() for r in recovered.getContextSwComponentPrototypeRefs()] == ["/Comp/A", "/Comp/B"]
+        assert recovered.getTargetDataPrototypeGroupRef().getValue() == "/Comp/A/Group"
+
+
+class TestWriteInnerRunnableEntityGroupInCompositionInstanceRef:
+    def test_write_none(self, writer):
+        parent = _parent()
+        writer.writeInnerRunnableEntityGroupInCompositionInstanceRef(parent, "INNER-RUNNABLE-ENTITY-GROUP-IN-COMPOSITION-INSTANCE-REF", None)
+        assert len(parent) == 0
+
+    def test_round_trip(self, writer, parser):
+        iref = InnerRunnableEntityGroupInCompositionInstanceRef()
+        iref.addContextSwComponentPrototypeRef(_ref("/Comp/A", "SW-COMPONENT-PROTOTYPE"))
+        iref.addContextSwComponentPrototypeRef(_ref("/Comp/B", "SW-COMPONENT-PROTOTYPE"))
+        iref.setTargetRunnableEntityGroupRef(_ref("/Comp/A/Group", "RUNNABLE-ENTITY-GROUP"))
+
+        parent = _parent()
+        writer.writeInnerRunnableEntityGroupInCompositionInstanceRef(parent, "INNER-RUNNABLE-ENTITY-GROUP-IN-COMPOSITION-INSTANCE-REF", iref)
+        child = parent[0]
+        assert child.tag == "INNER-RUNNABLE-ENTITY-GROUP-IN-COMPOSITION-INSTANCE-REF"
+        assert child.find("CONTEXT-SW-COMPONENT-PROTOTYPE-REF") is not None
+        assert child.find("TARGET-RUNNABLE-ENTITY-GROUP-REF") is not None
+
+        element = _serialize_and_wrap(parent)
+        recovered = InnerRunnableEntityGroupInCompositionInstanceRef()
+        parser.readInnerRunnableEntityGroupInCompositionInstanceRef(element, recovered)
+        assert [r.getValue() for r in recovered.getContextSwComponentPrototypeRefs()] == ["/Comp/A", "/Comp/B"]
+        assert recovered.getTargetRunnableEntityGroupRef().getValue() == "/Comp/A/Group"
+
+
+class TestWriteRunnableEntityInCompositionInstanceRef:
+    def test_write_none(self, writer):
+        parent = _parent()
+        writer.writeRunnableEntityInCompositionInstanceRef(parent, "RUNNABLE-ENTITY-IN-COMPOSITION-INSTANCE-REF", None)
+        assert len(parent) == 0
+
+    def test_round_trip(self, writer, parser):
+        iref = RunnableEntityInCompositionInstanceRef()
+        iref.addContextSwComponentPrototypeRef(_ref("/Comp/A", "SW-COMPONENT-PROTOTYPE"))
+        iref.setTargetRunnableEntityRef(_ref("/Comp/A/Behavior/Entity", "RUNNABLE-ENTITY"))
+
+        parent = _parent()
+        writer.writeRunnableEntityInCompositionInstanceRef(parent, "RUNNABLE-ENTITY-IN-COMPOSITION-INSTANCE-REF", iref)
+        child = parent[0]
+        assert child.tag == "RUNNABLE-ENTITY-IN-COMPOSITION-INSTANCE-REF"
+        assert child.find("CONTEXT-SW-COMPONENT-PROTOTYPE-REF") is not None
+        assert child.find("TARGET-RUNNABLE-ENTITY-REF") is not None
+
+        element = _serialize_and_wrap(parent)
+        recovered = RunnableEntityInCompositionInstanceRef()
+        parser.readRunnableEntityInCompositionInstanceRef(element, recovered)
+        assert [r.getValue() for r in recovered.getContextSwComponentPrototypeRefs()] == ["/Comp/A"]
+        assert recovered.getTargetRunnableEntityRef().getValue() == "/Comp/A/Behavior/Entity"
+
+
+class TestWriteVariableDataPrototypeInCompositionInstanceRef:
+    def test_write_none(self, writer):
+        parent = _parent()
+        writer.writeVariableDataPrototypeInCompositionInstanceRef(parent, "VARIABLE-DATA-PROTOTYPE-IN-COMPOSITION-INSTANCE-REF", None)
+        assert len(parent) == 0
+
+    def test_round_trip(self, writer, parser):
+        iref = VariableDataPrototypeInCompositionInstanceRef()
+        iref.setContextPortPrototypeRef(_ref("/Comp/A/PPort", "P-PORT-PROTOTYPE"))
+        iref.addContextSwComponentPrototypeRef(_ref("/Comp/A", "SW-COMPONENT-PROTOTYPE"))
+        iref.setTargetVariableDataPrototypeRef(_ref("/Comp/A/PPort/Data", "VARIABLE-DATA-PROTOTYPE"))
+
+        parent = _parent()
+        writer.writeVariableDataPrototypeInCompositionInstanceRef(parent, "VARIABLE-DATA-PROTOTYPE-IN-COMPOSITION-INSTANCE-REF", iref)
+        child = parent[0]
+        assert child.tag == "VARIABLE-DATA-PROTOTYPE-IN-COMPOSITION-INSTANCE-REF"
+        assert child.find("CONTEXT-PORT-PROTOTYPE-REF") is not None
+        assert child.find("CONTEXT-SW-COMPONENT-PROTOTYPE-REF") is not None
+        assert child.find("TARGET-VARIABLE-DATA-PROTOTYPE-REF") is not None
+
+        element = _serialize_and_wrap(parent)
+        recovered = VariableDataPrototypeInCompositionInstanceRef()
+        parser.readVariableDataPrototypeInCompositionInstanceRef(element, recovered)
+        assert recovered.getContextPortPrototypeRef().getValue() == "/Comp/A/PPort"
+        assert [r.getValue() for r in recovered.getContextSwComponentPrototypeRefs()] == ["/Comp/A"]
+        assert recovered.getTargetVariableDataPrototypeRef().getValue() == "/Comp/A/PPort/Data"
+
+    def test_round_trip_empty_wrapper(self, writer, parser):
+        iref = VariableDataPrototypeInCompositionInstanceRef()
+        parent = _parent()
+        writer.writeVariableDataPrototypeInCompositionInstanceRef(parent, "VARIABLE-DATA-PROTOTYPE-IN-COMPOSITION-INSTANCE-REF", iref)
+        element = _serialize_and_wrap(parent)
+        recovered = VariableDataPrototypeInCompositionInstanceRef()
+        parser.readVariableDataPrototypeInCompositionInstanceRef(element, recovered)
+        assert recovered.getContextPortPrototypeRef() is None
+        assert recovered.getContextSwComponentPrototypeRefs() == []
+        assert recovered.getTargetVariableDataPrototypeRef() is None


### PR DESCRIPTION
## Summary

Sync ImplicitCommunicationBehavior classes (InstanceRefs, DataPrototypeGroup) to AUTOSAR R23-11 spec, with parser/writer support and tests.

- Add `InstanceRefs` model classes under SWComponentTemplate/ImplicitCommunicationBehavior
- Add `DataPrototypeGroup` and `DataPrototypeGroupElement` model classes
- Register new classes in `models/__init__.py` and `ARPackage`
- Add parser and writer coverage
- Add unit and writer round-trip tests

Closes #589