### PR TITLE
feat: sync ECUCParameterDefTemplate to R23-11 spec

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List
+from typing import List, Optional
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpBlueprintable
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Boolean, CIdentifier, Float, Identifier, Limit
@@ -237,14 +237,35 @@ class EcucConfigurationClassEnum(AREnum):
 
 class EcucConfigurationVariantEnum(AREnum):
     """
-    Enumeration for ECUC configuration variant types.
+    Specifies which ConfigurationVariants are supported by this software module.
     """
 
     # EcucConfigurationVariantEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [x] test
+    # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.13, p.53
+    # Spec verified: R23-11
+    # (no methods)
+
+    # Recommended configuration for a module. Tags: atp.EnumerationLiteralIndex=1
+    RECOMMENDED_CONFIGURATION = "RECOMMENDED-CONFIGURATION"
+
+    # Specifies that the BSW Module implementation may use PreCompileTime and LinkTime configuration parameters. Tags: atp.EnumerationLiteralIndex=2
+    VARIANT_LINK_TIME = "VARIANT-LINK-TIME"
+
+    # Specifies that the BSW Module implementation may use PreCompileTime, LinkTime and PostBuild configuration parameters. Tags: atp.EnumerationLiteralIndex=3
+    VARIANT_POST_BUILD = "VARIANT-POST-BUILD"
+
+    # Specifies that the BSW Module implementation uses only PreCompileTime configuration parameters. Tags: atp.EnumerationLiteralIndex=6
+    VARIANT_PRE_COMPILE = "VARIANT-PRE-COMPILE"
 
     def __init__(self):
-        super().__init__([])
+        super().__init__(
+            [
+                EcucConfigurationVariantEnum.RECOMMENDED_CONFIGURATION,
+                EcucConfigurationVariantEnum.VARIANT_LINK_TIME,
+                EcucConfigurationVariantEnum.VARIANT_POST_BUILD,
+                EcucConfigurationVariantEnum.VARIANT_PRE_COMPILE,
+            ]
+        )
 
 
 class EcucAbstractConfigurationClass(ARObject, ABC):
@@ -1596,31 +1617,36 @@ class EcucConditionFormula(ARObject):
 
 class EcucDefinitionCollection(AtpBlueprintable):
     """
-    Represents an ECUC definition collection in the AUTOSAR model.
-
-    This class is used to group related ECUC definitions together.
-
-    Attributes:
-        definitions (List[EcucDefinitionElement]): A list of ECUC definition elements.
+    This represents the anchor point of an ECU Configuration Parameter Definition within the AUTOSAR templates structure. Tags: atp.recommendedPackage=EcucDefinitionCollections
     """
 
     # EcucDefinitionCollection method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getDefinitions               [x] impl  [ ] docstring  [ ] test
-    # [ ] addDefinition                [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.1, p.25
+    # Spec verified: R23-11
+    # [x] __init__         [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addModuleRef     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getModuleRefs    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.definitions: List[EcucDefinitionElement] = []
+        # References to the module definitions of individual software modules.
+        self.moduleRefs: List[RefType] = []
 
-    def getDefinitions(self) -> List[EcucDefinitionElement]:
-        return self.definitions
-
-    def addDefinition(self, value: EcucDefinitionElement):
+    def addModuleRef(self, value: RefType) -> "EcucDefinitionCollection":
+        """
+        Adds a reference to the module definition of an individual software module.
+        A None value is a no-op and does not append anything.
+        """
         if value is not None:
-            self.definitions.append(value)
+            self.moduleRefs.append(value)
         return self
+
+    def getModuleRefs(self) -> List[RefType]:
+        """
+        Gets the references to the module definitions of individual software modules.
+        """
+        return self.moduleRefs
 
 
 class EcucDestinationUriDef(Identifiable):
@@ -1853,45 +1879,67 @@ class EcucQueryExpression(ARObject):
 
 class EcucModuleDef(EcucDefinitionElement):
     """
-    ECUC module definition with API service prefix, container
-    definitions, and variant support properties.
+    Used as the top-level element for configuration definition for Software Modules, including BSW and RTE as well as ECU Infrastructure. Tags: atp.recommendedPackage=EcucModuleDefs
     """
 
     # EcucModuleDef method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getApiServicePrefix          [x] impl  [ ] docstring  [ ] test
