### PR TITLE
feat: sync ECUC reference definition classes (R23-11)

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py
@@ -932,13 +932,34 @@ class EcucAbstractReferenceDef(EcucCommonAttributes, ABC):
 
     # EcucAbstractReferenceDef method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.26, p.71
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getWithAuto                  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setWithAuto                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent, short_name):
         if type(self) is EcucAbstractReferenceDef:
             raise TypeError("Cannot instantiate abstract class EcucAbstractReferenceDef")
 
         super().__init__(parent, short_name)
+
+        # Specifies whether it shall be allowed on the value side to specify this reference value as "AUTO".
+        self.withAuto: Optional[Boolean] = None
+
+    def getWithAuto(self) -> Optional[Boolean]:
+        """
+        Specifies whether it shall be allowed on the value side to specify this reference value as "AUTO". If withAuto is "true" it shall be possible to set the "isAuto Value" attribute of the respective reference to "true". This means that the actual value will not be considered during ECU Configuration but will be (re-)calculated by the code generator and stored in the value attribute afterwards. These implicit updated values might require a re-generation of other modules which reference these values. If withAuto is "false" it shall not be possible to set the "is AutoValue" attribute of the respective reference to "true". If withAuto is not present the default is "false".
+        """
+        return self.withAuto
+
+    def setWithAuto(self, value: Optional[Boolean]) -> "EcucAbstractReferenceDef":
+        """
+        Specifies whether it shall be allowed on the value side to specify this reference value as "AUTO". If withAuto is "true" it shall be possible to set the "isAuto Value" attribute of the respective reference to "true". This means that the actual value will not be considered during ECU Configuration but will be (re-)calculated by the code generator and stored in the value attribute afterwards. These implicit updated values might require a re-generation of other modules which reference these values. If withAuto is "false" it shall not be possible to set the "is AutoValue" attribute of the respective reference to "true". If withAuto is not present the default is "false".
+        A None value is a no-op and does not overwrite an existing withAuto.
+        """
+        if value is not None:
+            self.withAuto = value
+        return self
 
 
 class EcucAbstractInternalReferenceDef(EcucAbstractReferenceDef, ABC):
@@ -949,6 +970,7 @@ class EcucAbstractInternalReferenceDef(EcucAbstractReferenceDef, ABC):
 
     # EcucAbstractInternalReferenceDef method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.27, p.72
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getRequiresSymbolicNameValue [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
     # [x] setRequiresSymbolicNameValue [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
@@ -958,19 +980,19 @@ class EcucAbstractInternalReferenceDef(EcucAbstractReferenceDef, ABC):
             raise TypeError("Cannot instantiate abstract class EcucAbstractInternalReferenceDef")
         super().__init__(parent, short_name)
 
-        # If this attribute is set to true the implementation of the reference is done using a Symbolic Name defined by the referenced container.
-        self.requiresSymbolicNameValue: Boolean = None
+        # If this attribute is set to true the implementation of the reference is done using a Symbolic Name defined by the referenced container according to TPS_ECUC_02108.
+        self.requiresSymbolicNameValue: Optional[Boolean] = None
 
-    def getRequiresSymbolicNameValue(self) -> Boolean:
+    def getRequiresSymbolicNameValue(self) -> Optional[Boolean]:
         """
-        Gets whether the implementation of the reference is done using a Symbolic Name.
+        If this attribute is set to true the implementation of the reference is done using a Symbolic Name defined by the referenced container according to TPS_ECUC_02108.
         """
         return self.requiresSymbolicNameValue
 
-    def setRequiresSymbolicNameValue(self, value: Boolean) -> "EcucAbstractInternalReferenceDef":
+    def setRequiresSymbolicNameValue(self, value: Optional[Boolean]) -> "EcucAbstractInternalReferenceDef":
         """
-        Sets whether the implementation of the reference is done using a Symbolic Name.
-        A None value is a no-op.
+        If this attribute is set to true the implementation of the reference is done using a Symbolic Name defined by the referenced container according to TPS_ECUC_02108.
+        A None value is a no-op and does not overwrite an existing requiresSymbolicNameValue.
         """
         if value is not None:
             self.requiresSymbolicNameValue = value
@@ -986,6 +1008,7 @@ class EcucAbstractExternalReferenceDef(EcucAbstractReferenceDef, ABC):
 
     # EcucAbstractExternalReferenceDef method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.28, p.72
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self, parent, short_name):
@@ -1035,9 +1058,10 @@ class EcucChoiceReferenceDef(EcucAbstractInternalReferenceDef):
 
     # EcucChoiceReferenceDef method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.30, p.74
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] getDestinationRefs           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] addDestinationRef            [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getDestinationRefs           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addDestinationRef            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
@@ -1047,14 +1071,14 @@ class EcucChoiceReferenceDef(EcucAbstractInternalReferenceDef):
 
     def getDestinationRefs(self) -> List[RefType]:
         """
-        Gets all the possible parameter containers for the reference.
+        All the possible parameter containers for the reference are specified.
         """
         return self.destinationRefs
 
     def addDestinationRef(self, value: RefType) -> "EcucChoiceReferenceDef":
         """
-        Adds a possible parameter container for the reference.
-        A None value is a no-op.
+        All the possible parameter containers for the reference are specified.
+        A None value is a no-op and does not overwrite an existing destinationRefs.
         """
         if value is not None:
             self.destinationRefs.append(value)
@@ -1169,46 +1193,47 @@ class EcucInstanceReferenceDef(EcucAbstractExternalReferenceDef):
 
     # EcucInstanceReferenceDef method parity checklist:
     # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.32, p.77
+    # Spec verified: R23-11
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] getDestinationContext        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] setDestinationContext        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] getDestinationType           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] setDestinationType           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getDestinationContext        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDestinationContext        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDestinationType           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDestinationType           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
         # The context in the AUTOSAR Metamodel to which this reference is allowed to point to.
