### PR TITLE
feat: sync Ecuc string/function param def classes (R23-11)

### DIFF
--- a/.agents/skills/sync-autosar-class/rules.md
+++ b/.agents/skills/sync-autosar-class/rules.md
@@ -136,8 +136,33 @@ The class must reflect the AUTOSAR PDF specification for its attributes.
 
 ### 1.4 Multiplicity
 
-- `*` → `List[T]` (default `[]`); `0..1` → optional single `T` (default `None`). A
-  bounded ordered mult like `0..2` still maps to `List[T]` with `getXxxs`/`addXxx`.
+The spec `Mult.` column decides the Python shape — and the **type annotations must
+match it exactly** (field, getter return, setter parameter, and parser/writer helper
+all agree; Rule 0001.3). Do not stop at the field default:
+
+- `*` (or any bounded many like `0..2`) → `List[T]` field (default `[]`) with plural
+  accessors (`getXxxs`/`addXxx`); `getXxxs() -> List[T]`, `addXxx(value: T)`.
+- `0..1` → **optional single**: the field, the getter return, **and** the setter
+  parameter must ALL be annotated `Optional[T]` (default `None`) — not bare `T`.
+  ```python
+  self.regularExpression: Optional[RegularExpression] = None
+
+  def getRegularExpression(self) -> Optional[RegularExpression]:
+      return self.regularExpression
+
+  def setRegularExpression(self, value: Optional[RegularExpression]):
+      if value is not None:
+          self.regularExpression = value
+      return self
+  ```
+  A bare `self.x: T = None` (or `getXxx(self) -> T` / `setXxx(self, value: T)`) is a
+  Rule 1.4 violation even if the field defaults to `None` and the tests pass. The
+  parser/writer helpers stay optional-typed too (`getChildElementOptional…` /
+  `setChildElementOptional…`), so a bare-`T` annotation on any one of them is drift.
+  Because tests/black/ruff do **not** catch a bare-`T` `0..1` annotation (the value is
+  still `None` at runtime), re-verify annotations against the `Mult.` column as part of
+  the Step 9b field-to-spec cross-check — a class whose `0..1` fields were written in an
+  earlier release often carries bare `T`; fix them rather than re-stamping over them.
 - A spec-`*` member whose **name is singular** still maps to a **plural** Python list
   field + plural accessors (`revisionLabel` `*` → `revisionLabels` +
   `addRevisionLabel`/`getRevisionLabels`). The per-item XML element keeps the singular

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py
@@ -632,6 +632,7 @@ class EcucCommonAttributes(EcucDefinitionElement, ABC):
 
     # EcucCommonAttributes method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.8, p.49
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getMultiplicityConfigClasses [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
     # [x] addMultiplicityConfigClass   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
@@ -652,57 +653,110 @@ class EcucCommonAttributes(EcucDefinitionElement, ABC):
 
         super().__init__(parent, short_name)
 
+        # Specifies in which MultiplicityConfigurationClass this parameter or reference is available in a particular ConfigurationVariant. This aggregation is optional if the surrounding EcucModuleDef has the Category STANDARDIZED_MODULE_DEFINITION. If the category attribute of the EcucModuleDef is set to VENDOR_SPECIFIC_MODULE_DEFINITION, then this aggregation is mandatory.
         self.multiplicityConfigClasses: List[EcucMultiplicityConfigurationClass] = []
-        self.origin: String = None
-        self.postBuildVariantMultiplicity: Boolean = None
-        self.postBuildVariantValue: Boolean = None
-        self.requiresIndex: Boolean = None
+
+        # String specifying if this configuration parameter is an AUTOSAR standardized configuration parameter or if the parameter is hardware- or vendor-specific.
+        self.origin: Optional[String] = None
+
+        # Indicates if a parameter or a reference may have different number of instances in different post-build variants (previously known as post-build selectable configuration sets). TRUE means yes, FALSE means no.
+        self.postBuildVariantMultiplicity: Optional[Boolean] = None
+
+        # Indicates if a parameter or a reference may have different value in different post-build variants (previously known as post-build selectable configuration sets). TRUE means yes, FALSE means no.
+        self.postBuildVariantValue: Optional[Boolean] = None
+
+        # Used to define whether the value element for this definition shall be provided with an index.
+        self.requiresIndex: Optional[Boolean] = None
+
+        # Specifies in which ValueConfigurationClass this parameter or reference is available in a particular ConfigurationVariant. This aggregation is optional if the surrounding EcucModuleDef has the Category STANDARDIZED_MODULE_DEFINITION. If the category attribute of the EcucModuleDef is set to VENDOR_SPECIFIC_MODULE_DEFINITION, then this aggregation is mandatory.
         self.valueConfigClasses: List[EcucValueConfigurationClass] = []
 
     def getMultiplicityConfigClasses(self) -> List[EcucMultiplicityConfigurationClass]:
+        """
+        Specifies in which MultiplicityConfigurationClass this parameter or reference is available in a particular ConfigurationVariant. This aggregation is optional if the surrounding EcucModuleDef has the Category STANDARDIZED_MODULE_DEFINITION. If the category attribute of the EcucModuleDef is set to VENDOR_SPECIFIC_MODULE_DEFINITION, then this aggregation is mandatory.
+        """
         return self.multiplicityConfigClasses
 
     def addMultiplicityConfigClass(self, value: EcucMultiplicityConfigurationClass):
+        """
+        Specifies in which MultiplicityConfigurationClass this parameter or reference is available in a particular ConfigurationVariant. This aggregation is optional if the surrounding EcucModuleDef has the Category STANDARDIZED_MODULE_DEFINITION. If the category attribute of the EcucModuleDef is set to VENDOR_SPECIFIC_MODULE_DEFINITION, then this aggregation is mandatory.
+        A None value is a no-op.
+        """
         if value is not None:
             self.multiplicityConfigClasses.append(value)
         return self
 
-    def getOrigin(self) -> String:
+    def getOrigin(self) -> Optional[String]:
+        """
+        String specifying if this configuration parameter is an AUTOSAR standardized configuration parameter or if the parameter is hardware- or vendor-specific.
+        """
         return self.origin
 
-    def setOrigin(self, value: String):
+    def setOrigin(self, value: Optional[String]):
+        """
+        String specifying if this configuration parameter is an AUTOSAR standardized configuration parameter or if the parameter is hardware- or vendor-specific.
+        A None value is a no-op and does not overwrite an existing origin.
+        """
         if value is not None:
             self.origin = value
         return self
 
-    def getPostBuildVariantMultiplicity(self) -> Boolean:
+    def getPostBuildVariantMultiplicity(self) -> Optional[Boolean]:
+        """
+        Indicates if a parameter or a reference may have different number of instances in different post-build variants (previously known as post-build selectable configuration sets). TRUE means yes, FALSE means no.
+        """
         return self.postBuildVariantMultiplicity
 
-    def setPostBuildVariantMultiplicity(self, value: Boolean):
+    def setPostBuildVariantMultiplicity(self, value: Optional[Boolean]):
+        """
+        Indicates if a parameter or a reference may have different number of instances in different post-build variants (previously known as post-build selectable configuration sets). TRUE means yes, FALSE means no.
+        A None value is a no-op and does not overwrite an existing postBuildVariantMultiplicity.
+        """
         if value is not None:
             self.postBuildVariantMultiplicity = value
         return self
 
-    def getPostBuildVariantValue(self) -> Boolean:
+    def getPostBuildVariantValue(self) -> Optional[Boolean]:
+        """
+        Indicates if a parameter or a reference may have different value in different post-build variants (previously known as post-build selectable configuration sets). TRUE means yes, FALSE means no.
+        """
         return self.postBuildVariantValue
 
-    def setPostBuildVariantValue(self, value: Boolean):
+    def setPostBuildVariantValue(self, value: Optional[Boolean]):
+        """
+        Indicates if a parameter or a reference may have different value in different post-build variants (previously known as post-build selectable configuration sets). TRUE means yes, FALSE means no.
+        A None value is a no-op and does not overwrite an existing postBuildVariantValue.
+        """
         if value is not None:
             self.postBuildVariantValue = value
         return self
 
-    def getRequiresIndex(self) -> Boolean:
+    def getRequiresIndex(self) -> Optional[Boolean]:
+        """
+        Used to define whether the value element for this definition shall be provided with an index.
+        """
         return self.requiresIndex
 
-    def setRequiresIndex(self, value: Boolean):
+    def setRequiresIndex(self, value: Optional[Boolean]):
+        """
+        Used to define whether the value element for this definition shall be provided with an index.
+        A None value is a no-op and does not overwrite an existing requiresIndex.
+        """
         if value is not None:
             self.requiresIndex = value
         return self
 
     def getValueConfigClasses(self) -> List[EcucValueConfigurationClass]:
+        """
+        Specifies in which ValueConfigurationClass this parameter or reference is available in a particular ConfigurationVariant. This aggregation is optional if the surrounding EcucModuleDef has the Category STANDARDIZED_MODULE_DEFINITION. If the category attribute of the EcucModuleDef is set to VENDOR_SPECIFIC_MODULE_DEFINITION, then this aggregation is mandatory.
+        """
         return self.valueConfigClasses
 
     def addValueConfigClass(self, value: EcucValueConfigurationClass):
+        """
+        Specifies in which ValueConfigurationClass this parameter or reference is available in a particular ConfigurationVariant. This aggregation is optional if the surrounding EcucModuleDef has the Category STANDARDIZED_MODULE_DEFINITION. If the category attribute of the EcucModuleDef is set to VENDOR_SPECIFIC_MODULE_DEFINITION, then this aggregation is mandatory.
+        A None value is a no-op.
+        """
         if value is not None:
             self.valueConfigClasses.append(value)
         return self
@@ -1163,20 +1217,21 @@ class EcucInstanceReferenceDef(EcucAbstractExternalReferenceDef):
 
 class EcucAbstractStringParamDef(EcucParameterDef, ABC):
     """
-    Abstract class that is used to collect the common properties for StringParamDefs, LinkerSymbolDef, FunctionNameDef and MultilineStringParamDefs.
+    Abstract class that is used to collect the common properties for StringParamDefs, LinkerSymbolDef, FunctionNameDef and MultilineStringParamDefs. atpVariation: [RS_ECUC_00083] Tags: vh.latestBindingTime=codeGenerationTime
     """
 
     # EcucAbstractStringParamDef method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.18, p.63
-    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] getDefaultValue              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
-    # [x] setDefaultValue              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
-    # [x] getMaxLength                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
-    # [x] setMaxLength                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
-    # [x] getMinLength                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
-    # [x] setMinLength                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
-    # [x] getRegularExpression         [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] setRegularExpression         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # Spec verified: R23-11
+    # [x] __init__             [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getDefaultValue      [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setDefaultValue      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMaxLength         [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setMaxLength         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMinLength         [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setMinLength         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRegularExpression [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setRegularExpression [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent, short_name):
         if type(self) is EcucAbstractStringParamDef:
@@ -1184,39 +1239,78 @@ class EcucAbstractStringParamDef(EcucParameterDef, ABC):
 
         super().__init__(parent, short_name)
 
-        self.defaultValue: VerbatimString = None
-        self.maxLength: PositiveInteger = None
-        self.minLength: PositiveInteger = None
-        self.regularExpression: RegularExpression = None
+        # Default value of the string configuration parameter.
+        self.defaultValue: Optional[VerbatimString] = None
 
-    def getDefaultValue(self) -> VerbatimString:
+        # Max length allowed for this string.
+        self.maxLength: Optional[PositiveInteger] = None
+
+        # Min length allowed for this string.
+        self.minLength: Optional[PositiveInteger] = None
+
+        # This represents the regular expression which shall be used to validate the string parameter value.
+        self.regularExpression: Optional[RegularExpression] = None
+
+    def getDefaultValue(self) -> Optional[VerbatimString]:
+        """
+        Default value of the string configuration parameter.
+        """
         return self.defaultValue
 
-    def setDefaultValue(self, value: VerbatimString):
+    def setDefaultValue(self, value: Optional[VerbatimString]):
+        """
+        Default value of the string configuration parameter.
+
+        A None value is a no-op and does not overwrite an existing defaultValue.
+        """
         if value is not None:
             self.defaultValue = value
         return self
 