-    # [ ] setApiServicePrefix          [x] impl  [ ] docstring  [ ] test
-    # [ ] getContainers                [x] impl  [ ] docstring  [ ] test
-    # [ ] createEcucParamConfContainerDef [x] impl  [ ] docstring  [ ] test
-    # [ ] createEcucChoiceContainerDef [x] impl  [ ] docstring  [ ] test
-    # [ ] getPostBuildVariantSupport   [x] impl  [ ] docstring  [ ] test
-    # [ ] setPostBuildVariantSupport   [x] impl  [ ] docstring  [ ] test
-    # [ ] getRefinedModuleDefRef       [x] impl  [ ] docstring  [ ] test
-    # [ ] setRefinedModuleDefRef       [x] impl  [ ] docstring  [ ] test
-    # [ ] getSupportedConfigVariants   [x] impl  [ ] docstring  [ ] test
-    # [ ] addSupportedConfigVariant    [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.2, p.32
+    # [x] __init__                       [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getApiServicePrefix            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setApiServicePrefix            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getContainers                  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createEcucParamConfContainerDef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] createEcucChoiceContainerDef   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPostBuildVariantSupport     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setPostBuildVariantSupport     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRefinedModuleDefRef         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setRefinedModuleDefRef         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSupportedConfigVariants     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addSupportedConfigVariant      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
+        # For modules where several instances of the VSMD can be defined the apiServicePrefix defines the API namespace of the derived instances, e.g. Cdd, Xfrm (ComXf, SomeIpXf, E2EXf).
         self.apiServicePrefix: CIdentifier = None
+
+        # Aggregates the top-level container definitions of this specific module definition. Stereotypes: atpSplitable Tags: atp.Splitkey=container.shortName xml.sequenceOffset=11
         self.containers: List[EcucContainerDef] = []
+
+        # Indicates if a module supports different post-build variants (previously known as post-build selectable configuration sets). TRUE means yes, FALSE means no.
         self.postBuildVariantSupport: Boolean = None
+
+        # Optional reference from the Vendor Specific Module Definition to the Standardized Module Definition it refines. In case this EcucModuleDef has the category STANDARDIZED_MODULE_DEFINITION this reference shall not be provided. In case this EcucModuleDef has the category VENDOR_SPECIFIC_MODULE_DEFINITION this reference is mandatory. Stereotypes: atpUriDef
         self.refinedModuleDefRef: RefType = None
+
+        # Specifies which ConfigurationVariants are supported by this software module. This attribute is optional if the EcucModuleDef has the category STANDARDIZED_MODULE_DEFINITION. If the category attribute of the EcucModuleDef is set to VENDOR_SPECIFIC_MODULE_DEFINITION then this attribute is mandatory.
         self.supportedConfigVariants: List[EcucConfigurationVariantEnum] = []
 
-    def getApiServicePrefix(self) -> CIdentifier:
+    def getApiServicePrefix(self) -> Optional[CIdentifier]:
+        """
+        Gets the API namespace of the derived instances, e.g. Cdd, Xfrm (ComXf, SomeIpXf, E2EXf).
+        """
         return self.apiServicePrefix
 
-    def setApiServicePrefix(self, value: CIdentifier):
+    def setApiServicePrefix(self, value: Optional[CIdentifier]):
+        """
+        Sets the API namespace of the derived instances, e.g. Cdd, Xfrm (ComXf, SomeIpXf, E2EXf).
+        A None value is a no-op and does not change the current value.
+        """
         if value is not None:
             self.apiServicePrefix = value
         return self
 
     def getContainers(self) -> List[EcucContainerDef]:
+        """
+        Gets the top-level container definitions of this specific module definition.
+        """
         return self.containers
 
     def createEcucParamConfContainerDef(self, short_name: str) -> "EcucParamConfContainerDef":
+        """
+        Creates or returns an existing EcucParamConfContainerDef aggregated as a top-level container of this module definition.
+        """
         if not self.IsElementExists(short_name):
             container_def = EcucParamConfContainerDef(self, short_name)
             self.addElement(container_def)
@@ -1899,6 +1947,9 @@ class EcucModuleDef(EcucDefinitionElement):
         return self.getElement(short_name)
 
     def createEcucChoiceContainerDef(self, short_name: str) -> EcucChoiceContainerDef:
+        """
+        Creates or returns an existing EcucChoiceContainerDef aggregated as a top-level container of this module definition.
+        """
         if not self.IsElementExists(short_name):
             container_def = EcucChoiceContainerDef(self, short_name)
             self.addElement(container_def)
@@ -1906,25 +1957,46 @@ class EcucModuleDef(EcucDefinitionElement):
         return self.getElement(short_name)
 
     def getPostBuildVariantSupport(self) -> Boolean:
+        """
+        Gets whether a module supports different post-build variants. TRUE means yes, FALSE means no.
+        """
         return self.postBuildVariantSupport
 
     def setPostBuildVariantSupport(self, value: Boolean):
+        """
+        Sets whether a module supports different post-build variants. TRUE means yes, FALSE means no.
+        A None value is a no-op and does not change the current value.
+        """
         if value is not None:
             self.postBuildVariantSupport = value
         return self
 
     def getRefinedModuleDefRef(self) -> RefType:
+        """
+        Gets the optional reference from the Vendor Specific Module Definition to the Standardized Module Definition it refines.
+        """
         return self.refinedModuleDefRef
 
     def setRefinedModuleDefRef(self, value: RefType):
+        """
+        Sets the optional reference from the Vendor Specific Module Definition to the Standardized Module Definition it refines.
+        A None value is a no-op and does not change the current value.
+        """
         if value is not None:
             self.refinedModuleDefRef = value
         return self
 
     def getSupportedConfigVariants(self) -> List[EcucConfigurationVariantEnum]:
+        """
+        Gets the ConfigurationVariants supported by this software module.
+        """
         return self.supportedConfigVariants
 
     def addSupportedConfigVariant(self, value: EcucConfigurationVariantEnum):
+        """
+        Adds a ConfigurationVariant supported by this software module.
+        A None value is a no-op and does not append anything.
+        """
         if value is not None:
             self.supportedConfigVariants.append(value)
         return self

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
@@ -51,7 +51,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingConstraint.
 from armodel.models.M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticContribution import DiagnosticServiceTable
 from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import EcucModuleConfigurationValues, EcucValueCollection
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwElement
-from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucModuleDef
+from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucDefinitionCollection, EcucModuleDef
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwCategory, HwType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import Collection
@@ -1220,6 +1220,12 @@ class ARPackage(CollectableElement):
             self.addElement(element)
         return self.getElement(short_name, EcucModuleDef)
 
+    def createEcucDefinitionCollection(self, short_name: str) -> EcucDefinitionCollection:
+        if not self.IsElementExists(short_name, EcucDefinitionCollection):
+            element = EcucDefinitionCollection(self, short_name)
+            self.addElement(element)
+        return self.getElement(short_name, EcucDefinitionCollection)
+
     def createSwSystemConst(self, short_name: str) -> SwSystemconst:
         if not self.IsElementExists(short_name, SwSystemconst):
             element = SwSystemconst(self, short_name)
@@ -1569,6 +1575,9 @@ class ARPackage(CollectableElement):
 
     def getEcucModuleDefs(self) -> List[EcucModuleDef]:
         return list(sorted(filter(lambda a: isinstance(a, EcucModuleDef), self.elements), key=lambda a: a.short_name))
+
+    def getEcucDefinitionCollections(self) -> List[EcucDefinitionCollection]:
+        return list(sorted(filter(lambda a: isinstance(a, EcucDefinitionCollection), self.elements), key=lambda a: a.short_name))
 
     def getSwSystemConsts(self) -> List[SwSystemconst]:
         return list(sorted(filter(lambda a: isinstance(a, SwSystemconst), self.elements), key=lambda a: a.short_name))

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -166,6 +166,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucChoiceContainerDef,
     EcucCommonAttributes,
     EcucContainerDef,
+    EcucDefinitionCollection,
     EcucDefinitionElement,
     EcucEnumerationLiteralDef,
     EcucEnumerationParamDef,
@@ -6706,9 +6707,18 @@ class ARXMLParser(AbstractARXMLParser):
     def readEcucModuleDef(self, element: ET.Element, module_def: EcucModuleDef):
         self.logger.debug("Read EcucModuleDef <%s>" % module_def.getShortName())
         self.readEcucDefinitionElement(element, module_def)
+        module_def.setApiServicePrefix(self.getChildElementOptionalLiteral(element, "API-SERVICE-PREFIX"))
         module_def.setPostBuildVariantSupport(self.getChildElementOptionalBooleanValue(element, "POST-BUILD-VARIANT-SUPPORT"))
+        module_def.setRefinedModuleDefRef(self.getChildElementOptionalRefType(element, "REFINED-MODULE-DEF-REF"))
         self.readEcucModuleDefSupportedConfigVariants(element, module_def)
         self.readEcucModuleDefContainers(element, module_def)
+
+    def readEcucDefinitionCollection(self, element: ET.Element, collection: EcucDefinitionCollection):
+        self.logger.debug("Read EcucDefinitionCollection <%s>" % collection.getShortName())
+        self.readARElement(element, collection)
+        module_refs = self.getChildElementRefTypeList(element, "MODULE-REFS/MODULE-REF")
+        for module_ref in module_refs:
+            collection.addModuleRef(module_ref)
 
     def readSwSystemconst(self, element: ET.Element, system_const: SwSystemconst):
         self.logger.debug("Read SwSystemconst <%s>" % system_const.getShortName())
@@ -8009,6 +8019,9 @@ class ARXMLParser(AbstractARXMLParser):
             elif tag_name == "ECUC-MODULE-DEF":
                 module_def = parent.createEcucModuleDef(self.getShortName(child_element))
                 self.readEcucModuleDef(child_element, module_def)
