### PR TITLE
feat: add ConsistencyNeeds and RunnableEntityGroup, extend SwComponentType with consistencyNeeds

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
@@ -21,7 +21,11 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import 
 )
 
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SensorActuatorSwComponentType
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import DataPrototypeGroup
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import (
+    ConsistencyNeeds,
+    DataPrototypeGroup,
+    RunnableEntityGroup,
+)
 from armodel.models.M2.MSR.AsamHdo.BaseTypes import SwBaseType
 from armodel.models.M2.MSR.AsamHdo.Units import PhysicalDimension, Unit
 from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import DataConstr
@@ -1018,6 +1022,18 @@ class ARPackage(CollectableElement):
             data_group = DataPrototypeGroup(self, short_name)
             self.addElement(data_group)
         return self.getElement(short_name, DataPrototypeGroup)
+
+    def createRunnableEntityGroup(self, short_name: str) -> RunnableEntityGroup:
+        if not self.IsElementExists(short_name, RunnableEntityGroup):
+            runnable_group = RunnableEntityGroup(self, short_name)
+            self.addElement(runnable_group)
+        return self.getElement(short_name, RunnableEntityGroup)
+
+    def createConsistencyNeeds(self, short_name: str) -> ConsistencyNeeds:
+        if not self.IsElementExists(short_name, ConsistencyNeeds):
+            consistency_needs = ConsistencyNeeds(self, short_name)
+            self.addElement(consistency_needs)
+        return self.getElement(short_name, ConsistencyNeeds)
 
     def createModeDeclarationGroup(self, short_name: str) -> ModeDeclarationGroup:
         if not self.IsElementExists(short_name, ModeDeclarationGroup):

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/__init__.py
@@ -6,11 +6,13 @@ InstanceRefs sub-module.
 
 from typing import List, Optional
 
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpStructureElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpBlueprintable, AtpStructureElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import *  # noqa: F401,F403
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
     InnerDataPrototypeGroupInCompositionInstanceRef,
+    InnerRunnableEntityGroupInCompositionInstanceRef,
+    RunnableEntityInCompositionInstanceRef,
     VariableDataPrototypeInCompositionInstanceRef,
 )
 