-    def getMaxLength(self) -> PositiveInteger:
+    def getMaxLength(self) -> Optional[PositiveInteger]:
+        """
+        Max length allowed for this string.
+        """
         return self.maxLength
 
-    def setMaxLength(self, value: PositiveInteger):
+    def setMaxLength(self, value: Optional[PositiveInteger]):
+        """
+        Max length allowed for this string.
+
+        A None value is a no-op and does not overwrite an existing maxLength.
+        """
         if value is not None:
             self.maxLength = value
         return self
 
-    def getMinLength(self) -> PositiveInteger:
+    def getMinLength(self) -> Optional[PositiveInteger]:
+        """
+        Min length allowed for this string.
+        """
         return self.minLength
 
-    def setMinLength(self, value: PositiveInteger):
+    def setMinLength(self, value: Optional[PositiveInteger]):
+        """
+        Min length allowed for this string.
+
+        A None value is a no-op and does not overwrite an existing minLength.
+        """
         if value is not None:
             self.minLength = value
         return self
 
-    def getRegularExpression(self) -> RegularExpression:
+    def getRegularExpression(self) -> Optional[RegularExpression]:
+        """
+        This represents the regular expression which shall be used to validate the string parameter value.
+        """
         return self.regularExpression
 
-    def setRegularExpression(self, value: RegularExpression):
+    def setRegularExpression(self, value: Optional[RegularExpression]):
+        """
+        This represents the regular expression which shall be used to validate the string parameter value.
+
+        A None value is a no-op and does not overwrite an existing regularExpression.
+        """
         if value is not None:
             self.regularExpression = value
         return self
@@ -1229,6 +1323,7 @@ class EcucStringParamDef(EcucAbstractStringParamDef):
 
     # EcucStringParamDef method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.19, p.64
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
@@ -1242,7 +1337,8 @@ class EcucFunctionNameDef(EcucAbstractStringParamDef):
 
     # EcucFunctionNameDef method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.22, p.65
-    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
@@ -1485,6 +1581,7 @@ class EcucParamConfContainerDef(EcucContainerDef):
     # [x] createEcucFloatParamDef      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
     # [x] createEcucEnumerationParamDef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
     # [x] createEcucFunctionNameDef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] createEcucMultilineStringParamDef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
     # [x] getReferences                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
     # [x] createEcucSymbolicNameReferenceDef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
     # [x] createEcucReferenceDef       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
@@ -1616,6 +1713,22 @@ class EcucParamConfContainerDef(EcucContainerDef):
             ref = EcucFunctionNameDef(self, short_name)
             self.addElement(ref)
             self.parameters.append(ref)
+        return self.getElement(short_name)
+
+    def createEcucMultilineStringParamDef(self, short_name: str) -> "EcucMultilineStringParamDef":
+        """
+        Creates a new ECUC multiline string parameter definition and adds it to the container.
+
+        Args:
+            short_name (str): The short name identifier for the new parameter definition.
+
+        Returns:
+            EcucMultilineStringParamDef: The newly created ECUC multiline string parameter definition.
+        """
+        if not self.IsElementExists(short_name):
+            param = EcucMultilineStringParamDef(self, short_name)
+            self.addElement(param)
+            self.parameters.append(param)
         return self.getElement(short_name)
 
     def getReferences(self) -> List[EcucAbstractReferenceDef]:
@@ -2002,6 +2115,7 @@ class EcucMultilineStringParamDef(EcucAbstractStringParamDef):
 
     # EcucMultilineStringParamDef method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.20, p.64
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -175,6 +175,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucFunctionNameDef,
     EcucIntegerParamDef,
     EcucModuleDef,
+    EcucMultilineStringParamDef,
     EcucMultiplicityConfigurationClass,
     EcucParamConfContainerDef,
     EcucParameterDef,
@@ -6593,7 +6594,22 @@ class ARXMLParser(AbstractARXMLParser):
         param_def.setRegularExpression(self.getChildElementOptionalLiteral(element, "REGULAR-EXPRESSION"))
 
     def readEcucStringParamDef(self, element: ET.Element, param_def: EcucStringParamDef):
-        self.readEcucAbstractStringParamDef(element, param_def)
+        self.readEcucParameterDef(element, param_def)
+        child_element = self.find(element, "ECUC-STRING-PARAM-DEF-VARIANTS/ECUC-STRING-PARAM-DEF-CONDITIONAL")
+        if child_element is not None:
+            param_def.setDefaultValue(self.getChildElementOptionalLiteral(child_element, "DEFAULT-VALUE"))
+            param_def.setMinLength(self.getChildElementOptionalIntegerValue(child_element, "MIN-LENGTH"))
+            param_def.setMaxLength(self.getChildElementOptionalIntegerValue(child_element, "MAX-LENGTH"))
+            param_def.setRegularExpression(self.getChildElementOptionalLiteral(child_element, "REGULAR-EXPRESSION"))
+
+    def readEcucMultilineStringParamDef(self, element: ET.Element, param_def: EcucMultilineStringParamDef):
+        self.readEcucParameterDef(element, param_def)
+        child_element = self.find(element, "ECUC-MULTILINE-STRING-PARAM-DEF-VARIANTS/ECUC-MULTILINE-STRING-PARAM-DEF-CONDITIONAL")
+        if child_element is not None:
+            param_def.setDefaultValue(self.getChildElementOptionalLiteral(child_element, "DEFAULT-VALUE"))
+            param_def.setMinLength(self.getChildElementOptionalIntegerValue(child_element, "MIN-LENGTH"))
+            param_def.setMaxLength(self.getChildElementOptionalIntegerValue(child_element, "MAX-LENGTH"))
+            param_def.setRegularExpression(self.getChildElementOptionalLiteral(child_element, "REGULAR-EXPRESSION"))
 
     def readEcucIntegerParamDef(self, element: ET.Element, param_def: EcucIntegerParamDef):
         self.readEcucParameterDef(element, param_def)
@@ -6626,12 +6642,13 @@ class ARXMLParser(AbstractARXMLParser):
         self.readEcucEnumerationParamDefLiterals(element, param_def)
 
     def readEcucFunctionNameDef(self, element: ET.Element, ref_def: EcucFunctionNameDef):
-        self.readEcucAbstractStringParamDef(element, ref_def)
+        self.readEcucParameterDef(element, ref_def)
         child_element = self.find(element, "ECUC-FUNCTION-NAME-DEF-VARIANTS/ECUC-FUNCTION-NAME-DEF-CONDITIONAL")
         if child_element is not None:
             ref_def.setDefaultValue(self.getChildElementOptionalLiteral(child_element, "DEFAULT-VALUE"))
             ref_def.setMinLength(self.getChildElementOptionalIntegerValue(child_element, "MIN-LENGTH"))
             ref_def.setMaxLength(self.getChildElementOptionalIntegerValue(child_element, "MAX-LENGTH"))
+            ref_def.setRegularExpression(self.getChildElementOptionalLiteral(child_element, "REGULAR-EXPRESSION"))
 
     def readEcucContainerDefParameters(self, element: ET.Element, container_def: EcucParamConfContainerDef):
         for child_element in self.findall(element, "PARAMETERS/*"):
@@ -6654,6 +6671,9 @@ class ARXMLParser(AbstractARXMLParser):
             elif tag_name == "ECUC-FUNCTION-NAME-DEF":
                 param_def = container_def.createEcucFunctionNameDef(self.getShortName(child_element))
                 self.readEcucFunctionNameDef(child_element, param_def)
+            elif tag_name == "ECUC-MULTILINE-STRING-PARAM-DEF":
+                param_def = container_def.createEcucMultilineStringParamDef(self.getShortName(child_element))
+                self.readEcucMultilineStringParamDef(child_element, param_def)
             else:
                 self.notImplemented("Unsupported Parameter <%s>" % tag_name)
 

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -167,6 +167,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucFunctionNameDef,
     EcucIntegerParamDef,
     EcucModuleDef,
+    EcucMultilineStringParamDef,
     EcucMultiplicityConfigurationClass,
     EcucParamConfContainerDef,
     EcucParameterDef,
@@ -6263,12 +6264,18 @@ class ARXMLWriter(AbstractARXMLWriter):
 
     def writeEcucAbstractStringParamDef(self, element: ET.Element, param_def: EcucAbstractStringParamDef):
         self.writeEcucParameterDef(element, param_def)
