### PR TITLE
feat: extend ECUC parameter definition model, parser and writer

### DIFF
--- a/scripts/eval_skill_static_checks.py
+++ b/scripts/eval_skill_static_checks.py
@@ -36,9 +36,7 @@ def check_continuity(top_level: List[str]) -> List[str]:
     findings: List[str] = []
     expected = [f"{n:04d}" for n in range(1, 17)]
     if top_level != expected:
-        findings.append(
-            f"top-level rule list is {top_level}, expected {expected}"
-        )
+        findings.append(f"top-level rule list is {top_level}, expected {expected}")
     seen = set()
     duplicates = [r for r in top_level if r in seen or seen.add(r)]
     if duplicates:
@@ -50,9 +48,7 @@ def check_dangling_refs(defined: List[str], referenced: Dict[str, int]) -> List[
     findings: List[str] = []
     defined_set = set(defined)
     for rid in referenced:
-        if rid not in defined_set and not any(
-            d == rid.split(".")[0] for d in defined_set
-        ):
+        if rid not in defined_set and not any(d == rid.split(".")[0] for d in defined_set):
             findings.append(f"referenced Rule {rid} has no definition")
     return findings
 

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py
@@ -191,11 +191,12 @@ class EcucScopeEnum(AREnum):
 
 class EcucDefinitionElement(Identifiable, ABC):
     """
-    Common class used to express the commonalities of configuration parameters, references and containers. If not stated otherwise the default multiplicity is exactly one mandatory instance per definition.
+    Common class used to express the commonalities of configuration parameters, references and containers. If not stated otherwise the default multiplicity is exactly one mandatory occurrence of the specified element.
     """
 
     # EcucDefinitionElement method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.6, p.46
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getEcucCond                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] setEcucCond                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
@@ -217,66 +218,128 @@ class EcucDefinitionElement(Identifiable, ABC):
             raise TypeError("EcucDefinitionElement is an abstract class.")
         super().__init__(parent, short_name)
 
-        self.ecucCond: EcucConditionSpecification = None
-        self.ecucValidationConds: List[EcucValidationCondition] = []
-        self.lowerMultiplicity: PositiveInteger = None
-        self.relatedTraceItemRef: RefType = None
-        self.scope: EcucScopeEnum = None
-        self.upperMultiplicity: PositiveInteger = None
-        self.upperMultiplicityInfinite: Boolean = None
+        # If it evaluates to true the Ecu Parameter definition shall be processed as specified. Otherwise the parameter definition shall be ignored.
+        self.ecucCond: Optional[EcucConditionSpecification] = None
 
-    def getEcucCond(self) -> EcucConditionSpecification:
+        # Collection of validation conditions which all need to evaluate to true in order to indicate a valid validation condition of the EcucDefinitionElement.
+        self.ecucValidationConds: List[EcucValidationCondition] = []
+
+        # The lower multiplicity of the specified element. 0: optional 1: at least one occurrence n: at least n occurrences.
+        self.lowerMultiplicity: Optional[PositiveInteger] = None
+
+        # This contains a sloppy reference to the Autosar compatible identifier of the element (EcucId).
+        self.relatedTraceItemRef: Optional[RefType] = None
+
+        # Specifies the scope of this configuration element.
+        self.scope: Optional[EcucScopeEnum] = None
+
+        # The upper multiplicity of the specified element. 0: no occurrence (used for VSMD) 1: at most one occurrence m: at most m occurrences If upperMultiplicity is set than upperMultiplicityInfinite shall not be used.
+        self.upperMultiplicity: Optional[PositiveInteger] = None
+
+        # To express an infinite number of occurrences of this element this attribute has to be set to true. If upperMultiplicityInfinite is set than upperMultiplicity shall not be used.
+        self.upperMultiplicityInfinite: Optional[Boolean] = None
+
+    def getEcucCond(self) -> Optional[EcucConditionSpecification]:
+        """
+        If it evaluates to true the Ecu Parameter definition shall be processed as specified. Otherwise the parameter definition shall be ignored.
+        """
         return self.ecucCond
 