@@ -99,3 +101,264 @@ class DataPrototypeGroup(AtpStructureElement):
             implicitDataAccess instance references
         """
         return self.implicitDataAccessIRefs
+
+
+class RunnableEntityGroup(AtpStructureElement):
+    """
+    This meta-class represents the ability to define a collection of
+    RunnableEntities. The collection can be nested.
+    """
+
+    # RunnableEntityGroup method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.100, p.223
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer
+    # [x] __init__                    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addRunnableEntityIRef        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRunnableEntityIRefs       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addRunnableEntityGroupIRef   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRunnableEntityGroupIRefs  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+
+    def __init__(self, parent: ARObject, short_name: str):
+        """
+        Initializes the RunnableEntityGroup with default values.
+        """
+        super().__init__(parent, short_name)
+
+        # This represents a collection of RunnableEntitys that belong to the
+        # enclosing RunnableEntityGroup.
+        self.runnableEntityIRefs: List[RunnableEntityInCompositionInstanceRef] = []
+
+        # This represents the ability to define nested groups of RunnableEntitys.
+        self.runnableEntityGroupIRefs: List[InnerRunnableEntityGroupInCompositionInstanceRef] = []
+
+    def addRunnableEntityIRef(self, value: Optional[RunnableEntityInCompositionInstanceRef]) -> "RunnableEntityGroup":
+        """
+        This represents a collection of RunnableEntitys that belong to the
+        enclosing RunnableEntityGroup. A None value is a no-op and does not
+        append to runnableEntityIRefs.
+
+        Args:
+            value: The RunnableEntityInCompositionInstanceRef to add
+
+        Returns:
+            RunnableEntityGroup: self for method chaining
+        """
+        if value is not None:
+            self.runnableEntityIRefs.append(value)
+        return self
+
+    def getRunnableEntityIRefs(self) -> List[RunnableEntityInCompositionInstanceRef]:
+        """
+        This represents a collection of RunnableEntitys that belong to the
+        enclosing RunnableEntityGroup.
+
+        Returns:
+            List[RunnableEntityInCompositionInstanceRef]: The list of
+            runnableEntity instance references
+        """
+        return self.runnableEntityIRefs
+
+    def addRunnableEntityGroupIRef(self, value: Optional[InnerRunnableEntityGroupInCompositionInstanceRef]) -> "RunnableEntityGroup":
+        """
+        This represents the ability to define nested groups of
+        RunnableEntitys. A None value is a no-op and does not append to
+        runnableEntityGroupIRefs.
+
+        Args:
+            value: The InnerRunnableEntityGroupInCompositionInstanceRef to add
+
+        Returns:
+            RunnableEntityGroup: self for method chaining
+        """
+        if value is not None:
+            self.runnableEntityGroupIRefs.append(value)
+        return self
+
+    def getRunnableEntityGroupIRefs(self) -> List[InnerRunnableEntityGroupInCompositionInstanceRef]:
+        """
+        This represents the ability to define nested groups of
+        RunnableEntitys.
+
+        Returns:
+            List[InnerRunnableEntityGroupInCompositionInstanceRef]: The list of
+            runnableEntityGroup instance references
+        """
+        return self.runnableEntityGroupIRefs
+
+
+class ConsistencyNeeds(AtpBlueprintable):
+    """
+    This meta-class represents the ability to define requirements on the
+    implicit communication behavior.
+    """
+
+    # ConsistencyNeeds method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.99, p.222
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer
+    # [x] __init__                        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] createDpgDoesNotRequireCoherency   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDpgDoesNotRequireCoherencys     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createDpgRequiresCoherency         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDpgRequiresCoherencys           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createRegDoesNotRequireStability   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRegDoesNotRequireStabilitys     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createRegRequiresStability         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRegRequiresStabilitys           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+
+    def __init__(self, parent: ARObject, short_name: str):
+        """
+        Initializes the ConsistencyNeeds with default values.
+        """
+        super().__init__(parent, short_name)
+
+        # This group of VariableDataPrototypes does not require coherency with
+        # respect to the implicit communication behavior.
+        self.dpgDoesNotRequireCoherency: List[DataPrototypeGroup] = []
+
+        # This group of VariableDataPrototypes requires coherency with respect
+        # to the implicit communication behavior, i.e. all read and write
+        # access to VariableDataPrototypes in the DataPrototypeGroup by the
+        # RunnableEntitys of the RunnableEntityGroup need to be handled in a
+        # coherent manner.
+        self.dpgRequiresCoherency: List[DataPrototypeGroup] = []
+
+        # This group of RunnableEntities does not require stability with
+        # respect to the implicit communication behavior.
+        self.regDoesNotRequireStability: List[RunnableEntityGroup] = []
+
+        # This group of RunnableEntities requires stability with respect to the
+        # implicit communication behavior, i.e. all read and write access to
+        # VariableDataPrototypes in the DataPrototypeGroup by the
+        # RunnableEntitys of the RunnableEntityGroup need to be handled in a
+        # stable manner.
+        self.regRequiresStability: List[RunnableEntityGroup] = []
+
+    def createDpgDoesNotRequireCoherency(self, short_name: str) -> DataPrototypeGroup:
+        """
+        This group of VariableDataPrototypes does not require coherency with
+        respect to the implicit communication behavior.
+        Returns the existing DataPrototypeGroup when the short name already
+        exists.
+
+        Args:
+            short_name: The short name of the DataPrototypeGroup
+
+        Returns:
+            DataPrototypeGroup: The created or existing DataPrototypeGroup
+        """
+        if not self.IsElementExists(short_name):
+            data_group = DataPrototypeGroup(self, short_name)
+            self.addElement(data_group)
+            self.dpgDoesNotRequireCoherency.append(data_group)
+        return self.getElement(short_name, DataPrototypeGroup)
+
+    def getDpgDoesNotRequireCoherencys(self) -> List[DataPrototypeGroup]:
+        """
+        This group of VariableDataPrototypes does not require coherency with
+        respect to the implicit communication behavior.
+
+        Returns:
+            List[DataPrototypeGroup]: The list of DataPrototypeGroups
+        """
+        return self.dpgDoesNotRequireCoherency
+
+    def createDpgRequiresCoherency(self, short_name: str) -> DataPrototypeGroup:
+        """
+        This group of VariableDataPrototypes requires coherency with respect
+        to the implicit communication behavior, i.e. all read and write access
+        to VariableDataPrototypes in the DataPrototypeGroup by the
+        RunnableEntitys of the RunnableEntityGroup need to be handled in a
+        coherent manner.
+        Returns the existing DataPrototypeGroup when the short name already
+        exists.
+
+        Args:
+            short_name: The short name of the DataPrototypeGroup
+
+        Returns:
+            DataPrototypeGroup: The created or existing DataPrototypeGroup
+        """
+        if not self.IsElementExists(short_name):
+            data_group = DataPrototypeGroup(self, short_name)
+            self.addElement(data_group)
+            self.dpgRequiresCoherency.append(data_group)
+        return self.getElement(short_name, DataPrototypeGroup)
+
+    def getDpgRequiresCoherencys(self) -> List[DataPrototypeGroup]:
+        """
+        This group of VariableDataPrototypes requires coherency with respect
+        to the implicit communication behavior, i.e. all read and write access
+        to VariableDataPrototypes in the DataPrototypeGroup by the
+        RunnableEntitys of the RunnableEntityGroup need to be handled in a
+        coherent manner.
+
+        Returns:
+            List[DataPrototypeGroup]: The list of DataPrototypeGroups
+        """
+        return self.dpgRequiresCoherency
+
+    def createRegDoesNotRequireStability(self, short_name: str) -> RunnableEntityGroup:
+        """
+        This group of RunnableEntities does not require stability with respect
+        to the implicit communication behavior.
+        Returns the existing RunnableEntityGroup when the short name already
+        exists.
+
+        Args:
+            short_name: The short name of the RunnableEntityGroup
+
+        Returns:
+            RunnableEntityGroup: The created or existing RunnableEntityGroup
+        """
+        if not self.IsElementExists(short_name):
+            runnable_group = RunnableEntityGroup(self, short_name)
+            self.addElement(runnable_group)
+            self.regDoesNotRequireStability.append(runnable_group)
+        return self.getElement(short_name, RunnableEntityGroup)
+
+    def getRegDoesNotRequireStabilitys(self) -> List[RunnableEntityGroup]:
+        """
+        This group of RunnableEntities does not require stability with respect
+        to the implicit communication behavior.
+
+        Returns:
+            List[RunnableEntityGroup]: The list of RunnableEntityGroups
+        """
+        return self.regDoesNotRequireStability
+
+    def createRegRequiresStability(self, short_name: str) -> RunnableEntityGroup:
+        """
+        This group of RunnableEntities requires stability with respect to the
+        implicit communication behavior, i.e. all read and write access to
+        VariableDataPrototypes in the DataPrototypeGroup by the
+        RunnableEntitys of the RunnableEntityGroup need to be handled in a
+        stable manner.
+        Returns the existing RunnableEntityGroup when the short name already
+        exists.
+
+        Args:
+            short_name: The short name of the RunnableEntityGroup
+
+        Returns:
+            RunnableEntityGroup: The created or existing RunnableEntityGroup
+        """
+        if not self.IsElementExists(short_name):
+            runnable_group = RunnableEntityGroup(self, short_name)
+            self.addElement(runnable_group)
+            self.regRequiresStability.append(runnable_group)
+        return self.getElement(short_name, RunnableEntityGroup)
+
+    def getRegRequiresStabilitys(self) -> List[RunnableEntityGroup]:
+        """
+        This group of RunnableEntities requires stability with respect to the
+        implicit communication behavior, i.e. all read and write access to
+        VariableDataPrototypes in the DataPrototypeGroup by the
+        RunnableEntitys of the RunnableEntityGroup need to be handled in a
+        stable manner.
+
+        Returns:
+            List[RunnableEntityGroup]: The list of RunnableEntityGroups
+        """
+        return self.regRequiresStability

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwComponentType.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwComponentType.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
         PRPortPrototype,
         RPortPrototype,
     )
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import (
+        ConsistencyNeeds,
+    )
     from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SoftwareComponentDocumentation import (
         SwComponentDocumentation,
     )
@@ -31,7 +34,10 @@ class SwComponentType(AtpType, ABC):
 
     # SwComponentType method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 3.1, p.64
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] createConsistencyNeeds       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getConsistencyNeeds          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
     # [x] createPPortPrototype         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
     # [x] createRPortPrototype         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
     # [x] createPRPortPrototype        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
@@ -54,6 +60,9 @@ class SwComponentType(AtpType, ABC):
             raise TypeError("SwComponentType is an abstract class.")
         super().__init__(parent, short_name)
 
+        # This represents the collection of ConsistencyNeeds owned by the enclosing SwComponentType.
+        self.consistencyNeeds: List[ConsistencyNeeds] = []
+
         # The PortPrototypes through which this SwComponent Type can communicate. The aggregation of PortPrototype is subject to variability with the purpose to support the conditional existence of PortPrototypes.
         self.ports: List[PortPrototype] = []
 
@@ -68,6 +77,34 @@ class SwComponentType(AtpType, ABC):
 
         # This allows for the specification of which UnitGroups are relevant in the context of referencing SwComponentType.
         self.unitGroupRefs: List[RefType] = []
+
+    def createConsistencyNeeds(self, short_name: str) -> ConsistencyNeeds:
+        """
+        Creates a ConsistencyNeeds owned by the enclosing SwComponentType.
+        Returns the existing ConsistencyNeeds when the short name already exists.
+
+        Args:
+            short_name: The short name of the ConsistencyNeeds
+
+        Returns:
+            The created or existing ConsistencyNeeds
+        """
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import ConsistencyNeeds
+
+        if not self.IsElementExists(short_name, ConsistencyNeeds):
+            consistency_needs = ConsistencyNeeds(self, short_name)
+            self.addElement(consistency_needs)
+            self.consistencyNeeds.append(consistency_needs)
+        return self.getElement(short_name, ConsistencyNeeds)
+
+    def getConsistencyNeeds(self) -> List[ConsistencyNeeds]:
+        """
+        Gets the collection of ConsistencyNeeds owned by the enclosing SwComponentType.
+
+        Returns:
+            List of ConsistencyNeeds instances
+        """
+        return self.consistencyNeeds
 
     def createPPortPrototype(self, short_name: str) -> PPortPrototype:
         """

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
@@ -125,10 +125,10 @@ class NmCoordinatorRoleEnum(AREnum):
 
     def __init__(self):
         super().__init__(
-            (
+            [
                 NmCoordinatorRoleEnum.ACTIVE,
                 NmCoordinatorRoleEnum.PASSIVE,
-            )
+            ]
         )
 
 

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -301,7 +301,11 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection i
     EndToEndProtectionSet,
     EndToEndProtectionVariablePrototype,
 )
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import DataPrototypeGroup
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import (
+    ConsistencyNeeds,
+    DataPrototypeGroup,
+    RunnableEntityGroup,
+)
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
     InnerDataPrototypeGroupInCompositionInstanceRef,
     InnerRunnableEntityGroupInCompositionInstanceRef,