-        # self.setChildElementOptionalLiteral(element, "DEFAULT-VALUE", param_def.getDefaultValue())
+        self.setChildElementOptionalLiteral(element, "DEFAULT-VALUE", param_def.getDefaultValue())
+        self.setChildElementOptionalIntegerValue(element, "MAX-LENGTH", param_def.getMaxLength())
+        self.setChildElementOptionalIntegerValue(element, "MIN-LENGTH", param_def.getMinLength())
+        self.setChildElementOptionalLiteral(element, "REGULAR-EXPRESSION", param_def.getRegularExpression())
 
     def writeEcucStringParamDef(self, element: ET.Element, param_def: EcucStringParamDef):
         if param_def is not None:
             child_element = ET.SubElement(element, "ECUC-STRING-PARAM-DEF")
-            self.writeEcucAbstractStringParamDef(child_element, param_def)
+            self.writeEcucParameterDef(child_element, param_def)
+            variants_tag = ET.SubElement(child_element, "ECUC-STRING-PARAM-DEF-VARIANTS")
+            cond_tag = ET.SubElement(variants_tag, "ECUC-STRING-PARAM-DEF-CONDITIONAL")
+            self.writeEcucAbstractStringParamDef(cond_tag, param_def)
 
     def writeEcucIntegerParamDef(self, element: ET.Element, param_def: EcucIntegerParamDef):
         if param_def is not None:
@@ -6312,13 +6319,18 @@ class ARXMLWriter(AbstractARXMLWriter):
     def writeEcucFunctionNameDef(self, element: ET.Element, param_def: EcucFunctionNameDef):
         if param_def is not None:
             child_element = ET.SubElement(element, "ECUC-FUNCTION-NAME-DEF")
-            self.writeEcucAbstractStringParamDef(child_element, param_def)
-
+            self.writeEcucParameterDef(child_element, param_def)
             variants_tag = ET.SubElement(child_element, "ECUC-FUNCTION-NAME-DEF-VARIANTS")
             cond_tag = ET.SubElement(variants_tag, "ECUC-FUNCTION-NAME-DEF-CONDITIONAL")
-            self.setChildElementOptionalLiteral(cond_tag, "DEFAULT-VALUE", param_def.getDefaultValue())
-            self.setChildElementOptionalIntegerValue(cond_tag, "MIN-LENGTH", param_def.getMinLength())
-            self.setChildElementOptionalIntegerValue(cond_tag, "MAX-LENGTH", param_def.getMaxLength())
+            self.writeEcucAbstractStringParamDef(cond_tag, param_def)
+
+    def writeEcucMultilineStringParamDef(self, element: ET.Element, param_def: EcucMultilineStringParamDef):
+        if param_def is not None:
+            child_element = ET.SubElement(element, "ECUC-MULTILINE-STRING-PARAM-DEF")
+            self.writeEcucParameterDef(child_element, param_def)
+            variants_tag = ET.SubElement(child_element, "ECUC-MULTILINE-STRING-PARAM-DEF-VARIANTS")
+            cond_tag = ET.SubElement(variants_tag, "ECUC-MULTILINE-STRING-PARAM-DEF-CONDITIONAL")
+            self.writeEcucAbstractStringParamDef(cond_tag, param_def)
 
     def writeEcucContainerDefParameters(self, element: ET.Element, container_def: EcucParamConfContainerDef):
         parameters = container_def.getParameters()
@@ -6337,6 +6349,8 @@ class ARXMLWriter(AbstractARXMLWriter):
                     self.writeEcucEnumerationParamDef(child_element, parameter)
                 elif isinstance(parameter, EcucFunctionNameDef):
                     self.writeEcucFunctionNameDef(child_element, parameter)
+                elif isinstance(parameter, EcucMultilineStringParamDef):
+                    self.writeEcucMultilineStringParamDef(child_element, parameter)
                 else:
                     self.notImplemented("Unsupported Parameter <%s>" % type(parameter))
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/test_ECUCParameterDefTemplate.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/test_ECUCParameterDefTemplate.py
@@ -256,6 +256,87 @@ class TestEcucCommonAttributes:
         with pytest.raises(TypeError):
             _instantiate(EcucCommonAttributes)
 