-    def setEcucCond(self, value: EcucConditionSpecification):
+    def setEcucCond(self, value: Optional[EcucConditionSpecification]):
+        """
+        If it evaluates to true the Ecu Parameter definition shall be processed as specified. Otherwise the parameter definition shall be ignored.
+        A None value is a no-op and does not overwrite an existing ecucCond.
+        """
         if value is not None:
             self.ecucCond = value
         return self
 
     def getEcucValidationConds(self) -> List[EcucValidationCondition]:
+        """
+        Collection of validation conditions which all need to evaluate to true in order to indicate a valid validation condition of the EcucDefinitionElement.
+        """
         return self.ecucValidationConds
 
     def addEcucValidationCond(self, value: EcucValidationCondition):
+        """
+        Collection of validation conditions which all need to evaluate to true in order to indicate a valid validation condition of the EcucDefinitionElement.
+        A None value is a no-op.
+        """
         if value is not None:
             self.ecucValidationConds.append(value)
         return self
 
-    def getLowerMultiplicity(self) -> PositiveInteger:
+    def getLowerMultiplicity(self) -> Optional[PositiveInteger]:
+        """
+        The lower multiplicity of the specified element. 0: optional 1: at least one occurrence n: at least n occurrences.
+        """
         return self.lowerMultiplicity
 
-    def setLowerMultiplicity(self, value: PositiveInteger):
+    def setLowerMultiplicity(self, value: Optional[PositiveInteger]):
+        """
+        The lower multiplicity of the specified element. 0: optional 1: at least one occurrence n: at least n occurrences.
+        A None value is a no-op and does not overwrite an existing lowerMultiplicity.
+        """
         if value is not None:
             self.lowerMultiplicity = value
         return self
 
-    def getRelatedTraceItemRef(self) -> RefType:
+    def getRelatedTraceItemRef(self) -> Optional[RefType]:
+        """
+        This contains a sloppy reference to the Autosar compatible identifier of the element (EcucId).
+        """
         return self.relatedTraceItemRef
 
-    def setRelatedTraceItemRef(self, value: RefType):
+    def setRelatedTraceItemRef(self, value: Optional[RefType]):
+        """
+        This contains a sloppy reference to the Autosar compatible identifier of the element (EcucId).
+        A None value is a no-op and does not overwrite an existing relatedTraceItemRef.
+        """
         if value is not None:
             self.relatedTraceItemRef = value
         return self
 
-    def getScope(self) -> EcucScopeEnum:
+    def getScope(self) -> Optional[EcucScopeEnum]:
+        """
+        Specifies the scope of this configuration element.
+        """
         return self.scope
 
-    def setScope(self, value: EcucScopeEnum):
+    def setScope(self, value: Optional[EcucScopeEnum]):
+        """
+        Specifies the scope of this configuration element.
+        A None value is a no-op and does not overwrite an existing scope.
+        """
         if value is not None:
             self.scope = value
         return self
 
-    def getUpperMultiplicity(self) -> PositiveInteger:
+    def getUpperMultiplicity(self) -> Optional[PositiveInteger]:
+        """
+        The upper multiplicity of the specified element. 0: no occurrence (used for VSMD) 1: at most one occurrence m: at most m occurrences If upperMultiplicity is set than upperMultiplicityInfinite shall not be used.
+        """
         return self.upperMultiplicity
 
-    def setUpperMultiplicity(self, value: PositiveInteger):
+    def setUpperMultiplicity(self, value: Optional[PositiveInteger]):
+        """
+        The upper multiplicity of the specified element. 0: no occurrence (used for VSMD) 1: at most one occurrence m: at most m occurrences If upperMultiplicity is set than upperMultiplicityInfinite shall not be used.
+        A None value is a no-op and does not overwrite an existing upperMultiplicity.
+        """
         if value is not None:
             self.upperMultiplicity = value
         return self
 
