### PR TITLE
feat: sync J1939NmNode class to R23-11 spec

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
@@ -394,18 +394,291 @@ class FlexrayNmNode(NmNode):
         super().__init__(parent, short_name)
 
 
-class J1939NmNode(NmNode):
+class J1939NmAddressConfigurationCapabilityEnum(AREnum):
     """
-    Represents a J1939 network management node in the system,
-    defining J1939-specific NM properties for heavy-duty
-    vehicle network management communication.
+    Defines the Address Configuration Capability options for the J1939NmNode.
     """
 
+    # Spec verified: R23-11
+    # J1939NmAddressConfigurationCapabilityEnum method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.322, p.692
+    # (no methods)
+
+    # Arbitrary Address Capable CA Tags: atp.EnumerationLiteralIndex=4 xml.name=J-1939-NM-AAC
+    J1939NM_AAC = "J-1939-NM-AAC"
+
+    # Command Configurable Address CA. Tags: atp.EnumerationLiteralIndex=3 xml.name=J-1939-NM-CCA
+    J1939NM_CCA = "J-1939-NM-CCA"
+
+    # Non-Configurable Address CA. Tags: atp.EnumerationLiteralIndex=0 xml.name=J-1939-NM-NCA
+    J1939NM_NCA = "J-1939-NM-NCA"
+
+    # Self-Configurable Address CA. Tags: atp.EnumerationLiteralIndex=2 xml.name=J-1939-NM-SCA
+    J1939NM_SCA = "J-1939-NM-SCA"
+
+    # Service Configurable Address CA. Tags: atp.EnumerationLiteralIndex=1 xml.name=J-1939-NM-SVCA
+    J1939NM_SVCA = "J-1939-NM-SVCA"
+
+    def __init__(self):
+        super().__init__(
+            (
+                J1939NmAddressConfigurationCapabilityEnum.J1939NM_AAC,
+                J1939NmAddressConfigurationCapabilityEnum.J1939NM_CCA,
+                J1939NmAddressConfigurationCapabilityEnum.J1939NM_NCA,
+                J1939NmAddressConfigurationCapabilityEnum.J1939NM_SCA,
+                J1939NmAddressConfigurationCapabilityEnum.J1939NM_SVCA,
+            )
+        )
+
+
+class J1939NodeName(ARObject):
+    """
+    This element contains attributes to configure the J1939NmNode NAME.
+    """
+
+    # Spec verified: R23-11
+    # J1939NodeName method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.321, p.691
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                                          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getArbitraryAddressCapable                        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setArbitraryAddressCapable                        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getEcuInstance                                    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setEcuInstance                                    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFunction                                       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFunction                                       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFunctionInstance                               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFunctionInstance                               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getIdentitiyNumber                                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIdentitiyNumber                                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getIndustryGroup                                  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIndustryGroup                                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getManufacturerCode                               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setManufacturerCode                               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getVehicleSystem                                  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setVehicleSystem                                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getVehicleSystemInstance                          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setVehicleSystemInstance                          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # Arbitrary Address Capable field of the NAME of this node.
+        self.arbitraryAddressCapable: Optional[Boolean] = None
+
+        # ECU Instance field of the NAME of this node.
+        self.ecuInstance: Optional[Integer] = None
+
+        # Function field of the NAME of this node.
+        self.function: Optional[Integer] = None
+
+        # Function Instance field of the NAME of this node.
+        self.functionInstance: Optional[Integer] = None
+
+        # Identity Number field of the NAME of this node.
+        self.identitiyNumber: Optional[Integer] = None
+
+        # Industry Group field of the NAME of this node.
+        self.industryGroup: Optional[Integer] = None
+
+        # Manufacturer Code field of the NAME of this node.
+        self.manufacturerCode: Optional[Integer] = None
+
+        # Vehicle System field of the NAME of this node.
+        self.vehicleSystem: Optional[Integer] = None
+
+        # Vehicle System Instance field of the NAME of this node.
+        self.vehicleSystemInstance: Optional[Integer] = None
+
+    def getArbitraryAddressCapable(self) -> Optional[Boolean]:
+        """
+        Arbitrary Address Capable field of the NAME of this node.
+        """
+        return self.arbitraryAddressCapable
+
+    def setArbitraryAddressCapable(self, value: Optional[Boolean]) -> "J1939NodeName":
+        """
+        Arbitrary Address Capable field of the NAME of this node.
+        A None value is a no-op and does not overwrite an existing arbitraryAddressCapable.
+        """
+        if value is not None:
+            self.arbitraryAddressCapable = value
+        return self
+
+    def getEcuInstance(self) -> Optional[Integer]:
+        """
+        ECU Instance field of the NAME of this node.
+        """
+        return self.ecuInstance
+
+    def setEcuInstance(self, value: Optional[Integer]) -> "J1939NodeName":
+        """
+        ECU Instance field of the NAME of this node.
+        A None value is a no-op and does not overwrite an existing ecuInstance.
+        """
+        if value is not None:
+            self.ecuInstance = value
+        return self
+
+    def getFunction(self) -> Optional[Integer]:
+        """
+        Function field of the NAME of this node.
+        """
+        return self.function
+
+    def setFunction(self, value: Optional[Integer]) -> "J1939NodeName":
+        """
+        Function field of the NAME of this node.
+        A None value is a no-op and does not overwrite an existing function.
+        """
+        if value is not None:
+            self.function = value
+        return self
+
+    def getFunctionInstance(self) -> Optional[Integer]:
+        """
+        Function Instance field of the NAME of this node.
+        """
+        return self.functionInstance
+
+    def setFunctionInstance(self, value: Optional[Integer]) -> "J1939NodeName":
+        """
+        Function Instance field of the NAME of this node.
+        A None value is a no-op and does not overwrite an existing functionInstance.
+        """
+        if value is not None:
+            self.functionInstance = value
+        return self
+
+    def getIdentitiyNumber(self) -> Optional[Integer]:
+        """
+        Identity Number field of the NAME of this node.
+        """
+        return self.identitiyNumber
+
+    def setIdentitiyNumber(self, value: Optional[Integer]) -> "J1939NodeName":
+        """
+        Identity Number field of the NAME of this node.
+        A None value is a no-op and does not overwrite an existing identitiyNumber.
+        """
+        if value is not None:
+            self.identitiyNumber = value
+        return self
+
+    def getIndustryGroup(self) -> Optional[Integer]:
+        """
+        Industry Group field of the NAME of this node.
+        """
+        return self.industryGroup
+
+    def setIndustryGroup(self, value: Optional[Integer]) -> "J1939NodeName":
+        """
+        Industry Group field of the NAME of this node.
+        A None value is a no-op and does not overwrite an existing industryGroup.
+        """
+        if value is not None:
+            self.industryGroup = value
+        return self
+
+    def getManufacturerCode(self) -> Optional[Integer]:
+        """
+        Manufacturer Code field of the NAME of this node.
+        """
+        return self.manufacturerCode
+
+    def setManufacturerCode(self, value: Optional[Integer]) -> "J1939NodeName":
+        """
+        Manufacturer Code field of the NAME of this node.
+        A None value is a no-op and does not overwrite an existing manufacturerCode.
+        """
+        if value is not None:
+            self.manufacturerCode = value
+        return self
+
+    def getVehicleSystem(self) -> Optional[Integer]:
+        """
+        Vehicle System field of the NAME of this node.
+        """
+        return self.vehicleSystem
+
+    def setVehicleSystem(self, value: Optional[Integer]) -> "J1939NodeName":
+        """
+        Vehicle System field of the NAME of this node.
+        A None value is a no-op and does not overwrite an existing vehicleSystem.
+        """
+        if value is not None:
+            self.vehicleSystem = value
+        return self
+
+    def getVehicleSystemInstance(self) -> Optional[Integer]:
+        """
+        Vehicle System Instance field of the NAME of this node.
+        """
+        return self.vehicleSystemInstance
+
+    def setVehicleSystemInstance(self, value: Optional[Integer]) -> "J1939NodeName":
+        """
+        Vehicle System Instance field of the NAME of this node.
+        A None value is a no-op and does not overwrite an existing vehicleSystemInstance.
+        """
+        if value is not None:
+            self.vehicleSystemInstance = value
+        return self
+
+
+class J1939NmNode(NmNode):
+    """
+    J1939 specific NM Node attributes.
+    """
+
+    # Spec verified: R23-11
     # J1939NmNode method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.320, p.691
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                                          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getAddressConfigurationCapability                 [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setAddressConfigurationCapability                 [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getNodeName                                       [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setNodeName                                       [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
+
+        # Defines the Address Configuration Capability of the J1939NmNode (corresponding to an SAE J1939 Controller Application, CA).
+        self.addressConfigurationCapability: Optional[J1939NmAddressConfigurationCapabilityEnum] = None
+
+        # NodeName configuration.
+        self.nodeName: Optional[J1939NodeName] = None
+
+    def getAddressConfigurationCapability(self) -> Optional[J1939NmAddressConfigurationCapabilityEnum]:
+        """
+        Defines the Address Configuration Capability of the J1939NmNode (corresponding to an SAE J1939 Controller Application, CA).
+        """
+        return self.addressConfigurationCapability
+
+    def setAddressConfigurationCapability(self, value: Optional[J1939NmAddressConfigurationCapabilityEnum]) -> "J1939NmNode":
+        """
+        Defines the Address Configuration Capability of the J1939NmNode (corresponding to an SAE J1939 Controller Application, CA).
+        A None value is a no-op and does not overwrite an existing addressConfigurationCapability.
+        """
+        if value is not None:
+            self.addressConfigurationCapability = value
+        return self
+
+    def getNodeName(self) -> Optional[J1939NodeName]:
+        """
+        NodeName configuration.
+        """
+        return self.nodeName
+
+    def setNodeName(self, value: Optional[J1939NodeName]) -> "J1939NmNode":
+        """
+        NodeName configuration.
+        A None value is a no-op and does not overwrite an existing nodeName.
+        """
+        if value is not None:
+            self.nodeName = value
+        return self
 
 
 class UdpNmNode(NmNode):
@@ -766,8 +1039,10 @@ class NmCluster(Identifiable, ABC):
     # [ ] setNmChannelSleepMaster      [x] impl  [ ] docstring  [ ] test
     # [ ] createCanNmNode              [x] impl  [ ] docstring  [ ] test
     # [ ] readUdpNmNode                [x] impl  [ ] docstring  [ ] test
+    # [ ] createJ1939NmNode            [x] impl  [ ] docstring  [ ] test
     # [ ] getCanNmNodes                [x] impl  [ ] docstring  [ ] test
     # [ ] getUdpNmNodes                [x] impl  [ ] docstring  [ ] test
+    # [ ] getJ1939NmNodes              [x] impl  [ ] docstring  [ ] test
     # [ ] getNmNodes                   [x] impl  [ ] docstring  [ ] test
     # [ ] getNmNodeDetectionEnabled    [x] impl  [ ] docstring  [ ] test
     # [ ] setNmNodeDetectionEnabled    [x] impl  [ ] docstring  [ ] test
@@ -830,11 +1105,21 @@ class NmCluster(Identifiable, ABC):
             self.nmNodes.append(node)
         return self.getElement(short_name)
 
+    def createJ1939NmNode(self, short_name: str) -> J1939NmNode:
+        if short_name not in self.elements:
+            node = J1939NmNode(self, short_name)
+            self.addElement(node)
+            self.nmNodes.append(node)
+        return self.getElement(short_name)
+
     def getCanNmNodes(self) -> List[CanNmNode]:
         return list(sorted(filter(lambda a: isinstance(a, CanNmNode), self.elements), key=lambda o: o.short_name))
 
     def getUdpNmNodes(self) -> List[UdpNmNode]:
         return list(sorted(filter(lambda a: isinstance(a, UdpNmNode), self.elements), key=lambda o: o.short_name))
+
+    def getJ1939NmNodes(self) -> List[J1939NmNode]:
+        return list(sorted(filter(lambda a: isinstance(a, J1939NmNode), self.elements), key=lambda o: o.short_name))
 
     def getNmNodes(self) -> List[NmNode]:
         return list(sorted(filter(lambda a: isinstance(a, NmNode), self.elements), key=lambda o: o.short_name))

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -487,6 +487,8 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import 
     CanNmCluster,
     CanNmClusterCoupling,
     CanNmNode,
+    J1939NmNode,
+    J1939NodeName,
     NmCluster,
     NmConfig,
     NmEcu,
@@ -609,6 +611,22 @@ class ARXMLParser(AbstractARXMLParser):
             range.setLowerCanId(self.getChildElementOptionalNumericalValue(child_element, "LOWER-CAN-ID"))
             range.setUpperCanId(self.getChildElementOptionalNumericalValue(child_element, "UPPER-CAN-ID"))
         return range
+
+    def getChildElementJ1939NodeName(self, element: ET.Element, key: str) -> J1939NodeName:
+        child_element = self.find(element, key)
+        node_name = None
+        if child_element is not None:
+            node_name = J1939NodeName()
+            node_name.setArbitraryAddressCapable(self.getChildElementOptionalBooleanValue(child_element, "ARBITRARY-ADDRESS-CAPABLE"))
+            node_name.setEcuInstance(self.getChildElementOptionalIntegerValue(child_element, "ECU-INSTANCE"))
+            node_name.setFunction(self.getChildElementOptionalIntegerValue(child_element, "FUNCTION"))
+            node_name.setFunctionInstance(self.getChildElementOptionalIntegerValue(child_element, "FUNCTION-INSTANCE"))
+            node_name.setIdentitiyNumber(self.getChildElementOptionalIntegerValue(child_element, "IDENTITIY-NUMBER"))
+            node_name.setIndustryGroup(self.getChildElementOptionalIntegerValue(child_element, "INDUSTRY-GROUP"))
+            node_name.setManufacturerCode(self.getChildElementOptionalIntegerValue(child_element, "MANUFACTURER-CODE"))
+            node_name.setVehicleSystem(self.getChildElementOptionalIntegerValue(child_element, "VEHICLE-SYSTEM"))
+            node_name.setVehicleSystemInstance(self.getChildElementOptionalIntegerValue(child_element, "VEHICLE-SYSTEM-INSTANCE"))
+        return node_name
 
     def readSd(self, element: ET.Element, sdg: Sdg):
         for child_element in self.findall(element, "./SD"):
@@ -5896,6 +5914,12 @@ class ARXMLParser(AbstractARXMLParser):
         self.readNmNode(element, nm_node)
         nm_node.setNmMsgCycleOffset(self.getChildElementOptionalTimeValue(element, "NM-MSG-CYCLE-OFFSET"))
 
+    def readJ1939NmNode(self, element: ET.Element, nm_node: J1939NmNode):
+        self.logger.debug("Read J1939NmNode <%s>" % nm_node.getShortName())
+        self.readNmNode(element, nm_node)
+        nm_node.setAddressConfigurationCapability(self.getChildElementOptionalLiteral(element, "ADDRESS-CONFIGURATION-CAPABILITY"))
+        nm_node.setNodeName(self.getChildElementJ1939NodeName(element, "NODE-NAME"))
+
     def readNmClusterNmNodes(self, element: ET.Element, cluster: NmCluster):
         self.logger.debug("readNmConfigNmNodes %s" % cluster.getShortName())
         for child_element in self.findall(element, "NM-NODES/*"):
@@ -5906,6 +5930,9 @@ class ARXMLParser(AbstractARXMLParser):
             elif tag_name == "UDP-NM-NODE":
                 nm_node = cluster.readUdpNmNode(self.getShortName(child_element))
                 self.readUdpNmNode(child_element, nm_node)
+            elif tag_name == "J-1939-NM-NODE":
+                nm_node = cluster.createJ1939NmNode(self.getShortName(child_element))
+                self.readJ1939NmNode(child_element, nm_node)
             else:
                 self.notImplemented("Unsupported Nm Node <%s>" % tag_name)
 

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -475,6 +475,8 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import 
     CanNmCluster,
     CanNmClusterCoupling,
     CanNmNode,
+    J1939NmNode,
+    J1939NodeName,
     NmCluster,
     NmConfig,
     NmEcu,
@@ -593,6 +595,19 @@ class ARXMLWriter(AbstractARXMLWriter):
             child_element = ET.SubElement(element, key)
             self.setChildElementOptionalNumericalValue(child_element, "LOWER-CAN-ID", range.getLowerCanId())
             self.setChildElementOptionalNumericalValue(child_element, "UPPER-CAN-ID", range.getUpperCanId())
+
+    def setChildElementJ1939NodeName(self, element: ET.Element, key: str, node_name: J1939NodeName):
+        if node_name is not None:
+            child_element = ET.SubElement(element, key)
+            self.setChildElementOptionalBooleanValue(child_element, "ARBITRARY-ADDRESS-CAPABLE", node_name.getArbitraryAddressCapable())
+            self.setChildElementOptionalIntegerValue(child_element, "ECU-INSTANCE", node_name.getEcuInstance())
+            self.setChildElementOptionalIntegerValue(child_element, "FUNCTION", node_name.getFunction())
+            self.setChildElementOptionalIntegerValue(child_element, "FUNCTION-INSTANCE", node_name.getFunctionInstance())
+            self.setChildElementOptionalIntegerValue(child_element, "IDENTITIY-NUMBER", node_name.getIdentitiyNumber())
+            self.setChildElementOptionalIntegerValue(child_element, "INDUSTRY-GROUP", node_name.getIndustryGroup())
+            self.setChildElementOptionalIntegerValue(child_element, "MANUFACTURER-CODE", node_name.getManufacturerCode())
+            self.setChildElementOptionalIntegerValue(child_element, "VEHICLE-SYSTEM", node_name.getVehicleSystem())
+            self.setChildElementOptionalIntegerValue(child_element, "VEHICLE-SYSTEM-INSTANCE", node_name.getVehicleSystemInstance())
 
     def writeSds(self, parent: ET.Element, sdg: Sdg):
         for sd in sdg.getSds():
@@ -4963,6 +4978,13 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.writeNmNode(child_element, nm_node)
         self.setChildElementOptionalTimeValue(child_element, "NM-MSG-CYCLE-OFFSET", nm_node.getNmMsgCycleOffset())
 
+    def writeJ1939NmNode(self, element: ET.Element, nm_node: J1939NmNode):
+        self.logger.debug("write J1939NmNode %s" % nm_node.getShortName())
+        child_element = ET.SubElement(element, "J-1939-NM-NODE")
+        self.writeNmNode(child_element, nm_node)
+        self.setChildElementOptionalLiteral(child_element, "ADDRESS-CONFIGURATION-CAPABILITY", nm_node.getAddressConfigurationCapability())
+        self.setChildElementJ1939NodeName(child_element, "NODE-NAME", nm_node.getNodeName())
+
     def writeNmClusterNmNodes(self, element: ET.Element, parent: NmCluster):
         nodes = parent.getNmNodes()
         if len(nodes) > 0:
@@ -4972,6 +4994,8 @@ class ARXMLWriter(AbstractARXMLWriter):
                     self.writeCanNmNode(child_element, node)
                 elif isinstance(node, UdpNmNode):
                     self.writeUdpNmNode(child_element, node)
+                elif isinstance(node, J1939NmNode):
+                    self.writeJ1939NmNode(child_element, node)
                 else:
                     self.notImplemented("Unsupported Nm Node <%s>" % type(node))
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/test_NetworkManagement.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/test_NetworkManagement.py
@@ -12,9 +12,11 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import 
     FlexrayNmClusterCoupling,
     FlexrayNmEcu,
     FlexrayNmNode,
+    J1939NmAddressConfigurationCapabilityEnum,
     J1939NmCluster,
     J1939NmEcu,
     J1939NmNode,
+    J1939NodeName,
     NmClusterCoupling,
     NmConfig,
     NmCoordinatorRoleEnum,
@@ -910,3 +912,174 @@ class Test_NmCoordinatorRoleEnum:
         enum = NmCoordinatorRoleEnum()
         enum.setValue(NmCoordinatorRoleEnum.ACTIVE)
         assert enum.getValue() == "active"
+
+
+class Test_J1939NmAddressConfigurationCapabilityEnum:
+    """Spec-driven tests for the J1939NmAddressConfigurationCapabilityEnum."""
+
+    def test_members(self):
+        """The five literals exist with the serialized XML form as value."""
+        enum = J1939NmAddressConfigurationCapabilityEnum()
+        values = enum.getEnumValues()
+        assert J1939NmAddressConfigurationCapabilityEnum.J1939NM_AAC == "J-1939-NM-AAC"
+        assert J1939NmAddressConfigurationCapabilityEnum.J1939NM_CCA == "J-1939-NM-CCA"
+        assert J1939NmAddressConfigurationCapabilityEnum.J1939NM_NCA == "J-1939-NM-NCA"
+        assert J1939NmAddressConfigurationCapabilityEnum.J1939NM_SCA == "J-1939-NM-SCA"
+        assert J1939NmAddressConfigurationCapabilityEnum.J1939NM_SVCA == "J-1939-NM-SVCA"
+        assert J1939NmAddressConfigurationCapabilityEnum.J1939NM_AAC in values
+        assert J1939NmAddressConfigurationCapabilityEnum.J1939NM_CCA in values
+        assert J1939NmAddressConfigurationCapabilityEnum.J1939NM_NCA in values
+        assert J1939NmAddressConfigurationCapabilityEnum.J1939NM_SCA in values
+        assert J1939NmAddressConfigurationCapabilityEnum.J1939NM_SVCA in values
+
+    def test_set_value(self):
+        """Value assignment with a typed enum instance."""
+        enum = J1939NmAddressConfigurationCapabilityEnum()
+        enum.setValue(J1939NmAddressConfigurationCapabilityEnum.J1939NM_AAC)
+        assert enum.getValue() == "J-1939-NM-AAC"
+
+
+class TestJ1939NodeName:
+    """Spec-driven tests for the J1939NodeName class."""
+
+    def _make_node_name(self):
+        return J1939NodeName()
+
+    def test_initialization(self):
+        """All J1939NodeName fields default to None."""
+        node_name = self._make_node_name()
+        assert node_name.getArbitraryAddressCapable() is None
+        assert node_name.getEcuInstance() is None
+        assert node_name.getFunction() is None
+        assert node_name.getFunctionInstance() is None
+        assert node_name.getIdentitiyNumber() is None
+        assert node_name.getIndustryGroup() is None
+        assert node_name.getManufacturerCode() is None
+        assert node_name.getVehicleSystem() is None
+        assert node_name.getVehicleSystemInstance() is None
+
+    def test_get_set_arbitrary_address_capable(self):
+        """arbitraryAddressCapable get/set with chaining and None no-op."""
+        node_name = self._make_node_name()
+        value = Boolean()
+        value.setValue(True)
+        assert node_name == node_name.setArbitraryAddressCapable(value)
+        assert node_name.getArbitraryAddressCapable() == value
+        assert node_name == node_name.setArbitraryAddressCapable(None)
+        assert node_name.getArbitraryAddressCapable() == value
+
+    def test_get_set_ecu_instance(self):
+        """ecuInstance get/set with chaining and None no-op."""
+        node_name = self._make_node_name()
+        value = Integer()
+        value.setValue(3)
+        assert node_name == node_name.setEcuInstance(value)
+        assert node_name.getEcuInstance() == value
+        assert node_name == node_name.setEcuInstance(None)
+        assert node_name.getEcuInstance() == value
+
+    def test_get_set_function(self):
+        """function get/set with chaining and None no-op."""
+        node_name = self._make_node_name()
+        value = Integer()
+        value.setValue(128)
+        assert node_name == node_name.setFunction(value)
+        assert node_name.getFunction() == value
+        assert node_name == node_name.setFunction(None)
+        assert node_name.getFunction() == value
+
+    def test_get_set_function_instance(self):
+        """functionInstance get/set with chaining and None no-op."""
+        node_name = self._make_node_name()
+        value = Integer()
+        value.setValue(4)
+        assert node_name == node_name.setFunctionInstance(value)
+        assert node_name.getFunctionInstance() == value
+        assert node_name == node_name.setFunctionInstance(None)
+        assert node_name.getFunctionInstance() == value
+
+    def test_get_set_identitiy_number(self):
+        """identitiyNumber get/set with chaining and None no-op."""
+        node_name = self._make_node_name()
+        value = Integer()
+        value.setValue(1234)
+        assert node_name == node_name.setIdentitiyNumber(value)
+        assert node_name.getIdentitiyNumber() == value
+        assert node_name == node_name.setIdentitiyNumber(None)
+        assert node_name.getIdentitiyNumber() == value
+
+    def test_get_set_industry_group(self):
+        """industryGroup get/set with chaining and None no-op."""
+        node_name = self._make_node_name()
+        value = Integer()
+        value.setValue(7)
+        assert node_name == node_name.setIndustryGroup(value)
+        assert node_name.getIndustryGroup() == value
+        assert node_name == node_name.setIndustryGroup(None)
+        assert node_name.getIndustryGroup() == value
+
+    def test_get_set_manufacturer_code(self):
+        """manufacturerCode get/set with chaining and None no-op."""
+        node_name = self._make_node_name()
+        value = Integer()
+        value.setValue(305)
+        assert node_name == node_name.setManufacturerCode(value)
+        assert node_name.getManufacturerCode() == value
+        assert node_name == node_name.setManufacturerCode(None)
+        assert node_name.getManufacturerCode() == value
+
+    def test_get_set_vehicle_system(self):
+        """vehicleSystem get/set with chaining and None no-op."""
+        node_name = self._make_node_name()
+        value = Integer()
+        value.setValue(2)
+        assert node_name == node_name.setVehicleSystem(value)
+        assert node_name.getVehicleSystem() == value
+        assert node_name == node_name.setVehicleSystem(None)
+        assert node_name.getVehicleSystem() == value
+
+    def test_get_set_vehicle_system_instance(self):
+        """vehicleSystemInstance get/set with chaining and None no-op."""
+        node_name = self._make_node_name()
+        value = Integer()
+        value.setValue(1)
+        assert node_name == node_name.setVehicleSystemInstance(value)
+        assert node_name.getVehicleSystemInstance() == value
+        assert node_name == node_name.setVehicleSystemInstance(None)
+        assert node_name.getVehicleSystemInstance() == value
+
+
+class TestJ1939NmNode:
+    """Spec-driven tests for the J1939NmNode class."""
+
+    def _make_node(self):
+        return J1939NmNode(MockParent(), "test_j1939_nm_node")
+
+    def test_initialization(self):
+        """J1939NmNode fields default to None."""
+        node = self._make_node()
+        assert node.getAddressConfigurationCapability() is None
+        assert node.getNodeName() is None
+
+    def test_get_set_address_configuration_capability(self):
+        """addressConfigurationCapability get/set with typed enum instance."""
+        node = self._make_node()
+        value = J1939NmAddressConfigurationCapabilityEnum()
+        value.setValue(J1939NmAddressConfigurationCapabilityEnum.J1939NM_SCA)
+        assert node == node.setAddressConfigurationCapability(value)
+        assert node.getAddressConfigurationCapability() == value
+        assert node.getAddressConfigurationCapability().getValue() == "J-1939-NM-SCA"
+        assert node == node.setAddressConfigurationCapability(None)
+        assert node.getAddressConfigurationCapability() == value
+
+    def test_get_set_node_name(self):
+        """nodeName get/set with chaining and None no-op."""
+        node = self._make_node()
+        value = J1939NodeName()
+        value.setArbitraryAddressCapable(Boolean().setValue(True))
+        value.setManufacturerCode(Integer().setValue(305))
+        assert node == node.setNodeName(value)
+        assert node.getNodeName() == value
+        assert node.getNodeName().getManufacturerCode().getValue() == 305
+        assert node == node.setNodeName(None)
+        assert node.getNodeName() == value

--- a/tests/test_armodel/parser/test_arxml_parser_internals.py
+++ b/tests/test_armodel/parser/test_arxml_parser_internals.py
@@ -27,6 +27,9 @@ from armodel.models import (
     SwDataDefProps,
 )
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import (
+    J1939NodeName,
+)
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import (
     EndToEndTransformationDescription,
 )
@@ -168,6 +171,49 @@ class TestRxIdentifierRange:
     def test_getChildElementRxIdentifierRange_missing_returns_None(self, parser):
         element = _snip("<X/>")
         assert parser.getChildElementRxIdentifierRange(element, "ABSENT") is None
+
+
+# ==================== J1939NodeName ====================
+
+
+class TestJ1939NodeName:
+    def test_getChildElementJ1939NodeName(self, parser):
+        element = _snip(
+            "<NODE-NAME>"
+            "<ARBITRARY-ADDRESS-CAPABLE>true</ARBITRARY-ADDRESS-CAPABLE>"
+            "<ECU-INSTANCE>1</ECU-INSTANCE>"
+            "<FUNCTION>2</FUNCTION>"
+            "<FUNCTION-INSTANCE>3</FUNCTION-INSTANCE>"
+            "<IDENTITIY-NUMBER>4</IDENTITIY-NUMBER>"
+            "<INDUSTRY-GROUP>5</INDUSTRY-GROUP>"
+            "<MANUFACTURER-CODE>6</MANUFACTURER-CODE>"
+            "<VEHICLE-SYSTEM>7</VEHICLE-SYSTEM>"
+            "<VEHICLE-SYSTEM-INSTANCE>8</VEHICLE-SYSTEM-INSTANCE>"
+            "</NODE-NAME>",
+            root_tag="PARENT",
+        )
+        node_name = parser.getChildElementJ1939NodeName(element, "NODE-NAME")
+        assert isinstance(node_name, J1939NodeName)
+        assert node_name.getArbitraryAddressCapable().getValue() is True
+        assert node_name.getEcuInstance().getValue() == 1
+        assert node_name.getFunction().getValue() == 2
+        assert node_name.getFunctionInstance().getValue() == 3
+        assert node_name.getIdentitiyNumber().getValue() == 4
+        assert node_name.getIndustryGroup().getValue() == 5
+        assert node_name.getManufacturerCode().getValue() == 6
+        assert node_name.getVehicleSystem().getValue() == 7
+        assert node_name.getVehicleSystemInstance().getValue() == 8
+
+    def test_getChildElementJ1939NodeName_empty(self, parser):
+        element = _snip("<NODE-NAME></NODE-NAME>", root_tag="PARENT")
+        node_name = parser.getChildElementJ1939NodeName(element, "NODE-NAME")
+        assert isinstance(node_name, J1939NodeName)
+        assert node_name.getArbitraryAddressCapable() is None
+        assert node_name.getEcuInstance() is None
+
+    def test_getChildElementJ1939NodeName_missing_returns_None(self, parser):
+        element = _snip("<X/>")
+        assert parser.getChildElementJ1939NodeName(element, "ABSENT") is None
 
 
 # ==================== _readVariableAccesses branching ====================

--- a/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
@@ -1674,6 +1674,48 @@ class TestNmConfigHandlers:
             warning_parser.readNmClusterNmNodes(element, cluster)
         assert any("Unsupported Nm Node" in r.getMessage() for r in caplog.records)
 
+    def test_readNmClusterNmNodes_j1939NmNode(self, parser):
+        from armodel.models import J1939NmCluster, NmConfig
+
+        config = NmConfig(parent=_autosar_root(), short_name="nmConfig")
+        cluster = J1939NmCluster(parent=config, short_name="jnm")
+        element = _snip(
+            "<NM-NODES>" "<J-1939-NM-NODE>" "<SHORT-NAME>node</SHORT-NAME>" "</J-1939-NM-NODE>" "</NM-NODES>",
+            root_tag="J-1939-NM-CLUSTER",
+        )
+        parser.readNmClusterNmNodes(element, cluster)
+        assert len(cluster.getNmNodes()) == 1
+        assert cluster.getNmNodes()[0].getShortName() == "node"
+
+    def test_readJ1939NmNode_sets_addressConfigurationCapability(self, parser):
+        from armodel.models import J1939NmCluster, J1939NmNode, NmConfig
+
+        config = NmConfig(parent=_autosar_root(), short_name="nmConfig")
+        cluster = J1939NmCluster(parent=config, short_name="jnm")
+        node = J1939NmNode(parent=cluster, short_name="node")
+        element = _snip(
+            "<SHORT-NAME>node</SHORT-NAME>" "<ADDRESS-CONFIGURATION-CAPABILITY>J-1939-NM-SCA</ADDRESS-CONFIGURATION-CAPABILITY>",
+            root_tag="J-1939-NM-NODE",
+        )
+        parser.readJ1939NmNode(element, node)
+        assert node.getAddressConfigurationCapability().getValue() == "J-1939-NM-SCA"
+
+    def test_readJ1939NmNode_sets_nodeName(self, parser):
+        from armodel.models import J1939NmCluster, J1939NmNode, NmConfig
+
+        config = NmConfig(parent=_autosar_root(), short_name="nmConfig")
+        cluster = J1939NmCluster(parent=config, short_name="jnm")
+        node = J1939NmNode(parent=cluster, short_name="node")
+        element = _snip(
+            "<SHORT-NAME>node</SHORT-NAME>" "<NODE-NAME>" "<ARBITRARY-ADDRESS-CAPABLE>true</ARBITRARY-ADDRESS-CAPABLE>" "<MANUFACTURER-CODE>305</MANUFACTURER-CODE>" "</NODE-NAME>",
+            root_tag="J-1939-NM-NODE",
+        )
+        parser.readJ1939NmNode(element, node)
+        node_name = node.getNodeName()
+        assert node_name is not None
+        assert node_name.getArbitraryAddressCapable().getValue() is True
+        assert node_name.getManufacturerCode().getValue() == 305
+
     def test_readCanNmNode_sets_nmNodeId(self, parser):
         from armodel.models import CanNmCluster, CanNmNode, NmConfig
 

--- a/tests/test_armodel/writer/test_writer_nm.py
+++ b/tests/test_armodel/writer/test_writer_nm.py
@@ -27,6 +27,9 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import 
     CanNmCluster,
     CanNmClusterCoupling,
     CanNmNode,
+    J1939NmAddressConfigurationCapabilityEnum,
+    J1939NmNode,
+    J1939NodeName,
     NmConfig,
     NmCoordinatorRoleEnum,
     NmEcu,
@@ -88,6 +91,12 @@ def _int(val=1):
     return i
 
 
+def _set_int_text(val=1):
+    i = Integer()
+    i.setValue(str(val))
+    return i
+
+
 def _pos_int(val=1):
     i = PositiveInteger()
     i.setValue(val)
@@ -116,6 +125,12 @@ def _literal(val="lit"):
     lit = ARLiteral()
     lit.setValue(val)
     return lit
+
+
+def _j1939_cap(val="J-1939-NM-SCA"):
+    cap = J1939NmAddressConfigurationCapabilityEnum()
+    cap.setValue(val)
+    return cap
 
 
 class TestWritePduToFrameMappings:
@@ -226,6 +241,38 @@ class TestWriteNmNode:
         assert role_tag.text == "active"
 
 
+class TestWriteJ1939NodeName:
+    def test_writes_all_fields(self, writer):
+        node_name = J1939NodeName()
+        node_name.setArbitraryAddressCapable(_bool(True))
+        node_name.setEcuInstance(_set_int_text(1))
+        node_name.setFunction(_set_int_text(2))
+        node_name.setFunctionInstance(_set_int_text(3))
+        node_name.setIdentitiyNumber(_set_int_text(4))
+        node_name.setIndustryGroup(_set_int_text(5))
+        node_name.setManufacturerCode(_set_int_text(6))
+        node_name.setVehicleSystem(_set_int_text(7))
+        node_name.setVehicleSystemInstance(_set_int_text(8))
+        parent = _parent()
+        writer.setChildElementJ1939NodeName(parent, "NODE-NAME", node_name)
+        child = parent.find("NODE-NAME")
+        assert child is not None
+        assert child.find("ARBITRARY-ADDRESS-CAPABLE").text == "true"
+        assert child.find("ECU-INSTANCE").text == "1"
+        assert child.find("FUNCTION").text == "2"
+        assert child.find("FUNCTION-INSTANCE").text == "3"
+        assert child.find("IDENTITIY-NUMBER").text == "4"
+        assert child.find("INDUSTRY-GROUP").text == "5"
+        assert child.find("MANUFACTURER-CODE").text == "6"
+        assert child.find("VEHICLE-SYSTEM").text == "7"
+        assert child.find("VEHICLE-SYSTEM-INSTANCE").text == "8"
+
+    def test_none_produces_no_element(self, writer):
+        parent = _parent()
+        writer.setChildElementJ1939NodeName(parent, "NODE-NAME", None)
+        assert parent.find("NODE-NAME") is None
+
+
 class TestWriteCanNmNode:
     def test_writes_can_nm_node(self, writer):
         node = CanNmNode(MockParent(), "can_nm_node")
@@ -277,6 +324,47 @@ class TestWriteNmClusterNmNodes:
         assert nodes_tag is not None
         assert nodes_tag.find("CAN-NM-NODE") is not None
         assert nodes_tag.find("UDP-NM-NODE") is not None
+
+    def test_with_j1939_node(self, writer):
+        cluster = CanNmCluster(MockParent(), "cluster")
+        node = cluster.createJ1939NmNode("j1939_node")
+        node.setAddressConfigurationCapability(_j1939_cap())
+        parent = _parent()
+        writer.writeNmClusterNmNodes(parent, cluster)
+        nodes_tag = parent.find("NM-NODES")
+        assert nodes_tag is not None
+        j1939_tag = nodes_tag.find("J-1939-NM-NODE")
+        assert j1939_tag is not None
+        assert j1939_tag.find("ADDRESS-CONFIGURATION-CAPABILITY") is not None
+        assert j1939_tag.find("ADDRESS-CONFIGURATION-CAPABILITY").text == "J-1939-NM-SCA"
+
+
+class TestWriteJ1939NmNode:
+    def test_writes_j1939_nm_node(self, writer):
+        node = J1939NmNode(MockParent(), "j1939_node")
+        node.setAddressConfigurationCapability(_j1939_cap())
+        node_name = J1939NodeName()
+        node_name.setArbitraryAddressCapable(_bool(True))
+        node_name.setManufacturerCode(_set_int_text(305))
+        node.setNodeName(node_name)
+        parent = _parent()
+        writer.writeJ1939NmNode(parent, node)
+        j1939_tag = parent.find("J-1939-NM-NODE")
+        assert j1939_tag is not None
+        assert j1939_tag.find("ADDRESS-CONFIGURATION-CAPABILITY").text == "J-1939-NM-SCA"
+        node_name_tag = j1939_tag.find("NODE-NAME")
+        assert node_name_tag is not None
+        assert node_name_tag.find("ARBITRARY-ADDRESS-CAPABLE").text == "true"
+        assert node_name_tag.find("MANUFACTURER-CODE").text == "305"
+
+    def test_without_optional_fields(self, writer):
+        node = J1939NmNode(MockParent(), "j1939_node")
+        parent = _parent()
+        writer.writeJ1939NmNode(parent, node)
+        j1939_tag = parent.find("J-1939-NM-NODE")
+        assert j1939_tag is not None
+        assert j1939_tag.find("ADDRESS-CONFIGURATION-CAPABILITY") is None
+        assert j1939_tag.find("NODE-NAME") is None
 
 
 class TestWriteCanNmClusterCoupling:


### PR DESCRIPTION
## Summary

Syncs the J1939 network-management classes to the AUTOSAR R23-11 spec (sync-autosar-class workflow).

## Changes

- **J1939NmNode** (\SystemTemplate/NetworkManagement.py\): add \ddressConfigurationCapability\ (enum attr) and \
odeName\ (aggregated \J1939NodeName\) with getters/setters
- **J1939NodeName**: new class - 9 scalar fields incl. \identitiyNumber\ (spec typo kept, matches XSD \IDENTITIY-NUMBER\)
- **J1939NmAddressConfigurationCapabilityEnum**: new enum, 5 literals, serialized XML member values (J-1939-NM-*)
- Parser: \eadJ1939NmNode\, \getChildElementJ1939NodeName\, \J-1939-NM-NODE\ dispatch branch
- Writer: \writeJ1939NmNode\, \setChildElementJ1939NodeName\, isinstance dispatch branch
- Model: \NmCluster.createJ1939NmNode\ / \getJ1939NmNodes\
- All three classes stamped \# Spec verified: R23-11\

## Verification

- 6024 tests pass (unit + integration)
- flake8 + ruff clean; black-clean on all 7 touched files
- Round-trip (write -> re-parse) verified

Closes #593