### PR TITLE
feat: sync DocumentationOnM1 classes and ECUC index

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate.py
@@ -1,12 +1,18 @@
 from abc import ABC
-from typing import List
+from typing import List, Optional
 
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import AnyInstanceRef
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARLiteral, ARNumerical
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    ARBoolean,
+    AREnum,
+    ARLiteral,
+    ARNumerical,
+    PositiveInteger,
+    RefType,
+)
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Identifiable
 
 
@@ -45,17 +51,41 @@ class EcucValueCollection(ARElement):
 
 class EcucIndexableValue(ARObject, ABC):
     """
-    Abstract base class for indexable ECUC values.
+    Used to support the specification of ordering of parameter values.
     """
 
     # EcucIndexableValue method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.46, p.110
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getIndex                     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIndex                     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         if type(self) is EcucIndexableValue:
             raise TypeError("EcucIndexableValue is an abstract class.")
 
         super().__init__()
+
+        # Used to support the specification of ordering of parameter values. Tags: xml.sequenceOffset=-5
+        self.index: Optional[PositiveInteger] = None
+
+    def getIndex(self) -> Optional[PositiveInteger]:
+        """
+        Used to support the specification of ordering of parameter values.
+        """
+        return self.index
+
+    def setIndex(self, value: Optional[PositiveInteger]) -> "EcucIndexableValue":
+        """
+        Used to support the specification of ordering of parameter values.
+
+        A None value is a no-op and does not overwrite an existing index.
+        """
+        if value is not None:
+            self.index = value
+        return self
 
 
 class EcucParameterValue(EcucIndexableValue, ABC):
@@ -284,6 +314,7 @@ class EcucContainerValue(Identifiable, EcucIndexableValue):
     # [ ] createSubContainer           [x] impl  [ ] docstring  [ ] test
 
     def __init__(self, parent: ARObject, short_name: str):
+        EcucIndexableValue.__init__(self)
         Identifiable.__init__(self, parent, short_name)
 
         self.definitionRef = None  # type: RefType

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/DocumentationOnM1/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/DocumentationOnM1/__init__.py
@@ -1,47 +1,147 @@
-from typing import List
-from armodel.models.M2.MSR.Documentation.Annotation import Annotation
+from __future__ import annotations
+
+from typing import List, Optional
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import AnyInstanceRef
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import String
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, MultilanguageReferrable
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.models.M2.MSR.Documentation.Chapters import PredefinedChapter
 
 
 class Documentation(ARElement):
     """
-    Represents documentation in the AUTOSAR model.
-
-    This class is used to provide documentation for AUTOSAR elements,
-    including annotations and text descriptions.
-
-    Attributes:
-        annotations (List[Annotation]): A list of annotations for the documentation.
-        description (String): The description text.
+    This meta-class represents the ability to handle a so called standalone documentation. Standalone means, that such a documentation is not embedded in another ARElement or identifiable object. The standalone documentation is an entity of its own which denotes its context by reference to other objects and instances.
     """
 
     # Documentation method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getAnnotations               [x] impl  [ ] docstring  [ ] test
-    # [ ] addAnnotation                [x] impl  [ ] docstring  [ ] test
-    # [ ] getDescription               [x] impl  [ ] docstring  [ ] test
-    # [ ] setDescription               [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table E.28, p.439
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addContext                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getContexts                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDocumentationContent     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDocumentationContent     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.annotations: List[Annotation] = []
-        self.description: String = None
+        # This is the context of the particular documentation.
+        self.contexts: List[DocumentationContext] = []
 
-    def getAnnotations(self) -> List[Annotation]:
-        return self.annotations
+        # This is the content of the documentation related to the specified contexts.
+        self.documentationContent: Optional[PredefinedChapter] = None
 
-    def addAnnotation(self, value: Annotation):
+    def addContext(self, value: DocumentationContext) -> "Documentation":
+        """
+        This is the context of the particular documentation.
+
+        A None value is a no-op and does not append an existing context.
+
+        Returns:
+            self for method chaining
+        """
         if value is not None:
-            self.annotations.append(value)
+            self.contexts.append(value)
         return self
 
-    def getDescription(self) -> String:
-        return self.description
+    def getContexts(self) -> List[DocumentationContext]:
+        """
+        This is the context of the particular documentation.
 
-    def setDescription(self, value: String):
+        Returns:
+            The contexts of the particular documentation
+        """
+        return self.contexts
+
+    def setDocumentationContent(self, value: Optional[PredefinedChapter]) -> "Documentation":
+        """
+        This is the content of the documentation related to the specified contexts.
+
+        A None value is a no-op and does not overwrite an existing documentationContent.
+
+        Returns:
+            self for method chaining
+        """
         if value is not None:
-            self.description = value
+            self.documentationContent = value
         return self