-    def getUpperMultiplicityInfinite(self) -> Boolean:
+    def getUpperMultiplicityInfinite(self) -> Optional[Boolean]:
+        """
+        To express an infinite number of occurrences of this element this attribute has to be set to true. If upperMultiplicityInfinite is set than upperMultiplicity shall not be used.
+        """
         return self.upperMultiplicityInfinite
 
-    def setUpperMultiplicityInfinite(self, value: Boolean):
+    def setUpperMultiplicityInfinite(self, value: Optional[Boolean]):
+        """
+        To express an infinite number of occurrences of this element this attribute has to be set to true. If upperMultiplicityInfinite is set than upperMultiplicity shall not be used.
+        A None value is a no-op and does not overwrite an existing upperMultiplicityInfinite.
+        """
         if value is not None:
             self.upperMultiplicityInfinite = value
         return self
@@ -370,6 +433,7 @@ class EcucAbstractConfigurationClass(ARObject, ABC):
 
     # EcucAbstractConfigurationClass method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.9, p.51
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getConfigClass               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
     # [x] setConfigClass               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
@@ -381,21 +445,38 @@ class EcucAbstractConfigurationClass(ARObject, ABC):
             raise TypeError("EcucAbstractConfigurationClass is an abstract class.")
         super().__init__()
 
-        self.configClass: EcucConfigurationClassEnum = None
-        self.configVariant: EcucConfigurationVariantEnum = None
+        # Specifies the ConfigurationClass for the given ConfigurationVariant.
+        self.configClass: Optional[EcucConfigurationClassEnum] = None
 
-    def getConfigClass(self) -> EcucConfigurationClassEnum:
+        # Specifies the ConfigurationVariant the ConfigurationClass is specified for.
+        self.configVariant: Optional[EcucConfigurationVariantEnum] = None
+
+    def getConfigClass(self) -> Optional[EcucConfigurationClassEnum]:
+        """
+        Specifies the ConfigurationClass for the given ConfigurationVariant.
+        """
         return self.configClass
 
-    def setConfigClass(self, value: EcucConfigurationClassEnum):
+    def setConfigClass(self, value: Optional[EcucConfigurationClassEnum]):
+        """
+        Specifies the ConfigurationClass for the given ConfigurationVariant.
+        A None value is a no-op and does not overwrite an existing configClass.
+        """
         if value is not None:
             self.configClass = value
         return self
 
-    def getConfigVariant(self) -> EcucConfigurationVariantEnum:
+    def getConfigVariant(self) -> Optional[EcucConfigurationVariantEnum]:
+        """
+        Specifies the ConfigurationVariant the ConfigurationClass is specified for.
+        """
         return self.configVariant
 
-    def setConfigVariant(self, value: EcucConfigurationVariantEnum):
+    def setConfigVariant(self, value: Optional[EcucConfigurationVariantEnum]):
+        """
+        Specifies the ConfigurationVariant the ConfigurationClass is specified for.
+        A None value is a no-op and does not overwrite an existing configVariant.
+        """
         if value is not None:
             self.configVariant = value
         return self