@@ -2725,6 +2729,52 @@ class ARXMLParser(AbstractARXMLParser):
         self.readDataPrototypeGroupDataPrototypeGroupIRefs(element, data_group)
         self.readDataPrototypeGroupImplicitDataAccessIRefs(element, data_group)
 
+    def readRunnableEntityGroupRunnableEntityGroupIRefs(self, element: ET.Element, parent: RunnableEntityGroup):
+        for child_element in self.findall(element, "RUNNABLE-ENTITY-GROUP-IREFS/RUNNABLE-ENTITY-GROUP-IREF"):
+            instance_ref = InnerRunnableEntityGroupInCompositionInstanceRef()
+            self.readInnerRunnableEntityGroupInCompositionInstanceRef(child_element, instance_ref)
+            parent.addRunnableEntityGroupIRef(instance_ref)
+
+    def readRunnableEntityGroupRunnableEntityIRefs(self, element: ET.Element, parent: RunnableEntityGroup):
+        for child_element in self.findall(element, "RUNNABLE-ENTITY-IREFS/RUNNABLE-ENTITY-IREF"):
+            instance_ref = RunnableEntityInCompositionInstanceRef()
+            self.readRunnableEntityInCompositionInstanceRef(child_element, instance_ref)
+            parent.addRunnableEntityIRef(instance_ref)
+
+    def readRunnableEntityGroup(self, element: ET.Element, runnable_group: RunnableEntityGroup):
+        self.logger.debug("readRunnableEntityGroup %s" % runnable_group.getShortName())
+        self.readIdentifiable(element, runnable_group)
+        self.readRunnableEntityGroupRunnableEntityGroupIRefs(element, runnable_group)
+        self.readRunnableEntityGroupRunnableEntityIRefs(element, runnable_group)
+
+    def readConsistencyNeedsDpgDoesNotRequireCoherencys(self, element: ET.Element, parent: ConsistencyNeeds):
+        for child_element in self.findall(element, "DPG-DOES-NOT-REQUIRE-COHERENCYS/DATA-PROTOTYPE-GROUP"):
+            data_group = parent.createDpgDoesNotRequireCoherency(self.getShortName(child_element))
+            self.readDataPrototypeGroup(child_element, data_group)
+
+    def readConsistencyNeedsDpgRequiresCoherencys(self, element: ET.Element, parent: ConsistencyNeeds):
+        for child_element in self.findall(element, "DPG-REQUIRES-COHERENCYS/DATA-PROTOTYPE-GROUP"):
+            data_group = parent.createDpgRequiresCoherency(self.getShortName(child_element))
+            self.readDataPrototypeGroup(child_element, data_group)
+
+    def readConsistencyNeedsRegDoesNotRequireStabilitys(self, element: ET.Element, parent: ConsistencyNeeds):
+        for child_element in self.findall(element, "REG-DOES-NOT-REQUIRE-STABILITYS/RUNNABLE-ENTITY-GROUP"):
+            runnable_group = parent.createRegDoesNotRequireStability(self.getShortName(child_element))
+            self.readRunnableEntityGroup(child_element, runnable_group)
+
+    def readConsistencyNeedsRegRequiresStabilitys(self, element: ET.Element, parent: ConsistencyNeeds):
+        for child_element in self.findall(element, "REG-REQUIRES-STABILITYS/RUNNABLE-ENTITY-GROUP"):
+            runnable_group = parent.createRegRequiresStability(self.getShortName(child_element))
+            self.readRunnableEntityGroup(child_element, runnable_group)
+
+    def readConsistencyNeeds(self, element: ET.Element, consistency_needs: ConsistencyNeeds):
+        self.logger.debug("readConsistencyNeeds %s" % consistency_needs.getShortName())
+        self.readIdentifiable(element, consistency_needs)
+        self.readConsistencyNeedsDpgDoesNotRequireCoherencys(element, consistency_needs)
+        self.readConsistencyNeedsDpgRequiresCoherencys(element, consistency_needs)
+        self.readConsistencyNeedsRegDoesNotRequireStabilitys(element, consistency_needs)
+        self.readConsistencyNeedsRegRequiresStabilitys(element, consistency_needs)
+
     def getModeGroupIRef(self, element: ET.Element, key: str) -> ModeGroupInAtomicSwcInstanceRef:
         instance_ref = None
         for child_element in self.findall(element, "%s/*" % key):