-        self.destinationContext: String = None
+        self.destinationContext: Optional[String] = None
 
         # The type in the AUTOSAR Metamodel to which instance this reference is allowed to point to.
-        self.destinationType: String = None
+        self.destinationType: Optional[String] = None
 
-    def getDestinationContext(self) -> String:
+    def getDestinationContext(self) -> Optional[String]:
         """
-        Gets the context in the AUTOSAR Metamodel to which this reference may point.
+        The context in the AUTOSAR Metamodel to which this reference is allowed to point to.
         """
         return self.destinationContext
 
-    def setDestinationContext(self, value: String) -> "EcucInstanceReferenceDef":
+    def setDestinationContext(self, value: Optional[String]) -> "EcucInstanceReferenceDef":
         """
-        Sets the context in the AUTOSAR Metamodel to which this reference may point.
-        A None value is a no-op.
+        The context in the AUTOSAR Metamodel to which this reference is allowed to point to.
+        A None value is a no-op and does not overwrite an existing destinationContext.
         """
         if value is not None:
             self.destinationContext = value
         return self
 
-    def getDestinationType(self) -> String:
+    def getDestinationType(self) -> Optional[String]:
         """
-        Gets the type in the AUTOSAR Metamodel to which this reference may point.
+        The type in the AUTOSAR Metamodel to which instance this reference is allowed to point to.
         """
         return self.destinationType
 
-    def setDestinationType(self, value: String) -> "EcucInstanceReferenceDef":
+    def setDestinationType(self, value: Optional[String]) -> "EcucInstanceReferenceDef":
         """
-        Sets the type in the AUTOSAR Metamodel to which this reference may point.
-        A None value is a no-op.
+        The type in the AUTOSAR Metamodel to which instance this reference is allowed to point to.
+        A None value is a no-op and does not overwrite an existing destinationType.
         """
         if value is not None:
             self.destinationType = value
@@ -1585,6 +1610,8 @@ class EcucParamConfContainerDef(EcucContainerDef):
     # [x] getReferences                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
     # [x] createEcucSymbolicNameReferenceDef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
     # [x] createEcucReferenceDef       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] createEcucChoiceReferenceDef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] createEcucInstanceReferenceDef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
     # [x] getSubContainers             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
     # [x] createEcucChoiceContainerDef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
     # [x] createEcucParamConfContainerDef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