+            elif tag_name == "ECUC-DEFINITION-COLLECTION":
+                collection = parent.createEcucDefinitionCollection(self.getShortName(child_element))
+                self.readEcucDefinitionCollection(child_element, collection)
             elif tag_name == "SW-SYSTEMCONST":
                 system_const = parent.createSwSystemConst(self.getShortName(child_element))
                 self.readSwSystemconst(child_element, system_const)

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -158,6 +158,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucChoiceContainerDef,
     EcucCommonAttributes,
     EcucContainerDef,
+    EcucDefinitionCollection,
     EcucDefinitionElement,
     EcucEnumerationLiteralDef,
     EcucEnumerationParamDef,
@@ -6414,24 +6415,39 @@ class ARXMLWriter(AbstractARXMLWriter):
 
     def writeEcucModuleDefContainers(self, element: ET.Element, module_def: EcucModuleDef):
         container_defs = module_def.getContainers()
-        if len(container_defs) > 0:
-            child_element = ET.SubElement(element, "CONTAINERS")
-            for container_def in container_defs:
-                if isinstance(container_def, EcucParamConfContainerDef):
-                    self.writeEcucParamConfContainerDef(child_element, container_def)
-                elif isinstance(container_def, EcucChoiceContainerDef):
-                    self.writeEcucChoiceContainerDef(child_element, container_def)
-                else:
-                    self.notImplemented("Unsupported Container <%s>" % type(container_def))
+        child_element = ET.SubElement(element, "CONTAINERS")
+        for container_def in container_defs:
+            if isinstance(container_def, EcucParamConfContainerDef):
+                self.writeEcucParamConfContainerDef(child_element, container_def)
+            elif isinstance(container_def, EcucChoiceContainerDef):
+                self.writeEcucChoiceContainerDef(child_element, container_def)
+            else:
+                self.notImplemented("Unsupported Container <%s>" % type(container_def))
 
     def writeEcucModuleDef(self, element: ET.Element, module_def: EcucModuleDef):
         if module_def is not None:
             self.logger.debug("Write EcucModuleDef <%s>" % module_def.getShortName())
             child_element = ET.SubElement(element, "ECUC-MODULE-DEF")
             self.writeEcucDefinitionElement(child_element, module_def)
+            self.setChildElementOptionalLiteral(child_element, "API-SERVICE-PREFIX", module_def.getApiServicePrefix())
             self.setChildElementOptionalBooleanValue(child_element, "POST-BUILD-VARIANT-SUPPORT", module_def.getPostBuildVariantSupport())
+            self.setChildElementOptionalRefType(child_element, "REFINED-MODULE-DEF-REF", module_def.getRefinedModuleDefRef())
             self.writeEcucModuleDefSupportedConfigVariants(child_element, module_def)
             self.writeEcucModuleDefContainers(child_element, module_def)
+
+    def writeEcucDefinitionCollectionModuleRefs(self, element: ET.Element, collection: EcucDefinitionCollection):
+        module_refs = collection.getModuleRefs()
+        if len(module_refs) > 0:
+            child_element = ET.SubElement(element, "MODULE-REFS")
+            for module_ref in module_refs:
+                self.setChildElementOptionalRefType(child_element, "MODULE-REF", module_ref)
+
+    def writeEcucDefinitionCollection(self, element: ET.Element, collection: EcucDefinitionCollection):
+        if collection is not None:
+            self.logger.debug("Write EcucDefinitionCollection <%s>" % collection.getShortName())
+            child_element = ET.SubElement(element, "ECUC-DEFINITION-COLLECTION")
+            self.writeARElement(child_element, collection)
+            self.writeEcucDefinitionCollectionModuleRefs(child_element, collection)
 
     def writeMacMulticastGroup(self, element: ET.Element, group: MacMulticastGroup):
         if group is not None:
@@ -8168,6 +8184,8 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeModeDeclarationMappingSet(element, ar_element)
         elif isinstance(ar_element, EcucModuleDef):
             self.writeEcucModuleDef(element, ar_element)