+    def _make(self):
+        class _Concrete(EcucCommonAttributes):
+            pass
+
+        return _Concrete(AUTOSAR.getInstance().createARPackage("Pkg_TestECA"), "sn")
+
+    def test_initialization_defaults(self):
+        obj = self._make()
+        assert obj.getMultiplicityConfigClasses() == []
+        assert obj.getOrigin() is None
+        assert obj.getPostBuildVariantMultiplicity() is None
+        assert obj.getPostBuildVariantValue() is None
+        assert obj.getRequiresIndex() is None
+        assert obj.getValueConfigClasses() == []
+
+    def test_get_set_origin_roundtrip(self):
+        obj = self._make()
+        assert obj.setOrigin("AUTOSAR_ECUC") is obj
+        assert obj.getOrigin() == "AUTOSAR_ECUC"
+
+    def test_set_origin_none_noop(self):
+        obj = self._make()
+        obj.setOrigin("AUTOSAR_ECUC")
+        obj.setOrigin(None)
+        assert obj.getOrigin() == "AUTOSAR_ECUC"
+
+    def test_get_set_post_build_variant_multiplicity_roundtrip(self):
+        obj = self._make()
+        assert obj.setPostBuildVariantMultiplicity(True) is obj
+        assert obj.getPostBuildVariantMultiplicity() is True
+
+    def test_set_post_build_variant_multiplicity_none_noop(self):
+        obj = self._make()
+        obj.setPostBuildVariantMultiplicity(True)
+        obj.setPostBuildVariantMultiplicity(None)
+        assert obj.getPostBuildVariantMultiplicity() is True
+
+    def test_get_set_post_build_variant_value_roundtrip(self):
+        obj = self._make()
+        assert obj.setPostBuildVariantValue(False) is obj
+        assert obj.getPostBuildVariantValue() is False
+
+    def test_set_post_build_variant_value_none_noop(self):
+        obj = self._make()
+        obj.setPostBuildVariantValue(False)
+        obj.setPostBuildVariantValue(None)
+        assert obj.getPostBuildVariantValue() is False
+
+    def test_get_set_requires_index_roundtrip(self):
+        obj = self._make()
+        assert obj.setRequiresIndex(True) is obj
+        assert obj.getRequiresIndex() is True
+
+    def test_set_requires_index_none_noop(self):
+        obj = self._make()
+        obj.setRequiresIndex(True)
+        obj.setRequiresIndex(None)
+        assert obj.getRequiresIndex() is True
+
+    def test_add_multiplicity_config_class(self):
+        obj = self._make()
+        item = EcucMultiplicityConfigurationClass()
+        assert obj.addMultiplicityConfigClass(item) is obj
+        assert obj.getMultiplicityConfigClasses() == [item]
+
+    def test_add_multiplicity_config_class_none_noop(self):
+        obj = self._make()
+        obj.addMultiplicityConfigClass(None)
+        assert obj.getMultiplicityConfigClasses() == []
+
+    def test_add_value_config_class(self):
+        obj = self._make()
+        item = EcucValueConfigurationClass()
+        assert obj.addValueConfigClass(item) is obj
+        assert obj.getValueConfigClasses() == [item]
+
+    def test_add_value_config_class_none_noop(self):
+        obj = self._make()
+        obj.addValueConfigClass(None)
+        assert obj.getValueConfigClasses() == []
+
 
 class TestEcucParameterDef:
     def test_rejects_direct_instantiation(self):
@@ -285,6 +366,87 @@ class TestEcucAbstractStringParamDef:
     def test_rejects_direct_instantiation(self):
         with pytest.raises(TypeError):
             _instantiate(EcucAbstractStringParamDef)
+
+    def _make(self):
+        class _Concrete(EcucAbstractStringParamDef):
+            pass
+
+        return _Concrete(AUTOSAR.getInstance().createARPackage("Pkg_TestEASPD"), "sn")
+
+    def test_initialization_defaults(self):
+        obj = self._make()
+        assert obj.getDefaultValue() is None
+        assert obj.getMaxLength() is None
+        assert obj.getMinLength() is None
+        assert obj.getRegularExpression() is None
+
+    def test_get_set_default_value_roundtrip(self):
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import VerbatimString
+
+        obj = self._make()
+        value = VerbatimString().setValue("default_value")
+        assert obj.setDefaultValue(value) is obj
+        assert obj.getDefaultValue() == value
+
+    def test_set_default_value_none_noop(self):
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import VerbatimString
+
+        obj = self._make()
+        value = VerbatimString().setValue("default_value")
+        obj.setDefaultValue(value)
+        obj.setDefaultValue(None)
+        assert obj.getDefaultValue() == value
+
+    def test_get_set_max_length_roundtrip(self):
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger
+
+        obj = self._make()
+        value = PositiveInteger().setValue("100")
+        assert obj.setMaxLength(value) is obj
+        assert obj.getMaxLength() == value
+
+    def test_set_max_length_none_noop(self):
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger
+
+        obj = self._make()
+        value = PositiveInteger().setValue("100")
+        obj.setMaxLength(value)
+        obj.setMaxLength(None)
+        assert obj.getMaxLength() == value
+
+    def test_get_set_min_length_roundtrip(self):
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger
+
+        obj = self._make()
+        value = PositiveInteger().setValue("1")
+        assert obj.setMinLength(value) is obj
+        assert obj.getMinLength() == value
+
+    def test_set_min_length_none_noop(self):
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger
+
+        obj = self._make()
+        value = PositiveInteger().setValue("1")
+        obj.setMinLength(value)
+        obj.setMinLength(None)
+        assert obj.getMinLength() == value
+
+    def test_get_set_regular_expression_roundtrip(self):
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RegularExpression
+
+        obj = self._make()
+        value = RegularExpression().setValue("[a-zA-Z]*")
+        assert obj.setRegularExpression(value) is obj
+        assert obj.getRegularExpression() == value
+
+    def test_set_regular_expression_none_noop(self):
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RegularExpression
+
+        obj = self._make()
+        value = RegularExpression().setValue("[a-zA-Z]*")
+        obj.setRegularExpression(value)
+        obj.setRegularExpression(None)
+        assert obj.getRegularExpression() == value
 
 
 class TestEcucAbstractConfigurationClass:

--- a/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
@@ -96,9 +96,14 @@ class TestEcucContainerDefParameters:
             <PARAMETERS>
                 <ECUC-STRING-PARAM-DEF>
                     <SHORT-NAME>ConfigString</SHORT-NAME>
-                    <DEFAULT-VALUE>default_value</DEFAULT-VALUE>
-                    <MAX-LENGTH>100</MAX-LENGTH>
-                    <MIN-LENGTH>1</MIN-LENGTH>
+                    <ECUC-STRING-PARAM-DEF-VARIANTS>
+                        <ECUC-STRING-PARAM-DEF-CONDITIONAL>
+                            <DEFAULT-VALUE>default_value</DEFAULT-VALUE>
+                            <MAX-LENGTH>100</MAX-LENGTH>
+                            <MIN-LENGTH>1</MIN-LENGTH>
+                            <REGULAR-EXPRESSION>[a-zA-Z]*</REGULAR-EXPRESSION>
+                        </ECUC-STRING-PARAM-DEF-CONDITIONAL>
+                    </ECUC-STRING-PARAM-DEF-VARIANTS>
                 </ECUC-STRING-PARAM-DEF>
             </PARAMETERS>
             """,
@@ -111,6 +116,7 @@ class TestEcucContainerDefParameters:
         assert params[0].getDefaultValue() is not None
         assert params[0].getMaxLength().getValue() == 100
         assert params[0].getMinLength().getValue() == 1
+        assert params[0].getRegularExpression() is not None
 
     def test_readEcucStringParamDef_without_default(self, parser):
         from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucParamConfContainerDef
@@ -132,6 +138,37 @@ class TestEcucContainerDefParameters:
         assert len(params) == 1
         assert params[0].getShortName() == "ConfigString"
         assert params[0].getDefaultValue() is None
+
+    def test_readEcucMultilineStringParamDef_with_default(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucParamConfContainerDef
+
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        container = EcucParamConfContainerDef(_autosar_root(), "ContainerDef")
+        element = _snip(
+            """
+            <PARAMETERS>
+                <ECUC-MULTILINE-STRING-PARAM-DEF>
+                    <SHORT-NAME>ConfigMulti</SHORT-NAME>
+                    <ECUC-MULTILINE-STRING-PARAM-DEF-VARIANTS>
+                        <ECUC-MULTILINE-STRING-PARAM-DEF-CONDITIONAL>
+                            <DEFAULT-VALUE>line1
+line2</DEFAULT-VALUE>
+                            <MAX-LENGTH>200</MAX-LENGTH>
+                            <MIN-LENGTH>2</MIN-LENGTH>
+                        </ECUC-MULTILINE-STRING-PARAM-DEF-CONDITIONAL>
+                    </ECUC-MULTILINE-STRING-PARAM-DEF-VARIANTS>
+                </ECUC-MULTILINE-STRING-PARAM-DEF>
+            </PARAMETERS>
+            """,
+            root_tag="ECUC-PARAM-CONF-CONTAINER-DEF",
+        )
+        parser.readEcucContainerDefParameters(element, container)
+        params = container.getParameters()
+        assert len(params) == 1
+        assert params[0].getShortName() == "ConfigMulti"
+        assert params[0].getDefaultValue() is not None
+        assert params[0].getMaxLength().getValue() == 200
+        assert params[0].getMinLength().getValue() == 2
 
     def test_readEcucIntegerParamDef_with_limits(self, parser):
         from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucParamConfContainerDef
@@ -301,6 +338,7 @@ class TestEcucContainerDefParameters:
                             <DEFAULT-VALUE>Init_MyModule</DEFAULT-VALUE>
                             <MIN-LENGTH>1</MIN-LENGTH>
                             <MAX-LENGTH>50</MAX-LENGTH>
+                            <REGULAR-EXPRESSION>[a-zA-Z_][a-zA-Z0-9_]*</REGULAR-EXPRESSION>
                         </ECUC-FUNCTION-NAME-DEF-CONDITIONAL>
                     </ECUC-FUNCTION-NAME-DEF-VARIANTS>
                 </ECUC-FUNCTION-NAME-DEF>
@@ -312,6 +350,10 @@ class TestEcucContainerDefParameters:
         params = container.getParameters()
         assert len(params) == 1
         assert params[0].getShortName() == "InitFunction"
+        assert params[0].getDefaultValue() is not None
+        assert params[0].getMinLength().getValue() == 1
+        assert params[0].getMaxLength().getValue() == 50
+        assert params[0].getRegularExpression() is not None
 
     def test_readEcucFunctionNameDef_without_value(self, parser):
         from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucParamConfContainerDef
@@ -347,7 +389,11 @@ class TestEcucContainerDefParameters:
                 </ECUC-BOOLEAN-PARAM-DEF>
                 <ECUC-STRING-PARAM-DEF>
                     <SHORT-NAME>Name</SHORT-NAME>
-                    <DEFAULT-VALUE>default</DEFAULT-VALUE>
+                    <ECUC-STRING-PARAM-DEF-VARIANTS>
+                        <ECUC-STRING-PARAM-DEF-CONDITIONAL>
+                            <DEFAULT-VALUE>default</DEFAULT-VALUE>
+                        </ECUC-STRING-PARAM-DEF-CONDITIONAL>
+                    </ECUC-STRING-PARAM-DEF-VARIANTS>
                 </ECUC-STRING-PARAM-DEF>
                 <ECUC-INTEGER-PARAM-DEF>
                     <SHORT-NAME>Count</SHORT-NAME>

--- a/tests/test_armodel/writer/test_writer_ecuc_def.py
+++ b/tests/test_armodel/writer/test_writer_ecuc_def.py
@@ -19,6 +19,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     Limit,
     PositiveInteger,
     RefType,
+    RegularExpression,
     UnlimitedInteger,
     VerbatimString,
 )
@@ -90,6 +91,12 @@ def _limit(value, interval=None):
 
 def _verbatim(value):
     v = VerbatimString()
+    v.setValue(value)
+    return v
+
+
+def _regex(value):
+    v = RegularExpression()
     v.setValue(value)
     return v
 
@@ -284,9 +291,21 @@ class TestWriterEcucStringParamDef:
     def test_full(self, writer):
         container = _make_container()
         param = container.createEcucStringParamDef("P")
+        param.setDefaultValue(_verbatim("dv"))
+        param.setMinLength(_posint(1))
+        param.setMaxLength(_posint(64))
+        param.setRegularExpression(_regex("[a-z]*"))
         parent = _parent()
         writer.writeEcucStringParamDef(parent, param)
         assert parent[0].tag == "ECUC-STRING-PARAM-DEF"
+        variants = parent[0].find("ECUC-STRING-PARAM-DEF-VARIANTS")
+        assert variants is not None
+        cond = variants.find("ECUC-STRING-PARAM-DEF-CONDITIONAL")
+        assert cond is not None
+        assert cond.find("DEFAULT-VALUE").text == "dv"
+        assert cond.find("MIN-LENGTH").text == "1"
+        assert cond.find("MAX-LENGTH").text == "64"
+        assert cond.find("REGULAR-EXPRESSION").text == "[a-z]*"
 
     def test_none(self, writer):
         parent = _parent()
@@ -398,6 +417,7 @@ class TestWriterEcucFunctionNameDef:
         param.setDefaultValue(_verbatim("fn"))
         param.setMinLength(_posint(1))
         param.setMaxLength(_posint(64))
+        param.setRegularExpression(_regex("[a-zA-Z_][a-zA-Z0-9_]*"))
         parent = _parent()
         writer.writeEcucFunctionNameDef(parent, param)
         assert parent[0].tag == "ECUC-FUNCTION-NAME-DEF"
@@ -408,6 +428,26 @@ class TestWriterEcucFunctionNameDef:
         assert cond.find("DEFAULT-VALUE").text == "fn"
         assert cond.find("MIN-LENGTH").text == "1"
         assert cond.find("MAX-LENGTH").text == "64"
+        assert cond.find("REGULAR-EXPRESSION").text == "[a-zA-Z_][a-zA-Z0-9_]*"
+
+
+class TestWriterEcucMultilineStringParamDef:
+    def test_full(self, writer):
+        container = _make_container()
+        param = container.createEcucMultilineStringParamDef("P")
+        param.setDefaultValue(_verbatim("line1\nline2"))
+        param.setMinLength(_posint(2))
+        param.setMaxLength(_posint(200))
+        parent = _parent()
+        writer.writeEcucMultilineStringParamDef(parent, param)
+        assert parent[0].tag == "ECUC-MULTILINE-STRING-PARAM-DEF"
+        variants = parent[0].find("ECUC-MULTILINE-STRING-PARAM-DEF-VARIANTS")
+        assert variants is not None
+        cond = variants.find("ECUC-MULTILINE-STRING-PARAM-DEF-CONDITIONAL")
+        assert cond is not None
+        assert cond.find("DEFAULT-VALUE").text == "line1\nline2"
+        assert cond.find("MIN-LENGTH").text == "2"
+        assert cond.find("MAX-LENGTH").text == "200"
 
     def test_none(self, writer):
         parent = _parent()
@@ -424,6 +464,7 @@ class TestWriterEcucContainerDefParameters:
         container.createEcucFloatParamDef("Fp")
         container.createEcucEnumerationParamDef("Ep")
         container.createEcucFunctionNameDef("Fn")
+        container.createEcucMultilineStringParamDef("Mp")
         parent = _parent()
         writer.writeEcucContainerDefParameters(parent, container)
         assert parent[0].tag == "PARAMETERS"
@@ -434,6 +475,7 @@ class TestWriterEcucContainerDefParameters:
         assert "ECUC-FLOAT-PARAM-DEF" in tags
         assert "ECUC-ENUMERATION-PARAM-DEF" in tags
         assert "ECUC-FUNCTION-NAME-DEF" in tags
+        assert "ECUC-MULTILINE-STRING-PARAM-DEF" in tags
 
     def test_empty(self, writer):
         container = _make_container()


### PR DESCRIPTION
Closes #603

Sync and stamp four ECUC parameter-definition model classes against AUTOSAR_CP_TPS_ECUConfiguration R23-11:
- EcucAbstractStringParamDef (Table 2.18)
- EcucStringParamDef (Table 2.19)
- EcucMultilineStringParamDef (Table 2.20)
- EcucFunctionNameDef (Table 2.22)

Quality gates: ruff clean, black clean, 6145 tests pass.