@@ -3907,6 +3957,10 @@ class ARXMLParser(AbstractARXMLParser):
         for ref in self.getChildElementRefTypeList(element, "UNIT-GROUP-REFS/UNIT-GROUP-REF"):
             parent.addUnitGroupRef(ref)
 
+    def readSwComponentTypeConsistencyNeeds(self, element: ET.Element, parent: SwComponentType):
+        for child_element in self.findall(element, "CONSISTENCY-NEEDSS/CONSISTENCY-NEEDS"):
+            self.readConsistencyNeeds(child_element, parent.createConsistencyNeeds(self.getShortName(child_element)))
+
     def readSwComponentTypeSwComponentDocumentation(self, element: ET.Element, parent: SwComponentType):
         child_element = self.find(element, "SW-COMPONENT-DOCUMENTATION")
         if child_element is None:
@@ -4029,11 +4083,12 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readSwComponentType(self, element: ET.Element, parent: SwComponentType):
         self.readIdentifiable(element, parent)
+        self.readSwComponentTypeSwComponentDocumentation(element, parent)
+        self.readSwComponentTypeConsistencyNeeds(element, parent)
         self.readSwComponentTypePorts(element, parent)
         self.readSwComponentTypePortGroups(element, parent)
         self.readSwComponentTypeSwcMappingConstraints(element, parent)
         self.readSwComponentTypeUnitGroups(element, parent)
-        self.readSwComponentTypeSwComponentDocumentation(element, parent)
 
     def readAtomicSwComponentTypeSymbolProps(self, element: ET.Element, sw_component: AtomicSwComponentType):
         child_element = self.find(element, "SYMBOL-PROPS")
@@ -7680,6 +7735,12 @@ class ARXMLParser(AbstractARXMLParser):
             elif tag_name == "DATA-PROTOTYPE-GROUP":
                 data_group = parent.createDataPrototypeGroup(self.getShortName(child_element))
                 self.readDataPrototypeGroup(child_element, data_group)
+            elif tag_name == "RUNNABLE-ENTITY-GROUP":
+                runnable_group = parent.createRunnableEntityGroup(self.getShortName(child_element))
+                self.readRunnableEntityGroup(child_element, runnable_group)
+            elif tag_name == "CONSISTENCY-NEEDS":
+                consistency_needs = parent.createConsistencyNeeds(self.getShortName(child_element))
+                self.readConsistencyNeeds(child_element, consistency_needs)
             elif tag_name == "COMPLEX-DEVICE-DRIVER-SW-COMPONENT-TYPE":
                 type = parent.createComplexDeviceDriverSwComponentType(self.getShortName(child_element))
                 self.readComplexDeviceDriverSwComponentType(child_element, type)

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -286,7 +286,11 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection i
     EndToEndProtectionSet,
     EndToEndProtectionVariablePrototype,
 )
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import DataPrototypeGroup
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import (
+    ConsistencyNeeds,
+    DataPrototypeGroup,
+    RunnableEntityGroup,
+)
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
     InnerDataPrototypeGroupInCompositionInstanceRef,
     InnerRunnableEntityGroupInCompositionInstanceRef,
@@ -1335,13 +1339,21 @@ class ARXMLWriter(AbstractARXMLWriter):
             for ref in refs:
                 self.setChildElementOptionalRefType(child_element, "UNIT-GROUP-REF", ref)
 
+    def writeSwComponentTypeConsistencyNeeds(self, element: ET.Element, parent: SwComponentType):
+        consistency_needs_list = parent.getConsistencyNeeds()
+        if len(consistency_needs_list) > 0:
+            child_element = ET.SubElement(element, "CONSISTENCY-NEEDSS")
+            for consistency_needs in consistency_needs_list:
+                self.writeConsistencyNeeds(child_element, consistency_needs)
+
     def writeSwComponentType(self, element: ET.Element, sw_component: SwComponentType):
         self.writeIdentifiable(element, sw_component)
+        self.writeSwComponentTypeSwComponentDocumentation(element, sw_component)
+        self.writeSwComponentTypeConsistencyNeeds(element, sw_component)
         self.writeSwComponentTypePorts(element, sw_component)
         self.writeSwComponentTypePortGroups(element, sw_component)
         self.writeSwComponentTypeSwcMappingConstraints(element, sw_component)
         self.writeSwComponentTypeUnitGroups(element, sw_component)
-        self.writeSwComponentTypeSwComponentDocumentation(element, sw_component)
 
     def writeSwComponentPrototype(self, element: ET.Element, prototype: SwComponentPrototype):
         prototype_tag = ET.SubElement(element, "SW-COMPONENT-PROTOTYPE")
@@ -2474,6 +2486,60 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.writeIdentifiable(child_element, data_group)
         self.writeDataPrototypeGroupDataPrototypeGroupIRefs(child_element, data_group)
         self.writeDataPrototypeGroupImplicitDataAccessIRefs(child_element, data_group)