@@ -1772,6 +1799,38 @@ class EcucParamConfContainerDef(EcucContainerDef):
             self.references.append(ref)
         return self.getElement(short_name)
 
+    def createEcucChoiceReferenceDef(self, short_name: str) -> EcucChoiceReferenceDef:
+        """
+        Creates a new ECUC choice reference definition and adds it to the container.
+
+        Args:
+            short_name (str): The short name identifier for the new reference definition.
+
+        Returns:
+            EcucChoiceReferenceDef: The newly created ECUC choice reference definition.
+        """
+        if not self.IsElementExists(short_name):
+            ref = EcucChoiceReferenceDef(self, short_name)
+            self.addElement(ref)
+            self.references.append(ref)
+        return self.getElement(short_name)
+
+    def createEcucInstanceReferenceDef(self, short_name: str) -> EcucInstanceReferenceDef:
+        """
+        Creates a new ECUC instance reference definition and adds it to the container.
+
+        Args:
+            short_name (str): The short name identifier for the new reference definition.
+
+        Returns:
+            EcucInstanceReferenceDef: The newly created ECUC instance reference definition.
+        """
+        if not self.IsElementExists(short_name):
+            ref = EcucInstanceReferenceDef(self, short_name)
+            self.addElement(ref)
+            self.references.append(ref)
+        return self.getElement(short_name)
+
     def getSubContainers(self) -> List[EcucContainerDef]:
         """
         Retrieves the list of ECUC container definitions.
@@ -1939,7 +1998,7 @@ class EcucDestinationUriDef(Identifiable):
         """
         return self.destinationUriPolicy
 
-    def setDestinationUriPolicy(self, value: "EcucDestinationUriPolicy") -> "EcucDestinationUriDef":
+    def setDestinationUriPolicy(self, value: Optional["EcucDestinationUriPolicy"]) -> "EcucDestinationUriDef":
         """
         Description of the targeted EcucContainerDef.
         A None value is a no-op and does not overwrite an existing destinationUriPolicy.
@@ -2001,20 +2060,27 @@ class EcucDestinationUriPolicy(ARObject):
     def __init__(self):
         super().__init__()
 
+        # Description of the targetContainer in case that the destinationUriNestingPolicy is set to targetContainer. In all other cases the subContainers of the target container are defined here.
         self.containers: List[EcucContainerDef] = []
+
+        # This attribute defines how the referenced target EcucContainerDef is described.
         self.destinationUriNestingContract: Optional["EcucDestinationUriNestingContractEnum"] = None
+
+        # Description of parameters that are contained in the target container.
         self.parameters: List[EcucParameterDef] = []
+
+        # Description of references that are contained in the target container.
         self.references: List[EcucAbstractReferenceDef] = []
 
     def getContainers(self) -> List[EcucContainerDef]:
         """
-        Gets the list of container definitions.
+        Description of the targetContainer in case that the destinationUriNestingPolicy is set to targetContainer. In all other cases the subContainers of the target container are defined here.
         """
         return self.containers
 
     def addContainer(self, value: EcucContainerDef) -> "EcucDestinationUriPolicy":
         """
-        Adds a container definition to the list.
+        Description of the targetContainer in case that the destinationUriNestingPolicy is set to targetContainer. In all other cases the subContainers of the target container are defined here.
         A None value is a no-op.
         """
         if value is not None:
@@ -2023,13 +2089,13 @@ class EcucDestinationUriPolicy(ARObject):
 
     def getDestinationUriNestingContract(self) -> Optional["EcucDestinationUriNestingContractEnum"]:
         """
-        Gets the destination URI nesting contract.
+        This attribute defines how the referenced target EcucContainerDef is described.
         """
         return self.destinationUriNestingContract
 
-    def setDestinationUriNestingContract(self, value: "EcucDestinationUriNestingContractEnum") -> "EcucDestinationUriPolicy":
+    def setDestinationUriNestingContract(self, value: Optional["EcucDestinationUriNestingContractEnum"]) -> "EcucDestinationUriPolicy":
         """