@@ -408,6 +489,7 @@ class EcucMultiplicityConfigurationClass(EcucAbstractConfigurationClass):
 
     # EcucMultiplicityConfigurationClass method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.11, p.52
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self):
@@ -421,65 +503,110 @@ class EcucContainerDef(EcucDefinitionElement, ABC):
 
     # EcucContainerDef method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.3, p.37
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] getDestinationUriRef         [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] setDestinationUriRef         [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getDestinationUriRefs       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addDestinationUriRef        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
     # [x] getMultiplicityConfigClasses [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
-    # [x] addMultiplicityConfigClass   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
-    # [x] getOrigin                    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] setOrigin                    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addMultiplicityConfigClass  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getOrigin                   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setOrigin                   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
     # [x] getPostBuildVariantMultiplicity [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
     # [x] setPostBuildVariantMultiplicity [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
-    # [x] getRequiresIndex             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
-    # [x] setRequiresIndex             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRequiresIndex            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setRequiresIndex            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         if type(self) is EcucContainerDef:
             raise TypeError("EcucContainerDef is an abstract class.")
         super().__init__(parent, short_name)
 
-        self.destinationUriRef: EcucDestinationUriDefRefType = None
+        # Several destinationUris can be defined for an Ecuc ContainerDef. With such destinationUris an Ecuc ContainerDef is applicable for several EcucUriReference Defs.
+        self.destinationUriRefs: List[EcucDestinationUriDefRefType] = []
+
+        # Specifies which MultiplicityConfigurationClass this container is available for which ConfigurationVariant.
         self.multiplicityConfigClasses: List[EcucMultiplicityConfigurationClass] = []
-        self.origin: String = None
-        self.postBuildVariantMultiplicity: Boolean = None
-        self.requiresIndex: Boolean = None
 
-    def getDestinationUriRef(self) -> EcucDestinationUriDefRefType:
-        return self.destinationUriRef
+        # This attribute specifies whether this configuration container is an AUTOSAR standardized container or whether it is vendor-specific.
+        self.origin: Optional[String] = None
 
-    def setDestinationUriRef(self, value: EcucDestinationUriDefRefType):
+        # Indicates if a container may have different number of instances in different post-build variants (previously known as post-build selectable configuration sets). TRUE means yes, FALSE means no.
+        self.postBuildVariantMultiplicity: Optional[Boolean] = None
+
+        # Used to define whether the value element for this definition shall be provided with an index.
+        self.requiresIndex: Optional[Boolean] = None
+
+    def getDestinationUriRefs(self) -> List[EcucDestinationUriDefRefType]:
+        """
+        Several destinationUris can be defined for an Ecuc ContainerDef. With such destinationUris an Ecuc ContainerDef is applicable for several EcucUriReference Defs.
+        """
+        return self.destinationUriRefs
+
+    def addDestinationUriRef(self, value: EcucDestinationUriDefRefType) -> "EcucContainerDef":
+        """
+        Several destinationUris can be defined for an Ecuc ContainerDef. With such destinationUris an Ecuc ContainerDef is applicable for several EcucUriReference Defs.
+        A None value is a no-op.
+        """
         if value is not None:
-            self.destinationUriRef = value
+            self.destinationUriRefs.append(value)
         return self
 
     def getMultiplicityConfigClasses(self) -> List[EcucMultiplicityConfigurationClass]:
+        """
+        Specifies which MultiplicityConfigurationClass this container is available for which ConfigurationVariant.
+        """
         return self.multiplicityConfigClasses
 
-    def addMultiplicityConfigClass(self, value: EcucMultiplicityConfigurationClass):
+    def addMultiplicityConfigClass(self, value: EcucMultiplicityConfigurationClass) -> "EcucContainerDef":
+        """
+        Specifies which MultiplicityConfigurationClass this container is available for which ConfigurationVariant.
+        A None value is a no-op.
+        """
         if value is not None:
             self.multiplicityConfigClasses.append(value)
         return self
 
-    def getOrigin(self) -> String:
+    def getOrigin(self) -> Optional[String]:
+        """
+        This attribute specifies whether this configuration container is an AUTOSAR standardized container or whether it is vendor-specific.
+        """
         return self.origin
 
-    def setOrigin(self, value: String):
+    def setOrigin(self, value: Optional[String]) -> "EcucContainerDef":
+        """
+        This attribute specifies whether this configuration container is an AUTOSAR standardized container or whether it is vendor-specific.
+        A None value is a no-op and does not overwrite an existing origin.
+        """
         if value is not None:
             self.origin = value
         return self
 
-    def getPostBuildVariantMultiplicity(self) -> Boolean:
+    def getPostBuildVariantMultiplicity(self) -> Optional[Boolean]:
+        """
+        Indicates if a container may have different number of instances in different post-build variants (previously known as post-build selectable configuration sets). TRUE means yes, FALSE means no.
+        """
         return self.postBuildVariantMultiplicity
 
-    def setPostBuildVariantMultiplicity(self, value: Boolean):
+    def setPostBuildVariantMultiplicity(self, value: Optional[Boolean]) -> "EcucContainerDef":
+        """
+        Indicates if a container may have different number of instances in different post-build variants (previously known as post-build selectable configuration sets). TRUE means yes, FALSE means no.
+        A None value is a no-op and does not overwrite an existing postBuildVariantMultiplicity.
+        """
         if value is not None:
             self.postBuildVariantMultiplicity = value
         return self
 
-    def getRequiresIndex(self) -> Boolean:
+    def getRequiresIndex(self) -> Optional[Boolean]:
+        """
+        Used to define whether the value element for this definition shall be provided with an index.
+        """
         return self.requiresIndex
 
-    def setRequiresIndex(self, value: Boolean):
+    def setRequiresIndex(self, value: Optional[Boolean]) -> "EcucContainerDef":
+        """
+        Used to define whether the value element for this definition shall be provided with an index.
+        A None value is a no-op and does not overwrite an existing requiresIndex.
+        """
         if value is not None:
             self.requiresIndex = value
         return self
@@ -1690,18 +1817,19 @@ class EcucDestinationUriDef(Identifiable):
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
+        # Description of the targeted EcucContainerDef.
         self.destinationUriPolicy: Optional["EcucDestinationUriPolicy"] = None
 
     def getDestinationUriPolicy(self) -> Optional["EcucDestinationUriPolicy"]:
         """
-        Gets the destination URI policy.
+        Description of the targeted EcucContainerDef.
         """
         return self.destinationUriPolicy
 
     def setDestinationUriPolicy(self, value: "EcucDestinationUriPolicy") -> "EcucDestinationUriDef":
         """
-        Sets the destination URI policy.
-        A None value is a no-op.
+        Description of the targeted EcucContainerDef.
+        A None value is a no-op and does not overwrite an existing destinationUriPolicy.
         """
         if value is not None:
             self.destinationUriPolicy = value

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -168,6 +168,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucContainerDef,
     EcucDefinitionCollection,
     EcucDefinitionElement,
+    EcucDestinationUriDefRefType,
     EcucEnumerationLiteralDef,
     EcucEnumerationParamDef,
     EcucFloatParamDef,
@@ -6520,10 +6521,33 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readEcucContainerDef(self, element: ET.Element, container_def: EcucContainerDef):
         self.readEcucDefinitionElement(element, container_def)
+        for uri_ref in self.getEcucDestinationUriRefs(element):
+            container_def.addDestinationUriRef(uri_ref)
         for cfg_class in self.getEcucMultiplicityConfigurationClasses(element):
             container_def.addMultiplicityConfigClass(cfg_class)
         container_def.setPostBuildVariantMultiplicity(self.getChildElementOptionalBooleanValue(element, "POST-BUILD-VARIANT-MULTIPLICITY"))
         container_def.setRequiresIndex(self.getChildElementOptionalBooleanValue(element, "REQUIRES-INDEX"))
+        origin_lit = self.getChildElementOptionalLiteral(element, "ORIGIN")
+        if origin_lit is not None:
+            origin = String()
+            origin.setValue(origin_lit.getValue())
+            container_def.setOrigin(origin)
+
+    def getEcucDestinationUriRefs(self, element: ET.Element) -> List[EcucDestinationUriDefRefType]:
+        uri_refs = []
+        for child_element in self.findall(element, "DESTINATION-URI-REFS/*"):
+            tag_name = self.getTagName(child_element)
+            if tag_name == "DESTINATION-URI-REF":
+                uri_ref = EcucDestinationUriDefRefType()
+                if "BASE" in child_element.attrib:
+                    uri_ref.setBase(child_element.attrib["BASE"])
+                if "DEST" in child_element.attrib:
+                    uri_ref.setDest(child_element.attrib["DEST"])
+                uri_ref.setValue(child_element.text)
+                uri_refs.append(uri_ref)
+            else:
+                self.notImplemented("Unsupported DestinationUriRef <%s>" % tag_name)
+        return uri_refs
 
     def readEcucValueConfigurationClass(self, element: ET.Element, cfg_class: EcucValueConfigurationClass):
         self.readEcucAbstractConfigurationClass(element, cfg_class)

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -160,6 +160,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucContainerDef,
     EcucDefinitionCollection,
     EcucDefinitionElement,
+    EcucDestinationUriDefRefType,
     EcucEnumerationLiteralDef,
     EcucEnumerationParamDef,
     EcucFloatParamDef,
@@ -6341,9 +6342,28 @@ class ARXMLWriter(AbstractARXMLWriter):
 
     def writeEcucContainerDef(self, element: ET.Element, container_def: EcucContainerDef):
         self.writeEcucDefinitionElement(element, container_def)
+        self.setEcucDestinationUriRefs(element, container_def.getDestinationUriRefs())
         self.setEcucMultiplicityConfigClasses(element, container_def.getMultiplicityConfigClasses())
+        self.setChildElementOptionalLiteral(element, "ORIGIN", container_def.getOrigin())
         self.setChildElementOptionalBooleanValue(element, "POST-BUILD-VARIANT-MULTIPLICITY", container_def.getPostBuildVariantMultiplicity())
         self.setChildElementOptionalBooleanValue(element, "REQUIRES-INDEX", container_def.getRequiresIndex())
+
+    def setEcucDestinationUriRefs(self, element: ET.Element, uri_refs: List[EcucDestinationUriDefRefType]):
+        if len(uri_refs) > 0:
+            child_element = ET.SubElement(element, "DESTINATION-URI-REFS")
+            for uri_ref in uri_refs:
+                if isinstance(uri_ref, EcucDestinationUriDefRefType):
+                    ref_element = ET.SubElement(child_element, "DESTINATION-URI-REF")
+                    base = uri_ref.getBase()
+                    if base is not None:
+                        ref_element.attrib["BASE"] = base
+                    dest = uri_ref.getDest()
+                    if dest is not None:
+                        ref_element.attrib["DEST"] = dest
+                    if uri_ref.value is not None:
+                        ref_element.text = uri_ref.value
+                else:
+                    self.notImplemented("Unsupported DestinationUriRef <%s>" % type(uri_ref))
 
     def writeEcucAbstractReferenceDef(self, element: ET.Element, reference: EcucAbstractReferenceDef):
         self.writeEcucCommonAttributes(element, reference)

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/test_ECUCParameterDefTemplate.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/test_ECUCParameterDefTemplate.py
@@ -55,7 +55,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucValidationCondition,
     EcucValueConfigurationClass,
 )
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Boolean, CIdentifier, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Boolean, CIdentifier, RefType, String
 from armodel.models.M2.MSR.Documentation.BlockElements.Formula import MlFormula
 
 