+
+    def writeRunnableEntityGroupRunnableEntityGroupIRefs(self, element: ET.Element, runnable_group: RunnableEntityGroup):
+        irefs = runnable_group.getRunnableEntityGroupIRefs()
+        if len(irefs) > 0:
+            child_element = ET.SubElement(element, "RUNNABLE-ENTITY-GROUP-IREFS")
+            for iref in irefs:
+                self.writeInnerRunnableEntityGroupInCompositionInstanceRef(child_element, "RUNNABLE-ENTITY-GROUP-IREF", iref)
+
+    def writeRunnableEntityGroupRunnableEntityIRefs(self, element: ET.Element, runnable_group: RunnableEntityGroup):
+        irefs = runnable_group.getRunnableEntityIRefs()
+        if len(irefs) > 0:
+            child_element = ET.SubElement(element, "RUNNABLE-ENTITY-IREFS")
+            for iref in irefs:
+                self.writeRunnableEntityInCompositionInstanceRef(child_element, "RUNNABLE-ENTITY-IREF", iref)
+
+    def writeRunnableEntityGroup(self, element: ET.Element, runnable_group: RunnableEntityGroup):
+        self.logger.debug("writeRunnableEntityGroup %s" % runnable_group.getShortName())
+        child_element = ET.SubElement(element, "RUNNABLE-ENTITY-GROUP")
+        self.writeIdentifiable(child_element, runnable_group)
+        self.writeRunnableEntityGroupRunnableEntityGroupIRefs(child_element, runnable_group)
+        self.writeRunnableEntityGroupRunnableEntityIRefs(child_element, runnable_group)
+
+    def writeConsistencyNeedsDpgDoesNotRequireCoherencys(self, element: ET.Element, consistency_needs: ConsistencyNeeds):
+        if len(consistency_needs.getDpgDoesNotRequireCoherencys()) > 0:
+            child_element = ET.SubElement(element, "DPG-DOES-NOT-REQUIRE-COHERENCYS")
+            for data_group in consistency_needs.getDpgDoesNotRequireCoherencys():
+                self.writeDataPrototypeGroup(child_element, data_group)
+
+    def writeConsistencyNeedsDpgRequiresCoherencys(self, element: ET.Element, consistency_needs: ConsistencyNeeds):
+        if len(consistency_needs.getDpgRequiresCoherencys()) > 0:
+            child_element = ET.SubElement(element, "DPG-REQUIRES-COHERENCYS")
+            for data_group in consistency_needs.getDpgRequiresCoherencys():
+                self.writeDataPrototypeGroup(child_element, data_group)
+
+    def writeConsistencyNeedsRegDoesNotRequireStabilitys(self, element: ET.Element, consistency_needs: ConsistencyNeeds):
+        if len(consistency_needs.getRegDoesNotRequireStabilitys()) > 0:
+            child_element = ET.SubElement(element, "REG-DOES-NOT-REQUIRE-STABILITYS")
+            for runnable_group in consistency_needs.getRegDoesNotRequireStabilitys():
+                self.writeRunnableEntityGroup(child_element, runnable_group)
+
+    def writeConsistencyNeedsRegRequiresStabilitys(self, element: ET.Element, consistency_needs: ConsistencyNeeds):
+        if len(consistency_needs.getRegRequiresStabilitys()) > 0:
+            child_element = ET.SubElement(element, "REG-REQUIRES-STABILITYS")
+            for runnable_group in consistency_needs.getRegRequiresStabilitys():
+                self.writeRunnableEntityGroup(child_element, runnable_group)
+
+    def writeConsistencyNeeds(self, element: ET.Element, consistency_needs: ConsistencyNeeds):
+        self.logger.debug("writeConsistencyNeeds %s" % consistency_needs.getShortName())
+        child_element = ET.SubElement(element, "CONSISTENCY-NEEDS")
+        self.writeIdentifiable(child_element, consistency_needs)
+        self.writeConsistencyNeedsDpgDoesNotRequireCoherencys(child_element, consistency_needs)
+        self.writeConsistencyNeedsDpgRequiresCoherencys(child_element, consistency_needs)
+        self.writeConsistencyNeedsRegDoesNotRequireStabilitys(child_element, consistency_needs)
+        self.writeConsistencyNeedsRegRequiresStabilitys(child_element, consistency_needs)
 
     def setPModeGroupInAtomicSwcInstanceRef(self, element: ET.Element, key: str, instance_ref: PModeGroupInAtomicSwcInstanceRef):
         if instance_ref is not None:
@@ -8092,6 +8158,10 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeMcGroup(element, ar_element)
         elif isinstance(ar_element, DataPrototypeGroup):
             self.writeDataPrototypeGroup(element, ar_element)
