### PR TITLE
feat: sync BlueprintGenerator & VariantHandling to R23-11 spec

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py
@@ -1,42 +1,71 @@
+from typing import Optional
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import VerbatimString
+from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
 
 
 class BlueprintGenerator(ARObject):
     """
-    Represents a blueprint generator in AUTOSAR.
-    Defines a generator for creating blueprints from templates.
+    This class express the Extended Language to generate blueprint derivates in complex
+    descriptions.
+
+    Package: M2::AUTOSARTemplates::CommonStructure::StandardizationTemplate::BlueprintGenerator
+    Base: ARObject
+
+    Attributes:
+        expression (VerbatimString): This represents a formal term in the expression
+            based on the extended language. (Multiplicity: 0..1)
+        introduction (DocumentationBlock): This represents a description that documents
+            how the blueprint generator shall be resolved when deriving objects from
+            blueprints. (Multiplicity: 0..1)
     """
 
     # BlueprintGenerator method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
-    # [ ] getGeneratorName             [x] impl  [x] docstring  [ ] test
-    # [ ] setGeneratorName             [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table E.11, p.424
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getExpression     [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setExpression     [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getIntroduction   [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setIntroduction   [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
 
     def __init__(self):
-        """
-        Initializes the BlueprintGenerator with default values.
-        """
         super().__init__()
-        self.generatorName: str = None
 
-    def getGeneratorName(self) -> str:
+        # This represents a formal term in the expression based on the extended language.
+        self.expression: Optional[VerbatimString] = None
+
+        # This represents a description that documents how the blueprint generator shall be resolved when deriving objects from blueprints.
+        self.introduction: Optional[DocumentationBlock] = None
+
+    def getExpression(self) -> Optional[VerbatimString]:
         """
-        Gets the generator name.
-
-        Returns:
-            String representing the generator name
+        This represents a formal term in the expression based on the extended language.
         """
-        return self.generatorName
+        return self.expression
 
-    def setGeneratorName(self, value: str):
+    def setExpression(self, value: Optional[VerbatimString]) -> "BlueprintGenerator":
         """
-        Sets the generator name.
-
-        Args:
-            value: String value to set
-
-        Returns:
-            self for method chaining
+        This represents a formal term in the expression based on the extended language. A
+        None value is a no-op and does not overwrite an existing expression.
         """
-        self.generatorName = value
+        if value is not None:
+            self.expression = value
+        return self
+
+    def getIntroduction(self) -> Optional[DocumentationBlock]:
+        """
+        This represents a description that documents how the blueprint generator shall be
+        resolved when deriving objects from blueprints.
+        """
+        return self.introduction
+
+    def setIntroduction(self, value: Optional[DocumentationBlock]) -> "BlueprintGenerator":
+        """
+        This represents a description that documents how the blueprint generator shall be
+        resolved when deriving objects from blueprints. A None value is a no-op and does
+        not overwrite an existing introduction.
+        """
+        if value is not None:
+            self.introduction = value
         return self

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
@@ -17,6 +17,7 @@ from armodel.models.M2.MSR.Documentation.Annotation import Annotation
 from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultiLanguageOverviewParagraph
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import CategoryString
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
+    PostBuildVariantCriterion,
     PredefinedVariant,
     SwSystemconstantValueSet,
 )
@@ -1257,6 +1258,12 @@ class ARPackage(CollectableElement):
             self.addElement(element)
         return self.getElement(short_name, PredefinedVariant)
 
+    def createPostBuildVariantCriterion(self, short_name: str) -> PostBuildVariantCriterion:
+        if not self.IsElementExists(short_name, PostBuildVariantCriterion):
+            element = PostBuildVariantCriterion(self, short_name)
+            self.addElement(element)
+        return self.getElement(short_name, PostBuildVariantCriterion)
+
     def createPhysicalDimension(self, short_name: str) -> PhysicalDimension:
         if not self.IsElementExists(short_name, PhysicalDimension):
             element = PhysicalDimension(self, short_name)
@@ -1602,6 +1609,14 @@ class ARPackage(CollectableElement):
         return list(
             sorted(
                 filter(lambda a: isinstance(a, PredefinedVariant), self.elements),
+                key=lambda a: a.short_name,
+            )
+        )
+
+    def getPostBuildVariantCriterions(self) -> List[PostBuildVariantCriterion]:
+        return list(
+            sorted(
+                filter(lambda a: isinstance(a, PostBuildVariantCriterion), self.elements),
                 key=lambda a: a.short_name,
             )
         )

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import String, RefType, ARNumerical, Identifier, Integer
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType, ARNumerical, Identifier, Integer
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation
 
 from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import (
@@ -10,81 +10,143 @@ from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import (
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import (
     DocumentationBlock,
 )
-from armodel.models.M2.MSR.Documentation.BlockElements.Formula import (
-    MlFormula,
-)
 from armodel.models.M2.MSR.AsamHdo.SpecialData import Sdg
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Enumerations import BindingTimeEnum
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintGenerator.BlueprintGenerator import BlueprintGenerator
 
 
-class PostBuildVariantCriterion(ARObject):
+class PostBuildVariantCriterion(ARElement):
     """
-    Represents a post-build variant criterion in the AUTOSAR model.
+    This class specifies one particular PostBuildVariantSelector.
 
-    This class is used to define criteria for post-build variants,
-    allowing for configuration after build time.
+    Package: M2::AUTOSARTemplates::GenericStructure::VariantHandling
+    Base: ARElement, ARObject, AtpDefinition, CollectableElement, Identifiable,
+        MultilanguageReferrable, PackageableElement, Referrable
+    Tags: atp.recommendedPackage=PostBuildVariantCriterions
 
     Attributes:
-        criterionName (String): The name of the criterion.
-        criterionValue (String): The value of the criterion.
+        compuMethodRef (CompuMethod): The compuMethod specifies the
+            possible values for the variant criterion serving as an
+            enumerator. (Multiplicity: 1)
     """
 
     # PostBuildVariantCriterion method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getCriterionName             [x] impl  [ ] docstring  [ ] test
-    # [ ] setCriterionName             [x] impl  [ ] docstring  [ ] test
-    # [ ] getCriterionValue            [x] impl  [ ] docstring  [ ] test
-    # [ ] setCriterionValue            [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 7.63, p.614
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getCompuMethodRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCompuMethodRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, parent, short_name: str):
+        super().__init__(parent, short_name)
 
-        self.criterionName: String = None
-        self.criterionValue: String = None
+        # The compuMethod specifies the possible values for the variant criterion serving as an enumerator.
+        self.compuMethodRef: RefType = None
 
-    def getCriterionName(self) -> String:
-        return self.criterionName
+    def getCompuMethodRef(self) -> RefType:
+        """
+        The compuMethod specifies the possible values for the variant criterion
+        serving as an enumerator.
+        """
+        return self.compuMethodRef
 
-    def setCriterionName(self, value: String):
+    def setCompuMethodRef(self, value: RefType) -> "PostBuildVariantCriterion":
+        """
+        The compuMethod specifies the possible values for the variant criterion
+        serving as an enumerator. A None value is a no-op and does not overwrite an
+        existing compuMethodRef.
+        """
         if value is not None:
-            self.criterionName = value
-        return self
-
-    def getCriterionValue(self) -> String:
-        return self.criterionValue
-
-    def setCriterionValue(self, value: String):
-        if value is not None:
-            self.criterionValue = value
+            self.compuMethodRef = value
         return self
 
 
 class PostBuildVariantCriterionValue(ARObject):
     """
-    Represents a post-build variant criterion value in the AUTOSAR model.
+    This class specifies a the value which must be assigned to a particular variant
+    criterion in order to bind the variation point. If multiple criterion/value pairs
+    are specified, they all must must match to bind the variation point.
 
-    This class is used to define values for post-build variant criteria.
+    Package: M2::AUTOSARTemplates::GenericStructure::VariantHandling
+    Base: ARObject
 
     Attributes:
-        value (String): The criterion value.
+        annotations (List[Annotation]): This provides the ability to add
+            information why the value is set like it is. (Multiplicity: *)
+        value (Integer): This is the particular value of the post-build
+            variant criterion. (Multiplicity: 1)
+        variantCriterionRef (PostBuildVariantCriterion): This association
+            selects the variant criterion whose value is specified.
+            (Multiplicity: 1)
     """
 
     # PostBuildVariantCriterionValue method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getValue                     [x] impl  [ ] docstring  [ ] test
-    # [ ] setValue                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 7.27, p.259
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getAnnotations          [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] addAnnotation           [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getValue                [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setValue                [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getVariantCriterionRef  [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setVariantCriterionRef  [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.value: String = None
+        # This provides the ability to add information why the value is set like it is.
+        self.annotations: List[Annotation] = []
 
-    def getValue(self) -> String:
+        # This is the particular value of the post-build variant criterion.
+        self.value: Optional[Integer] = None
+
+        # This association selects the variant criterion whose value is specified.
+        self.variantCriterionRef: RefType = None
+
+    def getAnnotations(self) -> List[Annotation]:
+        """
+        This provides the ability to add information why the value is set like it is.
+        """
+        return self.annotations
+
+    def addAnnotation(self, value: Annotation) -> "PostBuildVariantCriterionValue":
+        """
+        This provides the ability to add information why the value is set like it is. A
+        None value is a no-op and is not appended.
+        """
+        if value is not None:
+            self.annotations.append(value)
+        return self
+
+    def getValue(self) -> Optional[Integer]:
+        """
+        This is the particular value of the post-build variant criterion.
+        """
         return self.value
 
-    def setValue(self, value: String):
+    def setValue(self, value: Optional[Integer]) -> "PostBuildVariantCriterionValue":
+        """
+        This is the particular value of the post-build variant criterion. A None value
+        is a no-op and does not overwrite an existing value.
+        """
         if value is not None:
             self.value = value
+        return self
+
+    def getVariantCriterionRef(self) -> RefType:
+        """
+        This association selects the variant criterion whose value is specified.
+        """
+        return self.variantCriterionRef
+
+    def setVariantCriterionRef(self, value: RefType) -> "PostBuildVariantCriterionValue":
+        """
+        This association selects the variant criterion whose value is specified. A None
+        value is a no-op and does not overwrite an existing variantCriterionRef.
+        """
+        if value is not None:
+            self.variantCriterionRef = value
         return self
 
 
@@ -249,13 +311,10 @@ class SwSystemconstantValueSet(Identifiable):
 
 class PostBuildVariantCondition(ARObject):
     """
-    Specifies a post-build variant condition criterion/value pair.
-
-    This class specifies the value which must be assigned to a particular
-    variant criterion in order to bind the variation point. If multiple
-    criterion/value pairs are specified, they shall all match to bind the
-    variation point. In other words, binding can be represented by:
-    (criterion1 == value1) && (criterion2 == value2) ...
+    This class specifies the value which shall be assigned to a particular variant
+    criterion in order to bind the variation point. If multiple criterion/value pairs
+    are specified, they shall all match to bind the variation point. In other words
+    binding can be represented by (criterion1 == value1) && (condition2 == value2) ...
 
     Package: M2::AUTOSARTemplates::GenericStructure::VariantHandling
     Base: ARObject
@@ -263,67 +322,58 @@ class PostBuildVariantCondition(ARObject):
     Tags: vh.latestBindingTime=preCompileTime
 
     Attributes:
-        matchingCriterion (PostBuildVariantCriterion): The criterion
-            which needs to match the value in order to make the
-            PostBuildVariantCondition true. (Multiplicity: 1)
-        value (Integer): The particular value of the post-build variant
-            criterion. (Multiplicity: 1)
+        matchingCriterionRef (PostBuildVariantCriterion): This is the
+            criterion which needs to match the value in order to make the
+            PostbuildVariantCondition to be true. (Multiplicity: 1)
+        value (Integer): This is the particular value of the post-build
+            variant criterion. (Multiplicity: 1)
     """
 
     # PostBuildVariantCondition method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getMatchingCriterion         [x] impl  [x] docstring  [ ] test
-    # [ ] setMatchingCriterion         [x] impl  [x] docstring  [ ] test
-    # [ ] getValue                     [x] impl  [x] docstring  [ ] test
-    # [ ] setValue                     [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 7.6, p.232
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getMatchingCriterionRef [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setMatchingCriterionRef [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getValue                [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setValue                [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.matchingCriterion: PostBuildVariantCriterion = None
-        self.value: Integer = None
+        # This is the criterion which needs to match the value in order to make the PostbuildVariantCondition to be true.
+        self.matchingCriterionRef: RefType = None
 
-    def getMatchingCriterion(self) -> PostBuildVariantCriterion:
+        # This is the particular value of the post-build variant criterion.
+        self.value: Optional[Integer] = None
+
+    def getMatchingCriterionRef(self) -> RefType:
         """
-        Gets the matching criterion for this condition.
-
-        Returns:
-            PostBuildVariantCriterion: The criterion to match
+        This is the criterion which needs to match the value in order to make the
+        PostbuildVariantCondition to be true.
         """
-        return self.matchingCriterion
+        return self.matchingCriterionRef
 
-    def setMatchingCriterion(self, value: PostBuildVariantCriterion) -> "PostBuildVariantCondition":
+    def setMatchingCriterionRef(self, value: RefType) -> "PostBuildVariantCondition":
         """
-        Sets the matching criterion for this condition.
-
-        Args:
-            value: The criterion to match
-
-        Returns:
-            self for method chaining
+        This is the criterion which needs to match the value in order to make the
+        PostbuildVariantCondition to be true. A None value is a no-op and does not
+        overwrite an existing matchingCriterionRef.
         """
         if value is not None:
-            self.matchingCriterion = value
+            self.matchingCriterionRef = value
         return self
 
-    def getValue(self) -> Integer:
+    def getValue(self) -> Optional[Integer]:
         """
-        Gets the criterion value for this condition.
-
-        Returns:
-            Integer: The value to match
+        This is the particular value of the post-build variant criterion.
         """
         return self.value
 
-    def setValue(self, value: Integer) -> "PostBuildVariantCondition":
+    def setValue(self, value: Optional[Integer]) -> "PostBuildVariantCondition":
         """
-        Sets the criterion value for this condition.
-
-        Args:
-            value: The value to match
-
-        Returns:
-            self for method chaining
+        This is the particular value of the post-build variant criterion. A None value
+        is a no-op and does not overwrite an existing value.
         """
         if value is not None:
             self.value = value
@@ -332,53 +382,47 @@ class PostBuildVariantCondition(ARObject):
 
 class ConditionByFormula(ARObject):
     """
-    Represents a system condition computed based on system constants.
-
-    This class represents a condition which is computed based on system
-    constants according to a specified expression. The expected result is
-    interpreted as a boolean value where:
-    - "0" represents false
-    - Any non-zero value is considered true
+    This class represents a condition which is computed based on system constants
+    according to the specified expression. The expected result is considered as boolean
+    value. The result of the expression is interpreted as a condition. • "0" represents
+    "false"; • a value other than zero is considered "true"
 
     Package: M2::AUTOSARTemplates::GenericStructure::VariantHandling
-    Base: ARObject
+    Base: ARObject, FormulaExpression, SwSystemconstDependentFormula
     Stereotypes: atpMixedString
 
     Attributes:
-        bindingTime (BindingTimeEnum): Specifies the point in time when
-           the condition may be evaluated at earliest. At this point in
-           time, all referenced system constants shall have a value.
-           (Multiplicity: 1)
+        bindingTime (BindingTimeEnum): This attribute specifies the point in time when
+            condition may be evaluated at earliest. At this point in time all referenced
+            system constants shall have a value. (Multiplicity: 1)
     """
 
     # ConditionByFormula method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getBindingTime               [x] impl  [x] docstring  [ ] test
-    # [ ] setBindingTime               [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 7.5, p.231
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBindingTime    [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setBindingTime    [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
+        # This attribute specifies the point in time when condition may be evaluated at earliest. At this point in time all referenced system constants shall have a value.
         self.bindingTime: Optional["BindingTimeEnum"] = None
 
     def getBindingTime(self) -> Optional["BindingTimeEnum"]:
         """
-        Gets the binding time for this condition.
-
-        Returns:
-           BindingTimeEnum: When this condition may be evaluated, or None
+        This attribute specifies the point in time when condition may be evaluated at
+        earliest. At this point in time all referenced system constants shall have a
+        value.
         """
         return self.bindingTime
 
-    def setBindingTime(self, value: "BindingTimeEnum") -> "ConditionByFormula":
+    def setBindingTime(self, value: Optional["BindingTimeEnum"]) -> "ConditionByFormula":
         """
-        Sets the binding time for this condition.
-
-        Args:
-           value: When this condition may be evaluated
-
-        Returns:
-           self for method chaining
+        This attribute specifies the point in time when condition may be evaluated at
+        earliest. At this point in time all referenced system constants shall have a
+        value. A None value is a no-op and does not overwrite an existing bindingTime.
         """
         if value is not None:
             self.bindingTime = value
@@ -387,166 +431,151 @@ class ConditionByFormula(ARObject):
 
 class VariationPoint(ARObject):
     """
-    Represents a structural variation point in the AUTOSAR model.
-
-    This class represents the ability to express a "structural variation
-    point". The container of the variation point is part of the selected
-    variant if swSyscond evaluates to true and each postBuildVariantCriterion
-    is fulfilled.
+    This meta-class represents the ability to express a "structural variation point".
+    The container of the variation point is part of the selected variant if swSyscond
+    evaluates to true and each postBuildVariantCriterion is fulfilled.
 
     Package: M2::AUTOSARTemplates::GenericStructure::VariantHandling
     Base: ARObject
 
     Attributes:
-        desc (MultiLanguageOverviewParagraph): Allows to describe shortly
-            the purpose of the variation point. (Multiplicity: 0..1)
-        blueprintCondition (DocumentationBlock): Represents a description
-            that documents how the variation point shall be resolved when
-            deriving objects from the blueprint. Note that variationPoints
-            are not allowed within a blueprintCondition.
+        blueprintCondition (DocumentationBlock): This represents a description
+            that documents how the variation point shall be resolved when deriving
+            objects from the blueprint. Note that variationPoints are not allowed
+            within a blueprintCondition. (Multiplicity: 0..1)
+        desc (MultiLanguageOverviewParagraph): This allows to describe shortly the
+            purpose of the variation point. (Multiplicity: 0..1)
+        formalBlueprintGenerator (BlueprintGenerator): This represents a description
+            that documents how the variation point shall be resolved when deriving
+            objects from the blueprint by using ARMQL. Note that variationPoints are
+            not allowed within a formal BlueprintGenerator. (Multiplicity: 0..1)
+        postBuildVariantConditions (List[PostBuildVariantCondition]): This is the
+            set of post build variant conditions which all shall be fulfilled in
+            order to (postbuild) bind the variation point. (Multiplicity: *)
+        sdg (Sdg): An optional special data group is attached to every variation
+            point. These data can be used by external software systems to attach
+            application specific data. For example, a variant management system
+            might add an identifier, an URL or a specific classifier.
             (Multiplicity: 0..1)
-        formalBlueprintCondition (MlFormula): Denotes a formal blueprint
-            condition. This shall not be in contradiction with
-            blueprintCondition. It is recommended to use only one of the
-            two. (Multiplicity: 0..1)
-        postBuildVariantCondition (List[PostBuildVariantCondition]): The
-            set of post-build variant conditions which all shall be
-            fulfilled in order to bind the variation point.
-            (Multiplicity: *)
-        sdg (Sdg): An optional special data group attached to every
-            variation point. These data can be used by external software
-            systems to attach application specific data. For example, a
-            variant management system might add an identifier, an URL or
-            a specific classifier. (Multiplicity: 0..1)
-        shortLabel (Identifier): Provides a name to the particular variation
-            point to support the RTE generator. It is necessary for
-            supporting splitable aggregations and if binding time is
-            later than codeGenerationTime, as well as some RTE
-            conditions. It needs to be unique within the enclosing
-            Identifiables with the same ShortName. (Multiplicity: 0..1)
-        swSyscond (ConditionByFormula): This condition acts as Binding
-            Function for the VariationPoint. Note that the multiplicity
-            is 0..1 in order to support pure postBuild variants.
+        shortLabel (Identifier): This provides a name to the particular variation
+            point to support the RTE generator. It is necessary for supporting
+            splitable aggregations and if binding time is later than
+            codeGenerationTime, as well as some RTE conditions. It needs to be
+            unique within the enclosing Identifiables with the same ShortName.
             (Multiplicity: 0..1)
+        swSyscond (ConditionByFormula): This condition acts as Binding Function for
+            the Variation Point. Note that the multiplicity is 0..1 in order to
+            support pure postBuild variants. (Multiplicity: 0..1)
     """
 
     # VariationPoint method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getDesc                      [x] impl  [x] docstring  [ ] test
-    # [ ] setDesc                      [x] impl  [x] docstring  [ ] test
-    # [ ] getBlueprintCondition        [x] impl  [x] docstring  [ ] test
-    # [ ] setBlueprintCondition        [x] impl  [x] docstring  [ ] test
-    # [ ] getFormalBlueprintCondition  [x] impl  [x] docstring  [ ] test
-    # [ ] setFormalBlueprintCondition  [x] impl  [x] docstring  [ ] test
-    # [ ] getPostBuildVariantConditions [x] impl  [x] docstring  [ ] test
-    # [ ] addPostBuildVariantCondition [x] impl  [x] docstring  [ ] test
-    # [ ] getSdg                       [x] impl  [x] docstring  [ ] test
-    # [ ] setSdg                       [x] impl  [x] docstring  [ ] test
-    # [ ] getShortLabel                [x] impl  [x] docstring  [ ] test
-    # [ ] setShortLabel                [x] impl  [x] docstring  [ ] test
-    # [ ] getSwSyscond                 [x] impl  [x] docstring  [ ] test
-    # [ ] setSwSyscond                 [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 7.4, p.226
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBlueprintCondition             [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setBlueprintCondition             [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getDesc                           [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setDesc                           [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getFormalBlueprintGenerator       [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setFormalBlueprintGenerator       [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getPostBuildVariantConditions     [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] addPostBuildVariantCondition      [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getSdg                            [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setSdg                            [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getShortLabel                     [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setShortLabel                     [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getSwSyscond                      [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setSwSyscond                      [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.desc: Optional[MultiLanguageOverviewParagraph] = None
+        # This represents a description that documents how the variation point shall be resolved when deriving objects from the blueprint. Note that variationPoints are not allowed within a blueprintCondition.
         self.blueprintCondition: Optional[DocumentationBlock] = None
-        self.formalBlueprintCondition: Optional[MlFormula] = None
+
+        # This allows to describe shortly the purpose of the variation point.
+        self.desc: Optional[MultiLanguageOverviewParagraph] = None
+
+        # This represents a description that documents how the variation point shall be resolved when deriving objects from the blueprint by using ARMQL. Note that variationPoints are not allowed within a formal BlueprintGenerator.
+        self.formalBlueprintGenerator: Optional[BlueprintGenerator] = None
+
+        # This is the set of post build variant conditions which all shall be fulfilled in order to (postbuild) bind the variation point.
         self.postBuildVariantConditions: List["PostBuildVariantCondition"] = []
+
+        # An optional special data group is attached to every variation point. These data can be used by external software systems to attach application specific data. For example, a variant management system might add an identifier, an URL or a specific classifier.
         self.sdg: Optional[Sdg] = None
+
+        # This provides a name to the particular variation point to support the RTE generator. It is necessary for supporting splitable aggregations and if binding time is later than codeGenerationTime, as well as some RTE conditions. It needs to be unique with in the enclosing Identifiables with the same ShortName.
         self.shortLabel: Optional[Identifier] = None
+
+        # This condition acts as Binding Function for the Variation Point. Note that the multiplicity is 0..1 in order to support pure postBuild variants.
         self.swSyscond: Optional["ConditionByFormula"] = None
-
-    def getDesc(self) -> Optional[MultiLanguageOverviewParagraph]:
-        """
-        Gets the description of this variation point.
-
-        Returns:
-            MultiLanguageOverviewParagraph: The description, or None
-        """
-        return self.desc
-
-    def setDesc(self, value: MultiLanguageOverviewParagraph) -> "VariationPoint":
-        """
-        Sets the description of this variation point.
-
-        Args:
-            value: The description to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is not None:
-            self.desc = value
-        return self
 
     def getBlueprintCondition(self) -> Optional[DocumentationBlock]:
         """
-        Gets the blueprint condition documentation for this variation
-        point.
-
-        Returns:
-            DocumentationBlock: The condition documentation, or None
+        This represents a description that documents how the variation point shall be
+        resolved when deriving objects from the blueprint. Note that variationPoints
+        are not allowed within a blueprintCondition.
         """
         return self.blueprintCondition
 
-    def setBlueprintCondition(self, value: DocumentationBlock) -> "VariationPoint":
+    def setBlueprintCondition(self, value: Optional[DocumentationBlock]) -> "VariationPoint":
         """
-        Sets the blueprint condition documentation for this variation
-        point.
-
-        Args:
-            value: The condition documentation to set
-
-        Returns:
-            self for method chaining
+        This represents a description that documents how the variation point shall be
+        resolved when deriving objects from the blueprint. Note that variationPoints
+        are not allowed within a blueprintCondition. A None value is a no-op and does
+        not overwrite an existing blueprintCondition.
         """
         if value is not None:
             self.blueprintCondition = value
         return self
 
-    def getFormalBlueprintCondition(self) -> Optional[MlFormula]:
+    def getDesc(self) -> Optional[MultiLanguageOverviewParagraph]:
         """
-        Gets the formal blueprint condition for this variation point.
-
-        Returns:
-            MlFormula: The formal condition, or None
+        This allows to describe shortly the purpose of the variation point.
         """
-        return self.formalBlueprintCondition
+        return self.desc
 
-    def setFormalBlueprintCondition(self, value: MlFormula) -> "VariationPoint":
+    def setDesc(self, value: Optional[MultiLanguageOverviewParagraph]) -> "VariationPoint":
         """
-        Sets the formal blueprint condition for this variation point.
-
-        Args:
-            value: The formal condition to set
-
-        Returns:
-            self for method chaining
+        This allows to describe shortly the purpose of the variation point. A None value
+        is a no-op and does not overwrite an existing desc.
         """
         if value is not None:
-            self.formalBlueprintCondition = value
+            self.desc = value
+        return self
+
+    def getFormalBlueprintGenerator(self) -> Optional[BlueprintGenerator]:
+        """
+        This represents a description that documents how the variation point shall be
+        resolved when deriving objects from the blueprint by using ARMQL. Note that
+        variationPoints are not allowed within a formal BlueprintGenerator.
+        """
+        return self.formalBlueprintGenerator
+
+    def setFormalBlueprintGenerator(self, value: Optional[BlueprintGenerator]) -> "VariationPoint":
+        """
+        This represents a description that documents how the variation point shall be
+        resolved when deriving objects from the blueprint by using ARMQL. Note that
+        variationPoints are not allowed within a formal BlueprintGenerator. A None value
+        is a no-op and does not overwrite an existing formalBlueprintGenerator.
+        """
+        if value is not None:
+            self.formalBlueprintGenerator = value
         return self
 
     def getPostBuildVariantConditions(self) -> List["PostBuildVariantCondition"]:
         """
-        Gets the post-build variant conditions for this variation point.
-
-        Returns:
-            List[PostBuildVariantCondition]: The list of conditions
+        This is the set of post build variant conditions which all shall be fulfilled in
+        order to (postbuild) bind the variation point.
         """
         return self.postBuildVariantConditions
 
     def addPostBuildVariantCondition(self, value: "PostBuildVariantCondition") -> "VariationPoint":
         """
-        Adds a post-build variant condition to this variation point.
-
-        Args:
-            value: The condition to add
-
-        Returns:
-            self for method chaining
+        This is the set of post build variant conditions which all shall be fulfilled in
+        order to (postbuild) bind the variation point. A None value is a no-op and is
+        not appended.
         """
         if value is not None:
             self.postBuildVariantConditions.append(value)
@@ -554,22 +583,20 @@ class VariationPoint(ARObject):
 
     def getSdg(self) -> Optional[Sdg]:
         """
-        Gets the special data group for this variation point.
-
-        Returns:
-            Sdg: The special data group, or None
+        An optional special data group is attached to every variation point. These data
+        can be used by external software systems to attach application specific data.
+        For example, a variant management system might add an identifier, an URL or a
+        specific classifier.
         """
         return self.sdg
 
-    def setSdg(self, value: Sdg) -> "VariationPoint":
+    def setSdg(self, value: Optional[Sdg]) -> "VariationPoint":
         """
-        Sets the special data group for this variation point.
-
-        Args:
-            value: The special data group to set
-
-        Returns:
-            self for method chaining
+        An optional special data group is attached to every variation point. These data
+        can be used by external software systems to attach application specific data.
+        For example, a variant management system might add an identifier, an URL or a
+        specific classifier. A None value is a no-op and does not overwrite an existing
+        sdg.
         """
         if value is not None:
             self.sdg = value
@@ -577,22 +604,20 @@ class VariationPoint(ARObject):
 
     def getShortLabel(self) -> Optional[Identifier]:
         """
-        Gets the short label for this variation point.
-
-        Returns:
-            Identifier: The short label for RTE generator, or None
+        This provides a name to the particular variation point to support the RTE
+        generator. It is necessary for supporting splitable aggregations and if binding
+        time is later than codeGenerationTime, as well as some RTE conditions. It needs
+        to be unique within the enclosing Identifiables with the same ShortName.
         """
         return self.shortLabel
 
-    def setShortLabel(self, value: Identifier) -> "VariationPoint":
+    def setShortLabel(self, value: Optional[Identifier]) -> "VariationPoint":
         """
-        Sets the short label for this variation point.
-
-        Args:
-            value: The short label for RTE generator support
-
-        Returns:
-            self for method chaining
+        This provides a name to the particular variation point to support the RTE
+        generator. It is necessary for supporting splitable aggregations and if binding
+        time is later than codeGenerationTime, as well as some RTE conditions. It needs
+        to be unique within the enclosing Identifiables with the same ShortName. A None
+        value is a no-op and does not overwrite an existing shortLabel.
         """
         if value is not None:
             self.shortLabel = value
@@ -600,22 +625,16 @@ class VariationPoint(ARObject):
 
     def getSwSyscond(self) -> Optional["ConditionByFormula"]:
         """
-        Gets the system condition for this variation point.
-
-        Returns:
-            ConditionByFormula: The system condition, or None
+        This condition acts as Binding Function for the Variation Point. Note that the
+        multiplicity is 0..1 in order to support pure postBuild variants.
         """
         return self.swSyscond
 
-    def setSwSyscond(self, value: "ConditionByFormula") -> "VariationPoint":
+    def setSwSyscond(self, value: Optional["ConditionByFormula"]) -> "VariationPoint":
         """
-        Sets the system condition for this variation point.
-
-        Args:
-            value: The system condition to set
-
-        Returns:
-            self for method chaining
+        This condition acts as Binding Function for the Variation Point. Note that the
+        multiplicity is 0..1 in order to support pure postBuild variants. A None value is
+        a no-op and does not overwrite an existing swSyscond.
         """
         if value is not None:
             self.swSyscond = value

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -211,6 +211,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, NameToken, RefType, String
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import LifeCycleInfo, LifeCycleInfoSet, LifeCyclePeriod
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
+    PostBuildVariantCriterion,
     PredefinedVariant,
     SwSystemconstantValueSet,
     SwSystemconstValue,
@@ -7063,6 +7064,11 @@ class ARXMLParser(AbstractARXMLParser):
         self.readPredefinedVariantPostBuildVariantCriterionValueSetRefs(element, variant)
         self.readPredefinedVariantSwSystemconstantValueSetRefs(element, variant)
 
+    def readPostBuildVariantCriterion(self, element: ET.Element, criterion: PostBuildVariantCriterion):
+        self.logger.debug("Read PostBuildVariantCriterion <%s>" % criterion.getShortName())
+        self.readIdentifiable(element, criterion)
+        criterion.setCompuMethodRef(self.getChildElementOptionalRefType(element, "COMPU-METHOD-REF"))
+
     def readCommunicationController(self, element: ET.Element, controller: CommunicationController):
         controller.setWakeUpByControllerSupported(self.getChildElementOptionalBooleanValue(element, "WAKE-UP-BY-CONTROLLER-SUPPORTED"))
 
@@ -8329,6 +8335,9 @@ class ARXMLParser(AbstractARXMLParser):
             elif tag_name == "PREDEFINED-VARIANT":
                 variant = parent.createPredefinedVariant(self.getShortName(child_element))
                 self.readPredefinedVariant(child_element, variant)
+            elif tag_name == "POST-BUILD-VARIANT-CRITERION":
+                criterion = parent.createPostBuildVariantCriterion(self.getShortName(child_element))
+                self.readPostBuildVariantCriterion(child_element, criterion)
             elif tag_name == "NV-DATA-INTERFACE":
                 interface = parent.createNvDataInterface(self.getShortName(child_element))
                 self.readNvDataInterface(child_element, interface)

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -200,6 +200,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, Limit, RefType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import LifeCycleInfo, LifeCycleInfoSet, LifeCyclePeriod
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
+    PostBuildVariantCriterion,
     PredefinedVariant,
     SwSystemconstantValueSet,
     SwSystemconstValue,
@@ -7603,6 +7604,16 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.writePredefinedVariantPostBuildVariantCriterionValueSetRefs(child_element, variant)
         self.writePredefinedVariantSwSystemconstantValueSetRefs(child_element, variant)
 
+    def writePostBuildVariantCriterion(self, element: ET.Element, criterion: PostBuildVariantCriterion):
+        self.logger.debug("PostBuildVariantCriterion %s" % criterion.getShortName())
+        child_element = ET.SubElement(element, "POST-BUILD-VARIANT-CRITERION")
+        self.writeIdentifiable(child_element, criterion)
+        self.setChildElementOptionalRefType(
+            child_element,
+            "COMPU-METHOD-REF",
+            criterion.getCompuMethodRef(),
+        )
+
     def writeISignalGroupISignalRef(self, element: ET.Element, group: ISignalGroup):
         signal_refs = group.getISignalRefs()
         if len(signal_refs) > 0:
@@ -8466,6 +8477,8 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeSwSystemconstantValueSet(element, ar_element)
         elif isinstance(ar_element, PredefinedVariant):
             self.writePredefinedVariant(element, ar_element)
+        elif isinstance(ar_element, PostBuildVariantCriterion):
+            self.writePostBuildVariantCriterion(element, ar_element)
         elif isinstance(ar_element, McFunction):
             self.writeMcFunction(element, ar_element)
         elif isinstance(ar_element, McGroup):

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/test_BlueprintGenerator.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/test_BlueprintGenerator.py
@@ -1,11 +1,15 @@
 """
-This module contains tests for the BlueprintGenerator class in the
+Tests for the BlueprintGenerator class in the
 AUTOSAR CommonStructure.StandardizationTemplate.BlueprintGenerator module.
 """
 
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintGenerator.BlueprintGenerator import (
     BlueprintGenerator,
 )
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    VerbatimString,
+)
+from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
 
 
 class TestBlueprintGenerator:
@@ -13,7 +17,33 @@ class TestBlueprintGenerator:
     Test class for BlueprintGenerator functionality.
     """
 
-    def test_set_get_generator_name(self):
+    def test_initialization(self):
         obj = BlueprintGenerator()
-        assert obj.setGeneratorName("gen") is obj
-        assert obj.getGeneratorName() == "gen"
+        assert obj.getExpression() is None
+        assert obj.getIntroduction() is None
+
+    def test_set_get_expression(self):
+        obj = BlueprintGenerator()
+        expression = VerbatimString().setValue("some ARMQL")
+        assert obj.setExpression(expression) is obj
+        assert obj.getExpression() == expression
+
+    def test_set_expression_none_is_noop(self):
+        obj = BlueprintGenerator()
+        expression = VerbatimString().setValue("some ARMQL")
+        obj.setExpression(expression)
+        obj.setExpression(None)
+        assert obj.getExpression() == expression
+
+    def test_set_get_introduction(self):
+        obj = BlueprintGenerator()
+        introduction = DocumentationBlock()
+        assert obj.setIntroduction(introduction) is obj
+        assert obj.getIntroduction() == introduction
+
+    def test_set_introduction_none_is_noop(self):
+        obj = BlueprintGenerator()
+        introduction = DocumentationBlock()
+        obj.setIntroduction(introduction)
+        obj.setIntroduction(None)
+        assert obj.getIntroduction() == introduction

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py
@@ -2,6 +2,9 @@
 Tests for GenericStructure VariantHandling model classes.
 """
 
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintGenerator.BlueprintGenerator import (
+    BlueprintGenerator,
+)
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import (
     ARPackage,
 )
@@ -10,12 +13,14 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     ARNumerical,
+    Integer,
     RefType,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
     ConditionByFormula,
     PostBuildVariantCondition,
     PostBuildVariantCriterion,
+    PostBuildVariantCriterionValue,
     PredefinedVariant,
     SwSystemconstantValueSet,
     SwSystemconstValue,
@@ -113,31 +118,29 @@ def test_binding_time_enum_validate_enum_value():
 def test_post_build_variant_condition_getters_and_setters():
     from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer
 
-    criterion = PostBuildVariantCriterion()
-    criterion.setCriterionName("MyCriterion")
+    criterion_ref = RefType().setValue("/RootPkg/Criteria/MyCriterion")
 
     value = Integer()
     value.setValue(42)
 
     condition = PostBuildVariantCondition()
-    condition.setMatchingCriterion(criterion)
+    condition.setMatchingCriterionRef(criterion_ref)
     condition.setValue(value)
 
-    assert condition.getMatchingCriterion() == criterion
+    assert condition.getMatchingCriterionRef() == criterion_ref
     assert condition.getValue() == value
 
 
 def test_post_build_variant_condition_method_chaining():
     from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer
 
-    criterion = PostBuildVariantCriterion()
-    criterion.setCriterionName("MyCriterion")
+    criterion_ref = RefType().setValue("/RootPkg/Criteria/MyCriterion")
 
     value = Integer()
     value.setValue(42)
 
     condition = PostBuildVariantCondition()
-    result_criterion = condition.setMatchingCriterion(criterion)
+    result_criterion = condition.setMatchingCriterionRef(criterion_ref)
     result_value = condition.setValue(value)
 
     assert result_criterion is condition
@@ -147,10 +150,10 @@ def test_post_build_variant_condition_method_chaining():
 def test_post_build_variant_condition_none_values():
     condition = PostBuildVariantCondition()
 
-    condition.setMatchingCriterion(None)
+    condition.setMatchingCriterionRef(None)
     condition.setValue(None)
 
-    assert condition.getMatchingCriterion() is None
+    assert condition.getMatchingCriterionRef() is None
     assert condition.getValue() is None
 
 
@@ -200,19 +203,17 @@ def test_variation_point_add_post_build_conditions():
 
     variation_point = VariationPoint()
 
-    criterion1 = PostBuildVariantCriterion()
-    criterion1.setCriterionName("Criterion1")
+    criterion_ref1 = RefType().setValue("/RootPkg/Criteria/Criterion1")
     value1 = Integer()
     value1.setValue(1)
     condition1 = PostBuildVariantCondition()
-    condition1.setMatchingCriterion(criterion1).setValue(value1)
+    condition1.setMatchingCriterionRef(criterion_ref1).setValue(value1)
 
-    criterion2 = PostBuildVariantCriterion()
-    criterion2.setCriterionName("Criterion2")
+    criterion_ref2 = RefType().setValue("/RootPkg/Criteria/Criterion2")
     value2 = Integer()
     value2.setValue(2)
     condition2 = PostBuildVariantCondition()
-    condition2.setMatchingCriterion(criterion2).setValue(value2)
+    condition2.setMatchingCriterionRef(criterion_ref2).setValue(value2)
 
     result1 = variation_point.addPostBuildVariantCondition(condition1)
     result2 = variation_point.addPostBuildVariantCondition(condition2)
@@ -266,13 +267,119 @@ def test_variation_point_all_new_attributes():
     sys_cond.setBindingTime(binding_time)
     variation_point.setSwSyscond(sys_cond)
 
-    criterion = PostBuildVariantCriterion()
-    criterion.setCriterionName("TestCriterion")
+    criterion_ref = RefType().setValue("/RootPkg/Criteria/TestCriterion")
     pb_condition = PostBuildVariantCondition()
-    pb_condition.setMatchingCriterion(criterion).setValue(100)
+    pb_condition.setMatchingCriterionRef(criterion_ref).setValue(100)
     variation_point.addPostBuildVariantCondition(pb_condition)
 
     assert variation_point.getShortLabel() == "VP_Complete"
     assert variation_point.getSwSyscond() == sys_cond
     assert len(variation_point.getPostBuildVariantConditions()) == 1
     assert variation_point.getPostBuildVariantConditions()[0] == pb_condition
+
+
+class TestPostBuildVariantCriterion:
+    def test_initialization(self):
+        parent = ARPackage(None, "ParentPkg")
+        criterion = PostBuildVariantCriterion(parent, "MyCriterion")
+        assert criterion.getCompuMethodRef() is None
+
+    def test_set_get_compu_method_ref(self):
+        parent = ARPackage(None, "ParentPkg")
+        criterion = PostBuildVariantCriterion(parent, "MyCriterion")
+        compu_method_ref = RefType().setValue("/RootPkg/CompuMethods/MyCompuMethod")
+        assert criterion.setCompuMethodRef(compu_method_ref) is criterion
+        assert criterion.getCompuMethodRef() == compu_method_ref
+
+    def test_set_compu_method_ref_none_is_noop(self):
+        parent = ARPackage(None, "ParentPkg")
+        criterion = PostBuildVariantCriterion(parent, "MyCriterion")
+        compu_method_ref = RefType().setValue("/RootPkg/CompuMethods/MyCompuMethod")
+        criterion.setCompuMethodRef(compu_method_ref)
+        criterion.setCompuMethodRef(None)
+        assert criterion.getCompuMethodRef() == compu_method_ref
+
+
+class TestPostBuildVariantCriterionValue:
+    def test_initialization(self):
+        value = PostBuildVariantCriterionValue()
+        assert value.getAnnotations() == []
+        assert value.getValue() is None
+        assert value.getVariantCriterionRef() is None
+
+    def test_add_annotations_and_get(self):
+        value = PostBuildVariantCriterionValue()
+        annotation = Annotation()
+        assert value.addAnnotation(annotation) is value
+        assert value.getAnnotations() == [annotation]
+
+    def test_add_annotation_none_is_noop(self):
+        value = PostBuildVariantCriterionValue()
+        annotation = Annotation()
+        value.addAnnotation(annotation)
+        value.addAnnotation(None)
+        assert value.getAnnotations() == [annotation]
+
+    def test_set_get_value(self):
+        value = PostBuildVariantCriterionValue()
+        integer_value = Integer().setValue(5)
+        assert value.setValue(integer_value) is value
+        assert value.getValue() == integer_value
+
+    def test_set_value_none_is_noop(self):
+        value = PostBuildVariantCriterionValue()
+        integer_value = Integer().setValue(5)
+        value.setValue(integer_value)
+        value.setValue(None)
+        assert value.getValue() == integer_value
+
+    def test_set_get_variant_criterion_ref(self):
+        value = PostBuildVariantCriterionValue()
+        criterion_ref = RefType().setValue("/RootPkg/Criteria/MyCriterion")
+        assert value.setVariantCriterionRef(criterion_ref) is value
+        assert value.getVariantCriterionRef() == criterion_ref
+
+    def test_set_variant_criterion_ref_none_is_noop(self):
+        value = PostBuildVariantCriterionValue()
+        criterion_ref = RefType().setValue("/RootPkg/Criteria/MyCriterion")
+        value.setVariantCriterionRef(criterion_ref)
+        value.setVariantCriterionRef(None)
+        assert value.getVariantCriterionRef() == criterion_ref
+
+
+class TestPostBuildVariantCondition:
+    def test_initialization(self):
+        condition = PostBuildVariantCondition()
+        assert condition.getMatchingCriterionRef() is None
+        assert condition.getValue() is None
+
+
+class TestConditionByFormula:
+    def test_initialization(self):
+        condition = ConditionByFormula()
+        assert condition.getBindingTime() is None
+
+
+class TestVariationPoint:
+    def test_initialization(self):
+        variation_point = VariationPoint()
+        assert variation_point.getBlueprintCondition() is None
+        assert variation_point.getDesc() is None
+        assert variation_point.getFormalBlueprintGenerator() is None
+        assert variation_point.getPostBuildVariantConditions() == []
+        assert variation_point.getSdg() is None
+        assert variation_point.getShortLabel() is None
+        assert variation_point.getSwSyscond() is None
+
+    def test_set_get_formal_blueprint_generator(self):
+        variation_point = VariationPoint()
+        generator = BlueprintGenerator()
+        assert variation_point.setFormalBlueprintGenerator(generator) is variation_point
+        assert variation_point.getFormalBlueprintGenerator() == generator
+
+    def test_set_formal_blueprint_generator_none_is_noop(self):
+        variation_point = VariationPoint()
+        generator = BlueprintGenerator()
+        variation_point.setFormalBlueprintGenerator(generator)
+        variation_point.setFormalBlueprintGenerator(None)
+        assert variation_point.getFormalBlueprintGenerator() == generator

--- a/tests/test_armodel/parser/test_arxml_parser_dispatch.py
+++ b/tests/test_armodel/parser/test_arxml_parser_dispatch.py
@@ -501,6 +501,21 @@ class TestVariantAndLifecycleDispatch:
         _dispatch(parser, parent, _snip("PREDEFINED-VARIANT", "PV1"))
         assert len(parent.getPredefinedVariants()) == 1
 
+    def test_post_build_variant_criterion(self, parser):
+        parent = _make_parent()
+        _dispatch(
+            parser,
+            parent,
+            _snip(
+                "POST-BUILD-VARIANT-CRITERION",
+                "PBC1",
+                "<COMPU-METHOD-REF DEST='COMPU-METHOD'>/Pkg/CompuMethods/C1</COMPU-METHOD-REF>",
+            ),
+        )
+        criterions = parent.getPostBuildVariantCriterions()
+        assert len(criterions) == 1
+        assert criterions[0].getCompuMethodRef().getValue() == "/Pkg/CompuMethods/C1"
+
     def test_life_cycle_info_set(self, parser):
         parent = _make_parent()
         _dispatch(parser, parent, _snip("LIFE-CYCLE-INFO-SET", "LC1"))

--- a/tests/test_armodel/writer/test_writer_arpackage_dispatch.py
+++ b/tests/test_armodel/writer/test_writer_arpackage_dispatch.py
@@ -13,7 +13,9 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     ARBoolean,
     ARLiteral,
+    RefType,
 )
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import PostBuildVariantCriterion
 from armodel.writer.arxml_writer import ARXMLWriter
 
 
@@ -130,6 +132,7 @@ ELEMENT_TYPES_AND_TAGS = [
     ("SwSystemConst", "SW-SYSTEMCONST"),
     ("SwSystemconstantValueSet", "SW-SYSTEMCONSTANT-VALUE-SET"),
     ("PredefinedVariant", "PREDEFINED-VARIANT"),
+    ("PostBuildVariantCriterion", "POST-BUILD-VARIANT-CRITERION"),
     ("McGroup", "MC-GROUP"),
 ]
 
@@ -309,6 +312,38 @@ class TestWriteARPackageElements:
         tags = {child.tag for child in elements_tag}
         assert "SW-BASE-TYPE" in tags
         assert "COMPU-METHOD" in tags
+
+
+class TestWritePostBuildVariantCriterionRoundTrip:
+    def test_round_trip_preserves_compu_method_ref(self, writer, tmp_path):
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        pkg = _pkg()
+        criterion = pkg.createPostBuildVariantCriterion("MyCriterion")
+        compu_ref = RefType().setValue("/Pkg/CompuMethods/MyCompuMethod")
+        compu_ref.setDest("COMPU-METHOD")
+        criterion.setCompuMethodRef(compu_ref)
+
+        out_file = str(tmp_path / "postbuild.arxml")
+        writer.save(out_file, AUTOSAR.getInstance())
+
+        AUTOSAR.getInstance().new()
+        parser = ARXMLParser(options={"warning": True})
+        document = AUTOSAR.getInstance()
+        document.setARRelease("R23-11")
+        parser.load(out_file, document)
+
+        re_pkg = document.find("Pkg")
+        re_criterion = re_pkg.getElement("MyCriterion", PostBuildVariantCriterion)
+        assert re_criterion is not None
+        assert re_criterion.getCompuMethodRef().getValue() == "/Pkg/CompuMethods/MyCompuMethod"
+
+    def test_empty_compu_method_ref(self, writer):
+        pkg = _pkg()
+        criterion = pkg.createPostBuildVariantCriterion("NoRefCriterion")
+        parent = _parent()
+        writer.writePostBuildVariantCriterion(parent, criterion)
+        assert parent[0].find("COMPU-METHOD-REF") is None
 
     def test_skips_arpackage_elements(self, writer):
         parent = ET.Element("AR-PACKAGE")


### PR DESCRIPTION
## Summary
Sync model classes to the AUTOSAR R23-11 spec with reader/writer coverage:

- `BlueprintGenerator` — expression + introduction accessors
- `VariationPoint` — `formalBlueprintCondition` → `formalBlueprintGenerator`, `matchingCriterion` → `matchingCriterionRef`
- `PostBuildVariantCondition` — RefType-based criterion
- `PostBuildVariantCriterion` — compuMethodRef + reader/writer dispatch
- `PostBuildVariantCriterionValue` — annotations/value/variantCriterionRef

## Verification
- `npm run flake8`, `npm run black-check`, `ruff check` all pass
- 6263 unit + integration tests pass

Closes #615