@@ -696,7 +696,7 @@ class TestEcucContainerDef:
 
         assert container_def is not None
         assert container_def.getShortName() == "TestContainerDef"
-        assert container_def.getDestinationUriRef() is None
+        assert container_def.getDestinationUriRefs() == []
         assert container_def.getMultiplicityConfigClasses() == []
         assert container_def.getOrigin() is None
         assert container_def.getPostBuildVariantMultiplicity() is None
@@ -712,11 +712,13 @@ class TestEcucContainerDef:
         # Use EcucParamConfContainerDef as it's a concrete subclass of EcucContainerDef
         container_def = EcucParamConfContainerDef(parent, "TestContainerDef")
 
-        # Test setDestinationUriRef
+        # Test addDestinationUriRef
         uri_ref = EcucDestinationUriDefRefType()
-        result = container_def.setDestinationUriRef(uri_ref)
+        uri_ref.setValue("/Dest/Uri")
+        uri_ref.setDest("ECUC-DESTINATION-URI-DEF")
+        result = container_def.addDestinationUriRef(uri_ref)
         assert result == container_def
-        assert container_def.getDestinationUriRef() == uri_ref
+        assert uri_ref in container_def.getDestinationUriRefs()
 
         # Test addMultiplicityConfigClass
         mult_config = EcucMultiplicityConfigurationClass()
