### PR TITLE
chore: bump version to 1.9.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ writer.save('output.arxml', document)
 - `AUTOSAR` singleton: `getInstance()` / `new()` to reset
 - Model classes use wildcard exports in `__init__.py` — when adding a class, add `from .my_class import *` to parent `__init__.py`
 - Use `ABC` from `abc` module (not `ABCMeta`)
-- Current version: 1.9.3, Python >= 3.8 (CI tests 3.8–3.13)
+- Current version: 1.9.4, Python >= 3.8 (CI tests 3.8–3.13)
 - Dependencies: `colorama`, `openpyxl`, `lxml` (runtime)
 
 ### High-Level Data Flow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 py-armodel is a Python library for parsing, manipulating, and writing AUTOSAR XML (ARXML) files. It follows the AUTOSAR standard specifications and supports versions from 4.0.3 to R24-11, with particular focus on CP R23-11 standard compliance.
 
-**Current Version**: 1.9.3
+**Current Version**: 1.9.4
 **Python Requirements**: >= 3.8 (CI tests on 3.8-3.13)
 **License**: MIT
 **Repository**: http://github.com/melodypapa/py-armodel

--- a/README.md
+++ b/README.md
@@ -310,6 +310,19 @@ $connector-update src/armodel/tests/test_files/SoftwareComponents.arxml data/Sof
 
 ## 1.12. Change notes:
 
+**Version 1.9.4**
+
+* Synced SWC template classes to AUTOSAR R23-11 spec: `AtomicSwComponentType`, `SwcServiceDependency`, `RunnableEntity`, `WaitPoint`, `ExternalTriggeringPoint`, `ConsistencyNeeds`, `RunnableEntityGroup`, `Chapter`, `PortPrototype` annotations
+* Synced ECUC template classes to AUTOSAR R23-11 spec: `ECUCParameterDefTemplate`, `EcucParameterDef`, `EcucStringParamDef`, `EcucFunctionNameDef`, `EcucReferenceDef`, `EcucDestinationUriPolicy`, `EcucDerivation`, `EcucQuery`, `EcucConditionFormula`, doc block element classes, `ModeInBswModuleDescriptionInstanceRef`
+* Synced MSR text/data model classes: `TextModel`, `SwDataDefProps` (full spec verification), `SignalServiceTranslation`, `NumericalOrText`
+* Synced System/Network classes: `Pdu`, `FibexElement`, `PackageableElement`, `ISignal` and Communication specs, `NmNode`, `J1939NmNode`, `ObdControlServiceNeeds`
+* Synced `ImplementationDataType` (Table D.37), `DataPrototypeGroup`, InstanceRefs, `ServiceNeeds`/`ServiceMapping`, `ClientServerInterface` accessors, `AtpBlueprint`, `BaseTypes`, `Composition` instance refs, `InstantiationRTEEventProps`
+* Added `ShortNameFragment` read/write support
+* Added `ExecutableEntityActivationReason` support
+* Added `sync-autosar-class` agent skill and AUTOSAR spec PDF reorganization
+* Achieved full model test parity and fixed source import paths
+* Bumped project version metadata to 1.9.4
+
 **Version 1.9.3**
 
 * Added parse/write support for `NvDataInterface` (PR #485)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,31 @@
 Changelog
 =========
 
-Version 1.9.3 (Current)
-------------------------
+Version 1.9.4 (Current)
+-----------------------
+
+* Synced SWC template classes to AUTOSAR R23-11 spec: ``AtomicSwComponentType``,
+  ``SwcServiceDependency``, ``RunnableEntity``, ``WaitPoint``, ``ExternalTriggeringPoint``,
+  ``ConsistencyNeeds``, ``RunnableEntityGroup``, ``Chapter``, ``PortPrototype`` annotations
+* Synced ECUC template classes to AUTOSAR R23-11 spec: ``ECUCParameterDefTemplate``,
+  ``EcucParameterDef``, ``EcucStringParamDef``, ``EcucFunctionNameDef``,
+  ``EcucReferenceDef``, ``EcucDestinationUriPolicy``, ``EcucDerivation``, ``EcucQuery``,
+  ``EcucConditionFormula``, doc block element classes, ``ModeInBswModuleDescriptionInstanceRef``
+* Synced MSR text/data model classes: ``TextModel``, ``SwDataDefProps`` (full spec
+  verification), ``SignalServiceTranslation``, ``NumericalOrText``
+* Synced System/Network classes: ``Pdu``, ``FibexElement``, ``PackageableElement``,
+  ``ISignal`` and Communication specs, ``NmNode``, ``J1939NmNode``, ``ObdControlServiceNeeds``
+* Synced ``ImplementationDataType`` (Table D.37), ``DataPrototypeGroup``, InstanceRefs,
+  ``ServiceNeeds``/``ServiceMapping``, ``ClientServerInterface`` accessors, ``AtpBlueprint``,
+  ``BaseTypes``, ``Composition`` instance refs, ``InstantiationRTEEventProps``
+* Added ``ShortNameFragment`` read/write support
+* Added ``ExecutableEntityActivationReason`` support
+* Added ``sync-autosar-class`` agent skill and AUTOSAR spec PDF reorganization
+* Achieved full model test parity and fixed source import paths
+* Bumped project version metadata to 1.9.4
+
+Version 1.9.3
+-------------
 
 * Added parse/write support for ``NvDataInterface`` (PR #485)
 * Added ``--unescape-entities`` parameter to ``arxml-format`` CLI to normalize

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ Welcome to py-armodel's Documentation
 
 py-armodel is a Python library for parsing and generating AUTOSAR ARXML files. It provides comprehensive support for AUTOSAR models including software components, data types, communication patterns, and system configurations.
 
-**Current Version**: 1.9.3
+**Current Version**: 1.9.4
 **Python Requirements**: >= 3.8
 **License**: MIT
 

--- a/src/armodel/__init__.py
+++ b/src/armodel/__init__.py
@@ -5,7 +5,7 @@ This library provides ARXML parser and writer functionality for automotive
 ECU software development.
 """
 
-__version__ = "1.9.3"
+__version__ = "1.9.4"
 
 from armodel import models as _models
 from armodel.parser import ARXMLParser, FileListParser


### PR DESCRIPTION
## Summary
Prepare the v1.9.4 release.

- Bump `__version__` to 1.9.4
- Add v1.9.4 change notes to README and docs/changelog.rst (108 commits since v1.9.3)
- Update current version references in docs/index.rst, AGENTS.md, CLAUDE.md

## Verification
- 6263 unit + integration tests pass
- flake8 clean
- black-check clean (592 files unchanged)