+        elif isinstance(ar_element, RunnableEntityGroup):
+            self.writeRunnableEntityGroup(element, ar_element)
+        elif isinstance(ar_element, ConsistencyNeeds):
+            self.writeConsistencyNeeds(element, ar_element)
         else:
             self.notImplemented("Unsupported Elements of ARPackage <%s>" % type(ar_element))
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/test_ConsistencyNeeds.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/test_ConsistencyNeeds.py
@@ -1,0 +1,82 @@
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpBlueprintable
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import (
+    ConsistencyNeeds,
+    DataPrototypeGroup,
+    RunnableEntityGroup,
+)
+
+
+class TestConsistencyNeedsInitialization:
+    def test_initialization(self):
+        """Test ConsistencyNeeds __init__ defaults"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        consistency_needs = ConsistencyNeeds(ar_root, "Needs")
+
+        assert consistency_needs is not None
+        assert isinstance(consistency_needs, ConsistencyNeeds)
+        assert isinstance(consistency_needs, AtpBlueprintable)
+        assert consistency_needs.getShortName() == "Needs"
+        assert consistency_needs.getDpgDoesNotRequireCoherencys() == []
+        assert consistency_needs.getDpgRequiresCoherencys() == []
+        assert consistency_needs.getRegDoesNotRequireStabilitys() == []
+        assert consistency_needs.getRegRequiresStabilitys() == []
+
+
+class TestConsistencyNeedsDpgDoesNotRequireCoherency:
+    def test_create_get(self):
+        """Test createDpgDoesNotRequireCoherency and getDpgDoesNotRequireCoherencys"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        consistency_needs = ConsistencyNeeds(ar_root, "Needs")
+
+        data_group = consistency_needs.createDpgDoesNotRequireCoherency("Group")
+        assert isinstance(data_group, DataPrototypeGroup)
+        assert consistency_needs.getDpgDoesNotRequireCoherencys() == [data_group]
+
+    def test_create_existing_returns_same(self):
+        """Test creating a dpgDoesNotRequireCoherency with the same short name returns the existing one"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        consistency_needs = ConsistencyNeeds(ar_root, "Needs")
+
+        data_group = consistency_needs.createDpgDoesNotRequireCoherency("Group")
+        data_group_2 = consistency_needs.createDpgDoesNotRequireCoherency("Group")
+        assert data_group is data_group_2
+
+
+class TestConsistencyNeedsDpgRequiresCoherency:
+    def test_create_get(self):
+        """Test createDpgRequiresCoherency and getDpgRequiresCoherencys"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        consistency_needs = ConsistencyNeeds(ar_root, "Needs")
+
+        data_group = consistency_needs.createDpgRequiresCoherency("Group")
+        assert isinstance(data_group, DataPrototypeGroup)
+        assert consistency_needs.getDpgRequiresCoherencys() == [data_group]
+
+
+class TestConsistencyNeedsRegDoesNotRequireStability:
+    def test_create_get(self):
+        """Test createRegDoesNotRequireStability and getRegDoesNotRequireStabilitys"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        consistency_needs = ConsistencyNeeds(ar_root, "Needs")
+
+        runnable_group = consistency_needs.createRegDoesNotRequireStability("Group")
+        assert isinstance(runnable_group, RunnableEntityGroup)
+        assert consistency_needs.getRegDoesNotRequireStabilitys() == [runnable_group]
+
+
+class TestConsistencyNeedsRegRequiresStability:
+    def test_create_get(self):
+        """Test createRegRequiresStability and getRegRequiresStabilitys"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        consistency_needs = ConsistencyNeeds(ar_root, "Needs")
+
+        runnable_group = consistency_needs.createRegRequiresStability("Group")
+        assert isinstance(runnable_group, RunnableEntityGroup)
+        assert consistency_needs.getRegRequiresStabilitys() == [runnable_group]

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/test_RunnableEntityGroup.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/test_RunnableEntityGroup.py
@@ -1,0 +1,88 @@
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpStructureElement
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import RunnableEntityGroup
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
+    InnerRunnableEntityGroupInCompositionInstanceRef,
+    RunnableEntityInCompositionInstanceRef,
+)
+
+
+class TestRunnableEntityGroupInitialization:
+    def test_initialization(self):
+        """Test RunnableEntityGroup __init__ defaults"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        runnable_group = RunnableEntityGroup(ar_root, "Group")
+
+        assert runnable_group is not None
+        assert isinstance(runnable_group, RunnableEntityGroup)
+        assert isinstance(runnable_group, AtpStructureElement)
+        assert runnable_group.getShortName() == "Group"
+        assert runnable_group.runnableEntityIRefs == []
+        assert runnable_group.runnableEntityGroupIRefs == []
+
+
+class TestRunnableEntityGroupRunnableEntity:
+    def test_add_get_runnable_entity_iref(self):
+        """Test addRunnableEntityIRef appends and returns self"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        runnable_group = RunnableEntityGroup(ar_root, "Group")
+
+        iref = RunnableEntityInCompositionInstanceRef()
+        result = runnable_group.addRunnableEntityIRef(iref)
+        assert result is runnable_group
+        assert runnable_group.getRunnableEntityIRefs() == [iref]
+
+    def test_add_runnable_entity_iref_none_is_noop(self):
+        """Test adding a None runnableEntity iref is a no-op"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        runnable_group = RunnableEntityGroup(ar_root, "Group")
+
+        runnable_group.addRunnableEntityIRef(None)
+        assert runnable_group.getRunnableEntityIRefs() == []
+
+    def test_add_multiple_runnable_entity_irefs(self):
+        """Test adding multiple runnableEntity irefs"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        runnable_group = RunnableEntityGroup(ar_root, "Group")
+
+        iref1 = RunnableEntityInCompositionInstanceRef()
+        iref2 = RunnableEntityInCompositionInstanceRef()
+        runnable_group.addRunnableEntityIRef(iref1).addRunnableEntityIRef(iref2)
+        assert runnable_group.getRunnableEntityIRefs() == [iref1, iref2]
+
+
+class TestRunnableEntityGroupRunnableEntityGroup:
+    def test_add_get_runnable_entity_group_iref(self):
+        """Test addRunnableEntityGroupIRef appends and returns self"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        runnable_group = RunnableEntityGroup(ar_root, "Group")
+
+        iref = InnerRunnableEntityGroupInCompositionInstanceRef()
+        result = runnable_group.addRunnableEntityGroupIRef(iref)
+        assert result is runnable_group
+        assert runnable_group.getRunnableEntityGroupIRefs() == [iref]
+
+    def test_add_runnable_entity_group_iref_none_is_noop(self):
+        """Test adding a None runnableEntityGroup iref is a no-op"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        runnable_group = RunnableEntityGroup(ar_root, "Group")
+
+        runnable_group.addRunnableEntityGroupIRef(None)
+        assert runnable_group.getRunnableEntityGroupIRefs() == []
+
+    def test_add_multiple_runnable_entity_group_irefs(self):
+        """Test adding multiple runnableEntityGroup irefs"""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        runnable_group = RunnableEntityGroup(ar_root, "Group")
+
+        iref1 = InnerRunnableEntityGroupInCompositionInstanceRef()
+        iref2 = InnerRunnableEntityGroupInCompositionInstanceRef()
+        runnable_group.addRunnableEntityGroupIRef(iref1).addRunnableEntityGroupIRef(iref2)
+        assert runnable_group.getRunnableEntityGroupIRefs() == [iref1, iref2]

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_SwComponentType.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_SwComponentType.py
@@ -11,6 +11,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import (
     PRPortPrototype,
     RPortPrototype,
 )
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import ConsistencyNeeds
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SoftwareComponentDocumentation import (
     SwComponentDocumentation,
 )
@@ -46,11 +47,19 @@ class TestSwComponentType:
     def test_initialization(self):
         obj = self._create_concrete()
         assert obj.getShortName() == "TestSwComponentType"
+        assert obj.getConsistencyNeeds() == []
         assert obj.getPorts() == []
         assert obj.getPortGroups() == []
         assert obj.getSwcMappingConstraintsRefs() == []
         assert obj.getSwComponentDocumentation() is None
         assert obj.getUnitGroupRefs() == []
+
+    def test_create_get_consistency_needs(self):
+        obj = self._create_concrete()
+        consistency_needs = obj.createConsistencyNeeds("ConsistencyNeeds")
+        assert isinstance(consistency_needs, ConsistencyNeeds)
+        assert consistency_needs in obj.getConsistencyNeeds()
+        assert obj.createConsistencyNeeds("ConsistencyNeeds") == consistency_needs
 
     def test_get_set_swComponentDocumentation(self):
         obj = self._create_concrete()