@@ -725,9 +727,12 @@ class TestEcucContainerDef:
         assert mult_config in container_def.getMultiplicityConfigClasses()
 
         # Test setOrigin
-        result = container_def.setOrigin("TestOrigin")
+        origin = String()
+        origin.setValue("MANUFACTURER")
+        result = container_def.setOrigin(origin)
         assert result == container_def
-        assert container_def.getOrigin() == "TestOrigin"
+        assert container_def.getOrigin() == origin
+        assert container_def.getOrigin().getValue() == "MANUFACTURER"
 
         # Test setPostBuildVariantMultiplicity
         result = container_def.setPostBuildVariantMultiplicity(True)
@@ -738,6 +743,33 @@ class TestEcucContainerDef:
         result = container_def.setRequiresIndex(True)
         assert result == container_def
         assert container_def.getRequiresIndex() is True
+
+    def test_setters_none_noop(self):
+        """
+        Test EcucContainerDef setters with None values.
+        Verifies that setting None values doesn't change the stored values.
+        """
+        document = AUTOSAR.getInstance()
+        parent = document.createARPackage("TestPackage")
+        container_def = EcucParamConfContainerDef(parent, "TestContainerDef")
+
+        uri_ref = EcucDestinationUriDefRefType()
+        container_def.addDestinationUriRef(uri_ref)
+        result = container_def.addDestinationUriRef(None)
+        assert result == container_def
+        assert container_def.getDestinationUriRefs() == [uri_ref]
+
+        result = container_def.setPostBuildVariantMultiplicity(None)
+        assert result == container_def
+        assert container_def.getPostBuildVariantMultiplicity() is None
+
+        result = container_def.setRequiresIndex(None)
+        assert result == container_def
+        assert container_def.getRequiresIndex() is None
+
+        result = container_def.setOrigin(None)
+        assert result == container_def
+        assert container_def.getOrigin() is None
 
 
 class TestEcucValueConfigurationClass:

--- a/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
@@ -1139,11 +1139,7 @@ class TestEcucContainerAndModuleDef:
         from armodel.models import EcucParamConfContainerDef
 
         container = EcucParamConfContainerDef(_autosar_root(), "Cd")
-        element = _snip(
-            "<DESTINATION-URI-REFS>"
-            "<DESTINATION-URI-REF DEST=\"ECUC-DESTINATION-URI-DEF\">/Dest/Uri</DESTINATION-URI-REF>"
-            "</DESTINATION-URI-REFS>"
-        )
+        element = _snip("<DESTINATION-URI-REFS>" '<DESTINATION-URI-REF DEST="ECUC-DESTINATION-URI-DEF">/Dest/Uri</DESTINATION-URI-REF>' "</DESTINATION-URI-REFS>")
         parser.readEcucContainerDef(element, container)
         uri_refs = container.getDestinationUriRefs()
         assert len(uri_refs) == 1

--- a/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
@@ -1126,12 +1126,36 @@ class TestEcucContainerAndModuleDef:
             "<CONFIG-VARIANT>POST-BUILD</CONFIG-VARIANT>"
             "</ECUC-MULTIPLICITY-CONFIGURATION-CLASS>"
             "</MULTIPLICITY-CONFIG-CLASSES>"
+            "<ORIGIN>MANUFACTURER</ORIGIN>"
             "<POST-BUILD-VARIANT-MULTIPLICITY>true</POST-BUILD-VARIANT-MULTIPLICITY>"
             "<REQUIRES-INDEX>true</REQUIRES-INDEX>"
         )
         parser.readEcucContainerDef(element, container)
         assert len(container.getMultiplicityConfigClasses()) == 1
+        assert container.getOrigin().getValue() == "MANUFACTURER"
         assert container.getPostBuildVariantMultiplicity().getValue() is True