+
+    def getDocumentationContent(self) -> Optional[PredefinedChapter]:
+        """
+        This is the content of the documentation related to the specified contexts.
+
+        Returns:
+            The content of the documentation related to the specified contexts
+        """
+        return self.documentationContent
+
+
+class DocumentationContext(MultilanguageReferrable):
+    """
+    This class represents the ability to denote a context of a so called standalone documentation. Note that this is an <<atpMixed>>. The contents needs to be considered as ordered.
+    """
+
+    # DocumentationContext method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 9.56, p.327
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setFeatureIRef          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFeatureIRef          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIdentifiableRef      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getIdentifiableRef      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+
+    def __init__(self, parent: ARObject, short_name: str):
+        super().__init__(parent, short_name)
+
+        # This refers to a particular feature (instance in the M0 model) to which is the context of the documentation.
+        self.featureIRef: Optional[AnyInstanceRef] = None
+
+        # This is an identifiable object which is part of the context of the documentation.
+        self.identifiableRef: Optional[RefType] = None
+
+    def setFeatureIRef(self, value: Optional[AnyInstanceRef]) -> "DocumentationContext":
+        """
+        This refers to a particular feature (instance in the M0 model) to which is the context of the documentation.
+
+        A None value is a no-op and does not overwrite an existing featureIRef.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.featureIRef = value
+        return self
+
+    def getFeatureIRef(self) -> Optional[AnyInstanceRef]:
+        """
+        This refers to a particular feature (instance in the M0 model) to which is the context of the documentation.
+
+        Returns:
+            The feature (instance in the M0 model) to which is the context of the documentation
+        """
+        return self.featureIRef
+
+    def setIdentifiableRef(self, value: Optional[RefType]) -> "DocumentationContext":
+        """
+        This is an identifiable object which is part of the context of the documentation.
+
+        A None value is a no-op and does not overwrite an existing identifiableRef.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.identifiableRef = value
+        return self
+
+    def getIdentifiableRef(self) -> Optional[RefType]:
+        """
+        This is an identifiable object which is part of the context of the documentation.
+
+        Returns:
+            The identifiable object which is part of the context of the documentation
+        """
+        return self.identifiableRef

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Any
 
 from armodel.models.M2.MSR.DataDictionary.SystemConstant import SwSystemconst
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import Documentation
 from armodel.models.M2.MSR.AsamHdo.AdminData import AdminData
 from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultilanguageLongName
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation
@@ -836,6 +837,12 @@ class ARPackage(CollectableElement):
             set = LifeCycleInfoSet(self, short_name)
             self.addElement(set)
         return self.getElement(short_name, LifeCycleInfoSet)