--- a/tests/test_armodel/writer/test_writer_consistency_needs.py
+++ b/tests/test_armodel/writer/test_writer_consistency_needs.py
@@ -1,0 +1,136 @@
+"""Tests for reading and writing ConsistencyNeeds elements."""
+
+import os
+import tempfile
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import (
+    ConsistencyNeeds,
+    DataPrototypeGroup,
+    RunnableEntityGroup,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
+    InnerRunnableEntityGroupInCompositionInstanceRef,
+    RunnableEntityInCompositionInstanceRef,
+    VariableDataPrototypeInCompositionInstanceRef,
+)
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+def make_ref(value: str, dest: str = "DATA-PROTOTYPE-GROUP") -> RefType:
+    ref = RefType()
+    ref.setValue(value)
+    ref.setDest(dest)
+    return ref
+
+
+def _build_document(consistency_needs: ConsistencyNeeds):
+    AUTOSAR.getInstance().setARRelease("R23-11")
+    document = AUTOSAR.getInstance()
+    document.clear()
+    ar_root = document.createARPackage("AUTOSAR")
+    ar_root.addElement(consistency_needs)
+    return document
+
+
+def _reload(file_path):
+    document_2 = AUTOSAR.getInstance()
+    document_2.clear()
+    ARXMLParser().load(file_path, document_2)
+    package = document_2.getARPackages()[0]
+    return next(element for element in package.elements if isinstance(element, ConsistencyNeeds))
+
+
+class TestWriteConsistencyNeeds:
+    def test_round_trip_populated(self):
+        """Test parse -> write -> re-parse of populated aggregation lists."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        consistency_needs = ConsistencyNeeds(ar_root, "ConsistencyNeeds")
+
+        dpg_not_coherent = consistency_needs.createDpgDoesNotRequireCoherency("DpgNotCoherent")
+        implicit_iref = VariableDataPrototypeInCompositionInstanceRef()
+        implicit_iref.addContextSwComponentPrototypeRef(make_ref("/Comp/A", "SW-COMPONENT-PROTOTYPE"))
+        implicit_iref.setContextPortPrototypeRef(make_ref("/Comp/A/PPort", "P-PORT-PROTOTYPE"))
+        implicit_iref.setTargetVariableDataPrototypeRef(make_ref("/Comp/A/PPort/Data", "VARIABLE-DATA-PROTOTYPE"))
+        dpg_not_coherent.addImplicitDataAccessIRef(implicit_iref)
+
+        dpg_coherent = consistency_needs.createDpgRequiresCoherency("DpgCoherent")
+
+        reg_not_stable = consistency_needs.createRegDoesNotRequireStability("RegNotStable")
+        runnable_iref = RunnableEntityInCompositionInstanceRef()
+        runnable_iref.addContextSwComponentPrototypeRef(make_ref("/Comp/A", "SW-COMPONENT-PROTOTYPE"))
+        runnable_iref.setTargetRunnableEntityRef(make_ref("/Comp/A/Runnable", "RUNNABLE-ENTITY"))
+        reg_not_stable.addRunnableEntityIRef(runnable_iref)
+
+        reg_stable = consistency_needs.createRegRequiresStability("RegStable")
+        inner_iref = InnerRunnableEntityGroupInCompositionInstanceRef()
+        inner_iref.addContextSwComponentPrototypeRef(make_ref("/Comp/A", "SW-COMPONENT-PROTOTYPE"))
+        inner_iref.setTargetRunnableEntityGroupRef(make_ref("/Comp/A/Group"))
+        reg_stable.addRunnableEntityGroupIRef(inner_iref)
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, _build_document(consistency_needs))
+            consistency_needs_2 = _reload(file_path)
+            assert consistency_needs_2.getShortName() == "ConsistencyNeeds"
+
+            dpg_not_coherent_2 = consistency_needs_2.getDpgDoesNotRequireCoherencys()
+            assert len(dpg_not_coherent_2) == 1
+            assert isinstance(dpg_not_coherent_2[0], DataPrototypeGroup)
+            assert dpg_not_coherent_2[0].getShortName() == "DpgNotCoherent"
+            implicit_refs = dpg_not_coherent_2[0].getImplicitDataAccessIRefs()
+            assert len(implicit_refs) == 1
+            assert implicit_refs[0].getTargetVariableDataPrototypeRef().getValue() == "/Comp/A/PPort/Data"
+
+            dpg_coherent_2 = consistency_needs_2.getDpgRequiresCoherencys()
+            assert len(dpg_coherent_2) == 1
+            assert isinstance(dpg_coherent_2[0], DataPrototypeGroup)
+            assert dpg_coherent_2[0].getShortName() == "DpgCoherent"
+
+            reg_not_stable_2 = consistency_needs_2.getRegDoesNotRequireStabilitys()
+            assert len(reg_not_stable_2) == 1
+            assert isinstance(reg_not_stable_2[0], RunnableEntityGroup)
+            assert reg_not_stable_2[0].getShortName() == "RegNotStable"
+            runnable_refs = reg_not_stable_2[0].getRunnableEntityIRefs()
+            assert len(runnable_refs) == 1
+            assert runnable_refs[0].getTargetRunnableEntityRef().getValue() == "/Comp/A/Runnable"
+
+            reg_stable_2 = consistency_needs_2.getRegRequiresStabilitys()
+            assert len(reg_stable_2) == 1
+            assert isinstance(reg_stable_2[0], RunnableEntityGroup)
+            assert reg_stable_2[0].getShortName() == "RegStable"
+            inner_refs = reg_stable_2[0].getRunnableEntityGroupIRefs()
+            assert len(inner_refs) == 1
+            assert inner_refs[0].getTargetRunnableEntityGroupRef().getValue() == "/Comp/A/Group"
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+    def test_round_trip_unset_emits_no_wrappers(self):
+        """Test empty aggregation lists round-trip to no wrapper elements."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        consistency_needs = ConsistencyNeeds(ar_root, "ConsistencyNeeds")
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, _build_document(consistency_needs))
+            with open(file_path, "r", encoding="utf-8") as file_handle:
+                content = file_handle.read()
+            assert "DPG-DOES-NOT-REQUIRE-COHERENCYS" not in content
+            assert "DPG-REQUIRES-COHERENCYS" not in content
+            assert "REG-DOES-NOT-REQUIRE-STABILITYS" not in content
+            assert "REG-REQUIRES-STABILITYS" not in content
+
+            consistency_needs_2 = _reload(file_path)
+            assert consistency_needs_2.getShortName() == "ConsistencyNeeds"
+            assert consistency_needs_2.getDpgDoesNotRequireCoherencys() == []
+            assert consistency_needs_2.getDpgRequiresCoherencys() == []
+            assert consistency_needs_2.getRegDoesNotRequireStabilitys() == []
+            assert consistency_needs_2.getRegRequiresStabilitys() == []
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)

--- a/tests/test_armodel/writer/test_writer_consistency_needs.py
+++ b/tests/test_armodel/writer/test_writer_consistency_needs.py
@@ -57,7 +57,7 @@ class TestWriteConsistencyNeeds:
         implicit_iref.setTargetVariableDataPrototypeRef(make_ref("/Comp/A/PPort/Data", "VARIABLE-DATA-PROTOTYPE"))
         dpg_not_coherent.addImplicitDataAccessIRef(implicit_iref)
 
-        dpg_coherent = consistency_needs.createDpgRequiresCoherency("DpgCoherent")
+        consistency_needs.createDpgRequiresCoherency("DpgCoherent")
 
         reg_not_stable = consistency_needs.createRegDoesNotRequireStability("RegNotStable")
         runnable_iref = RunnableEntityInCompositionInstanceRef()