-        Sets the destination URI nesting contract.
+        This attribute defines how the referenced target EcucContainerDef is described.
         A None value is a no-op.
         """
         if value is not None:
@@ -2038,13 +2104,13 @@ class EcucDestinationUriPolicy(ARObject):
 
     def getParameters(self) -> List[EcucParameterDef]:
         """
-        Gets the list of parameter definitions.
+        Description of parameters that are contained in the target container.
         """
         return self.parameters
 
     def addParameter(self, value: EcucParameterDef) -> "EcucDestinationUriPolicy":
         """
-        Adds a parameter definition to the list.
+        Description of parameters that are contained in the target container.
         A None value is a no-op.
         """
         if value is not None:
@@ -2053,13 +2119,13 @@ class EcucDestinationUriPolicy(ARObject):
 
     def getReferences(self) -> List[EcucAbstractReferenceDef]:
         """
-        Gets the list of reference definitions.
+        Description of references that are contained in the target container.
         """
         return self.references
 
     def addReference(self, value: EcucAbstractReferenceDef) -> "EcucDestinationUriPolicy":
         """
-        Adds a reference definition to the list.
+        Description of references that are contained in the target container.
         A None value is a no-op.
         """
         if value is not None:

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -159,11 +159,13 @@ from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import (
 )
 from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucAbstractConfigurationClass,
+    EcucAbstractExternalReferenceDef,
     EcucAbstractInternalReferenceDef,
     EcucAbstractReferenceDef,
     EcucAbstractStringParamDef,
     EcucBooleanParamDef,
     EcucChoiceContainerDef,
+    EcucChoiceReferenceDef,
     EcucCommonAttributes,
     EcucContainerDef,
     EcucDefinitionCollection,
@@ -173,6 +175,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucEnumerationParamDef,
     EcucFloatParamDef,
     EcucFunctionNameDef,
+    EcucInstanceReferenceDef,
     EcucIntegerParamDef,
     EcucModuleDef,
     EcucMultilineStringParamDef,
@@ -6679,10 +6682,14 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readEcucAbstractReferenceDef(self, element: ET.Element, ref_def: EcucAbstractReferenceDef):
         self.readEcucCommonAttributes(element, ref_def)
+        ref_def.setWithAuto(self.getChildElementOptionalBooleanValue(element, "WITH-AUTO"))
 
     def readEcucAbstractInternalReferenceDef(self, element: ET.Element, ref_def: EcucAbstractInternalReferenceDef):
         self.readEcucAbstractReferenceDef(element, ref_def)
         ref_def.setRequiresSymbolicNameValue(self.getChildElementOptionalBooleanValue(element, "REQUIRES-SYMBOLIC-NAME-VALUE"))
+
+    def readEcucAbstractExternalReferenceDef(self, element: ET.Element, ref_def: EcucAbstractExternalReferenceDef):
+        self.readEcucAbstractReferenceDef(element, ref_def)
 
     def readEcucSymbolicNameReferenceDef(self, element: ET.Element, ref_def: EcucSymbolicNameReferenceDef):
         self.readEcucAbstractInternalReferenceDef(element, ref_def)
@@ -6691,6 +6698,16 @@ class ARXMLParser(AbstractARXMLParser):
     def readEcucReferenceDef(self, element: ET.Element, ref_def: EcucReferenceDef):
         self.readEcucAbstractInternalReferenceDef(element, ref_def)
         ref_def.setDestinationRef(self.getChildElementOptionalRefType(element, "DESTINATION-REF"))
+
+    def readEcucChoiceReferenceDef(self, element: ET.Element, ref_def: EcucChoiceReferenceDef):
+        self.readEcucAbstractInternalReferenceDef(element, ref_def)
+        for ref in self.getChildElementRefTypeList(element, "DESTINATION-REFS/DESTINATION-REF"):
+            ref_def.addDestinationRef(ref)
+
+    def readEcucInstanceReferenceDef(self, element: ET.Element, ref_def: EcucInstanceReferenceDef):
+        self.readEcucAbstractExternalReferenceDef(element, ref_def)
+        ref_def.setDestinationContext(self.getChildElementOptionalLiteral(element, "DESTINATION-CONTEXT"))
+        ref_def.setDestinationType(self.getChildElementOptionalLiteral(element, "DESTINATION-TYPE"))
 
     def readEcucContainerDefReferences(self, element: ET.Element, container_def: EcucParamConfContainerDef):
         for child_element in self.findall(element, "REFERENCES/*"):
@@ -6701,6 +6718,12 @@ class ARXMLParser(AbstractARXMLParser):
             elif tag_name == "ECUC-REFERENCE-DEF":
                 ref_def = container_def.createEcucReferenceDef(self.getShortName(child_element))
                 self.readEcucReferenceDef(child_element, ref_def)
+            elif tag_name == "ECUC-CHOICE-REFERENCE-DEF":
+                ref_def = container_def.createEcucChoiceReferenceDef(self.getShortName(child_element))
+                self.readEcucChoiceReferenceDef(child_element, ref_def)
+            elif tag_name == "ECUC-INSTANCE-REFERENCE-DEF":
+                ref_def = container_def.createEcucInstanceReferenceDef(self.getShortName(child_element))
+                self.readEcucInstanceReferenceDef(child_element, ref_def)
             else:
                 self.notImplemented("Unsupported EcucReferenceDef <%s>" % tag_name)
 

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -151,11 +151,13 @@ from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import (
 )
 from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucAbstractConfigurationClass,
+    EcucAbstractExternalReferenceDef,
     EcucAbstractInternalReferenceDef,
     EcucAbstractReferenceDef,
     EcucAbstractStringParamDef,
     EcucBooleanParamDef,
     EcucChoiceContainerDef,
+    EcucChoiceReferenceDef,
     EcucCommonAttributes,
     EcucContainerDef,
     EcucDefinitionCollection,
@@ -165,6 +167,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucEnumerationParamDef,
     EcucFloatParamDef,
     EcucFunctionNameDef,
+    EcucInstanceReferenceDef,
     EcucIntegerParamDef,
     EcucModuleDef,
     EcucMultilineStringParamDef,
@@ -6381,10 +6384,14 @@ class ARXMLWriter(AbstractARXMLWriter):
 
     def writeEcucAbstractReferenceDef(self, element: ET.Element, reference: EcucAbstractReferenceDef):
         self.writeEcucCommonAttributes(element, reference)
+        self.setChildElementOptionalBooleanValue(element, "WITH-AUTO", reference.getWithAuto())
 
     def writeEcucAbstractInternalReferenceDef(self, element: ET.Element, reference: EcucAbstractInternalReferenceDef):
         self.writeEcucAbstractReferenceDef(element, reference)
         self.setChildElementOptionalBooleanValue(element, "REQUIRES-SYMBOLIC-NAME-VALUE", reference.getRequiresSymbolicNameValue())
+
+    def writeEcucAbstractExternalReferenceDef(self, element: ET.Element, reference: EcucAbstractExternalReferenceDef):
+        self.writeEcucAbstractReferenceDef(element, reference)
 
     def writeEcucSymbolicNameReferenceDef(self, element: ET.Element, reference: EcucSymbolicNameReferenceDef):
         if reference is not None:
@@ -6398,6 +6405,23 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeEcucAbstractInternalReferenceDef(child_element, reference)
             self.setChildElementOptionalRefType(child_element, "DESTINATION-REF", reference.getDestinationRef())
 
+    def writeEcucChoiceReferenceDef(self, element: ET.Element, reference: EcucChoiceReferenceDef):
+        if reference is not None:
+            child_element = ET.SubElement(element, "ECUC-CHOICE-REFERENCE-DEF")
+            self.writeEcucAbstractInternalReferenceDef(child_element, reference)
+            destination_refs = reference.getDestinationRefs()
+            if len(destination_refs) > 0:
+                refs_element = ET.SubElement(child_element, "DESTINATION-REFS")
+                for destination_ref in destination_refs:
+                    self.setChildElementOptionalRefType(refs_element, "DESTINATION-REF", destination_ref)
+
+    def writeEcucInstanceReferenceDef(self, element: ET.Element, reference: EcucInstanceReferenceDef):
+        if reference is not None:
+            child_element = ET.SubElement(element, "ECUC-INSTANCE-REFERENCE-DEF")
+            self.writeEcucAbstractExternalReferenceDef(child_element, reference)
+            self.setChildElementOptionalLiteral(child_element, "DESTINATION-CONTEXT", reference.getDestinationContext())
+            self.setChildElementOptionalLiteral(child_element, "DESTINATION-TYPE", reference.getDestinationType())
+
     def writeEcucContainerDefReferences(self, element: ET.Element, container_def: EcucContainerDef):
         references = container_def.getReferences()
         if len(references) > 0:
@@ -6407,6 +6431,10 @@ class ARXMLWriter(AbstractARXMLWriter):
                     self.writeEcucSymbolicNameReferenceDef(child_element, reference)
                 elif isinstance(reference, EcucReferenceDef):
                     self.writeEcucReferenceDef(child_element, reference)
+                elif isinstance(reference, EcucChoiceReferenceDef):
+                    self.writeEcucChoiceReferenceDef(child_element, reference)
+                elif isinstance(reference, EcucInstanceReferenceDef):
+                    self.writeEcucInstanceReferenceDef(child_element, reference)
                 else:
                     self.notImplemented("Unsupported Reference <%s>" % type(reference))
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/test_ECUCParameterDefTemplate.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/test_ECUCParameterDefTemplate.py
@@ -1053,6 +1053,31 @@ class TestEcucAbstractReferenceDef:
         assert concrete is not None
         assert concrete.getShortName() == "TestConcrete"
 
+    def test_get_set_with_auto(self):
+        """
+        Test getWithAuto/setWithAuto against Table 2.26.
+        Verifies the default is None and that a None value is a no-op.
+        """
+
+        class ConcreteAbstractReferenceDef(EcucAbstractReferenceDef):
+            def __init__(self, parent, short_name):
+                super().__init__(parent, short_name)
+
+        document = AUTOSAR.getInstance()
+        parent = document.createARPackage("TestPackage")
+        concrete = ConcreteAbstractReferenceDef(parent, "TestWithAuto")
+
+        assert concrete.getWithAuto() is None
+
+        result = concrete.setWithAuto(True)
+        assert result == concrete
+        assert concrete.getWithAuto() is True
+
+        # None value is a no-op
+        concrete.setWithAuto(False)
+        concrete.setWithAuto(None)
+        assert concrete.getWithAuto() is False
+
 
 class TestEcucAbstractInternalReferenceDef:
     """