+        elif isinstance(ar_element, EcucDefinitionCollection):
+            self.writeEcucDefinitionCollection(element, ar_element)
         elif isinstance(ar_element, EcucModuleConfigurationValues):
             self.writeEcucModuleConfigurationValues(element, ar_element)
         elif isinstance(ar_element, SwSystemconst):

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/test_ECUCParameterDefTemplate.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/test_ECUCParameterDefTemplate.py
@@ -3,12 +3,11 @@ Test cases for the ECUC Parameter Definition Template classes.
 These tests ensure 100% code coverage for all ECUC parameter definition classes.
 """
 
-import pytest
 from typing import Optional, get_type_hints
 
+import pytest
+
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, CIdentifier, RefType
 from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucAbstractConfigurationClass,
     EcucAbstractExternalReferenceDef,
@@ -45,6 +44,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucValidationCondition,
     EcucValueConfigurationClass,
 )
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Boolean, CIdentifier, RefType
 
 
 class TestEcucConditionSpecification:

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/test_ECUCParameterDefTemplate.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/test_ECUCParameterDefTemplate.py
@@ -4,8 +4,11 @@ These tests ensure 100% code coverage for all ECUC parameter definition classes.
 """
 
 import pytest
+from typing import Optional, get_type_hints
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, CIdentifier, RefType
 from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucAbstractConfigurationClass,
     EcucAbstractExternalReferenceDef,
@@ -19,6 +22,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucConditionSpecification,
     EcucConfigurationClassEnum,
     EcucConfigurationVariantEnum,
+    EcucDefinitionCollection,
     EcucDefinitionElement,
     EcucDerivationSpecification,
     EcucDestinationUriDefRefType,
@@ -29,6 +33,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucFunctionNameDef,
     EcucInstanceReferenceDef,
     EcucIntegerParamDef,
+    EcucModuleDef,
     EcucMultiplicityConfigurationClass,
     EcucParamConfContainerDef,
     EcucParameterDef,
@@ -238,8 +243,7 @@ class TestEcucConfigurationClassEnum:
 class TestEcucConfigurationVariantEnum:
     """
     Test class for EcucConfigurationVariantEnum functionality.
-    This class contains test methods for validating the behavior of
-    the EcucConfigurationVariantEnum class, including its initialization.
+    Verifies the four spec literals of Table 2.13 and the registered enum values.
     """
 
     def test_initialization(self):
@@ -251,7 +255,38 @@ class TestEcucConfigurationVariantEnum:
         config_variant_enum = EcucConfigurationVariantEnum()
 
         assert config_variant_enum is not None
-        assert config_variant_enum.enumValues == []
+        assert isinstance(config_variant_enum, AREnum)
+
+    def test_literal_members(self):
+        """
+        Test that the four spec literals are defined with their XSD value strings.
+        """
+        assert EcucConfigurationVariantEnum.RECOMMENDED_CONFIGURATION == "RECOMMENDED-CONFIGURATION"
+        assert EcucConfigurationVariantEnum.VARIANT_LINK_TIME == "VARIANT-LINK-TIME"
+        assert EcucConfigurationVariantEnum.VARIANT_POST_BUILD == "VARIANT-POST-BUILD"
+        assert EcucConfigurationVariantEnum.VARIANT_PRE_COMPILE == "VARIANT-PRE-COMPILE"
+
+    def test_enum_values(self):
+        """
+        Test that the registered enum values match the spec literals in order.
+        """
+        config_variant_enum = EcucConfigurationVariantEnum()
+
+        assert config_variant_enum.getEnumValues() == [
+            "RECOMMENDED-CONFIGURATION",
+            "VARIANT-LINK-TIME",
+            "VARIANT-POST-BUILD",
+            "VARIANT-PRE-COMPILE",
+        ]
+
+    def test_set_value(self):
+        """
+        Test that a spec literal can be set as the enum value.
+        """
+        config_variant_enum = EcucConfigurationVariantEnum()
+        config_variant_enum.setValue(EcucConfigurationVariantEnum.VARIANT_PRE_COMPILE)
+
+        assert config_variant_enum.getValue() == "VARIANT-PRE-COMPILE"
 
 
 class TestEcucAbstractConfigurationClass:
@@ -1454,3 +1489,162 @@ class TestEcucParamConfContainerDef:
         assert param_conf_container.getParameters() == []
         assert param_conf_container.getReferences() == []
         assert param_conf_container.getSubContainers() == []