--- a/tests/test_armodel/writer/test_writer_runnable_entity_group.py
+++ b/tests/test_armodel/writer/test_writer_runnable_entity_group.py
@@ -1,0 +1,96 @@
+"""Tests for reading and writing RunnableEntityGroup elements."""
+
+import os
+import tempfile
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import RunnableEntityGroup
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior.InstanceRefs import (
+    InnerRunnableEntityGroupInCompositionInstanceRef,
+    RunnableEntityInCompositionInstanceRef,
+)
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+def make_ref(value: str, dest: str = "RUNNABLE-ENTITY-GROUP") -> RefType:
+    ref = RefType()
+    ref.setValue(value)
+    ref.setDest(dest)
+    return ref
+
+
+def _build_document(group: RunnableEntityGroup):
+    AUTOSAR.getInstance().setARRelease("R23-11")
+    document = AUTOSAR.getInstance()
+    document.clear()
+    ar_root = document.createARPackage("AUTOSAR")
+    ar_root.addElement(group)
+    return document
+
+
+def _reload(file_path):
+    document_2 = AUTOSAR.getInstance()
+    document_2.clear()
+    ARXMLParser().load(file_path, document_2)
+    package = document_2.getARPackages()[0]
+    return next(element for element in package.elements if isinstance(element, RunnableEntityGroup))
+
+
+class TestWriteRunnableEntityGroup:
+    def test_round_trip_populated(self):
+        """Test parse -> write -> re-parse of populated runnableEntityIRefs and runnableEntityGroupIRefs."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        group = RunnableEntityGroup(ar_root, "RunnableGroup")
+
+        inner_iref = InnerRunnableEntityGroupInCompositionInstanceRef()
+        inner_iref.addContextSwComponentPrototypeRef(make_ref("/Comp/A", "SW-COMPONENT-PROTOTYPE"))
+        inner_iref.addContextSwComponentPrototypeRef(make_ref("/Comp/B", "SW-COMPONENT-PROTOTYPE"))
+        inner_iref.setTargetRunnableEntityGroupRef(make_ref("/Comp/A/Group"))
+        group.addRunnableEntityGroupIRef(inner_iref)
+
+        runnable_iref = RunnableEntityInCompositionInstanceRef()
+        runnable_iref.addContextSwComponentPrototypeRef(make_ref("/Comp/A", "SW-COMPONENT-PROTOTYPE"))
+        runnable_iref.setTargetRunnableEntityRef(make_ref("/Comp/A/Runnable", "RUNNABLE-ENTITY"))
+        group.addRunnableEntityIRef(runnable_iref)
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, _build_document(group))
+            group_2 = _reload(file_path)
+            assert group_2.getShortName() == "RunnableGroup"
+            inner_refs = group_2.getRunnableEntityGroupIRefs()
+            assert len(inner_refs) == 1
+            assert [r.getValue() for r in inner_refs[0].getContextSwComponentPrototypeRefs()] == ["/Comp/A", "/Comp/B"]
+            assert inner_refs[0].getTargetRunnableEntityGroupRef().getValue() == "/Comp/A/Group"
+            runnable_refs = group_2.getRunnableEntityIRefs()
+            assert len(runnable_refs) == 1
+            assert [r.getValue() for r in runnable_refs[0].getContextSwComponentPrototypeRefs()] == ["/Comp/A"]
+            assert runnable_refs[0].getTargetRunnableEntityRef().getValue() == "/Comp/A/Runnable"
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+    def test_round_trip_unset_emits_no_wrappers(self):
+        """Test empty iref lists round-trip to no wrapper elements."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        group = RunnableEntityGroup(ar_root, "RunnableGroup")
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, _build_document(group))
+            with open(file_path, "r", encoding="utf-8") as file_handle:
+                content = file_handle.read()
+            assert "RUNNABLE-ENTITY-GROUP-IREFS" not in content
+            assert "RUNNABLE-ENTITY-IREFS" not in content
+
+            group_2 = _reload(file_path)
+            assert group_2.getShortName() == "RunnableGroup"
+            assert group_2.getRunnableEntityGroupIRefs() == []
+            assert group_2.getRunnableEntityIRefs() == []
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)

--- a/tests/test_armodel/writer/test_writer_sw_component.py
+++ b/tests/test_armodel/writer/test_writer_sw_component.py
@@ -790,6 +790,9 @@ class TestSwComponentTypeRoundTrip:
         app.addSwcMappingConstraintRef(_ref("/Mapping/Const1"))
         app.addSwcMappingConstraintRef(_ref("/Mapping/Const2"))
         app.addUnitGroupRef(_ref("/Units/Group1"))
+        consistency_needs = app.createConsistencyNeeds("Needs")
+        consistency_needs.createDpgRequiresCoherency("DpgGroup")
+        consistency_needs.createRegRequiresStability("RegGroup")
 
         out_file = tmp_path / "sw_component_type_out.arxml"
         ARXMLWriter().save(str(out_file), document)
@@ -809,6 +812,11 @@ class TestSwComponentTypeRoundTrip:
         assert len(swc.getPortGroups()) == 1
         assert [r.getValue() for r in swc.getSwcMappingConstraintsRefs()] == ["/Mapping/Const1", "/Mapping/Const2"]
         assert [r.getValue() for r in swc.getUnitGroupRefs()] == ["/Units/Group1"]
+        assert len(swc.getConsistencyNeeds()) == 1
+        consistency_needs_2 = swc.getConsistencyNeeds()[0]
+        assert consistency_needs_2.getShortName() == "Needs"
+        assert len(consistency_needs_2.getDpgRequiresCoherencys()) == 1
+        assert len(consistency_needs_2.getRegRequiresStabilitys()) == 1
 
     def test_round_trip_empty_refs(self, tmp_path):
         document = AUTOSAR.getInstance()


### PR DESCRIPTION
## Summary

Syncs AUTOSAR model classes against their PDF spec tables via the sync-autosar-class workflow.

## Changes

- **RunnableEntityGroup** (Table 4.100, p.223, `AtpStructureElement` base): `runnableEntityIRefs` + `runnableEntityGroupIRefs` with add/get accessors, reader/writer, ARPackage factory, model + round-trip tests. All classes stamped `# Spec verified: R23-11`.
- **ConsistencyNeeds** (Table 4.99, p.222, `AtpBlueprintable` base): dpg/reg coherency-stability aggregation lists with create/get accessors, reader/writer, ARPackage factory, model + round-trip tests
- **SwComponentType** (Table 3.1, p.64): added `consistencyNeeds` field + `createConsistencyNeeds`/`getConsistencyNeeds` (first in display order); reader/writer reordered to XSD sequenceOffset order (`SW-COMPONENT-DOCUMENTATIONS` → `CONSISTENCY-NEEDSS` → `PORTS` → `PORT-GROUPS` → `SWC-MAPPING-CONSTRAINT-REFS` → `UNIT-GROUP-REFS`)
- **NmCoordinatorRoleEnum**: Enum value container fix (tuple → list)

## Verification

- 6016/6016 tests pass (incl. integration round-trip)
- `black-check` and `flake8` clean
- ARPackage-level parse → write → re-parse verified

Closes #591