+
+    def createDocumentation(self, short_name: str) -> Documentation:
+        if not self.IsElementExists(short_name, Documentation):
+            documentation = Documentation(self, short_name)
+            self.addElement(documentation)
+        return self.getElement(short_name, Documentation)
 
     def createClientServerInterface(self, short_name: str) -> ClientServerInterface:
         if not self.IsElementExists(short_name, ClientServerInterface):

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
@@ -715,23 +715,71 @@ class Boolean(ARBoolean):
 
 class Identifier(ARLiteral):
     """
-    An Identifier is a string with a number of constraints on its appearance, satisfying the requirements typical
-    programming languages define for their Identifiers.
-    This datatype represents a string, that can be used as a c-Identifier.
-    It shall start with a letter, may consist of letters, digits and underscores.
-
-    Tags:
-        * xml.xsd.customType=IDENTIFIER
-        * xml.xsd.maxLength=128
-        * xml.xsd.pattern=[a-zA-Z][a-zA-Z0-9_]*
-        * xml.xsd.type=string
+    An Identifier is a string with a number of constraints on its appearance, satisfying the requirements typical programming languages define for their Identifiers. This datatype represents a string, that can be used as a c-Identifier. It shall start with a letter, may consist of letters, digits and underscores.
     """
 
     # Identifier method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.5, p.61
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__            [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBlueprintValue   [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setBlueprintValue   [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getNamePattern      [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setNamePattern      [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self):
         super().__init__()
+
+        # This represents a description that documents how the value shall be defined when deriving objects from the blueprint.
+        self.blueprintValue: Optional[String] = None
+
+        # This attribute represents a pattern which shall be used to define the value of the identifier if the identifier in question is part of a blueprint. For more details refer to TPS_StandardizationTemplate.
+        self.namePattern: Optional[String] = None
+
+    def getBlueprintValue(self) -> Optional[String]:
+        """
+        This represents a description that documents how the value shall be defined when deriving objects from the blueprint.
+
+        Returns:
+            The blueprint value, or None if not set
+        """
+        return self.blueprintValue
+
+    def setBlueprintValue(self, value: Optional[String]) -> "Identifier":
+        """
+        This represents a description that documents how the value shall be defined when deriving objects from the blueprint.
+
+        A None value is a no-op and does not overwrite an existing blueprintValue.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.blueprintValue = value
+        return self
+
+    def getNamePattern(self) -> Optional[String]:
+        """
+        This attribute represents a pattern which shall be used to define the value of the identifier if the identifier in question is part of a blueprint. For more details refer to TPS_StandardizationTemplate.
+
+        Returns:
+            The name pattern, or None if not set
+        """
+        return self.namePattern
+
+    def setNamePattern(self, value: Optional[String]) -> "Identifier":
+        """
+        This attribute represents a pattern which shall be used to define the value of the identifier if the identifier in question is part of a blueprint. For more details refer to TPS_StandardizationTemplate.
+
+        A None value is a no-op and does not overwrite an existing namePattern.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.namePattern = value
+        return self
 
 
 class CIdentifier(ARLiteral):

--- a/src/armodel/models/M2/MSR/Documentation/Chapters.py
+++ b/src/armodel/models/M2/MSR/Documentation/Chapters.py
@@ -89,6 +89,48 @@ class Chapter(Identifiable):
         return self.chapterModel
 
 
+class PredefinedChapter(ARObject):
+    """
+    This represents a predefined chapter.
+    """
+
+    # PredefinedChapter method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 9.62, p.331
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__            [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] setChapterModel     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getChapterModel     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This is the content of the predefined chapter.
+        self.chapterModel: Optional[ChapterModel] = None
+
+    def setChapterModel(self, value: Optional[ChapterModel]) -> "PredefinedChapter":
+        """
+        This is the content of the predefined chapter.
+
+        A None value is a no-op and does not overwrite an existing chapterModel.
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.chapterModel = value
+        return self
+
+    def getChapterModel(self) -> Optional[ChapterModel]:
+        """
+        This is the content of the predefined chapter.
+
+        Returns:
+            The content of the predefined chapter
+        """
+        return self.chapterModel
+
+
 class ChapterModel(ARObject):
     """
     This is the basic content model of a chapter except the Chapter title. This can be utilized in general chapters as well as in predefined chapters.

--- a/src/armodel/models/__init__.py
+++ b/src/armodel/models/__init__.py
@@ -134,6 +134,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import *  # noqa: F403
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import *  # noqa: F403
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.RolesAndRights.AtpDefinition import *  # noqa: F403
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import *  # noqa: F403
 
 # Additional SWComponentTemplate imports
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs import *  # noqa: F403

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -200,6 +200,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
 )
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwDescriptionEntity, HwElement, HwPinGroup
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwAttributeDef, HwCategory, HwType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import Documentation, DocumentationContext
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import AnyInstanceRef
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage, ReferenceBase
@@ -598,6 +599,7 @@ from armodel.models.M2.MSR.Documentation.Chapters import (
     ChapterOrMsrQuery,
     MsrQueryChapter,
     MsrQueryTopic1,
+    PredefinedChapter,
     Topic1,
     TopicContent,
     TopicContentOrMsrQuery,
@@ -4080,6 +4082,29 @@ class ARXMLParser(AbstractARXMLParser):
             chapter_model.setChapter(chapter_or_msr_query)
         return chapter_model
 
+    def readPredefinedChapter(self, element: ET.Element) -> PredefinedChapter:
+        predefined = PredefinedChapter()
+        chapter_model_element = self.find(element, "CHAPTER-MODEL")
+        if chapter_model_element is not None:
+            predefined.setChapterModel(self.readChapterModel(chapter_model_element, None))
+        return predefined
+
+    def readDocumentationContext(self, element: ET.Element, parent: ARObject) -> DocumentationContext:
+        context = DocumentationContext(parent, self.getShortName(element))
+        self.readMultilanguageReferrable(element, context)
+        context.setFeatureIRef(self.getAnyInstanceRef(element, "FEATURE-IREF"))
+        context.setIdentifiableRef(self.getChildElementOptionalRefType(element, "IDENTIFIABLE-REF"))
+        return context
+
+    def readDocumentation(self, element: ET.Element, documentation: Documentation):
+        self.readARElement(element, documentation)
+        for context_element in self.findall(element, "CONTEXTS/DOCUMENTATION-CONTEXT"):
+            documentation.addContext(self.readDocumentationContext(context_element, documentation))
+        documentation_content_element = self.find(element, "DOCUMENTATION-CONTENT")
+        if documentation_content_element is not None:
+            documentation.setDocumentationContent(self.readPredefinedChapter(documentation_content_element))
+        return documentation
+
     def readChapterContent(self, element: ET.Element, parent: Chapter) -> ChapterContent:
         chapter_content = ChapterContent()
         topic_content_or_msr_query = self.readTopicContentOrMsrQuery(element, chapter_content)
@@ -7429,6 +7454,7 @@ class ARXMLParser(AbstractARXMLParser):
         param_value.setDefinitionRef(self.getChildElementOptionalRefType(element, "DEFINITION-REF"))
         for annotation in self.getAnnotations(element):
             param_value.addAnnotation(annotation)
+        param_value.setIndex(self.getChildElementOptionalPositiveInteger(element, "INDEX"))
 
     def getEcucTextualParamValue(self, element: ET.Element) -> EcucTextualParamValue:
         param_value = EcucTextualParamValue()
@@ -7456,6 +7482,7 @@ class ARXMLParser(AbstractARXMLParser):
         value.setDefinitionRef(self.getChildElementOptionalRefType(element, "DEFINITION-REF"))
         for annotation in self.getAnnotations(element):
             value.addAnnotation(annotation)
+        value.setIndex(self.getChildElementOptionalPositiveInteger(element, "INDEX"))
 
     def getEcucReferenceValue(self, element: ET.Element) -> EcucReferenceValue:
         value = EcucReferenceValue()
@@ -7493,6 +7520,7 @@ class ARXMLParser(AbstractARXMLParser):
     def readEcucContainerValue(self, element: ET.Element, container_value: EcucContainerValue):
         self.readIdentifiable(element, container_value)
         container_value.setDefinitionRef(self.getChildElementOptionalRefType(element, "DEFINITION-REF"))
+        container_value.setIndex(self.getChildElementOptionalPositiveInteger(element, "INDEX"))
         self.readEcucContainerValueParameterValues(element, container_value)
         self.readEcucContainerValueReferenceValues(element, container_value)
         self.readEcucContainerValueSubContainers(element, container_value)
@@ -8226,6 +8254,9 @@ class ARXMLParser(AbstractARXMLParser):
             elif tag_name == "DIAGNOSTIC-SERVICE-TABLE":
                 table = parent.createDiagnosticServiceTable(self.getShortName(child_element))
                 self.readDiagnosticServiceTable(child_element, table)
+            elif tag_name == "DOCUMENTATION":
+                documentation = parent.createDocumentation(self.getShortName(child_element))
+                self.readDocumentation(child_element, documentation)
             elif tag_name == "MULTIPLEXED-I-PDU":
                 i_pdu = parent.createMultiplexedIPdu(self.getShortName(child_element))
                 self.readMultiplexedIPdu(child_element, i_pdu)

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -190,6 +190,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
 )
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwDescriptionEntity, HwElement, HwPinGroup
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwAttributeDef, HwCategory, HwType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import Documentation, DocumentationContext
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import AnyInstanceRef
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage, ReferenceBase
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import Collection
@@ -579,6 +580,7 @@ from armodel.models.M2.MSR.Documentation.Chapters import (
     ChapterModel,
     MsrQueryChapter,
     MsrQueryTopic1,
+    PredefinedChapter,
     Topic1,
     TopicContent,
     TopicContentOrMsrQuery,
@@ -1328,6 +1330,35 @@ class ARXMLWriter(AbstractARXMLWriter):
                 self.writeChapter(child_element, chapter_item, "CHAPTER")
             if chapter.getMsrQueryChapter() is not None:
                 self.writeMsrQueryChapter(child_element, chapter.getMsrQueryChapter())
+
+    def writePredefinedChapter(self, element: ET.Element, predefined: Optional[PredefinedChapter]):
+        if predefined is not None:
+            chapter_model = predefined.getChapterModel()
+            if chapter_model is not None:
+                self.writeChapterModel(element, chapter_model)
+        return predefined
+
+    def writeDocumentationContext(self, element: ET.Element, context: DocumentationContext):
+        self.writeMultilanguageReferrable(element, context)
+        feature_iref = context.getFeatureIRef()
+        if feature_iref is not None:
+            self.setAnyInstanceRef(element, "FEATURE-IREF", feature_iref)
+        self.setChildElementOptionalRefType(element, "IDENTIFIABLE-REF", context.getIdentifiableRef())
+
+    def writeDocumentation(self, element: ET.Element, documentation: Documentation):
+        child_element = ET.SubElement(element, "DOCUMENTATION")
+        self.writeARElement(child_element, documentation)
+        contexts = documentation.getContexts()
+        if len(contexts) > 0:
+            contexts_tag = ET.SubElement(child_element, "CONTEXTS")
+            for context in contexts:
+                context_el = ET.SubElement(contexts_tag, "DOCUMENTATION-CONTEXT")
+                self.writeDocumentationContext(context_el, context)
+        documentation_content = documentation.getDocumentationContent()
+        if documentation_content is not None:
+            content_el = ET.SubElement(child_element, "DOCUMENTATION-CONTENT")
+            self.writePredefinedChapter(content_el, documentation_content)
+        return documentation
 
     def writeChapterContent(self, element: ET.Element, chapter_content: ChapterContent):
         child_element = ET.SubElement(element, "CHAPTER-CONTENT")
@@ -7408,6 +7439,7 @@ class ARXMLWriter(AbstractARXMLWriter):
     def writeEcucParameterValue(self, element: ET.Element, param_value: EcucParameterValue):
         self.setChildElementOptionalRefType(element, "DEFINITION-REF", param_value.getDefinitionRef())
         self.setAnnotations(element, param_value.getAnnotations())
+        self.setChildElementOptionalPositiveInteger(element, "INDEX", param_value.getIndex())
 
     def setEcucTextualParamValue(self, element: ET.Element, param_value: EcucTextualParamValue):
         child_element = ET.SubElement(element, "ECUC-TEXTUAL-PARAM-VALUE")
@@ -7434,6 +7466,7 @@ class ARXMLWriter(AbstractARXMLWriter):
     def writeEcucAbstractReferenceValue(self, element: ET.Element, value: EcucAbstractReferenceValue):
         self.setChildElementOptionalRefType(element, "DEFINITION-REF", value.getDefinitionRef())
         self.setAnnotations(element, value.getAnnotations())
+        self.setChildElementOptionalPositiveInteger(element, "INDEX", value.getIndex())
 
     def setEcucReferenceValue(self, element: ET.Element, value=None):
         if value is not None:
@@ -7474,6 +7507,7 @@ class ARXMLWriter(AbstractARXMLWriter):
         child_element = ET.SubElement(element, "ECUC-CONTAINER-VALUE")
         self.writeIdentifiable(child_element, container_value)
         self.setChildElementOptionalRefType(child_element, "DEFINITION-REF", container_value.getDefinitionRef())
+        self.setChildElementOptionalPositiveInteger(child_element, "INDEX", container_value.getIndex())
         self.writeEcucContainerValueParameterValues(child_element, container_value)
         self.writeEcucContainerValueReferenceValues(child_element, container_value)
         self.writeEcucContainerValueSubContainers(child_element, container_value)
@@ -8376,6 +8410,8 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeDiagnosticConnection(element, ar_element)
         elif isinstance(ar_element, DiagnosticServiceTable):
             self.writeDiagnosticServiceTable(element, ar_element)
+        elif isinstance(ar_element, Documentation):
+            self.writeDocumentation(element, ar_element)
         elif isinstance(ar_element, MultiplexedIPdu):
             self.writeMultiplexedIPdu(element, ar_element)
         elif isinstance(ar_element, UserDefinedIPdu):

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate/test_ECUCDescriptionTemplate.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate/test_ECUCDescriptionTemplate.py
@@ -66,6 +66,33 @@ def test_ecuc_indexable_value_abstract():
         pass  # Expected
 
 
+def test_ecuc_indexable_value_index_methods():
+    """
+    Test EcucIndexableValue index accessors (via a concrete subclass).
+
+    Test Steps:
+    1. Create an EcucNumericalParamValue instance (concrete subclass)
+    2. Test initial index value
+    3. Test index getter and setter with method chaining
+    4. Test setIndex(None) is a no-op
+    """
+    value = EcucNumericalParamValue()
+
+    # Test initial value
+    assert value.index is None
+
+    # Test getter and setter
+    index = ARNumerical()
+    index.setValue("4")
+    result = value.setIndex(index)
+    assert result == value  # Method chaining
+    assert value.getIndex() == index
+
+    # Test None is a no-op
+    value.setIndex(None)
+    assert value.getIndex() == index
+
+
 def test_ecuc_parameter_value_abstract():
     """
     Test EcucParameterValue abstract class.

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/DocumentationOnM1/test_Documentation.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/DocumentationOnM1/test_Documentation.py
@@ -1,0 +1,79 @@
+"""
+Tests for the DocumentationOnM1 package classes (Documentation and
+DocumentationContext).
+"""
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import (
+    Documentation,
+    DocumentationContext,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import (
+    AnyInstanceRef,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    RefType,
+)
+from armodel.models.M2.MSR.Documentation.Chapters import PredefinedChapter
+
+
+def _parent():
+    document = AUTOSAR.getInstance()
+    return document.createARPackage("AUTOSAR")
+
+
+class TestDocumentation:
+    """Test class for the Documentation class."""
+
+    def test_initialization(self):
+        parent = _parent()
+        documentation = Documentation(parent, "MyDoc")
+        assert documentation.getShortName() == "MyDoc"
+        assert documentation.getContexts() == []
+        assert documentation.getDocumentationContent() is None
+
+    def test_add_get_context(self):
+        parent = _parent()
+        documentation = Documentation(parent, "MyDoc")
+        context = DocumentationContext(parent, "Context1")
+        assert documentation.addContext(context) is documentation
+        assert documentation.getContexts() == [context]
+
+    def test_set_get_documentation_content(self):
+        parent = _parent()
+        documentation = Documentation(parent, "MyDoc")
+        predefined = PredefinedChapter()
+        assert documentation.setDocumentationContent(predefined) is documentation
+        assert documentation.getDocumentationContent() is predefined
+        documentation.setDocumentationContent(None)
+        assert documentation.getDocumentationContent() is predefined
+
+
+class TestDocumentationContext:
+    """Test class for the DocumentationContext class."""
+
+    def test_initialization(self):
+        parent = _parent()
+        context = DocumentationContext(parent, "Context1")
+        assert context.getShortName() == "Context1"
+        assert context.getFeatureIRef() is None
+        assert context.getIdentifiableRef() is None
+
+    def test_set_get_feature_iref(self):
+        parent = _parent()
+        context = DocumentationContext(parent, "Context1")
+        iref = AnyInstanceRef()
+        assert context.setFeatureIRef(iref) is context
+        assert context.getFeatureIRef() is iref
+        context.setFeatureIRef(None)
+        assert context.getFeatureIRef() is iref
+
+    def test_set_get_identifiable_ref(self):
+        parent = _parent()
+        context = DocumentationContext(parent, "Context1")
+        ref = RefType()
+        ref.setValue("/Some/Path")
+        assert context.setIdentifiableRef(ref) is context
+        assert context.getIdentifiableRef() is ref
+        context.setIdentifiableRef(None)
+        assert context.getIdentifiableRef() is ref

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_PrimitiveTypes.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_PrimitiveTypes.py
@@ -1065,3 +1065,55 @@ class TestCIdentifier:
 
         unlimited_int = UnlimitedInteger()
         assert unlimited_int is not None
+
+
+class TestIdentifier:
+    """
+    Test class for Identifier functionality.
+    """
+
+    def test_initialization(self):
+        """
+        Test Identifier initialization.
+        """
+        identifier = Identifier()
+
+        # Verify basic properties
+        assert identifier is not None
+        assert identifier._value is None
+        assert identifier.blueprintValue is None
+        assert identifier.namePattern is None
+
+    def test_blueprint_value_methods(self):
+        """
+        Test blueprint value methods.
+        """
+        identifier = Identifier()
+
+        assert identifier.getBlueprintValue() is None
+
+        bp_value = String()
+        bp_value.setValue("TestValue")
+        result = identifier.setBlueprintValue(bp_value)
+        assert result is identifier  # Verify method chaining
+        assert identifier.getBlueprintValue() == bp_value
+
+        identifier.setBlueprintValue(None)
+        assert identifier.getBlueprintValue() == bp_value
+
+    def test_name_pattern_methods(self):
+        """
+        Test name pattern methods.
+        """
+        identifier = Identifier()
+
+        assert identifier.getNamePattern() is None
+
+        name_pattern = String()
+        name_pattern.setValue("TestPattern")
+        result = identifier.setNamePattern(name_pattern)
+        assert result is identifier  # Verify method chaining
+        assert identifier.getNamePattern() == name_pattern
+
+        identifier.setNamePattern(None)
+        assert identifier.getNamePattern() == name_pattern

--- a/tests/test_armodel/models/M2/MSR/Documentation/test_Chapters.py
+++ b/tests/test_armodel/models/M2/MSR/Documentation/test_Chapters.py
@@ -13,6 +13,7 @@ from armodel.models.M2.MSR.Documentation.Chapters import (
     ChapterOrMsrQuery,
     MsrQueryChapter,
     MsrQueryTopic1,
+    PredefinedChapter,
     Topic1,
     TopicContent,
     TopicContentOrMsrQuery,
@@ -52,6 +53,22 @@ class TestChapter:
         assert chapter.getChapterModel() is chapter_model
         chapter.setChapterModel(None)
         assert chapter.getChapterModel() is chapter_model
+
+
+class TestPredefinedChapter:
+    """Test class for PredefinedChapter class."""
+
+    def test_initialization(self):
+        predefined = PredefinedChapter()
+        assert predefined.getChapterModel() is None
+
+    def test_set_get_chapter_model(self):
+        predefined = PredefinedChapter()
+        chapter_model = ChapterModel()
+        assert predefined.setChapterModel(chapter_model) is predefined
+        assert predefined.getChapterModel() is chapter_model
+        predefined.setChapterModel(None)
+        assert predefined.getChapterModel() is chapter_model
 
 
 class TestDocumentationLeafClasses:

--- a/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
@@ -805,6 +805,7 @@ class TestGetEcucInstanceReferenceValue:
         element = _snip(
             """
             <DEFINITION-REF DEST="ECUC-REFERENCE-DEF">/Path/To/Def</DEFINITION-REF>
+            <INDEX>9</INDEX>
             <VALUE-IREF>
                 <BASE-REF DEST="SW-COMPONENT-TYPE">/Base/Path</BASE-REF>
                 <CONTEXT-ELEMENT-REF DEST="R-PORT-PROTOTYPE">/Context/El1</CONTEXT-ELEMENT-REF>
@@ -816,6 +817,8 @@ class TestGetEcucInstanceReferenceValue:
         value = parser.getEcucInstanceReferenceValue(element)
         assert value is not None
         assert value.getDefinitionRef() is not None
+        assert value.getIndex() is not None
+        assert value.getIndex().getValue() == 9
         iref = value.valueRef
         assert iref is not None
         assert iref.getBaseRef() is not None
@@ -970,6 +973,7 @@ class TestReadEcucContainerValue:
             """
             <SHORT-NAME>MyContainer</SHORT-NAME>
             <DEFINITION-REF DEST="ECUC-PARAM-CONF-CONTAINER-DEF">/Path/To/ContainerDef</DEFINITION-REF>
+            <INDEX>7</INDEX>
             <PARAMETER-VALUES>
                 <ECUC-TEXTUAL-PARAM-VALUE>
                     <DEFINITION-REF DEST="ECUC-STRING-PARAM-DEF">/Path/To/StringDef</DEFINITION-REF>
@@ -992,6 +996,8 @@ class TestReadEcucContainerValue:
         )
         parser.readEcucContainerValue(element, container)
         assert container.getDefinitionRef() is not None
+        assert container.getIndex() is not None
+        assert container.getIndex().getValue() == 7
         assert len(container.getParameterValues()) == 1
         assert len(container.getReferenceValues()) == 1
         assert len(container.getSubContainers()) == 1
@@ -1007,6 +1013,7 @@ class TestReadEcucContainerValue:
         )
         parser.readEcucContainerValue(element, container)
         assert container.getDefinitionRef() is None
+        assert container.getIndex() is None
         assert len(container.getParameterValues()) == 0
         assert len(container.getReferenceValues()) == 0
         assert len(container.getSubContainers()) == 0
@@ -1385,6 +1392,23 @@ class TestEcucParameterValue:
         parser.readEcucParameterValue(element, param_value)
         assert param_value.getDefinitionRef() is not None
         assert len(param_value.getAnnotations()) == 1
+
+    def test_readEcucParameterValue_reads_index(self, parser):
+        from armodel.models import EcucTextualParamValue
+
+        param_value = EcucTextualParamValue()
+        element = _snip("<INDEX>4</INDEX>")
+        parser.readEcucParameterValue(element, param_value)
+        assert param_value.getIndex() is not None
+        assert param_value.getIndex().getValue() == 4
+
+    def test_readEcucParameterValue_without_index(self, parser):
+        from armodel.models import EcucTextualParamValue
+
+        param_value = EcucTextualParamValue()
+        element = _snip("")
+        parser.readEcucParameterValue(element, param_value)
+        assert param_value.getIndex() is None
 
     def test_readEcucContainerValueParameterValues_unsupported_warns(self, warning_parser, caplog):
         from armodel.models import EcucContainerValue

--- a/tests/test_armodel/writer/test_writer_documentation.py
+++ b/tests/test_armodel/writer/test_writer_documentation.py
@@ -1,0 +1,169 @@
+"""
+Tests for writer/parser serialization of the DocumentationOnM1 package
+(Documentation, DocumentationContext) and PredefinedChapter.
+"""
+
+import xml.etree.cElementTree as ET
+
+import pytest
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import (
+    DocumentationContext,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import (
+    AnyInstanceRef,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    RefType,
+)
+from armodel.models.M2.MSR.Documentation.Chapters import ChapterModel, PredefinedChapter
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+def _parent():
+    return ET.Element("PARENT")
+
+
+def _ref(value, dest=None):
+    ref = RefType()
+    ref.setValue(value)
+    if dest is not None:
+        ref.setDest(dest)
+    return ref
+
+
+def _make_documentation():
+    pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+    return pkg.createDocumentation("Doc1")
+
+
+class TestWriterPredefinedChapter:
+    def test_with_chapter_model(self, writer):
+        predefined = PredefinedChapter()
+        predefined.setChapterModel(ChapterModel())
+        parent = _parent()
+        writer.writePredefinedChapter(parent, predefined)
+        assert parent.find("CHAPTER-MODEL") is not None
+
+    def test_without_chapter_model(self, writer):
+        predefined = PredefinedChapter()
+        parent = _parent()
+        writer.writePredefinedChapter(parent, predefined)
+        assert len(parent) == 0
+
+    def test_none(self, writer):
+        parent = _parent()
+        writer.writePredefinedChapter(parent, None)
+        assert len(parent) == 0
+
+
+class TestWriterDocumentation:
+    def test_full(self, writer):
+        documentation = _make_documentation()
+        context = DocumentationContext(documentation, "Ctx1")
+        iref = AnyInstanceRef()
+        iref.setBaseRef(_ref("/base", "SW-COMPONENT-TYPE"))
+        iref.setTargetRef(_ref("/target", "SW-COMPONENT-TYPE"))
+        context.setFeatureIRef(iref)
+        context.setIdentifiableRef(_ref("/id", "IDENTIFIABLE"))
+        documentation.addContext(context)
+        predefined = PredefinedChapter()
+        predefined.setChapterModel(ChapterModel())
+        documentation.setDocumentationContent(predefined)
+        parent = _parent()
+        writer.writeDocumentation(parent, documentation)
+        assert parent[0].tag == "DOCUMENTATION"
+        assert parent[0].find("SHORT-NAME").text == "Doc1"
+        contexts = parent[0].findall("CONTEXTS/DOCUMENTATION-CONTEXT")
+        assert len(contexts) == 1
+        assert contexts[0].find("SHORT-NAME").text == "Ctx1"
+        assert contexts[0].find("FEATURE-IREF") is not None
+        assert contexts[0].find("FEATURE-IREF/BASE-REF") is not None
+        assert contexts[0].find("FEATURE-IREF/TARGET-REF") is not None
+        assert contexts[0].find("IDENTIFIABLE-REF") is not None
+        content = parent[0].find("DOCUMENTATION-CONTENT")
+        assert content is not None
+        assert content.find("CHAPTER-MODEL") is not None
+
+    def test_minimal(self, writer):
+        documentation = _make_documentation()
+        parent = _parent()
+        writer.writeDocumentation(parent, documentation)
+        assert parent[0].tag == "DOCUMENTATION"
+        assert parent[0].find("CONTEXTS") is None
+        assert parent[0].find("DOCUMENTATION-CONTENT") is None
+
+
+class TestDocumentationRoundTrip:
+    def test_round_trip(self, tmp_path):
+        document = AUTOSAR.getInstance()
+        document.clear()
+        document.setARRelease("R23-11")
+        pkg = document.createARPackage("Pkg")
+        documentation = pkg.createDocumentation("Doc1")
+        context = DocumentationContext(documentation, "Ctx1")
+        iref = AnyInstanceRef()
+        iref.setBaseRef(_ref("/base", "SW-COMPONENT-TYPE"))
+        iref.setTargetRef(_ref("/target", "SW-COMPONENT-TYPE"))
+        context.setFeatureIRef(iref)
+        context.setIdentifiableRef(_ref("/id", "IDENTIFIABLE"))
+        documentation.addContext(context)
+        predefined = PredefinedChapter()
+        chapter_model = ChapterModel()
+        predefined.setChapterModel(chapter_model)
+        documentation.setDocumentationContent(predefined)
+
+        out_file = tmp_path / "documentation_out.arxml"
+        ARXMLWriter().save(str(out_file), document)
+
+        reloaded = AUTOSAR.getInstance()
+        reloaded.clear()
+        reloaded.setARRelease("R23-11")
+        ARXMLParser().load(str(out_file), reloaded)
+
+        doc = reloaded.find("/Pkg/Doc1")
+        assert doc is not None
+        assert len(doc.getContexts()) == 1
+        ctx = doc.getContexts()[0]
+        assert ctx.getShortName() == "Ctx1"
+        assert ctx.getFeatureIRef() is not None
+        assert ctx.getFeatureIRef().getBaseRef() is not None
+        assert ctx.getFeatureIRef().getTargetRef() is not None
+        assert ctx.getIdentifiableRef() is not None
+        assert doc.getDocumentationContent() is not None
+        assert doc.getDocumentationContent().getChapterModel() is not None
+
+    def test_round_trip_empty(self, tmp_path):
+        document = AUTOSAR.getInstance()
+        document.clear()
+        document.setARRelease("R23-11")
+        pkg = document.createARPackage("Pkg")
+        pkg.createDocumentation("Doc1")
+
+        out_file = tmp_path / "documentation_empty_out.arxml"
+        ARXMLWriter().save(str(out_file), document)
+
+        reloaded = AUTOSAR.getInstance()
+        reloaded.clear()
+        reloaded.setARRelease("R23-11")
+        ARXMLParser().load(str(out_file), reloaded)
+
+        doc = reloaded.find("/Pkg/Doc1")
+        assert doc is not None
+        assert doc.getContexts() == []
+        assert doc.getDocumentationContent() is None

--- a/tests/test_armodel/writer/test_writer_ecuc_values_variant.py
+++ b/tests/test_armodel/writer/test_writer_ecuc_values_variant.py
@@ -180,12 +180,21 @@ class TestWriterEcucParameterValue:
         writer.writeEcucParameterValue(parent, param)
         assert parent.find("ANNOTATIONS/ANNOTATION") is not None
 
+    def test_with_index(self, writer):
+        param = EcucNumericalParamValue()
+        param.setIndex(_numerical(4))
+        parent = _parent()
+        writer.writeEcucParameterValue(parent, param)
+        assert parent.find("INDEX") is not None
+        assert parent.find("INDEX").text == "4"
+
     def test_minimal(self, writer):
         param = EcucTextualParamValue()
         parent = _parent()
         writer.writeEcucParameterValue(parent, param)
         assert parent.find("DEFINITION-REF") is None
         assert parent.find("ANNOTATIONS") is None
+        assert parent.find("INDEX") is None
 
 
 class TestWriterEcucContainerValueParameterValues:
@@ -249,6 +258,7 @@ class TestWriterEcucContainerValueReferenceValues:
         ref_val = EcucReferenceValue()
         ref_val.setValueRef(_ref("/v", "ECUC-CONTAINER-VALUE"))
         ref_val.setDefinitionRef(_ref("/d1", "ECUC-REFERENCE-DEF"))
+        ref_val.setIndex(_numerical(3))
         container.addReferenceValue(ref_val)
         iref_val = EcucInstanceReferenceValue()
         iref_val.setDefinitionRef(_ref("/d2", "ECUC-REFERENCE-DEF"))
@@ -263,6 +273,9 @@ class TestWriterEcucContainerValueReferenceValues:
         tags = {c.tag for c in parent[0]}
         assert "ECUC-REFERENCE-VALUE" in tags
         assert "ECUC-INSTANCE-REFERENCE-VALUE" in tags
+        ref_el = parent[0].find("ECUC-REFERENCE-VALUE")
+        assert ref_el.find("INDEX") is not None
+        assert ref_el.find("INDEX").text == "3"
         iref_el = parent[0].find("ECUC-INSTANCE-REFERENCE-VALUE")
         assert iref_el.find("VALUE-IREF") is not None
         assert iref_el.find("VALUE-IREF/BASE-REF") is not None
@@ -279,6 +292,7 @@ class TestWriterEcucContainValue:
     def test_full(self, writer):
         container = _make_container()
         container.setDefinitionRef(_ref("/d", "ECUC-PARAM-CONF-CONTAINER-DEF"))
+        container.setIndex(_numerical(7))
         textual = EcucTextualParamValue()
         textual.setValue(_literal("txt"))
         container.addParameterValue(textual)
@@ -291,6 +305,8 @@ class TestWriterEcucContainValue:
         assert parent[0].tag == "ECUC-CONTAINER-VALUE"
         assert parent[0].find("SHORT-NAME").text == "cv"
         assert parent[0].find("DEFINITION-REF") is not None
+        assert parent[0].find("INDEX") is not None
+        assert parent[0].find("INDEX").text == "7"
         assert parent[0].find("PARAMETER-VALUES") is not None
         assert parent[0].find("REFERENCE-VALUES") is not None
         assert parent[0].find("SUB-CONTAINERS") is not None
@@ -301,6 +317,7 @@ class TestWriterEcucContainValue:
         writer.writeEcucContainValue(parent, container)
         assert parent[0].tag == "ECUC-CONTAINER-VALUE"
         assert parent[0].find("DEFINITION-REF") is None
+        assert parent[0].find("INDEX") is None
         assert parent[0].find("PARAMETER-VALUES") is None
         assert parent[0].find("REFERENCE-VALUES") is None
         assert parent[0].find("SUB-CONTAINERS") is None


### PR DESCRIPTION
Closes #611

## Summary
Implement spec-aligned `Documentation` / `DocumentationContext` / `PredefinedChapter` model classes per AUTOSAR R23-11, with reader/writer coverage.

## Changes
- Expand `Documentation` and add `DocumentationContext` in GenericStructure/DocumentationOnM1 (Table E.28 / 9.56)
- Add `PredefinedChapter` in MSR Documentation/Chapters (Table 9.62)
- Add `Identifier.blueprintValue` / `namePattern` (Table 4.5)
- Add `EcucIndexableValue.index` (PositiveInteger), wire reader/writer for ECUC value INDEX
- Add `ARPackage.createDocumentation()`
- Add parser/writer for DOCUMENTATION / DOCUMENTATION-CONTEXT / DOCUMENTATION-CONTENT / PREDEFINED-CHAPTER / CHAPTER-MODEL
- Add unit tests

## Quality Gates
- flake8: pass
- tests (6240): pass
- black-check: pass