+
+
+class TestEcucModuleDef:
+    """
+    Test class for EcucModuleDef functionality against Table 2.2.
+    """
+
+    def _make_module(self):
+        document = AUTOSAR.getInstance()
+        pkg = document.createARPackage("PkgModuleDef")
+        return EcucModuleDef(pkg, "Md")
+
+    def test_initialization(self):
+        """
+        Test EcucModuleDef __init__ defaults.
+        """
+        module_def = self._make_module()
+        assert module_def.getShortName() == "Md"
+        assert module_def.getApiServicePrefix() is None
+        assert module_def.getContainers() == []
+        assert module_def.getPostBuildVariantSupport() is None
+        assert module_def.getRefinedModuleDefRef() is None
+        assert module_def.getSupportedConfigVariants() == []
+
+    def test_api_service_prefix_is_optional(self):
+        """Test the optional apiServicePrefix type contract."""
+        assert EcucModuleDef.__init__.__annotations__
+        assert get_type_hints(EcucModuleDef.getApiServicePrefix)["return"] == Optional[CIdentifier]
+        assert get_type_hints(EcucModuleDef.setApiServicePrefix)["value"] == Optional[CIdentifier]
+
+    def test_set_get_api_service_prefix(self):
+        """
+        Test setApiServicePrefix returns self and getApiServicePrefix round-trips.
+        """
+        module_def = self._make_module()
+        prefix = CIdentifier()
+        prefix.setValue("Cdd")
+        result = module_def.setApiServicePrefix(prefix)
+        assert result is module_def
+        assert module_def.getApiServicePrefix() is prefix
+
+    def test_set_api_service_prefix_none_is_noop(self):
+        """
+        Test setting a None apiServicePrefix is a no-op.
+        """
+        module_def = self._make_module()
+        prefix = CIdentifier()
+        prefix.setValue("Cdd")
+        module_def.setApiServicePrefix(prefix)
+        module_def.setApiServicePrefix(None)
+        assert module_def.getApiServicePrefix() is prefix
+
+    def test_create_get_containers(self):
+        """
+        Test createEcucParamConfContainerDef appends to getContainers.
+        """
+        module_def = self._make_module()
+        container = module_def.createEcucParamConfContainerDef("Ct")
+        assert container.getShortName() == "Ct"
+        assert module_def.getContainers() == [container]
+
+    def test_create_choice_container(self):
+        """
+        Test createEcucChoiceContainerDef appends to getContainers.
+        """
+        module_def = self._make_module()
+        container = module_def.createEcucChoiceContainerDef("Ct")
+        assert container.getShortName() == "Ct"
+        assert module_def.getContainers() == [container]
+
+    def test_set_get_post_build_variant_support(self):
+        """
+        Test setPostBuildVariantSupport returns self and getPostBuildVariantSupport round-trips.
+        """
+        module_def = self._make_module()
+        value = Boolean()
+        value.setValue(True)
+        result = module_def.setPostBuildVariantSupport(value)
+        assert result is module_def
+        assert module_def.getPostBuildVariantSupport() is value
+
+    def test_set_get_refined_module_def_ref(self):
+        """
+        Test setRefinedModuleDefRef returns self and getRefinedModuleDefRef round-trips.
+        """
+        module_def = self._make_module()
+        ref = RefType()
+        ref.setValue("/PkgModuleDef/StMd")
+        result = module_def.setRefinedModuleDefRef(ref)
+        assert result is module_def
+        assert module_def.getRefinedModuleDefRef() is ref
+
+    def test_set_refined_module_def_ref_none_is_noop(self):
+        """
+        Test setting a None refinedModuleDefRef is a no-op.
+        """
+        module_def = self._make_module()
+        ref = RefType()
+        ref.setValue("/PkgModuleDef/StMd")
+        module_def.setRefinedModuleDefRef(ref)
+        module_def.setRefinedModuleDefRef(None)
+        assert module_def.getRefinedModuleDefRef() is ref
+
+    def test_add_get_supported_config_variants(self):
+        """
+        Test addSupportedConfigVariant appends and returns self for chaining.
+        """
+        module_def = self._make_module()
+        variant = EcucConfigurationVariantEnum()
+        variant.setValue(EcucConfigurationVariantEnum.VARIANT_PRE_COMPILE)
+        result = module_def.addSupportedConfigVariant(variant)
+        assert result is module_def
+        assert module_def.getSupportedConfigVariants() == [variant]
+
+    def test_add_supported_config_variant_none_is_noop(self):
+        """
+        Test adding a None supportedConfigVariant is a no-op.
+        """
+        module_def = self._make_module()
+        module_def.addSupportedConfigVariant(None)
+        assert module_def.getSupportedConfigVariants() == []
+
+
+class TestEcucDefinitionCollection:
+    """
+    Test class for EcucDefinitionCollection functionality against Table 2.1.
+    """
+
+    def _make_collection(self):
+        document = AUTOSAR.getInstance()
+        pkg = document.createARPackage("PkgEcucDefinitionCollection")
+        return EcucDefinitionCollection(pkg, "Coll")
+
+    def test_initialization(self):
+        """
+        Test EcucDefinitionCollection __init__ defaults.
+        """
+        collection = self._make_collection()
+        assert collection.getShortName() == "Coll"
+        assert collection.getModuleRefs() == []
+
+    def test_add_get_module_refs(self):
+        """
+        Test addModuleRef appends and returns self for chaining.
+        """
+        collection = self._make_collection()
+        module_ref = RefType()
+        module_ref.setValue("/PkgModuleDef/Md")
+        result = collection.addModuleRef(module_ref)
+        assert result is collection
+        assert collection.getModuleRefs() == [module_ref]
+
+    def test_add_module_ref_none_is_noop(self):
+        """
+        Test adding a None module ref is a no-op.
+        """
+        collection = self._make_collection()
+        collection.addModuleRef(None)
+        assert collection.getModuleRefs() == []