+
+    def test_readEcucContainerDef_destination_uri_refs(self, parser):
+        from armodel.models import EcucParamConfContainerDef
+
+        container = EcucParamConfContainerDef(_autosar_root(), "Cd")
+        element = _snip(
+            "<DESTINATION-URI-REFS>"
+            "<DESTINATION-URI-REF DEST=\"ECUC-DESTINATION-URI-DEF\">/Dest/Uri</DESTINATION-URI-REF>"
+            "</DESTINATION-URI-REFS>"
+        )
+        parser.readEcucContainerDef(element, container)
+        uri_refs = container.getDestinationUriRefs()
+        assert len(uri_refs) == 1
+        assert uri_refs[0].getValue() == "/Dest/Uri"
+        assert uri_refs[0].getDest() == "ECUC-DESTINATION-URI-DEF"
+
+    def test_getEcucDestinationUriRefs_unsupported_warns(self, warning_parser, caplog):
+        element = _snip("<DESTINATION-URI-REFS><BAD/></DESTINATION-URI-REFS>")
+        with caplog.at_level(logging.ERROR):
+            result = warning_parser.getEcucDestinationUriRefs(element)
+        assert result == []
+        assert any("Unsupported DestinationUriRef" in r.getMessage() for r in caplog.records)
 
     def test_getEcucValueConfigurationClasses_unsupported_warns(self, warning_parser, caplog):
         element = _snip("<VALUE-CONFIG-CLASSES><BAD/></VALUE-CONFIG-CLASSES>")

--- a/tests/test_armodel/writer/test_writer_ecuc_def.py
+++ b/tests/test_armodel/writer/test_writer_ecuc_def.py
@@ -7,6 +7,7 @@ import pytest
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucDefinitionCollection,
+    EcucDestinationUriDefRefType,
     EcucMultiplicityConfigurationClass,
     EcucValueConfigurationClass,
 )
@@ -444,12 +445,21 @@ class TestWriterEcucContainerDefParameters:
 class TestWriterEcucContainerDef:
     def test_full(self, writer):
         container = _make_container()
+        uri_ref = EcucDestinationUriDefRefType()
+        uri_ref.setValue("/Dest/Uri")
+        uri_ref.setDest("ECUC-DESTINATION-URI-DEF")
+        container.addDestinationUriRef(uri_ref)
         container.addMultiplicityConfigClass(EcucMultiplicityConfigurationClass().setConfigClass(_literal("mc")))
+        container.setOrigin(_literal("MANUFACTURER"))
         container.setPostBuildVariantMultiplicity(_bool(True))
         container.setRequiresIndex(_bool(False))
         parent = _parent()
         writer.writeEcucContainerDef(parent, container)
+        assert parent.find("DESTINATION-URI-REFS") is not None
+        assert parent.find("DESTINATION-URI-REFS/DESTINATION-URI-REF").text == "/Dest/Uri"
+        assert parent.find("DESTINATION-URI-REFS/DESTINATION-URI-REF").attrib["DEST"] == "ECUC-DESTINATION-URI-DEF"
         assert parent.find("MULTIPLICITY-CONFIG-CLASSES") is not None
+        assert parent.find("ORIGIN").text == "MANUFACTURER"
         assert parent.find("POST-BUILD-VARIANT-MULTIPLICITY").text == "true"
         assert parent.find("REQUIRES-INDEX").text == "false"
         assert parent.find("MULTIPLE-CONFIGURATION-CONTAINER") is None
@@ -458,7 +468,9 @@ class TestWriterEcucContainerDef:
         container = _make_container()
         parent = _parent()
         writer.writeEcucContainerDef(parent, container)
+        assert parent.find("DESTINATION-URI-REFS") is None
         assert parent.find("MULTIPLICITY-CONFIG-CLASSES") is None
+        assert parent.find("ORIGIN") is None
         assert parent.find("POST-BUILD-VARIANT-MULTIPLICITY") is None
         assert parent.find("REQUIRES-INDEX") is None
         assert parent.find("MULTIPLE-CONFIGURATION-CONTAINER") is None


### PR DESCRIPTION
## Summary

- Extend `ECUCParameterDefTemplate` model classes
- Add ARXML parser handlers for ECUC param/container defs
- Add ARXML writer serialization for ECUC defs
- Add unit, parser, and writer tests

Closes #601

## Test plan

- `npm run flake8` — pass
- `npm run black-check` — pass
- `python scripts/run_tests.py` — 6121 passed
- `python -m build` — success