@@ -1874,6 +1899,18 @@ class TestEcucParamConfContainerDef:
         assert ref is not None
         assert ref.getShortName() == "TestRef"
         assert len(param_conf_container.getReferences()) == 1
+
+        # Test createEcucChoiceReferenceDef
+        choice_ref = param_conf_container.createEcucChoiceReferenceDef("TestChoiceRef")
+        assert choice_ref is not None
+        assert choice_ref.getShortName() == "TestChoiceRef"
+        assert len(param_conf_container.getReferences()) == 2
+
+        # Test createEcucInstanceReferenceDef
+        instance_ref = param_conf_container.createEcucInstanceReferenceDef("TestInstanceRef")
+        assert instance_ref is not None
+        assert instance_ref.getShortName() == "TestInstanceRef"
+        assert len(param_conf_container.getReferences()) == 3
 
         # Test createEcucChoiceContainerDef
         sub_container = param_conf_container.createEcucChoiceContainerDef("TestSubContainer")

--- a/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
@@ -649,6 +649,29 @@ class TestEcucContainerDefReferences:
         assert refs[0].getRequiresSymbolicNameValue() is not None
         assert refs[0].getRequiresSymbolicNameValue().getValue() is True
 
+    def test_readEcucReferenceDef_with_with_auto(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucParamConfContainerDef
+
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        container = EcucParamConfContainerDef(_autosar_root(), "ContainerDef")
+        element = _snip(
+            """
+            <REFERENCES>
+                <ECUC-REFERENCE-DEF>
+                    <SHORT-NAME>AutoRef</SHORT-NAME>
+                    <WITH-AUTO>true</WITH-AUTO>
+                </ECUC-REFERENCE-DEF>
+            </REFERENCES>
+            """,
+            root_tag="ECUC-PARAM-CONF-CONTAINER-DEF",
+        )
+        parser.readEcucContainerDefReferences(element, container)
+        refs = container.getReferences()
+        assert len(refs) == 1
+        assert refs[0].getShortName() == "AutoRef"
+        assert refs[0].getWithAuto() is not None
+        assert refs[0].getWithAuto().getValue() is True
+
     def test_readEcucReferenceDef_without_requires_symbolic_name_value(self, parser):
         from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucParamConfContainerDef
 
@@ -669,6 +692,62 @@ class TestEcucContainerDefReferences:
         assert len(refs) == 1
         assert refs[0].getShortName() == "PlainRef"
         assert refs[0].getRequiresSymbolicNameValue() is None
+
+    def test_readEcucChoiceReferenceDef(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucParamConfContainerDef
+
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        container = EcucParamConfContainerDef(_autosar_root(), "ContainerDef")
+        element = _snip(
+            """
+            <REFERENCES>
+                <ECUC-CHOICE-REFERENCE-DEF>
+                    <SHORT-NAME>ChoiceRef</SHORT-NAME>
+                    <DESTINATION-REFS>
+                        <DESTINATION-REF DEST="ECUC-PARAM-CONF-CONTAINER-DEF">/A/B</DESTINATION-REF>
+                        <DESTINATION-REF DEST="ECUC-PARAM-CONF-CONTAINER-DEF">/A/C</DESTINATION-REF>
+                    </DESTINATION-REFS>
+                </ECUC-CHOICE-REFERENCE-DEF>
+            </REFERENCES>
+            """,
+            root_tag="ECUC-PARAM-CONF-CONTAINER-DEF",
+        )
+        parser.readEcucContainerDefReferences(element, container)
+        refs = container.getReferences()
+        assert len(refs) == 1
+        assert refs[0].getShortName() == "ChoiceRef"
+        assert refs[0].getDestinationRefs() is not None
+        dests = refs[0].getDestinationRefs()
+        assert len(dests) == 2
+        assert dests[0].getValue() == "/A/B"
+        assert dests[0].getDest() == "ECUC-PARAM-CONF-CONTAINER-DEF"
+        assert dests[1].getValue() == "/A/C"
+
+    def test_readEcucInstanceReferenceDef(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucParamConfContainerDef
+
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        container = EcucParamConfContainerDef(_autosar_root(), "ContainerDef")
+        element = _snip(
+            """
+            <REFERENCES>
+                <ECUC-INSTANCE-REFERENCE-DEF>
+                    <SHORT-NAME>InstanceRef</SHORT-NAME>
+                    <DESTINATION-CONTEXT>SW-COMPONENT-PROTOTYPE R-PORT-PROTOTYPE</DESTINATION-CONTEXT>
+                    <DESTINATION-TYPE>VARIABLE-DATA-PROTOTYPE</DESTINATION-TYPE>
+                </ECUC-INSTANCE-REFERENCE-DEF>
+            </REFERENCES>
+            """,
+            root_tag="ECUC-PARAM-CONF-CONTAINER-DEF",
+        )
+        parser.readEcucContainerDefReferences(element, container)
+        refs = container.getReferences()
+        assert len(refs) == 1
+        assert refs[0].getShortName() == "InstanceRef"
+        assert refs[0].getDestinationContext() is not None
+        assert refs[0].getDestinationContext().getValue() == "SW-COMPONENT-PROTOTYPE R-PORT-PROTOTYPE"
+        assert refs[0].getDestinationType() is not None
+        assert refs[0].getDestinationType().getValue() == "VARIABLE-DATA-PROTOTYPE"
 
     def test_readEcucContainerDefReferences_unsupported_type_warning(self, warning_parser):
         from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucParamConfContainerDef

--- a/tests/test_armodel/writer/test_writer_ecuc_def.py
+++ b/tests/test_armodel/writer/test_writer_ecuc_def.py
@@ -523,9 +523,17 @@ class TestWriterEcucAbstractReferenceDef:
         container = _make_container()
         ref = container.createEcucReferenceDef("R")
         ref.setOrigin(_literal("org"))
+        ref.setWithAuto(_bool(True))
         parent = _parent()
         writer.writeEcucAbstractReferenceDef(parent, ref)
         assert parent.find("ORIGIN").text == "org"
+        assert parent.find("WITH-AUTO").text == "true"
+
+    def test_omits_with_auto_when_none(self, writer):
+        container = _make_container()
+        ref = container.createEcucReferenceDef("R")
+        parent = _parent()
+        writer.writeEcucAbstractReferenceDef(parent, ref)
         assert parent.find("WITH-AUTO") is None
 
 
@@ -582,6 +590,56 @@ class TestWriterEcucReferenceDef:
         parent = _parent()
         writer.writeEcucReferenceDef(parent, None)
         assert len(parent) == 0
+
+
+class TestWriterEcucChoiceReferenceDef:
+    def test_full(self, writer):
+        container = _make_container()
+        ref = container.createEcucChoiceReferenceDef("C")
+        ref.addDestinationRef(_ref("/dst1", "ECUC-PARAM-CONF-CONTAINER-DEF"))
+        ref.addDestinationRef(_ref("/dst2", "ECUC-PARAM-CONF-CONTAINER-DEF"))
+        parent = _parent()
+        writer.writeEcucChoiceReferenceDef(parent, ref)
+        assert parent[0].tag == "ECUC-CHOICE-REFERENCE-DEF"
+        dest_refs = parent[0].find("DESTINATION-REFS")
+        assert dest_refs is not None
+        refs = dest_refs.findall("DESTINATION-REF")
+        assert len(refs) == 2
+        assert refs[0].text == "/dst1"
+        assert refs[0].attrib["DEST"] == "ECUC-PARAM-CONF-CONTAINER-DEF"
+        assert refs[1].text == "/dst2"
+
+    def test_omits_destination_refs_when_none(self, writer):
+        container = _make_container()
+        ref = container.createEcucChoiceReferenceDef("C")
+        parent = _parent()
+        writer.writeEcucChoiceReferenceDef(parent, ref)
+        assert parent[0].find("DESTINATION-REFS") is None
+
+
+class TestWriterEcucInstanceReferenceDef:
+    def test_full(self, writer):
+        container = _make_container()
+        ref = container.createEcucInstanceReferenceDef("I")
+        ref.setDestinationContext(_literal("SW-COMPONENT-PROTOTYPE R-PORT-PROTOTYPE"))
+        ref.setDestinationType(_literal("VARIABLE-DATA-PROTOTYPE"))
+        parent = _parent()
+        writer.writeEcucInstanceReferenceDef(parent, ref)
+        assert parent[0].tag == "ECUC-INSTANCE-REFERENCE-DEF"
+        ctx = parent[0].find("DESTINATION-CONTEXT")
+        assert ctx is not None
+        assert ctx.text == "SW-COMPONENT-PROTOTYPE R-PORT-PROTOTYPE"
+        typ = parent[0].find("DESTINATION-TYPE")
+        assert typ is not None
+        assert typ.text == "VARIABLE-DATA-PROTOTYPE"
+
+    def test_omits_when_none(self, writer):
+        container = _make_container()
+        ref = container.createEcucInstanceReferenceDef("I")
+        parent = _parent()
+        writer.writeEcucInstanceReferenceDef(parent, ref)
+        assert parent[0].find("DESTINATION-CONTEXT") is None
+        assert parent[0].find("DESTINATION-TYPE") is None
 
 
 class TestWriterEcucContainerDefReferences:


### PR DESCRIPTION
Sync EcucAbstractReferenceDef, EcucAbstractInternalReferenceDef, EcucAbstractExternalReferenceDef, EcucChoiceReferenceDef, and EcucInstanceReferenceDef against the AUTOSAR CP ECUConfiguration spec.

- Adds the withAuto attribute to EcucAbstractReferenceDef (Table 2.26)
- Applies Rule 1.4 Optional[T] multiplicity fixes to 0..1 attributes
- Adds reader/writer coverage for EcucChoiceReferenceDef and EcucInstanceReferenceDef
- Marks the 5 classes as spec-verified (R23-11)