--- a/tests/test_armodel/parser/test_arxml_parser_dispatch.py
+++ b/tests/test_armodel/parser/test_arxml_parser_dispatch.py
@@ -461,6 +461,11 @@ class TestEcucDispatch:
         _dispatch(parser, parent, _snip("ECUC-MODULE-DEF", "EMD1"))
         assert len(parent.getEcucModuleDefs()) == 1
 
+    def test_ecuc_definition_collection(self, parser):
+        parent = _make_parent()
+        _dispatch(parser, parent, _snip("ECUC-DEFINITION-COLLECTION", "EDC1"))
+        assert len(parent.getEcucDefinitionCollections()) == 1
+
 
 # ==================== Diagnostic ====================
 

--- a/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
@@ -1208,4 +1208,63 @@ class TestEcucParameterValue:
         assert any("Unsupported EcucParameterValue" in r.getMessage() for r in caplog.records)
 
 
+# ==================== EcucModuleDef apiServicePrefix / refinedModuleDef ====================
+
+
+class TestEcucModuleDefApiAndRefined:
+    def test_readEcucModuleDef_reads_api_and_refined(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucModuleDef
+
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        module_def = EcucModuleDef(parent=_autosar_root(), short_name="Md")
+        element = _snip(
+            "<API-SERVICE-PREFIX>Cdd</API-SERVICE-PREFIX>" '<REFINED-MODULE-DEF-REF DEST="ECUC-MODULE-DEF">/Pkg/StMd</REFINED-MODULE-DEF-REF>',
+            root_tag="ECUC-MODULE-DEF",
+        )
+        parser.readEcucModuleDef(element, module_def)
+        assert module_def.getApiServicePrefix() is not None
+        assert module_def.getApiServicePrefix().getValue() == "Cdd"
+        assert module_def.getRefinedModuleDefRef() is not None
+        assert module_def.getRefinedModuleDefRef().getValue() == "/Pkg/StMd"
+        assert module_def.getRefinedModuleDefRef().getDest() == "ECUC-MODULE-DEF"
+
+    def test_readEcucModuleDef_without_api_and_refined(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucModuleDef
+
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        module_def = EcucModuleDef(parent=_autosar_root(), short_name="Md")
+        element = _snip("", root_tag="ECUC-MODULE-DEF")
+        parser.readEcucModuleDef(element, module_def)
+        assert module_def.getApiServicePrefix() is None
+        assert module_def.getRefinedModuleDefRef() is None
+
+
+# ==================== EcucDefinitionCollection (Table 2.1) ====================
+
+
+class TestEcucDefinitionCollection:
+    def test_readEcucDefinitionCollection(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucDefinitionCollection
+
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        collection = EcucDefinitionCollection(parent=_autosar_root(), short_name="Coll")
+        element = _snip(
+            "<MODULE-REFS>" '<MODULE-REF DEST="ECUC-MODULE-DEF">/Pkg/Mod</MODULE-REF>' "</MODULE-REFS>",
+            root_tag="ECUC-DEFINITION-COLLECTION",
+        )
+        parser.readEcucDefinitionCollection(element, collection)
+        assert len(collection.getModuleRefs()) == 1
+        assert collection.getModuleRefs()[0].getValue() == "/Pkg/Mod"
+        assert collection.getModuleRefs()[0].getDest() == "ECUC-MODULE-DEF"
+
+    def test_readEcucDefinitionCollection_empty(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucDefinitionCollection
+
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        collection = EcucDefinitionCollection(parent=_autosar_root(), short_name="Coll")
+        element = _snip("", root_tag="ECUC-DEFINITION-COLLECTION")
+        parser.readEcucDefinitionCollection(element, collection)
+        assert collection.getModuleRefs() == []
+
+
 # ==================== SystemSignalGroup (L5249) ====================

--- a/tests/test_armodel/writer/test_writer_arpackage_dispatch.py
+++ b/tests/test_armodel/writer/test_writer_arpackage_dispatch.py
@@ -125,6 +125,7 @@ ELEMENT_TYPES_AND_TAGS = [
     ("PortPrototypeBlueprint", "PORT-PROTOTYPE-BLUEPRINT"),
     ("ModeDeclarationMappingSet", "MODE-DECLARATION-MAPPING-SET"),
     ("EcucModuleDef", "ECUC-MODULE-DEF"),
+    ("EcucDefinitionCollection", "ECUC-DEFINITION-COLLECTION"),
     ("EcucModuleConfigurationValues", "ECUC-MODULE-CONFIGURATION-VALUES"),
     ("SwSystemConst", "SW-SYSTEMCONST"),
     ("SwSystemconstantValueSet", "SW-SYSTEMCONSTANT-VALUE-SET"),

--- a/tests/test_armodel/writer/test_writer_ecuc_def.py
+++ b/tests/test_armodel/writer/test_writer_ecuc_def.py
@@ -6,12 +6,14 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
+    EcucDefinitionCollection,
     EcucMultiplicityConfigurationClass,
     EcucValueConfigurationClass,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa E501
     ARBoolean,
     ARLiteral,
+    CIdentifier,
     Float,
     Limit,
     PositiveInteger,
@@ -632,7 +634,9 @@ class TestWriterEcucModuleDefContainers:
         module = _make_module()
         parent = _parent()
         writer.writeEcucModuleDefContainers(parent, module)
-        assert len(parent) == 0
+        assert len(parent) == 1
+        assert parent[0].tag == "CONTAINERS"
+        assert len(parent[0]) == 0
 
 
 class TestWriterEcucModuleDef:
@@ -650,7 +654,50 @@ class TestWriterEcucModuleDef:
         assert parent[0].find("SUPPORTED-CONFIG-VARIANTS") is not None
         assert parent[0].find("CONTAINERS") is not None
 
+    def test_full_with_api_service_prefix_and_refined(self, writer):
+        module = _make_module()
+        prefix = CIdentifier()
+        prefix.setValue("Cdd")
+        module.setApiServicePrefix(prefix)
+        module.setRefinedModuleDefRef(_ref("/Pkg/StMd", dest="ECUC-MODULE-DEF"))
+        parent = _parent()
+        writer.writeEcucModuleDef(parent, module)
+        assert parent[0].tag == "ECUC-MODULE-DEF"
+        assert parent[0].find("API-SERVICE-PREFIX").text == "Cdd"
+        refined = parent[0].find("REFINED-MODULE-DEF-REF")
+        assert refined is not None
+        assert refined.text == "/Pkg/StMd"
+        assert refined.attrib.get("DEST") == "ECUC-MODULE-DEF"
+
     def test_none(self, writer):
         parent = _parent()
         writer.writeEcucModuleDef(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterEcucDefinitionCollection:
+    def test_full(self, writer):
+        pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+        collection = EcucDefinitionCollection(pkg, "Coll")
+        collection.addModuleRef(_ref("/Pkg/Mod", dest="ECUC-MODULE-DEF"))
+        parent = _parent()
+        writer.writeEcucDefinitionCollection(parent, collection)
+        assert parent[0].tag == "ECUC-DEFINITION-COLLECTION"
+        assert parent[0].find("SHORT-NAME").text == "Coll"
+        refs = parent[0].findall("MODULE-REFS/MODULE-REF")
+        assert len(refs) == 1
+        assert refs[0].text == "/Pkg/Mod"
+        assert refs[0].attrib.get("DEST") == "ECUC-MODULE-DEF"
+
+    def test_empty(self, writer):
+        pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+        collection = EcucDefinitionCollection(pkg, "Coll")
+        parent = _parent()
+        writer.writeEcucDefinitionCollection(parent, collection)
+        assert parent[0].tag == "ECUC-DEFINITION-COLLECTION"
+        assert parent[0].find("MODULE-REFS") is None
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writeEcucDefinitionCollection(parent, None)
         assert len(parent) == 0


### PR DESCRIPTION
## Summary
Syncs the `ECUCParameterDefTemplate` model classes to the AUTOSAR R23-11 specification (AUTOSAR_CP_TPS_ECUConfiguration.pdf).

Refs #597

### Changes
- **EcucConfigurationVariantEnum**: populate literals `RECOMMENDED-CONFIGURATION`, `VARIANT-LINK-TIME`, `VARIANT-POST-BUILD`, `VARIANT-PRE-COMPILE`
- **EcucDefinitionCollection**: rename `definitions` -> `moduleRefs`; add `addModuleRef`/`getModuleRefs`
- **ARPackage**: add `createEcucDefinitionCollection`/`getEcucDefinitionCollections`
- **EcucModuleDef**: sync `apiServicePrefix`, `postBuildVariantSupport`, `refinedModuleDefRef`, `supportedConfigVariants` with `Optional` type contracts
- **Writer**: add `ECUC-DEFINITION-COLLECTION` and `EcucModuleDef` attribute serialization
- **Parser**: dispatch support for `EcucDefinitionCollection` / `EcucModuleDef`

## Test plan
- [x] Affected unit tests pass (`406 passed`)
- [x] Black formatting applied (line length 200)