### PR TITLE
feat: sync VariationPoint and Sdg closure to AUTOSAR spec

### DIFF
--- a/docs/superpowers/plans/2026-08-16-variation-point-parsing-writing.md
+++ b/docs/superpowers/plans/2026-08-16-variation-point-parsing-writing.md
@@ -1,0 +1,1059 @@
+# VariationPoint Parsing and Writing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Add full ARXML reader/writer support for the structural `VariationPoint` (package `M2::AUTOSARTemplates::GenericStructure::VariantHandling`), per `docs/requirements/xsd/AUTOSAR_00046.xsd` (authoritative) and `autosar/markdown/AUTOSAR_FO_TPS_GenericStructureTemplate.md` (Tables 7.4–7.6, Section 7.6).
+
+**Architecture:** The `VariationPoint` model class already exists with impl/docstring/test parity, but nothing holds one and neither parser nor writer touches `<VARIATION-POINT>`. We attach an optional `variationPoint` attribute to the `Identifiable` base class (the same central hook that already reads/writes `DESC`, `ADMIN-DATA`, etc. for every Identifiable element), add mixed-content formula support to `ConditionByFormula` (ordered text + inline reference items so round-trips are lossless), then wire reader methods into `readIdentifiable()` and writer methods into `writeIdentifiable()`.
+
+**Tech Stack:** Python 3.8+, lxml/ElementTree, pytest. No new dependencies.
+
+## Spec Summary (verified against `docs/requirements/xsd/AUTOSAR_00046.xsd`)
+
+### VARIATION-POINT (xsd group `AR:VARIATION-POINT`, line 99470)
+
+`<VARIATION-POINT>` appears as an optional child of any variable element (xsd lines 1154, 1561, 2523, ... — spec examples: `SWC-INTERNAL-BEHAVIOR`, `RUNNABLE-ENTITY`). Child **sequence order is fixed by the XSD** (`xml.sequenceOffset` 10–50):
+
+| # | Element | XSD type | Model attribute |
+|---|---------|----------|-----------------|
+| 1 | `SHORT-LABEL` (offset 10) | `AR:IDENTIFIER` | `shortLabel` |
+| 2 | `DESC` (20) | `AR:MULTI-LANGUAGE-OVERVIEW-PARAGRAPH` | `desc` |
+| 3 | `BLUEPRINT-CONDITION` (28) | `AR:DOCUMENTATION-BLOCK` | `blueprintCondition` |
+| 4 | `FORMAL-BLUEPRINT-CONDITION` (29) | `AR:BLUEPRINT-FORMULA` | — **obsolete, not supported** |
+| 5 | `FORMAL-BLUEPRINT-GENERATOR` (30) | `AR:BLUEPRINT-GENERATOR` | `formalBlueprintGenerator` |
+| 6 | `SW-SYSCOND` (30) | `AR:CONDITION-BY-FORMULA` | `swSyscond` |
+| 7 | `POST-BUILD-VARIANT-CONDITIONS` (40) | wrapper, unbounded `POST-BUILD-VARIANT-CONDITION` | `postBuildVariantConditions` |
+| 8 | `SDG` (50) | `AR:SDG` | `sdg` |
+
+The writer MUST emit children in this order. (The markdown spec examples show SHORT-LABEL before DESC as well — `AUTOSAR_FO_TPS_GenericStructureTemplate.md:13061`.)
+
+### CONDITION-BY-FORMULA (xsd line 18334)
+
+- `mixed="true"`; content = unbounded choice of `AR-OBJECT` / `FORMULA-EXPRESSION` / `SW-SYSTEMCONST-DEPENDENT-FORMULA` groups → in practice: free text interleaved with inline reference elements.
+- Attribute `BINDING-TIME` of type `AR:BINDING-TIME-ENUM--SIMPLE` (optional in XSD).
+- `SW-SYSTEMCONST-DEPENDENT-FORMULA` (xsd line 89067) allows **two** inline ref elements, both `DEST`-typed `SW-SYSTEMCONST--SUBTYPES-ENUM`:
+  - `SYSC-REF` — internal (coded) value of the system constant
+  - `SYSC-STRING-REF` — system constant evaluated as string
+
+### POST-BUILD-VARIANT-CONDITION (xsd line 71152)
+
+Sequence:
+- `MATCHING-CRITERION-REF` — extension of `AR:REF`, `DEST` = `POST-BUILD-VARIANT-CRITERION--SUBTYPES-ENUM` (**tag is `MATCHING-CRITERION-REF`, NOT `POST-BUILD-VARIANT-CRITERION-REF`**)
+- `VALUE` — XSD type `AR:INTEGER-VALUE-VARIATION-POINT` (mixed, may carry `BINDING-TIME`/`SD`/`SHORT-LABEL`/`BLUEPRINT-VALUE` attributes). **Handled as plain Integer text** — matches the existing codebase precedent: `readSwSystemconstValue` (`arxml_parser.py:7022`) already reads a `*-VALUE-VARIATION-POINT` VALUE element as a plain numerical. Attribute value pattern features on VALUE are out of scope (deviation, noted below).
+
+### BLUEPRINT-GENERATOR (xsd line 7395)
+
+Sequence: `INTRODUCTION` (`AR:DOCUMENTATION-BLOCK`, offset 10) then `EXPRESSION` (`AR:VERBATIM-STRING`, offset 20). Writer must emit INTRODUCTION first.
+
+### Notes / deviations
+
+- Spec markdown line 5618 ("SHORT-LABEL as XML attribute") refers to the *attribute value pattern* (`ATTRIBUTE-VALUE-VARIATION-POINT` attributeGroup, xsd:6672), NOT the structural variation point. Structural SHORT-LABEL is a child element (xsd:99477).
+- `FORMAL-BLUEPRINT-CONDITION` (xsd:99497) is `atp.Status="obsolete"` and has no model attribute — skipped.
+- VALUE's variation-point attributes/formula content not captured (attribute value pattern out of scope; matches SwSystemconstValue precedent).
+- Known deviation: AUTOSAR allows variation points on non-Identifiable elements too (reference pattern `*-REF-CONDITIONAL`, property set pattern `*-VARIANTS`). This plan covers the structural/aggregation pattern attached to `Identifiable`, which is the dominant use.
+- Implemented deviation (reader round-trip whitespace): the writer's `minidom.toprettyxml` (`abstract_arxml_writer.py:saveToFile`) reformats mixed-content elements, wrapping `SW-SYSCOND` text/tail fragments in newline+indentation. To keep parse→write→re-parse lossless, `readConditionByFormula` strips that formatting boundary via `_stripMixedContentWhitespace`. Consequently the byte-for-byte corpus copy (Task 5 Step 4) was **skipped** — a pretty-printed mixed-content file cannot round-trip byte-identically against a single-line source.
+- Implemented deviation (writer hook guard): `writeIdentifiable`/`readIdentifiable` are also called for `ARPackage` (a `CollectableElement`, not an `Identifiable`), which lacks `getVariationPoint`/`setVariationPoint`; both hooks are guarded with `isinstance(identifiable, Identifiable)`.
+
+## Existing State (verified)
+
+- Model: `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py` — `VariationPoint` (line 432), `ConditionByFormula` (383), `PostBuildVariantCondition` (312) fully implemented with getters/setters. Parity checklists show reader/writer columns all `[ ]` or blank.
+- `ConditionByFormula` has only `bindingTime` — no formula content storage. Must be extended.
+- Parser `readIdentifiable` at `src/armodel/parser/arxml_parser.py:766` — central hook, no VARIATION-POINT handling.
+- Writer `writeIdentifiable` at `src/armodel/writer/arxml_writer.py:838` — central hook, no VARIATION-POINT handling.
+- Parser already imports from `VariantHandling` (`arxml_parser.py:213`) — extend that import. Writer imports `SwSystemconstValue` from the same package.
+- Helpers confirmed: parser `getSdg` (`arxml_parser.py:674`), `getMultiLanguageOverviewParagraph` (:856), `getDocumentationBlock` (:3403), `getChildElementOptionalIdentifier` (`abstract_arxml_parser.py:136`), `getChildElementOptionalIntegerValue` (:237), `getChildElementRefType` (:290). Writer: `setSdg` (`arxml_writer.py:653`), `setMultiLanguageOverviewParagraph` (:763), `writeDocumentationBlock` (:1614), `setChildElementOptionalIntegerValue` (`abstract_arxml_writer.py:97`), `setChildElementOptionalRefType` (:109).
+- Tests: `tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py` exists. Parser snippet helper `_snip` + `parser` fixture in `tests/test_armodel/parser/conftest.py` / `_helpers.py`. Writer tests in `tests/test_armodel/writer/`.
+- No `VARIATION-POINT` in any existing test ARXML file.
+
+---
+
+### Task 1: Attach variationPoint to Identifiable
+
+**Files:**
+- Modify: `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py`
+- Test: `tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py`
+
+- [x] **Step 1: Write the failing test**
+
+Append to `tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py`:
+
+```python
+def test_identifiable_holds_variation_point():
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage
+
+    parent = ARPackage(None, "Pkg")
+    criterion = PostBuildVariantCriterion(parent, "MyCriterion")
+    variation_point = VariationPoint()
+
+    assert criterion.getVariationPoint() is None
+
+    result = criterion.setVariationPoint(variation_point)
+
+    assert criterion.getVariationPoint() is variation_point
+    assert result is criterion
+```
+
+(`PostBuildVariantCriterion` extends `ARElement` → `Identifiable`, and is already imported at the top of the test file — no new import needed beyond the local `ARPackage` one shown.)
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py::test_identifiable_holds_variation_point -v`
+Expected: FAIL with `AttributeError: 'PostBuildVariantCriterion' object has no attribute 'getVariationPoint'`
+
+- [x] **Step 3: Write minimal implementation**
+
+In `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py`:
+
+3a. Extend the `typing` import at the top of the file to include `TYPE_CHECKING` (the file already imports `List`, `Optional`, etc. from `typing`), and add a guarded import after the existing imports:
+
+```python
+from typing import ..., TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import VariationPoint
+```
+
+(The runtime import would be circular: `VariantHandling` imports `Identifiable` from this module. `TYPE_CHECKING` keeps the annotation string-only.)
+
+3b. In `Identifiable.__init__` (after `self.desc`, around line 383), add:
+
+```python
+        # Structural variation point attached to this element (pattern: aggregation,
+        # TPS_GST 7.6; XSD group AR:VARIATION-POINT, AUTOSAR_00046.xsd:99470).
+        # Deviation: spec also allows variation points on non-Identifiable elements
+        # (reference pattern, property set pattern); only the Identifiable
+        # aggregation pattern is supported.
+        self.variationPoint: Optional["VariationPoint"] = None
+```
+
+3c. Add getter/setter after the existing `getDesc`/`setDesc` methods of `Identifiable`:
+
+```python
+    def getVariationPoint(self) -> Optional["VariationPoint"]:
+        """
+        Returns the structural variation point of this element, if any.
+        """
+        return self.variationPoint
+
+    def setVariationPoint(self, value: Optional["VariationPoint"]) -> "Identifiable":
+        """
+        Sets the structural variation point of this element. A None value is a no-op
+        and does not overwrite an existing variationPoint.
+        """
+        if value is not None:
+            self.variationPoint = value
+        return self
+```
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py::test_identifiable_holds_variation_point -v`
+Expected: PASS
+
+- [x] **Step 5: Run the full VariantHandling model test module (regression)**
+
+Run: `pytest tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py -v`
+Expected: all PASS
+
+- [x] **Step 6: Commit**
+
+```bash
+git add src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py \
+        tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py
+git commit -m "feat: attach structural variationPoint to Identifiable base class"
+```
+
+---
+
+### Task 2: ConditionByFormula mixed-content formula items
+
+**Files:**
+- Modify: `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py` (class `ConditionByFormula`, line 383)
+- Test: `tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py`
+
+`SW-SYSCOND` (`CONDITION-BY-FORMULA`, xsd:18334, `mixed="true"`) carries a formula as mixed content: text interleaved with `SYSC-REF` and `SYSC-STRING-REF` elements (xsd:89075/89088). To round-trip losslessly we store an ordered list of items — plain `str` fragments and `(tag, RefType)` tuples, where tag is `"SYSC-REF"` or `"SYSC-STRING-REF"` (the two elements differ semantically: coded value vs string evaluation, so the tag must survive).
+
+- [x] **Step 1: Write the failing test**
+
+Append to `tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py`:
+
+```python
+def test_condition_by_formula_formula_items_ordered():
+    sysc_ref = RefType().setValue("/SwSystemconsts/SY_TURBO").setDest("SW-SYSTEMCONST")
+    string_ref = RefType().setValue("/SwSystemconsts/SY_MODE").setDest("SW-SYSTEMCONST")
+
+    condition = ConditionByFormula()
+
+    assert condition.getFormulaItems() == []
+
+    result_text = condition.addFormulaText("defined(")
+    result_ref = condition.addFormulaRef(sysc_ref)
+    result_tail = condition.addFormulaText(") && ")
+    result_string_ref = condition.addFormulaRef(string_ref, tag="SYSC-STRING-REF")
+
+    items = condition.getFormulaItems()
+    assert items[0] == "defined("
+    assert items[1] == ("SYSC-REF", sysc_ref)
+    assert items[2] == ") && "
+    assert items[3] == ("SYSC-STRING-REF", string_ref)
+    assert len(items) == 4
+    assert result_text is condition
+    assert result_ref is condition
+    assert result_tail is condition
+    assert result_string_ref is condition
+
+
+def test_condition_by_formula_add_none_is_no_op():
+    condition = ConditionByFormula()
+
+    condition.addFormulaText(None)
+    condition.addFormulaRef(None)
+
+    assert condition.getFormulaItems() == []
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py::test_condition_by_formula_formula_items_ordered -v`
+Expected: FAIL with `AttributeError: 'ConditionByFormula' object has no attribute 'getFormulaItems'`
+
+- [x] **Step 3: Write minimal implementation**
+
+In `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py`, class `ConditionByFormula`:
+
+3a. In the file-level `from typing import List, Optional` (line 1), add `Tuple, Union`:
+
+```python
+from typing import List, Optional, Tuple, Union
+```
+
+3b. In `ConditionByFormula.__init__` (after the `bindingTime` assignment), add:
+
+```python
+        # Formula content of the atpMixedString SW-SYSCOND (XSD CONDITION-BY-FORMULA,
+        # AUTOSAR_00046.xsd:18334): ordered text fragments (str) and inline system
+        # constant references stored as (tag, ref) tuples, in document order.
+        # tag is "SYSC-REF" (coded value) or "SYSC-STRING-REF" (string evaluation).
+        self.formulaItems: List[Union[str, Tuple[str, RefType]]] = []
+```
+
+3c. Add methods after `setBindingTime`:
+
+```python
+    def getFormulaItems(self) -> List[Union[str, Tuple[str, RefType]]]:
+        """
+        Returns the formula content in document order: plain text fragments (str)
+        and inline system constant references as (tag, RefType) tuples, where tag
+        is "SYSC-REF" or "SYSC-STRING-REF", as they appear inside SW-SYSCOND.
+        """
+        return self.formulaItems
+
+    def addFormulaText(self, value: str) -> "ConditionByFormula":
+        """
+        Appends a plain text fragment to the formula content. A None value is a no-op.
+        """
+        if value is not None:
+            self.formulaItems.append(value)
+        return self
+
+    def addFormulaRef(self, value: RefType, tag: str = "SYSC-REF") -> "ConditionByFormula":
+        """
+        Appends an inline system constant reference to the formula content. tag is
+        "SYSC-REF" (internal/coded value) or "SYSC-STRING-REF" (string evaluation).
+        A None value is a no-op.
+        """
+        if value is not None:
+            self.formulaItems.append((tag, value))
+        return self
+```
+
+3d. Update the `ConditionByFormula` parity checklist block (lines ~400-405):
+
+```python
+    # ConditionByFormula method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 7.5, p.231
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBindingTime    [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
+    # [x] setBindingTime    [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getFormulaItems   [x] impl  [x] docstring  [x] test  [ ] reader  [ ] writer
+    # [x] addFormulaText    [x] impl  [x] docstring  [x] test  [ ] reader  [ ] writer
+    # [x] addFormulaRef     [x] impl  [x] docstring  [x] test  [ ] reader  [ ] writer
+```
+
+(reader/writer columns stay open until Tasks 3–4 mark them `[x]`.)
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py -v`
+Expected: all PASS
+
+- [x] **Step 5: Commit**
+
+```bash
+git add src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py \
+        tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py
+git commit -m "feat: add ordered mixed-content formula items to ConditionByFormula"
+```
+
+---
+
+### Task 3: Parser — readVariationPoint and hook
+
+**Files:**
+- Modify: `src/armodel/parser/arxml_parser.py`
+- Test: `tests/test_armodel/parser/test_arxml_parser_variation_point.py` (new)
+
+- [x] **Step 1: Write the failing tests**
+
+Create `tests/test_armodel/parser/test_arxml_parser_variation_point.py`. First copy the `_snip` helper exactly as a sibling parser test file defines it (e.g. `test_arxml_parser_handlers.py:54`), then:
+
+```python
+"""Parser tests for the structural VARIATION-POINT element."""
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
+    ConditionByFormula,
+    PostBuildVariantCondition,
+    VariationPoint,
+)
+
+NS = "http://autosar.org/schema/r4.0"
+
+
+class TestReadVariationPoint:
+    def test_read_variation_point_minimal(self, parser):
+        element = _snip("<VARIATION-POINT><SHORT-LABEL>VP1</SHORT-LABEL></VARIATION-POINT>")
+        vp_element = element.find("{%s}VARIATION-POINT" % NS)
+
+        vp = parser.readVariationPoint(vp_element, VariationPoint())
+
+        assert vp is not None
+        assert vp.getShortLabel().getValue() == "VP1"
+        assert vp.getSwSyscond() is None
+        assert vp.getPostBuildVariantConditions() == []
+
+    def test_read_variation_point_full(self, parser):
+        inner = (
+            "<VARIATION-POINT>"
+            "<SHORT-LABEL>VP_Turbo</SHORT-LABEL>"
+            "<SW-SYSCOND BINDING-TIME=\"CODE-GENERATION-TIME\">"
+            "defined(<SYSC-REF DEST=\"SW-SYSTEMCONST\">/Demo/SystemConstants/SY_TURBO</SYSC-REF>)"
+            " &amp;&amp; <SYSC-STRING-REF DEST=\"SW-SYSTEMCONST\">/Demo/SystemConstants/SY_MODE</SYSC-STRING-REF> == 0"
+            "</SW-SYSCOND>"
+            "<POST-BUILD-VARIANT-CONDITIONS>"
+            "<POST-BUILD-VARIANT-CONDITION>"
+            "<MATCHING-CRITERION-REF DEST=\"POST-BUILD-VARIANT-CRITERION\">/Demo/Criterions/Country</MATCHING-CRITERION-REF>"
+            "<VALUE>1</VALUE>"
+            "</POST-BUILD-VARIANT-CONDITION>"
+            "</POST-BUILD-VARIANT-CONDITIONS>"
+            "</VARIATION-POINT>"
+        )
+        vp_element = _snip(inner).find("{%s}VARIATION-POINT" % NS)
+
+        vp = parser.readVariationPoint(vp_element, VariationPoint())
+
+        sw_syscond = vp.getSwSyscond()
+        assert isinstance(sw_syscond, ConditionByFormula)
+        assert sw_syscond.getBindingTime().getValue() == "codeGenerationTime"
+        items = sw_syscond.getFormulaItems()
+        assert items[0] == "defined("
+        assert items[1][0] == "SYSC-REF"
+        assert items[1][1].getValue() == "/Demo/SystemConstants/SY_TURBO"
+        assert items[1][1].getDest() == "SW-SYSTEMCONST"
+        assert items[2] == ") && "
+        assert items[3][0] == "SYSC-STRING-REF"
+        assert items[3][1].getValue() == "/Demo/SystemConstants/SY_MODE"
+        assert items[4] == " == 0"
+
+        conditions = vp.getPostBuildVariantConditions()
+        assert len(conditions) == 1
+        assert isinstance(conditions[0], PostBuildVariantCondition)
+        assert conditions[0].getMatchingCriterionRef().getValue() == "/Demo/Criterions/Country"
+        assert conditions[0].getMatchingCriterionRef().getDest() == "POST-BUILD-VARIANT-CRITERION"
+        assert conditions[0].getValue().getValue() == 1
+
+    def test_read_identifiable_picks_up_variation_point(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import PostBuildVariantCriterion
+
+        inner = (
+            "<POST-BUILD-VARIANT-CRITERION>"
+            "<SHORT-NAME>Country</SHORT-NAME>"
+            "<COMPU-METHOD-REF DEST=\"COMPU-METHOD\">/Demo/CompuMethods/CountryEnum</COMPU-METHOD-REF>"
+            "<VARIATION-POINT><SHORT-LABEL>VP_Country</SHORT-LABEL></VARIATION-POINT>"
+            "</POST-BUILD-VARIANT-CRITERION>"
+        )
+        element = _snip(inner).find("{%s}POST-BUILD-VARIANT-CRITERION" % NS)
+
+        criterion = PostBuildVariantCriterion(ARPackage(None, "Pkg"), "Country")
+        parser.readIdentifiable(element, criterion)
+
+        vp = criterion.getVariationPoint()
+        assert vp is not None
+        assert vp.getShortLabel().getValue() == "VP_Country"
+```
+
+(`_snip` and the `parser` fixture come from `tests/test_armodel/parser/conftest.py` / `_helpers.py`; mirror exactly what a sibling test file does.)
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_armodel/parser/test_arxml_parser_variation_point.py -v`
+Expected: FAIL with `AttributeError: 'ARXMLParser' object has no attribute 'readVariationPoint'`
+
+- [x] **Step 3: Write the implementation**
+
+3a. In `src/armodel/parser/arxml_parser.py`, extend the `VariantHandling` import at line 213:
+
+```python
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
+    ConditionByFormula,
+    PostBuildVariantCondition,
+    PostBuildVariantCriterion,
+    PredefinedVariant,
+    SwSystemconstantValueSet,
+    SwSystemconstValue,
+    VariationPoint,
+)
+```
+
+Add imports (near the existing `Enumerations`/`PrimitiveTypes` parser imports; `RefType` is already imported at line 211):
+
+```python
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Enumerations import BindingTimeEnum
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintGenerator.BlueprintGenerator import BlueprintGenerator
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import VerbatimString
+```
+
+Add a module-level constant after the import block:
+
+```python
+#: Mapping between BindingTimeEnum camelCase values and their XML attribute tokens
+#: (AR:BINDING-TIME-ENUM--SIMPLE).
+BINDING_TIME_XML_MAP = {
+    "codeGenerationTime": "CODE-GENERATION-TIME",
+    "linkTime": "LINK-TIME",
+    "preCompileTime": "PRE-COMPILE-TIME",
+    "systemDesignTime": "SYSTEM-DESIGN-TIME",
+}
+```
+
+3b. Add reader methods in `arxml_parser.py` right after `getSdg` (after line 684, before `readAdminDataSdgs`):
+
+```python
+    def readBlueprintGenerator(self, element: ET.Element, generator: BlueprintGenerator) -> BlueprintGenerator:
+        self.readARObjectAttributes(element, generator)
+        generator.setIntroduction(self.getDocumentationBlock(element, "INTRODUCTION"))
+        expression_element = self.find(element, "EXPRESSION")
+        if expression_element is not None:
+            generator.setExpression(VerbatimString().setValue(expression_element.text))
+        return generator
+
+    def readConditionByFormula(self, element: ET.Element, condition: ConditionByFormula) -> ConditionByFormula:
+        self.readARObjectAttributes(element, condition)
+        if "BINDING-TIME" in element.attrib:
+            binding_time = None
+            for camel, token in BINDING_TIME_XML_MAP.items():
+                if token == element.attrib["BINDING-TIME"]:
+                    binding_time = camel
+                    break
+            if binding_time is not None:
+                condition.setBindingTime(BindingTimeEnum().setValue(binding_time))
+            else:
+                self.notImplemented("Unsupported BINDING-TIME <%s>" % element.attrib["BINDING-TIME"])
+        if element.text is not None:
+            condition.addFormulaText(element.text)
+        for child_element in element:
+            tag_name = self.getTagName(child_element)
+            if tag_name in ("SYSC-REF", "SYSC-STRING-REF"):
+                ref = RefType()
+                if "DEST" in child_element.attrib:
+                    ref.setDest(child_element.attrib["DEST"])
+                ref.setValue(child_element.text)
+                condition.addFormulaRef(ref, tag=tag_name)
+                if child_element.tail is not None:
+                    condition.addFormulaText(child_element.tail)
+            else:
+                self.notImplemented("Unsupported SW-SYSCOND content <%s>" % tag_name)
+        return condition
+
+    def readPostBuildVariantCondition(self, element: ET.Element, condition: PostBuildVariantCondition) -> PostBuildVariantCondition:
+        self.readARObjectAttributes(element, condition)
+        condition.setMatchingCriterionRef(self.getChildElementRefType("", element, "MATCHING-CRITERION-REF"))
+        condition.setValue(self.getChildElementOptionalIntegerValue(element, "VALUE"))
+        return condition
+
+    def readVariationPoint(self, element: ET.Element, variation_point: VariationPoint) -> VariationPoint:
+        self.readARObjectAttributes(element, variation_point)
+        variation_point.setShortLabel(self.getChildElementOptionalIdentifier(element, "SHORT-LABEL"))
+        variation_point.setDesc(self.getMultiLanguageOverviewParagraph(element, "DESC"))
+        variation_point.setBlueprintCondition(self.getDocumentationBlock(element, "BLUEPRINT-CONDITION"))
+        # FORMAL-BLUEPRINT-CONDITION is obsolete (atp.Status="obsolete") and has no
+        # model attribute — deliberately not read.
+        formal_element = self.find(element, "FORMAL-BLUEPRINT-GENERATOR")
+        if formal_element is not None:
+            variation_point.setFormalBlueprintGenerator(self.readBlueprintGenerator(formal_element, BlueprintGenerator()))
+        sw_syscond_element = self.find(element, "SW-SYSCOND")
+        if sw_syscond_element is not None:
+            variation_point.setSwSyscond(self.readConditionByFormula(sw_syscond_element, ConditionByFormula()))
+        for child_element in self.findall(element, "POST-BUILD-VARIANT-CONDITIONS/*"):
+            tag_name = self.getTagName(child_element)
+            if tag_name == "POST-BUILD-VARIANT-CONDITION":
+                variation_point.addPostBuildVariantCondition(
+                    self.readPostBuildVariantCondition(child_element, PostBuildVariantCondition()))
+            else:
+                self.notImplemented("Unsupported POST-BUILD-VARIANT-CONDITIONS content <%s>" % tag_name)
+        sdg_element = self.find(element, "SDG")
+        if sdg_element is not None:
+            variation_point.setSdg(self.getSdg(sdg_element))
+        return variation_point
+```
+
+3c. Hook into `readIdentifiable` (`arxml_parser.py:766`) — append after the `setAdminData` line (line 776):
+
+```python
+        variation_point_element = self.find(element, "VARIATION-POINT")
+        if variation_point_element is not None:
+            identifiable.setVariationPoint(self.readVariationPoint(variation_point_element, VariationPoint()))
+```
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_armodel/parser/test_arxml_parser_variation_point.py -v`
+Expected: all PASS
+
+- [x] **Step 5: Run the whole parser test suite (regression)**
+
+Run: `pytest tests/test_armodel/parser/ -x -q`
+Expected: all PASS (readIdentifiable is a hot path; this catches accidental double-parse issues)
+
+- [x] **Step 6: Commit**
+
+```bash
+git add src/armodel/parser/arxml_parser.py tests/test_armodel/parser/test_arxml_parser_variation_point.py
+git commit -m "feat: parse structural VARIATION-POINT in readIdentifiable"
+```
+
+---
+
+### Task 4: Writer — writeVariationPoint and hook
+
+**Files:**
+- Modify: `src/armodel/writer/arxml_writer.py`
+- Test: `tests/test_armodel/writer/test_writer_variation_point.py` (new)
+
+- [x] **Step 1: Write the failing test**
+
+Create `tests/test_armodel/writer/test_writer_variation_point.py`:
+
+```python
+"""Writer tests for the structural VARIATION-POINT element."""
+
+import xml.etree.ElementTree as ET
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintGenerator.BlueprintGenerator import (
+    BlueprintGenerator,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Enumerations import (
+    BindingTimeEnum,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    Identifier,
+    Integer,
+    RefType,
+    VerbatimString,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
+    ConditionByFormula,
+    PostBuildVariantCondition,
+    PostBuildVariantCriterion,
+    VariationPoint,
+)
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+def _write_vp_to_element(vp: VariationPoint) -> ET.Element:
+    document = AUTOSAR.getInstance()
+    document.clear()
+    document.setARRelease("R23-11")
+    writer = ARXMLWriter()
+    element = ET.Element("PARENT")
+    writer.writeVariationPoint(element, vp)
+    return element
+
+
+class TestWriteVariationPoint:
+    def test_write_minimal(self):
+        vp = VariationPoint()
+        vp.setShortLabel(Identifier().setValue("VP1"))
+
+        element = _write_vp_to_element(vp)
+
+        vp_element = element.find("VARIATION-POINT")
+        assert vp_element is not None
+        assert vp_element.find("SHORT-LABEL").text == "VP1"
+
+    def test_write_full_roundtrip_content(self):
+        vp = VariationPoint()
+        vp.setShortLabel(Identifier().setValue("VP_Turbo"))
+
+        syscond = ConditionByFormula()
+        syscond.setBindingTime(BindingTimeEnum().setValue("codeGenerationTime"))
+        syscond.addFormulaText("defined(")
+        syscond.addFormulaRef(RefType().setValue("/Demo/SystemConstants/SY_TURBO").setDest("SW-SYSTEMCONST"))
+        syscond.addFormulaText(")")
+        vp.setSwSyscond(syscond)
+
+        condition = PostBuildVariantCondition()
+        condition.setMatchingCriterionRef(RefType().setValue("/Demo/Criterions/Country").setDest("POST-BUILD-VARIANT-CRITERION"))
+        condition.setValue(Integer().setValue(1))
+        vp.addPostBuildVariantCondition(condition)
+
+        generator = BlueprintGenerator()
+        generator.setExpression(VerbatimString().setValue("LET Name = \"Example\";"))
+        vp.setFormalBlueprintGenerator(generator)
+
+        element = _write_vp_to_element(vp)
+
+        vp_element = element.find("VARIATION-POINT")
+
+        # XSD sequence order: SHORT-LABEL, DESC, BLUEPRINT-CONDITION,
+        # FORMAL-BLUEPRINT-GENERATOR, SW-SYSCOND, POST-BUILD-VARIANT-CONDITIONS, SDG
+        child_tags = [child.tag for child in vp_element]
+        assert child_tags.index("SHORT-LABEL") < child_tags.index("SW-SYSCOND")
+        assert child_tags.index("SW-SYSCOND") < child_tags.index("POST-BUILD-VARIANT-CONDITIONS")
+        assert child_tags.index("FORMAL-BLUEPRINT-GENERATOR") < child_tags.index("SW-SYSCOND")
+        assert vp_element.find("SHORT-LABEL").text == "VP_Turbo"
+
+        syscond_element = vp_element.find("SW-SYSCOND")
+        assert syscond_element is not None
+        assert syscond_element.attrib["BINDING-TIME"] == "CODE-GENERATION-TIME"
+        assert syscond_element.text == "defined("
+        refs = syscond_element.findall("SYSC-REF")
+        assert len(refs) == 1
+        assert refs[0].attrib["DEST"] == "SW-SYSTEMCONST"
+        assert refs[0].text == "/Demo/SystemConstants/SY_TURBO"
+        assert refs[0].tail == ")"
+
+        conditions_wrapper = vp_element.find("POST-BUILD-VARIANT-CONDITIONS")
+        condition_element = conditions_wrapper.find("POST-BUILD-VARIANT-CONDITION")
+        ref_element = condition_element.find("MATCHING-CRITERION-REF")
+        assert ref_element.text == "/Demo/Criterions/Country"
+        assert ref_element.attrib["DEST"] == "POST-BUILD-VARIANT-CRITERION"
+        assert condition_element.find("VALUE").text == "1"
+
+        # XSD BLUEPRINT-GENERATOR sequence: INTRODUCTION before EXPRESSION
+        formal = vp_element.find("FORMAL-BLUEPRINT-GENERATOR")
+        formal_tags = [child.tag for child in formal]
+        assert formal_tags == ["EXPRESSION"]
+        assert formal.find("EXPRESSION").text == "LET Name = \"Example\";"
+
+    def test_write_none_creates_no_element(self):
+        vp = None
+
+        document = AUTOSAR.getInstance()
+        document.clear()
+        document.setARRelease("R23-11")
+        writer = ARXMLWriter()
+        element = ET.Element("PARENT")
+        writer.writeVariationPoint(element, vp)
+
+        assert element.find("VARIATION-POINT") is None
+
+    def test_write_identifiable_emits_variation_point(self):
+        document = AUTOSAR.getInstance()
+        document.clear()
+        document.setARRelease("R23-11")
+
+        criterion = PostBuildVariantCriterion(document, "Country")
+        vp = VariationPoint()
+        vp.setShortLabel(Identifier().setValue("VP_Country"))
+        criterion.setVariationPoint(vp)
+
+        writer = ARXMLWriter()
+        element = ET.Element("POST-BUILD-VARIANT-CRITERION")
+        writer.writeIdentifiable(element, criterion)
+
+        vp_element = element.find("VARIATION-POINT")
+        assert vp_element is not None
+        assert vp_element.find("SHORT-LABEL").text == "VP_Country"
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_armodel/writer/test_writer_variation_point.py -v`
+Expected: FAIL with `AttributeError: 'ARXMLWriter' object has no attribute 'writeVariationPoint'`
+
+- [x] **Step 3: Write the implementation**
+
+3a. In `src/armodel/writer/arxml_writer.py`, extend/confirm imports:
+
+```python
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintGenerator.BlueprintGenerator import BlueprintGenerator
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Enumerations import BindingTimeEnum
+```
+
+(`SwSystemconstValue` from `VariantHandling` is already imported — add `ConditionByFormula`, `PostBuildVariantCondition`, `VariationPoint` to that import. `RefType`, `Integer`, `Identifier`, `VerbatimString` are already imported or trivially added.)
+
+Add the module-level constant after the import block (mirror the parser's):
+
+```python
+#: Mapping between BindingTimeEnum camelCase values and their XML attribute tokens
+#: (AR:BINDING-TIME-ENUM--SIMPLE).
+BINDING_TIME_XML_MAP = {
+    "codeGenerationTime": "CODE-GENERATION-TIME",
+    "linkTime": "LINK-TIME",
+    "preCompileTime": "PRE-COMPILE-TIME",
+    "systemDesignTime": "SYSTEM-DESIGN-TIME",
+}
+```
+
+3b. Add writer methods right after `setSdg` (`arxml_writer.py:653`):
+
+```python
+    def writeBlueprintGenerator(self, element: ET.Element, generator: BlueprintGenerator):
+        if generator is not None:
+            child_element = ET.SubElement(element, "FORMAL-BLUEPRINT-GENERATOR")
+            self.writeARObjectAttributes(child_element, generator)
+            # XSD sequence: INTRODUCTION (offset 10) before EXPRESSION (offset 20).
+            self.writeDocumentationBlock(child_element, "INTRODUCTION", generator.getIntroduction())
+            expression = generator.getExpression()
+            if expression is not None:
+                expression_element = ET.SubElement(child_element, "EXPRESSION")
+                expression_element.text = expression.getValue()
+
+    def writeConditionByFormula(self, element: ET.Element, condition: ConditionByFormula):
+        if condition is not None:
+            child_element = ET.SubElement(element, "SW-SYSCOND")
+            self.writeARObjectAttributes(child_element, condition)
+            binding_time = condition.getBindingTime()
+            if binding_time is not None:
+                token = BINDING_TIME_XML_MAP.get(binding_time.getValue())
+                if token is None:
+                    self.notImplemented("Unsupported BINDING-TIME <%s>" % binding_time.getValue())
+                else:
+                    child_element.attrib["BINDING-TIME"] = token
+            last_ref = None
+            for item in condition.getFormulaItems():
+                if isinstance(item, str):
+                    if last_ref is None:
+                        child_element.text = item if child_element.text is None else child_element.text + item
+                    else:
+                        last_ref.tail = item if last_ref.tail is None else last_ref.tail + item
+                else:
+                    tag, ref = item
+                    last_ref = ET.SubElement(child_element, tag)
+                    if ref.getDest() is not None:
+                        last_ref.attrib["DEST"] = ref.getDest()
+                    last_ref.text = ref.getValue()
+
+    def writePostBuildVariantCondition(self, element: ET.Element, condition: PostBuildVariantCondition):
+        child_element = ET.SubElement(element, "POST-BUILD-VARIANT-CONDITION")
+        self.writeARObjectAttributes(child_element, condition)
+        self.setChildElementOptionalRefType(child_element, "MATCHING-CRITERION-REF", condition.getMatchingCriterionRef())
+        self.setChildElementOptionalIntegerValue(child_element, "VALUE", condition.getValue())
+
+    def writeVariationPoint(self, element: ET.Element, variation_point: VariationPoint):
+        if variation_point is not None:
+            child_element = ET.SubElement(element, "VARIATION-POINT")
+            self.writeARObjectAttributes(child_element, variation_point)
+            # XSD sequence (AUTOSAR_00046.xsd group AR:VARIATION-POINT, line 99470):
+            # SHORT-LABEL, DESC, BLUEPRINT-CONDITION, [FORMAL-BLUEPRINT-CONDITION obsolete],
+            # FORMAL-BLUEPRINT-GENERATOR, SW-SYSCOND, POST-BUILD-VARIANT-CONDITIONS, SDG.
+            short_label = variation_point.getShortLabel()
+            if short_label is not None:
+                label_element = ET.SubElement(child_element, "SHORT-LABEL")
+                label_element.text = short_label.getValue()
+            self.setMultiLanguageOverviewParagraph(child_element, "DESC", variation_point.getDesc())
+            self.writeDocumentationBlock(child_element, "BLUEPRINT-CONDITION", variation_point.getBlueprintCondition())
+            self.writeBlueprintGenerator(child_element, variation_point.getFormalBlueprintGenerator())
+            self.writeConditionByFormula(child_element, variation_point.getSwSyscond())
+            conditions = variation_point.getPostBuildVariantConditions()
+            if len(conditions) > 0:
+                conditions_element = ET.SubElement(child_element, "POST-BUILD-VARIANT-CONDITIONS")
+                for condition in conditions:
+                    self.writePostBuildVariantCondition(conditions_element, condition)
+            self.setSdg(child_element, variation_point.getSdg())
+```
+
+Note: `writeBlueprintGenerator` emits its own `FORMAL-BLUEPRINT-GENERATOR` container element (it is only called from `writeVariationPoint` today); do NOT call it as a bare helper.
+
+3c. Hook into `writeIdentifiable` (`arxml_writer.py:838`) — append after the `setAdminData` line (line 844):
+
+```python
+        self.writeVariationPoint(element, identifiable.getVariationPoint())
+```
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_armodel/writer/test_writer_variation_point.py -v`
+Expected: all PASS
+
+- [x] **Step 5: Run the whole writer test suite (regression)**
+
+Run: `pytest tests/test_armodel/writer/ -x -q`
+Expected: all PASS
+
+- [x] **Step 6: Commit**
+
+```bash
+git add src/armodel/writer/arxml_writer.py tests/test_armodel/writer/test_writer_variation_point.py
+git commit -m "feat: write structural VARIATION-POINT in writeIdentifiable"
+```
+
+---
+
+### Task 5: End-to-end parse → write → re-parse round-trip test
+
+**Files:**
+- Create: `tests/test_armodel/parser/data/VariationPoint.arxml`
+- Test: `tests/test_armodel/parser/test_arxml_parser_variation_point.py` (append class)
+
+- [x] **Step 1: Create the sample ARXML file**
+
+Create `tests/test_armodel/parser/data/VariationPoint.arxml` (schema header mirrors the existing integration files; the parser resolves the `xmlns` automatically):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_4-2-2.xsd">
+  <AR-PACKAGES>
+    <AR-PACKAGE>
+      <SHORT-NAME>Demo</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE>
+          <SHORT-NAME>SystemConstants</SHORT-NAME>
+          <ELEMENTS>
+            <SW-SYSTEMCONST>
+              <SHORT-NAME>SY_TURBO</SHORT-NAME>
+            </SW-SYSTEMCONST>
+          </ELEMENTS>
+        </AR-PACKAGE>
+        <AR-PACKAGE>
+          <SHORT-NAME>Criterions</SHORT-NAME>
+          <ELEMENTS>
+            <POST-BUILD-VARIANT-CRITERION>
+              <SHORT-NAME>Country</SHORT-NAME>
+              <VARIATION-POINT>
+                <SHORT-LABEL>VP_Country</SHORT-LABEL>
+              </VARIATION-POINT>
+            </POST-BUILD-VARIANT-CRITERION>
+          </ELEMENTS>
+        </AR-PACKAGE>
+        <AR-PACKAGE>
+          <SHORT-NAME>SwComponents</SHORT-NAME>
+          <ELEMENTS>
+            <APPLICATION-SW-COMPONENT-TYPE>
+              <SHORT-NAME>MySWC</SHORT-NAME>
+              <INTERNAL-BEHAVIORS>
+                <SWC-INTERNAL-BEHAVIOR>
+                  <SHORT-NAME>Ib_MySWC</SHORT-NAME>
+                  <RUNNABLES>
+                    <RUNNABLE-ENTITY>
+                      <SHORT-NAME>Run2</SHORT-NAME>
+                    </RUNNABLE-ENTITY>
+                  </RUNNABLES>
+                  <VARIATION-POINT>
+                    <SHORT-LABEL>VP1</SHORT-LABEL>
+                    <SW-SYSCOND BINDING-TIME="CODE-GENERATION-TIME">defined(<SYSC-REF DEST="SW-SYSTEMCONST">/Demo/SystemConstants/SY_TURBO</SYSC-REF>) &amp;&amp; <SYSC-REF DEST="SW-SYSTEMCONST">/Demo/SystemConstants/SY_TURBO</SYSC-REF> == 0</SW-SYSCOND>
+                    <POST-BUILD-VARIANT-CONDITIONS>
+                      <POST-BUILD-VARIANT-CONDITION>
+                        <MATCHING-CRITERION-REF DEST="POST-BUILD-VARIANT-CRITERION">/Demo/Criterions/Country</MATCHING-CRITERION-REF>
+                        <VALUE>1</VALUE>
+                      </POST-BUILD-VARIANT-CONDITION>
+                    </POST-BUILD-VARIANT-CONDITIONS>
+                  </VARIATION-POINT>
+                </SWC-INTERNAL-BEHAVIOR>
+              </INTERNAL-BEHAVIORS>
+            </APPLICATION-SW-COMPONENT-TYPE>
+          </ELEMENTS>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>
+```
+
+(Modeled on the spec listing at `AUTOSAR_FO_TPS_GenericStructureTemplate.md:12988-13113`, with the XSD-correct `MATCHING-CRITERION-REF` tag.)
+
+- [x] **Step 2: Write the round-trip test**
+
+Append to `tests/test_armodel/parser/test_arxml_parser_variation_point.py`:
+
+```python
+import os
+
+import pytest
+
+from armodel.models import AUTOSAR
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+
+VARIATION_POINT_ARXML = os.path.join(os.path.dirname(__file__), "data", "VariationPoint.arxml")
+
+
+@pytest.mark.integration
+class TestVariationPointRoundTrip:
+    def test_parse_write_reparse_preserves_variation_point(self, tmp_path):
+        AUTOSAR.getInstance().new()
+        AUTOSAR.setARRelease("R23-11")
+        document = AUTOSAR.getInstance()
+        parser = ARXMLParser()
+        parser.load(VARIATION_POINT_ARXML, document)
+
+        demo_pkg = document.getARPackageByFullName("Demo")
+        swc_pkg = demo_pkg.getARPackageByFullName("Demo/SwComponents")
+        swc = swc_pkg.getElements()[0]
+        behavior = document.getBehavior(swc)
+
+        vp = behavior.getVariationPoint()
+        assert vp is not None
+        assert vp.getShortLabel().getValue() == "VP1"
+        items = vp.getSwSyscond().getFormulaItems()
+        assert items[0] == "defined("
+        assert items[1][1].getValue() == "/Demo/SystemConstants/SY_TURBO"
+        conditions = vp.getPostBuildVariantConditions()
+        assert conditions[0].getMatchingCriterionRef().getValue() == "/Demo/Criterions/Country"
+
+        output = str(tmp_path / "VariationPoint_roundtrip.arxml")
+        writer = ARXMLWriter()
+        writer.save(output, document)
+
+        AUTOSAR.getInstance().new()
+        AUTOSAR.setARRelease("R23-11")
+        document2 = AUTOSAR.getInstance()
+        parser2 = ARXMLParser()
+        parser2.load(output, document2)
+
+        demo_pkg2 = document2.getARPackageByFullName("Demo")
+        swc_pkg2 = demo_pkg2.getARPackageByFullName("Demo/SwComponents")
+        swc2 = swc_pkg2.getElements()[0]
+        behavior2 = document2.getBehavior(swc2)
+
+        vp2 = behavior2.getVariationPoint()
+        assert vp2 is not None
+        assert vp2.getShortLabel().getValue() == "VP1"
+        items2 = vp2.getSwSyscond().getFormulaItems()
+        assert items2[0] == items[0]
+        assert items2[1][0] == items[1][0]
+        assert items2[1][1].getValue() == items[1][1].getValue()
+        assert items2[1][1].getDest() == items[1][1].getDest()
+        conditions2 = vp2.getPostBuildVariantConditions()
+        assert conditions2[0].getMatchingCriterionRef().getValue() == "/Demo/Criterions/Country"
+        assert conditions2[0].getValue().getValue() == 1
+
+        # Criterion element's own variation point also survives
+        crit_pkg2 = document2.getARPackageByFullName("Demo/Criterions")
+        criterion2 = crit_pkg2.getElements()[0]
+        assert criterion2.getVariationPoint().getShortLabel().getValue() == "VP_Country"
+```
+
+Adjustment note for the implementer: verify the exact navigation API names (`getARPackageByFullName`, `getElements`, `getBehavior`) against `src/armodel/models/M2/AUTOSARTemplates/AutosarTopLevelStructure` before running; if `getARPackageByFullName` does not exist, use whatever navigation pattern `tests/integration_tests/test_roundtrip.py` uses and copy it.
+
+- [x] **Step 3: Run the round-trip test**
+
+Run: `pytest tests/test_armodel/parser/test_arxml_parser_variation_point.py -v -m integration`
+Expected: PASS. If the parse step fails on `SW-SYSTEMCONST` or `POST-BUILD-VARIANT-CRITERION` handling, read the error: `POST-BUILD-VARIANT-CRITERION` is already parsed (`arxml_parser.py:8338`); `SW-SYSTEMCONST` support must be verified — if unsupported, drop the `SystemConstants` package from the ARXML file and change the `SYSC-REF` targets to `/Demo/Criterions/Country` refs (the parser does not resolve SYSC-REF targets, so the test remains valid).
+
+- [x] **Step 4: Copy the file into the integration test corpus**
+
+```bash
+cp tests/test_armodel/parser/data/VariationPoint.arxml tests/integration_tests/test_files/VariationPoint.arxml
+```
+
+Run: `pytest tests/integration_tests/ -q -k VariationPoint`
+Expected: PASS (the round-trip harness auto-discovers files in `tests/integration_tests/test_files/`, per `tests/integration_tests/config.yaml` and its README)
+
+- [x] **Step 5: Commit**
+
+```bash
+git add tests/test_armodel/parser/data/VariationPoint.arxml \
+        tests/test_armodel/parser/test_arxml_parser_variation_point.py \
+        tests/integration_tests/test_files/VariationPoint.arxml
+git commit -m "test: add VARIATION-POINT round-trip coverage"
+```
+
+---
+
+### Task 6: Parity checklist updates, full validation
+
+**Files:**
+- Modify: `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py`
+- Modify: `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py`
+
+- [x] **Step 1: Update parity checklists**
+
+In `VariantHandling/__init__.py`:
+
+`VariationPoint` checklist — mark reader columns `[x]` for the setters used by the parser (`setBlueprintCondition`, `setDesc`, `setFormalBlueprintGenerator`, `addPostBuildVariantCondition`, `setSdg`, `setShortLabel`, `setSwSyscond`) and writer columns `[x]` for the getters used by the writer (`getBlueprintCondition`, `getDesc`, `getFormalBlueprintGenerator`, `getPostBuildVariantConditions`, `getSdg`, `getShortLabel`, `getSwSyscond`). Concretely change the block at lines ~471-488 so every row reads:
+
+```python
+    # [x] __init__                          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBlueprintCondition             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBlueprintCondition             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDesc                           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDesc                           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFormalBlueprintGenerator       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFormalBlueprintGenerator       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPostBuildVariantConditions     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addPostBuildVariantCondition      [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getSdg                            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSdg                            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getShortLabel                     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setShortLabel                     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwSyscond                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwSyscond                      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+```
+
+(`addPostBuildVariantCondition` gets both `[x] reader` and `[x] writer` — the writer iterates the collection via the getter; the parser appends via the adder.)
+
+`ConditionByFormula` checklist (updated in Task 2) — flip `getBindingTime` writer, `setBindingTime` reader, and all three formula-item rows to `[x] reader [x] writer`:
+
+```python
+    # [x] getBindingTime    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBindingTime    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFormulaItems   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addFormulaText    [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] addFormulaRef     [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+```
+
+`PostBuildVariantCondition` checklist (~lines 332-339) — flip reader/writer columns:
+
+```python
+    # [x] __init__                [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getMatchingCriterionRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMatchingCriterionRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getValue                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setValue                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+```
+
+In `BlueprintGenerator.py` — mark reader column `[x]` for `setExpression`/`setIntroduction` and writer column `[x]` for `getExpression`/`getIntroduction`.
+
+- [x] **Step 2: Run the full test suite**
+
+Run: `python scripts/run_tests.py`
+Expected: all PASS, no regressions from the `readIdentifiable`/`writeIdentifiable` hooks
+
+- [x] **Step 3: Run lint and format checks**
+
+Run: `npm run flake8 && npm run black-check`
+Expected: PASS. If black fails, run `npm run black` on the touched files only, re-run tests, then proceed.
+
+- [x] **Step 4: Commit**
+
+```bash
+git add src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py \
+        src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py
+git commit -m "docs: update variation point parity checklists after reader/writer sync"
+```
+
+---
+
+## Self-Review Checklist (done)
+
+- **XSD coverage (AUTOSAR_00046.xsd):** SHORT-LABEL ✓ DESC ✓ BLUEPRINT-CONDITION ✓ FORMAL-BLUEPRINT-CONDITION (obsolete — skipped, documented) ✓ FORMAL-BLUEPRINT-GENERATOR ✓ SW-SYSCOND (bindingTime + SYSC-REF + SYSC-STRING-REF mixed content) ✓ POST-BUILD-VARIANT-CONDITIONS/MATCHING-CRITERION-REF/VALUE ✓ SDG ✓. Writer child order = XSD sequence offsets 10→50 ✓. BLUEPRINT-GENERATOR order INTRODUCTION→EXPRESSION ✓.
+- **Out of scope and stated:** reference pattern (`*-REF-CONDITIONAL`), property set pattern (`*-VARIANTS`), attribute value pattern (VALUE attributes/formulas, `ATTRIBUTE-VALUE-VARIATION-POINT` attributeGroup).
+- **Placeholders:** none — every step carries full code.
+- **Type consistency:** `getFormulaItems/addFormulaText/addFormulaRef(tag)` with `(tag, RefType)` tuples (Task 2) match parser (Task 3) and writer (Task 4). `readVariationPoint`/`writeVariationPoint` names match the tests. `BINDING_TIME_XML_MAP` defined identically in parser and writer. `MATCHING-CRITERION-REF` used consistently in parser, writer, tests, and sample ARXML.
+- **Risks flagged inline:** circular import handled via `TYPE_CHECKING`; enum token mapping explicit; VALUE treated as plain Integer per `SwSystemconstValue` precedent (xsd:7022); `SW-SYSTEMCONST` parse support to be verified in Task 5 Step 3 with documented fallback.

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py
@@ -21,7 +21,8 @@ class BlueprintGenerator(ARObject):
     """
 
     # BlueprintGenerator method parity checklist:
-    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table E.11, p.424
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table E.12, p.424
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getExpression     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintGenerator/BlueprintGenerator.py
@@ -24,10 +24,10 @@ class BlueprintGenerator(ARObject):
     # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table E.11, p.424
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] getExpression     [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
-    # [x] setExpression     [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
-    # [x] getIntroduction   [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
-    # [x] setIntroduction   [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getExpression     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setExpression     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getIntroduction   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIntroduction   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Enumerations.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Enumerations.py
@@ -39,3 +39,23 @@ class BindingTimeEnum(AREnum):
 
     def __init__(self):
         super().__init__(["codeGenerationTime", "linkTime", "preCompileTime", "systemDesignTime"])
+
+
+class XmlSpaceEnum(AREnum):
+    """
+    This attribute is used to signal an intention that in that element, white space
+    should be preserved by applications. It is defined according to xml:space as
+    declared by W3C.
+    """
+
+    # XmlSpaceEnum method parity checklist:
+    # (no methods) — enum value form serialized on Sd.xmlSpace; XSD-only (no Enumeration table)
+    # [ ] __init__     [x] impl  [ ] docstring  [ ] test  [—] reader  [—] writer
+
+    # The value "default" signals that applications' default white-space processing modes are acceptable for this element. Tags: atp.EnumerationValue=0
+    DEFAULT = "default"
+    # the value "preserve" indicates the intent that applications preserve all the white space. Tags: atp.EnumerationValue=1
+    PRESERVE = "preserve"
+
+    def __init__(self):
+        super().__init__((XmlSpaceEnum.DEFAULT, XmlSpaceEnum.PRESERVE))

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultilanguageLongName, MultiLanguageOverviewParagraph
     from armodel.models.M2.MSR.Documentation.Annotation import Annotation
     from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import VariationPoint
 
 
 class Referrable(ARObject, ABC):
@@ -381,6 +382,12 @@ class Identifiable(MultilanguageReferrable, ABC):
         self.category: Optional[CategoryString] = None
         self.introduction: Optional[DocumentationBlock] = None
         self.desc: Optional[MultiLanguageOverviewParagraph] = None
+        # Structural variation point attached to this element (pattern: aggregation,
+        # TPS_GST 7.6; XSD group AR:VARIATION-POINT, AUTOSAR_00046.xsd:99470).
+        # Deviation: spec also allows variation points on non-Identifiable elements
+        # (reference pattern, property set pattern); only the Identifiable
+        # aggregation pattern is supported.
+        self.variationPoint: Optional["VariationPoint"] = None
 
     def getTotalElement(self) -> int:
         """
@@ -522,6 +529,21 @@ class Identifiable(MultilanguageReferrable, ABC):
             self for method chaining
         """
         self.desc = value
+        return self
+
+    def getVariationPoint(self) -> Optional["VariationPoint"]:
+        """
+        Returns the structural variation point of this element, if any.
+        """
+        return self.variationPoint
+
+    def setVariationPoint(self, value: Optional["VariationPoint"]) -> "Identifiable":
+        """
+        Sets the structural variation point of this element. A None value is a no-op
+        and does not overwrite an existing variationPoint.
+        """
+        if value is not None:
+            self.variationPoint = value
         return self
 
     def getCategory(self) -> Optional[CategoryString]:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py
@@ -367,6 +367,8 @@ class Identifiable(MultilanguageReferrable, ABC):
     # [ ] setIntroduction              [x] impl  [x] docstring  [ ] test
     # [ ] addAnnotation                [x] impl  [x] docstring  [ ] test
     # [ ] getAnnotations               [x] impl  [x] docstring  [ ] test
+    # [x] getVariationPoint            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setVariationPoint            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         if type(self) is Identifiable:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
@@ -1238,6 +1238,23 @@ class VerbatimString(ARLiteral):
         super().__init__()
 
 
+class VerbatimStringPlain(ARLiteral):
+    """
+    This primitive represents a string in which white-space needs to be preserved.
+    This primitive is applied in cases where xml:space attribute cannot be provided by
+    the primitive type but needs to be provided by the container class. This is in
+    particular the case in applications of [TPS_XMLSPR_00024].
+    """
+
+    # VerbatimStringPlain method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.68, p.115
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+
 class RegularExpression(ARLiteral):
     """
     Represents a regular expression in AUTOSAR models.
@@ -1282,6 +1299,23 @@ class McdIdentifier(ARLiteral):
 
     # McdIdentifier method parity checklist:
     # [ ] __init__                     [x] impl  [ ] docstring  [x] test
+
+    def __init__(self):
+        super().__init__()
+
+
+class Numerical(ARLiteral):
+    """
+    This primitive specifies a numerical value. It can be denoted in different formats
+    such as Decimal, Octal, Hexadecimal, Float. See the xsd pattern for details. The
+    value can be expressed in octal, hexadecimal, binary representation. Negative
+    numbers can only be expressed in decimal or float notation.
+    """
+
+    # Numerical method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table E.58, p.92
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self):
         super().__init__()

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple, Union
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType, ARNumerical, Identifier, Integer
@@ -403,12 +403,21 @@ class ConditionByFormula(ARObject):
     # [x] __init__          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getBindingTime    [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
     # [x] setBindingTime    [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getFormulaItems   [x] impl  [x] docstring  [x] test  [ ] reader  [ ] writer
+    # [x] addFormulaText    [x] impl  [x] docstring  [x] test  [ ] reader  [ ] writer
+    # [x] addFormulaRef     [x] impl  [x] docstring  [x] test  [ ] reader  [ ] writer
 
     def __init__(self):
         super().__init__()
 
         # This attribute specifies the point in time when condition may be evaluated at earliest. At this point in time all referenced system constants shall have a value.
         self.bindingTime: Optional["BindingTimeEnum"] = None
+
+        # Formula content of the atpMixedString SW-SYSCOND (XSD CONDITION-BY-FORMULA,
+        # AUTOSAR_00046.xsd:18334): ordered text fragments (str) and inline system
+        # constant references stored as (tag, ref) tuples, in document order.
+        # tag is "SYSC-REF" (coded value) or "SYSC-STRING-REF" (string evaluation).
+        self.formulaItems: List[Union[str, Tuple[str, RefType]]] = []
 
     def getBindingTime(self) -> Optional["BindingTimeEnum"]:
         """
@@ -426,6 +435,32 @@ class ConditionByFormula(ARObject):
         """
         if value is not None:
             self.bindingTime = value
+        return self
+
+    def getFormulaItems(self) -> List[Union[str, Tuple[str, RefType]]]:
+        """
+        Returns the formula content in document order: plain text fragments (str)
+        and inline system constant references as (tag, RefType) tuples, where tag
+        is "SYSC-REF" or "SYSC-STRING-REF", as they appear inside SW-SYSCOND.
+        """
+        return self.formulaItems
+
+    def addFormulaText(self, value: str) -> "ConditionByFormula":
+        """
+        Appends a plain text fragment to the formula content. A None value is a no-op.
+        """
+        if value is not None:
+            self.formulaItems.append(value)
+        return self
+
+    def addFormulaRef(self, value: RefType, tag: str = "SYSC-REF") -> "ConditionByFormula":
+        """
+        Appends an inline system constant reference to the formula content. tag is
+        "SYSC-REF" (internal/coded value) or "SYSC-STRING-REF" (string evaluation).
+        A None value is a no-op.
+        """
+        if value is not None:
+            self.formulaItems.append((tag, value))
         return self
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py
@@ -333,10 +333,10 @@ class PostBuildVariantCondition(ARObject):
     # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 7.6, p.232
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__                [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] getMatchingCriterionRef [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
-    # [x] setMatchingCriterionRef [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
-    # [x] getValue                [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
-    # [x] setValue                [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getMatchingCriterionRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMatchingCriterionRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getValue                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setValue                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
@@ -401,11 +401,11 @@ class ConditionByFormula(ARObject):
     # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 7.5, p.231
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] getBindingTime    [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
-    # [x] setBindingTime    [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
-    # [x] getFormulaItems   [x] impl  [x] docstring  [x] test  [ ] reader  [ ] writer
-    # [x] addFormulaText    [x] impl  [x] docstring  [x] test  [ ] reader  [ ] writer
-    # [x] addFormulaRef     [x] impl  [x] docstring  [x] test  [ ] reader  [ ] writer
+    # [x] getBindingTime    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBindingTime    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFormulaItems   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addFormulaText    [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] addFormulaRef     [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
 
     def __init__(self):
         super().__init__()
@@ -507,20 +507,20 @@ class VariationPoint(ARObject):
     # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 7.4, p.226
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__                          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # [x] getBlueprintCondition             [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
-    # [x] setBlueprintCondition             [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
-    # [x] getDesc                           [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
-    # [x] setDesc                           [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
-    # [x] getFormalBlueprintGenerator       [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
-    # [x] setFormalBlueprintGenerator       [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
-    # [x] getPostBuildVariantConditions     [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
-    # [x] addPostBuildVariantCondition      [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
-    # [x] getSdg                            [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
-    # [x] setSdg                            [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
-    # [x] getShortLabel                     [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
-    # [x] setShortLabel                     [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
-    # [x] getSwSyscond                      [x] impl  [x] docstring  [x] test  [—] reader  [ ] writer
-    # [x] setSwSyscond                      [x] impl  [x] docstring  [x] test  [ ] reader  [—] writer
+    # [x] getBlueprintCondition             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBlueprintCondition             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDesc                           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDesc                           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFormalBlueprintGenerator       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFormalBlueprintGenerator       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPostBuildVariantConditions     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addPostBuildVariantCondition      [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getSdg                            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSdg                            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getShortLabel                     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setShortLabel                     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwSyscond                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwSyscond                      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType, ARNumerical, Identifier, Integer
@@ -331,6 +331,7 @@ class PostBuildVariantCondition(ARObject):
 
     # PostBuildVariantCondition method parity checklist:
     # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 7.6, p.232
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__                [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getMatchingCriterionRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
@@ -399,25 +400,17 @@ class ConditionByFormula(ARObject):
 
     # ConditionByFormula method parity checklist:
     # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 7.5, p.231
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getBindingTime    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
     # [x] setBindingTime    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
-    # [x] getFormulaItems   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
-    # [x] addFormulaText    [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
-    # [x] addFormulaRef     [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
 
     def __init__(self):
         super().__init__()
 
         # This attribute specifies the point in time when condition may be evaluated at earliest. At this point in time all referenced system constants shall have a value.
         self.bindingTime: Optional["BindingTimeEnum"] = None
-
-        # Formula content of the atpMixedString SW-SYSCOND (XSD CONDITION-BY-FORMULA,
-        # AUTOSAR_00046.xsd:18334): ordered text fragments (str) and inline system
-        # constant references stored as (tag, ref) tuples, in document order.
-        # tag is "SYSC-REF" (coded value) or "SYSC-STRING-REF" (string evaluation).
-        self.formulaItems: List[Union[str, Tuple[str, RefType]]] = []
 
     def getBindingTime(self) -> Optional["BindingTimeEnum"]:
         """
@@ -435,32 +428,6 @@ class ConditionByFormula(ARObject):
         """
         if value is not None:
             self.bindingTime = value
-        return self
-
-    def getFormulaItems(self) -> List[Union[str, Tuple[str, RefType]]]:
-        """
-        Returns the formula content in document order: plain text fragments (str)
-        and inline system constant references as (tag, RefType) tuples, where tag
-        is "SYSC-REF" or "SYSC-STRING-REF", as they appear inside SW-SYSCOND.
-        """
-        return self.formulaItems
-
-    def addFormulaText(self, value: str) -> "ConditionByFormula":
-        """
-        Appends a plain text fragment to the formula content. A None value is a no-op.
-        """
-        if value is not None:
-            self.formulaItems.append(value)
-        return self
-
-    def addFormulaRef(self, value: RefType, tag: str = "SYSC-REF") -> "ConditionByFormula":
-        """
-        Appends an inline system constant reference to the formula content. tag is
-        "SYSC-REF" (internal/coded value) or "SYSC-STRING-REF" (string evaluation).
-        A None value is a no-op.
-        """
-        if value is not None:
-            self.formulaItems.append((tag, value))
         return self
 
 
@@ -496,7 +463,7 @@ class VariationPoint(ARObject):
             point to support the RTE generator. It is necessary for supporting
             splitable aggregations and if binding time is later than
             codeGenerationTime, as well as some RTE conditions. It needs to be
-            unique within the enclosing Identifiables with the same ShortName.
+            unique with in the enclosing Identifiables with the same ShortName.
             (Multiplicity: 0..1)
         swSyscond (ConditionByFormula): This condition acts as Binding Function for
             the Variation Point. Note that the multiplicity is 0..1 in order to
@@ -505,6 +472,7 @@ class VariationPoint(ARObject):
 
     # VariationPoint method parity checklist:
     # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 7.4, p.226
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__                          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getBlueprintCondition             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
@@ -642,7 +610,7 @@ class VariationPoint(ARObject):
         This provides a name to the particular variation point to support the RTE
         generator. It is necessary for supporting splitable aggregations and if binding
         time is later than codeGenerationTime, as well as some RTE conditions. It needs
-        to be unique within the enclosing Identifiables with the same ShortName.
+        to be unique with in the enclosing Identifiables with the same ShortName.
         """
         return self.shortLabel
 
@@ -651,7 +619,7 @@ class VariationPoint(ARObject):
         This provides a name to the particular variation point to support the RTE
         generator. It is necessary for supporting splitable aggregations and if binding
         time is later than codeGenerationTime, as well as some RTE conditions. It needs
-        to be unique within the enclosing Identifiables with the same ShortName. A None
+        to be unique with in the enclosing Identifiables with the same ShortName. A None
         value is a no-op and does not overwrite an existing shortLabel.
         """
         if value is not None:

--- a/src/armodel/models/M2/MSR/AsamHdo/SpecialData.py
+++ b/src/armodel/models/M2/MSR/AsamHdo/SpecialData.py
@@ -1,129 +1,347 @@
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import NameToken, Numerical, RefType, VerbatimStringPlain
 from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultiLanguageOverviewParagraph
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import MultilanguageReferrable
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from typing import List
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Enumerations import XmlSpaceEnum
+from typing import List, Optional
 
 
 class Sd(ARObject):
     """
-    Represents special data with a global identifier and value.
-    Base: ARObject
+    This class represents a primitive element in a special data group.
     """
 
     # Sd method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getGID                       [x] impl  [ ] docstring  [ ] test
-    # [ ] setGID                       [x] impl  [ ] docstring  [ ] test
-    # [ ] getValue                     [x] impl  [ ] docstring  [ ] test
-    # [ ] setValue                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.22, p.91
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getGID       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setGID       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getValue     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setValue     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getXmlSpace  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setXmlSpace  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.gid: str = ""
-        self.value: str = ""
+        # This attributes specifies an identifier. Gid comes from the SGML/XML-Term "Generic Identifier" which is the element name in XML. The role of this attribute is the same as the name of an XML - element.
+        self.gid: Optional[NameToken] = None
 
-    def getGID(self) -> str:
+        # This is the value of the special data.
+        self.value: Optional[VerbatimStringPlain] = None
+
+        # This attribute is used to signal an intention that in that element, white space should be preserved by applications. It is defined according to xml:space as declared by W3C.
+        self.xmlSpace: Optional[XmlSpaceEnum] = None
+
+    def getGID(self) -> Optional[NameToken]:
+        """
+        This attributes specifies an identifier. Gid comes from the SGML/XML-Term "Generic Identifier" which is the element name in XML. The role of this attribute is the same as the name of an XML - element.
+        """
         return self.gid
 
-    def setGID(self, value: str):
-        self.gid = value
+    def setGID(self, value: Optional[NameToken]) -> "Sd":
+        """
+        This attributes specifies an identifier. Gid comes from the SGML/XML-Term "Generic Identifier" which is the element name in XML. The role of this attribute is the same as the name of an XML - element. A None value is a no-op and does not overwrite an existing gid.
+        """
+        if value is not None:
+            self.gid = value
         return self
 
-    def getValue(self) -> str:
+    def getValue(self) -> Optional[VerbatimStringPlain]:
+        """
+        This is the value of the special data.
+        """
         return self.value
 
-    def setValue(self, value: str):
-        self.value = value
+    def setValue(self, value: Optional[VerbatimStringPlain]) -> "Sd":
+        """
+        This is the value of the special data. A None value is a no-op and does not overwrite an existing value.
+        """
+        if value is not None:
+            self.value = value
+        return self
+
+    def getXmlSpace(self) -> Optional[XmlSpaceEnum]:
+        """
+        This attribute is used to signal an intention that in that element, white space should be preserved by applications. It is defined according to xml:space as declared by W3C.
+        """
+        return self.xmlSpace
+
+    def setXmlSpace(self, value: Optional[XmlSpaceEnum]) -> "Sd":
+        """
+        This attribute is used to signal an intention that in that element, white space should be preserved by applications. It is defined according to xml:space as declared by W3C. A None value is a no-op and does not overwrite an existing xmlSpace.
+        """
+        if value is not None:
+            self.xmlSpace = value
         return self
 
 
 class SdgCaption(MultilanguageReferrable):
     """
-    Represents a caption for special data groups with multilingual description.
-    Base: MultilanguageReferrable
+    This meta-class represents the caption of a special data group. This allows to have some parts of special data as identifiable.
     """
 
     # SdgCaption method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getDesc                      [x] impl  [ ] docstring  [ ] test
-    # [ ] setDesc                      [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.21, p.91
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getDesc      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDesc      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent, short_name):
         super().__init__(parent, short_name)
 
-        self.desc: MultiLanguageOverviewParagraph = None
+        # This represents a general but brief (one paragraph) description what the special data in question is about. It is only one paragraph! Desc is intended to be collected into overview tables. This property helps a human reader to identify the special data in question.
+        self.desc: Optional[MultiLanguageOverviewParagraph] = None
 
-    def getDesc(self) -> MultiLanguageOverviewParagraph:
+    def getDesc(self) -> Optional[MultiLanguageOverviewParagraph]:
+        """
+        This represents a general but brief (one paragraph) description what the special data in question is about. It is only one paragraph! Desc is intended to be collected into overview tables. This property helps a human reader to identify the special data in question.
+        """
         return self.desc
 
-    def setDesc(self, value: MultiLanguageOverviewParagraph):
+    def setDesc(self, value: Optional[MultiLanguageOverviewParagraph]) -> "SdgCaption":
+        """
+        This represents a general but brief (one paragraph) description what the special data in question is about. It is only one paragraph! Desc is intended to be collected into overview tables. This property helps a human reader to identify the special data in question. A None value is a no-op and does not overwrite an existing desc.
+        """
         if value is not None:
             self.desc = value
         return self
 
 
-class Sdg(ARObject):
+class Sdf(ARObject):
     """
-    Represents a special data group containing special data items and references.
-    Base: ARObject
+    This class represents a numerical value in a special data group which may be subject to variability.
     """
 
-    # Sdg method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getGID                       [x] impl  [ ] docstring  [ ] test
-    # [ ] setGID                       [x] impl  [ ] docstring  [ ] test
-    # [ ] addSd                        [x] impl  [ ] docstring  [ ] test
-    # [ ] getSds                       [x] impl  [ ] docstring  [ ] test
-    # [ ] getSdgCaption                [x] impl  [ ] docstring  [ ] test
-    # [ ] createSdgCaption             [x] impl  [ ] docstring  [ ] test
-    # [ ] getSdgContentsTypes          [x] impl  [ ] docstring  [ ] test
-    # [ ] addSdgContentsType           [x] impl  [ ] docstring  [ ] test
-    # [ ] getSdxRefs                   [x] impl  [ ] docstring  [ ] test
-    # [ ] addSdxRef                    [x] impl  [ ] docstring  [ ] test
+    # Sdf method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.23, p.92
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getGID       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setGID       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getValue     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setValue     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.gid: str = ""
-        self.sd: List[Sd] = []
-        self.sdgCaption: SdgCaption = None
-        self.sdgContentsTypes: List[Sdg] = []
-        self.sdxRefs: List[RefType] = []
+        # This attributes specifies an identifier. Gid comes from the SGML/XML-Term "Generic Identifier" which is the element name in XML. The role of this attribute is the same as the name of an XML - element.
+        self.gid: Optional[NameToken] = None
 
-    def getGID(self) -> str:
+        # This is the value of the special data.
+        self.value: Optional[Numerical] = None
+
+    def getGID(self) -> Optional[NameToken]:
+        """
+        This attributes specifies an identifier. Gid comes from the SGML/XML-Term "Generic Identifier" which is the element name in XML. The role of this attribute is the same as the name of an XML - element.
+        """
         return self.gid
 
-    def setGID(self, value: str):
-        self.gid = value
+    def setGID(self, value: Optional[NameToken]) -> "Sdf":
+        """
+        This attributes specifies an identifier. Gid comes from the SGML/XML-Term "Generic Identifier" which is the element name in XML. The role of this attribute is the same as the name of an XML - element. A None value is a no-op and does not overwrite an existing gid.
+        """
+        if value is not None:
+            self.gid = value
         return self
 
-    def addSd(self, sd: Sd):
-        self.sd.append(sd)
+    def getValue(self) -> Optional[Numerical]:
+        """
+        This is the value of the special data.
+        """
+        return self.value
+
+    def setValue(self, value: Optional[Numerical]) -> "Sdf":
+        """
+        This is the value of the special data. A None value is a no-op and does not overwrite an existing value.
+        """
+        if value is not None:
+            self.value = value
+        return self
+
+
+class SdgContents(ARObject):
+    """
+    This meta-class represents the possible contents of a special data group. It can be an arbitrary mix of references, of primitive special data and nested special data groups.
+    """
+
+    # SdgContents method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.20, p.91
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addSd        [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getSds       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addSdf       [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getSdfs      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addSdg       [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getSdgs      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addSdxRef    [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getSdxRefs   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addSdxfRef   [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getSdxfRefs  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This is one particular special data element.
+        self.sd: List[Sd] = []
+
+        # This is one particular special data element.
+        self.sdf: List[Sdf] = []
+
+        # This aggregation allows to express nested special data groups. By this, any structure can be represented in SpeicalData.
+        self.sdg: List["Sdg"] = []
+
+        # Reference to any identifiable element. This allows to use Sdg even to establish arbitrary relationships.
+        self.sdxRefs: List[RefType] = []
+
+        # Additional reference with variant support.
+        self.sdxfRefs: List[RefType] = []
+
+    def addSd(self, sd: Optional[Sd]) -> "SdgContents":
+        """
+        This is one particular special data element. A None value is a no-op and is not appended.
+        """
+        if sd is not None:
+            self.sd.append(sd)
         return self
 
     def getSds(self) -> List[Sd]:
+        """
+        This is one particular special data element.
+        """
         return self.sd
 
-    def getSdgCaption(self) -> SdgCaption:
+    def addSdf(self, sdf: Optional[Sdf]) -> "SdgContents":
+        """
+        This is one particular special data element. A None value is a no-op and is not appended.
+        """
+        if sdf is not None:
+            self.sdf.append(sdf)
+        return self
+
+    def getSdfs(self) -> List[Sdf]:
+        """
+        This is one particular special data element.
+        """
+        return self.sdf
+
+    def addSdg(self, sdg: Optional["Sdg"]) -> "SdgContents":
+        """
+        This aggregation allows to express nested special data groups. By this, any structure can be represented in SpeicalData. A None value is a no-op and is not appended.
+        """
+        if sdg is not None:
+            self.sdg.append(sdg)
+        return self
+
+    def getSdgs(self) -> List["Sdg"]:
+        """
+        This aggregation allows to express nested special data groups. By this, any structure can be represented in SpeicalData.
+        """
+        return self.sdg
+
+    def addSdxRef(self, value: Optional[RefType]) -> "SdgContents":
+        """
+        Reference to any identifiable element. This allows to use Sdg even to establish arbitrary relationships. A None value is a no-op and is not appended.
+        """
+        if value is not None:
+            self.sdxRefs.append(value)
+        return self
+
+    def getSdxRefs(self) -> List[RefType]:
+        """
+        Reference to any identifiable element. This allows to use Sdg even to establish arbitrary relationships.
+        """
+        return self.sdxRefs
+
+    def addSdxfRef(self, value: Optional[RefType]) -> "SdgContents":
+        """
+        Additional reference with variant support. A None value is a no-op and is not appended.
+        """
+        if value is not None:
+            self.sdxfRefs.append(value)
+        return self
+
+    def getSdxfRefs(self) -> List[RefType]:
+        """
+        Additional reference with variant support.
+        """
+        return self.sdxfRefs
+
+
+class Sdg(ARObject):
+    """
+    Sdg (SpecialDataGroup) is a generic model which can be used to keep arbitrary information which is not explicitly modeled in the meta-model. Sdg can have various contents as defined by sdgContentsType. Special Data should only be used moderately since all elements should be defined in the meta-model. Thereby SDG should be considered as a temporary solution when no explicit model is available. If an sdg Caption is available, it is possible to establish a reference to the sdg structure.
+    """
+
+    # Sdg method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.19, p.90
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__            [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getGID              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setGID              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSdgCaption       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createSdgCaption    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSdgContentsType  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSdgContentsType  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This attributes specifies an identifier. Gid comes from the SGML/XML-Term "Generic Identifier" which is the element name in XML. The role of this attribute is the same as the name of an XML - element.
+        self.gid: Optional[NameToken] = None
+
+        # This aggregation allows to assign the properties of Identifiable to the sdg. By this, a shortName etc. can be assigned to the Sdg.
+        self.sdgCaption: Optional[SdgCaption] = None
+
+        # This is the content of the Sdg.
+        self.sdgContentsType: Optional[SdgContents] = None
+
+    def getGID(self) -> Optional[NameToken]:
+        """
+        This attributes specifies an identifier. Gid comes from the SGML/XML-Term "Generic Identifier" which is the element name in XML. The role of this attribute is the same as the name of an XML - element.
+        """
+        return self.gid
+
+    def setGID(self, value: Optional[NameToken]) -> "Sdg":
+        """
+        This attributes specifies an identifier. Gid comes from the SGML/XML-Term "Generic Identifier" which is the element name in XML. The role of this attribute is the same as the name of an XML - element. A None value is a no-op and does not overwrite an existing gid.
+        """
+        if value is not None:
+            self.gid = value
+        return self
+
+    def getSdgCaption(self) -> Optional[SdgCaption]:
+        """
+        This aggregation allows to assign the properties of Identifiable to the sdg. By this, a shortName etc. can be assigned to the Sdg.
+        """
         return self.sdgCaption
 
     def createSdgCaption(self, short_name: str) -> SdgCaption:
+        """
+        This aggregation allows to assign the properties of Identifiable to the sdg. By this, a shortName etc. can be assigned to the Sdg.
+        """
         caption = SdgCaption(self, short_name)
         self.sdgCaption = caption
         return caption
 
-    def getSdgContentsTypes(self) -> List["Sdg"]:
-        return self.sdgContentsTypes
+    def getSdgContentsType(self) -> Optional[SdgContents]:
+        """
+        This is the content of the Sdg.
+        """
+        return self.sdgContentsType
 
-    def addSdgContentsType(self, sdg: "Sdg"):
-        self.sdgContentsTypes.append(sdg)
-
-    def getSdxRefs(self) -> List[RefType]:
-        return self.sdxRefs
-
-    def addSdxRef(self, value: RefType):
+    def setSdgContentsType(self, value: Optional[SdgContents]) -> "Sdg":
+        """
+        This is the content of the Sdg. A None value is a no-op and does not overwrite an existing sdgContentsType.
+        """
         if value is not None:
-            self.sdxRefs.append(value)
+            self.sdgContentsType = value
         return self

--- a/src/armodel/models/M2/MSR/Documentation/TextModel/MultilanguageData.py
+++ b/src/armodel/models/M2/MSR/Documentation/TextModel/MultilanguageData.py
@@ -36,25 +36,36 @@ class MultiLanguageParagraph(Paginateable):
 
 class MultiLanguageOverviewParagraph(ARObject):
     """
-    Multi-language overview paragraph with language-specific overview
-    entries.
+    This is the content of a multilingual paragraph in an overview item.
     """
 
     # MultiLanguageOverviewParagraph method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] addL2                        [x] impl  [ ] docstring  [ ] test
-    # [ ] getL2s                       [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 9.90, p.348
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addL2       [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getL2s      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self):
         super().__init__()
 
+        # This represents the text in one particular language.
         self.l2: List[LOverviewParagraph] = []
 
-    def addL2(self, l2: LOverviewParagraph):
-        self.l2.append(l2)
+    def addL2(self, l2: Optional[LOverviewParagraph]) -> "MultiLanguageOverviewParagraph":
+        """
+        This represents the text in one particular language. A None value is a no-op and
+        is not appended.
+        """
+        if l2 is not None:
+            self.l2.append(l2)
         return self
 
     def getL2s(self) -> List[LOverviewParagraph]:
+        """
+        This represents the text in one particular language.
+        """
         return self.l2
 
 

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -1,4 +1,5 @@
 import os
+import re
 import xml.etree.ElementTree as ET
 from typing import List, Optional
 
@@ -719,7 +720,7 @@ class ARXMLParser(AbstractARXMLParser):
             else:
                 self.notImplemented("Unsupported BINDING-TIME <%s>" % element.attrib["BINDING-TIME"])
         if element.text is not None:
-            condition.addFormulaText(element.text)
+            condition.addFormulaText(self._stripMixedContentWhitespace(element.text))
         for child_element in element:
             tag_name = self.getTagName(child_element)
             if tag_name in ("SYSC-REF", "SYSC-STRING-REF"):
@@ -729,10 +730,16 @@ class ARXMLParser(AbstractARXMLParser):
                 ref.setValue(child_element.text)
                 condition.addFormulaRef(ref, tag=tag_name)
                 if child_element.tail is not None:
-                    condition.addFormulaText(child_element.tail)
+                    condition.addFormulaText(self._stripMixedContentWhitespace(child_element.tail))
             else:
                 self.notImplemented("Unsupported SW-SYSCOND content <%s>" % tag_name)
         return condition
+
+    def _stripMixedContentWhitespace(self, text: str) -> str:
+        # The writer pretty-prints with minidom.toprettyxml, which wraps mixed-content
+        # text fragments (element.text / tail) in newline + indentation. Strip that
+        # formatting boundary while preserving meaningful internal whitespace.
+        return re.sub(r"^\s*\n\s*", "", re.sub(r"\s*\n\s*$", "", text))
 
     def readPostBuildVariantCondition(self, element: ET.Element, condition: PostBuildVariantCondition) -> PostBuildVariantCondition:
         self.readARObjectAttributes(element, condition)
@@ -857,9 +864,10 @@ class ARXMLParser(AbstractARXMLParser):
 
         identifiable.setAdminData(self.getAdminData(element, "ADMIN-DATA"))
 
-        variation_point_element = self.find(element, "VARIATION-POINT")
-        if variation_point_element is not None:
-            identifiable.setVariationPoint(self.readVariationPoint(variation_point_element, VariationPoint()))
+        if isinstance(identifiable, Identifiable):
+            variation_point_element = self.find(element, "VARIATION-POINT")
+            if variation_point_element is not None:
+                identifiable.setVariationPoint(self.readVariationPoint(variation_point_element, VariationPoint()))
 
     def readARElement(self, element: ET.Element, ar_element: ARElement):
         self.readIdentifiable(element, ar_element)

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -1,5 +1,4 @@
 import os
-import re
 import xml.etree.ElementTree as ET
 from typing import List, Optional
 
@@ -211,7 +210,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Enumerations import BindingTimeEnum
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Describable, Identifiable, MultilanguageReferrable, Referrable, ShortNameFragment
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, NameToken, RefType, String, VerbatimString
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, NameToken, Numerical, RefType, String, VerbatimString, VerbatimStringPlain
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import LifeCycleInfo, LifeCycleInfoSet, LifeCyclePeriod
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
     ConditionByFormula,
@@ -573,7 +572,7 @@ from armodel.models.M2.MSR.AsamHdo.ComputationMethod import (
     CompuScales,
 )
 from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import DataConstr, DataConstrRule, InternalConstrs, PhysConstrs
-from armodel.models.M2.MSR.AsamHdo.SpecialData import Sd, Sdg
+from armodel.models.M2.MSR.AsamHdo.SpecialData import Sd, Sdf, Sdg, SdgContents
 from armodel.models.M2.MSR.AsamHdo.Units import PhysicalDimension, Unit
 from armodel.models.M2.MSR.CalibrationData.CalibrationValue import SwValueCont, SwValues
 from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod
@@ -623,7 +622,6 @@ from armodel.models.M2.MSR.Documentation.TextModel.MsrQuery import MsrQueryArg, 
 from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultilanguageLongName, MultiLanguageOverviewParagraph, MultiLanguageParagraph, MultiLanguagePlainText, MultiLanguageVerbatim
 from armodel.parser.abstract_arxml_parser import AbstractARXMLParser
 
-
 #: Mapping between BindingTimeEnum camelCase values and their XML attribute tokens
 #: (AR:BINDING-TIME-ENUM--SIMPLE).
 BINDING_TIME_XML_MAP = {
@@ -669,34 +667,54 @@ class ARXMLParser(AbstractARXMLParser):
             node_name.setVehicleSystemInstance(self.getChildElementOptionalIntegerValue(child_element, "VEHICLE-SYSTEM-INSTANCE"))
         return node_name
 
-    def readSd(self, element: ET.Element, sdg: Sdg):
+    def readSd(self, element: ET.Element, contents: SdgContents):
         for child_element in self.findall(element, "./SD"):
             sd = Sd()
             self.readARObjectAttributes(child_element, sd)
             if "GID" in child_element.attrib:
-                sd.setGID(child_element.attrib["GID"])
-            sd.setValue(child_element.text)
-            sdg.addSd(sd)
+                sd.setGID(NameToken().setValue(child_element.attrib["GID"]))
+            if child_element.text is not None and child_element.text.strip() != "":
+                sd.setValue(VerbatimStringPlain().setValue(child_element.text))
+            contents.addSd(sd)
+
+    def readSdf(self, element: ET.Element, contents: SdgContents):
+        for child_element in self.findall(element, "./SDF"):
+            sdf = Sdf()
+            self.readARObjectAttributes(child_element, sdf)
+            if "GID" in child_element.attrib:
+                sdf.setGID(NameToken().setValue(child_element.attrib["GID"]))
+            if child_element.text is not None and child_element.text.strip() != "":
+                sdf.setValue(Numerical().setValue(child_element.text))
+            contents.addSdf(sdf)
 
     def readSdgCaption(self, element: ET.Element, sdg: Sdg):
         child_element = self.find(element, "SDG-CAPTION")
         if child_element is not None:
             sdg.createSdgCaption(self.getShortName(child_element))
 
-    def readSdgSdxRefs(self, element: ET.SubElement, sdg: Sdg):
+    def readSdgSdxRefs(self, element: ET.SubElement, contents: SdgContents):
         for ref in self.getChildElementRefTypeList(element, "SDX-REF"):
-            sdg.addSdxRef(ref)
+            contents.addSdxRef(ref)
+
+    def readSdgSdxfRefs(self, element: ET.SubElement, contents: SdgContents):
+        for ref in self.getChildElementRefTypeList(element, "SDXF"):
+            contents.addSdxfRef(ref)
 
     def getSdg(self, element: ET.Element) -> Sdg:
         sdg = Sdg()
         self.readARObjectAttributes(element, sdg)
         if "GID" in element.attrib:
-            sdg.setGID(element.attrib["GID"])
+            sdg.setGID(NameToken().setValue(element.attrib["GID"]))
         self.readSdgCaption(element, sdg)
-        self.readSd(element, sdg)
+        contents = SdgContents()
+        self.readSd(element, contents)
+        self.readSdf(element, contents)
         for child_element in self.findall(element, "SDG"):
-            sdg.addSdgContentsType(self.getSdg(child_element))
-        self.readSdgSdxRefs(element, sdg)
+            contents.addSdg(self.getSdg(child_element))
+        self.readSdgSdxRefs(element, contents)
+        self.readSdgSdxfRefs(element, contents)
+        if len(contents.getSds()) > 0 or len(contents.getSdfs()) > 0 or len(contents.getSdgs()) > 0 or len(contents.getSdxRefs()) > 0 or len(contents.getSdxfRefs()) > 0:
+            sdg.setSdgContentsType(contents)
         return sdg
 
     def readBlueprintGenerator(self, element: ET.Element, generator: BlueprintGenerator) -> BlueprintGenerator:
@@ -719,27 +737,7 @@ class ARXMLParser(AbstractARXMLParser):
                 condition.setBindingTime(BindingTimeEnum().setValue(binding_time))
             else:
                 self.notImplemented("Unsupported BINDING-TIME <%s>" % element.attrib["BINDING-TIME"])
-        if element.text is not None:
-            condition.addFormulaText(self._stripMixedContentWhitespace(element.text))
-        for child_element in element:
-            tag_name = self.getTagName(child_element)
-            if tag_name in ("SYSC-REF", "SYSC-STRING-REF"):
-                ref = RefType()
-                if "DEST" in child_element.attrib:
-                    ref.setDest(child_element.attrib["DEST"])
-                ref.setValue(child_element.text)
-                condition.addFormulaRef(ref, tag=tag_name)
-                if child_element.tail is not None:
-                    condition.addFormulaText(self._stripMixedContentWhitespace(child_element.tail))
-            else:
-                self.notImplemented("Unsupported SW-SYSCOND content <%s>" % tag_name)
         return condition
-
-    def _stripMixedContentWhitespace(self, text: str) -> str:
-        # The writer pretty-prints with minidom.toprettyxml, which wraps mixed-content
-        # text fragments (element.text / tail) in newline + indentation. Strip that
-        # formatting boundary while preserving meaningful internal whitespace.
-        return re.sub(r"^\s*\n\s*", "", re.sub(r"\s*\n\s*$", "", text))
 
     def readPostBuildVariantCondition(self, element: ET.Element, condition: PostBuildVariantCondition) -> PostBuildVariantCondition:
         self.readARObjectAttributes(element, condition)

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -140,6 +140,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.SignalServiceTranslation
     SignalServiceTranslationPropsSet,
 )
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint import PortPrototypeBlueprint
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintGenerator.BlueprintGenerator import BlueprintGenerator
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword import Keyword, KeywordSet
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping import SwcBswMapping, SwcBswRunnableMapping, SwcBswSynchronizedModeGroupPrototype, SwcBswSynchronizedTrigger
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingConstraint.ExecutionOrderConstraint import ExecutionOrderConstraint
@@ -206,15 +207,19 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage, ReferenceBase
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import Collection
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.EngineeringObject import AutosarEngineeringObject, EngineeringObject
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Enumerations import BindingTimeEnum
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Describable, Identifiable, MultilanguageReferrable, Referrable, ShortNameFragment
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, NameToken, RefType, String
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, NameToken, RefType, String, VerbatimString
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import LifeCycleInfo, LifeCycleInfoSet, LifeCyclePeriod
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
+    ConditionByFormula,
+    PostBuildVariantCondition,
     PostBuildVariantCriterion,
     PredefinedVariant,
     SwSystemconstantValueSet,
     SwSystemconstValue,
+    VariationPoint,
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
     ClientServerAnnotation,
@@ -618,6 +623,16 @@ from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import Mult
 from armodel.parser.abstract_arxml_parser import AbstractARXMLParser
 
 
+#: Mapping between BindingTimeEnum camelCase values and their XML attribute tokens
+#: (AR:BINDING-TIME-ENUM--SIMPLE).
+BINDING_TIME_XML_MAP = {
+    "codeGenerationTime": "CODE-GENERATION-TIME",
+    "linkTime": "LINK-TIME",
+    "preCompileTime": "PRE-COMPILE-TIME",
+    "systemDesignTime": "SYSTEM-DESIGN-TIME",
+}
+
+
 class ARXMLParser(AbstractARXMLParser):
     """
     Main ARXML parser that loads AUTOSAR XML files into the model.
@@ -682,6 +697,73 @@ class ARXMLParser(AbstractARXMLParser):
             sdg.addSdgContentsType(self.getSdg(child_element))
         self.readSdgSdxRefs(element, sdg)
         return sdg
+
+    def readBlueprintGenerator(self, element: ET.Element, generator: BlueprintGenerator) -> BlueprintGenerator:
+        self.readARObjectAttributes(element, generator)
+        generator.setIntroduction(self.getDocumentationBlock(element, "INTRODUCTION"))
+        expression_element = self.find(element, "EXPRESSION")
+        if expression_element is not None:
+            generator.setExpression(VerbatimString().setValue(expression_element.text))
+        return generator
+
+    def readConditionByFormula(self, element: ET.Element, condition: ConditionByFormula) -> ConditionByFormula:
+        self.readARObjectAttributes(element, condition)
+        if "BINDING-TIME" in element.attrib:
+            binding_time = None
+            for camel, token in BINDING_TIME_XML_MAP.items():
+                if token == element.attrib["BINDING-TIME"]:
+                    binding_time = camel
+                    break
+            if binding_time is not None:
+                condition.setBindingTime(BindingTimeEnum().setValue(binding_time))
+            else:
+                self.notImplemented("Unsupported BINDING-TIME <%s>" % element.attrib["BINDING-TIME"])
+        if element.text is not None:
+            condition.addFormulaText(element.text)
+        for child_element in element:
+            tag_name = self.getTagName(child_element)
+            if tag_name in ("SYSC-REF", "SYSC-STRING-REF"):
+                ref = RefType()
+                if "DEST" in child_element.attrib:
+                    ref.setDest(child_element.attrib["DEST"])
+                ref.setValue(child_element.text)
+                condition.addFormulaRef(ref, tag=tag_name)
+                if child_element.tail is not None:
+                    condition.addFormulaText(child_element.tail)
+            else:
+                self.notImplemented("Unsupported SW-SYSCOND content <%s>" % tag_name)
+        return condition
+
+    def readPostBuildVariantCondition(self, element: ET.Element, condition: PostBuildVariantCondition) -> PostBuildVariantCondition:
+        self.readARObjectAttributes(element, condition)
+        condition.setMatchingCriterionRef(self.getChildElementRefType("", element, "MATCHING-CRITERION-REF"))
+        condition.setValue(self.getChildElementOptionalIntegerValue(element, "VALUE"))
+        return condition
+
+    def readVariationPoint(self, element: ET.Element, variation_point: VariationPoint) -> VariationPoint:
+        self.readARObjectAttributes(element, variation_point)
+        variation_point.setShortLabel(self.getChildElementOptionalIdentifier(element, "SHORT-LABEL"))
+        variation_point.setDesc(self.getMultiLanguageOverviewParagraph(element, "DESC"))
+        variation_point.setBlueprintCondition(self.getDocumentationBlock(element, "BLUEPRINT-CONDITION"))
+        # FORMAL-BLUEPRINT-CONDITION is obsolete (atp.Status="obsolete") and has no
+        # model attribute — deliberately not read.
+        formal_element = self.find(element, "FORMAL-BLUEPRINT-GENERATOR")
+        if formal_element is not None:
+            variation_point.setFormalBlueprintGenerator(self.readBlueprintGenerator(formal_element, BlueprintGenerator()))
+        sw_syscond_element = self.find(element, "SW-SYSCOND")
+        if sw_syscond_element is not None:
+            variation_point.setSwSyscond(self.readConditionByFormula(sw_syscond_element, ConditionByFormula()))
+        for child_element in self.findall(element, "POST-BUILD-VARIANT-CONDITIONS/*"):
+            tag_name = self.getTagName(child_element)
+            if tag_name == "POST-BUILD-VARIANT-CONDITION":
+                variation_point.addPostBuildVariantCondition(
+                    self.readPostBuildVariantCondition(child_element, PostBuildVariantCondition()))
+            else:
+                self.notImplemented("Unsupported POST-BUILD-VARIANT-CONDITIONS content <%s>" % tag_name)
+        sdg_element = self.find(element, "SDG")
+        if sdg_element is not None:
+            variation_point.setSdg(self.getSdg(sdg_element))
+        return variation_point
 
     def readAdminDataSdgs(self, element: ET.Element, admin_data: AdminData):
         for child_element in self.findall(element, "SDGS/*"):
@@ -774,6 +856,10 @@ class ARXMLParser(AbstractARXMLParser):
         identifiable.setIntroduction(self.getDocumentationBlock(element, "INTRODUCTION"))
 
         identifiable.setAdminData(self.getAdminData(element, "ADMIN-DATA"))
+
+        variation_point_element = self.find(element, "VARIATION-POINT")
+        if variation_point_element is not None:
+            identifiable.setVariationPoint(self.readVariationPoint(variation_point_element, VariationPoint()))
 
     def readARElement(self, element: ET.Element, ar_element: ARElement):
         self.readIdentifiable(element, ar_element)

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -763,8 +763,7 @@ class ARXMLParser(AbstractARXMLParser):
         for child_element in self.findall(element, "POST-BUILD-VARIANT-CONDITIONS/*"):
             tag_name = self.getTagName(child_element)
             if tag_name == "POST-BUILD-VARIANT-CONDITION":
-                variation_point.addPostBuildVariantCondition(
-                    self.readPostBuildVariantCondition(child_element, PostBuildVariantCondition()))
+                variation_point.addPostBuildVariantCondition(self.readPostBuildVariantCondition(child_element, PostBuildVariantCondition()))
             else:
                 self.notImplemented("Unsupported POST-BUILD-VARIANT-CONDITIONS content <%s>" % tag_name)
         sdg_element = self.find(element, "SDG")

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -132,6 +132,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.SignalServiceTranslation
     SignalServiceTranslationPropsSet,
 )
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint import PortPrototypeBlueprint
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintGenerator.BlueprintGenerator import BlueprintGenerator
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword import Keyword, KeywordSet
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping import SwcBswMapping, SwcBswRunnableMapping, SwcBswSynchronizedModeGroupPrototype, SwcBswSynchronizedTrigger
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingConstraint.ExecutionOrderConstraint import EOCExecutableEntityRef, ExecutionOrderConstraint
@@ -195,15 +196,19 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage, ReferenceBase
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import Collection
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.EngineeringObject import AutosarEngineeringObject, EngineeringObject
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Enumerations import BindingTimeEnum
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Describable, Identifiable, MultilanguageReferrable, Referrable, ShortNameFragment
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, Limit, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, Identifier, Integer, Limit, RefType, VerbatimString
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import LifeCycleInfo, LifeCycleInfoSet, LifeCyclePeriod
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
+    ConditionByFormula,
+    PostBuildVariantCondition,
     PostBuildVariantCriterion,
     PredefinedVariant,
     SwSystemconstantValueSet,
     SwSystemconstValue,
+    VariationPoint,
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
     ClientServerAnnotation,
@@ -598,6 +603,16 @@ from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import Mult
 from armodel.writer.abstract_arxml_writer import AbstractARXMLWriter
 
 
+#: Mapping between BindingTimeEnum camelCase values and their XML attribute tokens
+#: (AR:BINDING-TIME-ENUM--SIMPLE).
+BINDING_TIME_XML_MAP = {
+    "codeGenerationTime": "CODE-GENERATION-TIME",
+    "linkTime": "LINK-TIME",
+    "preCompileTime": "PRE-COMPILE-TIME",
+    "systemDesignTime": "SYSTEM-DESIGN-TIME",
+}
+
+
 class ARXMLWriter(AbstractARXMLWriter):
     """
     Main ARXML writer that serializes the AUTOSAR model back to ARXML
@@ -661,6 +676,70 @@ class ARXMLWriter(AbstractARXMLWriter):
                 self.setSdg(child_element, sdg_item)
             self.writeSds(child_element, sdg)
             self.writeSdgSdxRefs(child_element, sdg)
+
+    def writeBlueprintGenerator(self, element: ET.Element, generator: BlueprintGenerator):
+        if generator is not None:
+            child_element = ET.SubElement(element, "FORMAL-BLUEPRINT-GENERATOR")
+            self.writeARObjectAttributes(child_element, generator)
+            # XSD sequence: INTRODUCTION (offset 10) before EXPRESSION (offset 20).
+            self.writeDocumentationBlock(child_element, "INTRODUCTION", generator.getIntroduction())
+            expression = generator.getExpression()
+            if expression is not None:
+                expression_element = ET.SubElement(child_element, "EXPRESSION")
+                expression_element.text = expression.getValue()
+
+    def writeConditionByFormula(self, element: ET.Element, condition: ConditionByFormula):
+        if condition is not None:
+            child_element = ET.SubElement(element, "SW-SYSCOND")
+            self.writeARObjectAttributes(child_element, condition)
+            binding_time = condition.getBindingTime()
+            if binding_time is not None:
+                token = BINDING_TIME_XML_MAP.get(binding_time.getValue())
+                if token is None:
+                    self.notImplemented("Unsupported BINDING-TIME <%s>" % binding_time.getValue())
+                else:
+                    child_element.attrib["BINDING-TIME"] = token
+            last_ref = None
+            for item in condition.getFormulaItems():
+                if isinstance(item, str):
+                    if last_ref is None:
+                        child_element.text = item if child_element.text is None else child_element.text + item
+                    else:
+                        last_ref.tail = item if last_ref.tail is None else last_ref.tail + item
+                else:
+                    tag, ref = item
+                    last_ref = ET.SubElement(child_element, tag)
+                    if ref.getDest() is not None:
+                        last_ref.attrib["DEST"] = ref.getDest()
+                    last_ref.text = ref.getValue()
+
+    def writePostBuildVariantCondition(self, element: ET.Element, condition: PostBuildVariantCondition):
+        child_element = ET.SubElement(element, "POST-BUILD-VARIANT-CONDITION")
+        self.writeARObjectAttributes(child_element, condition)
+        self.setChildElementOptionalRefType(child_element, "MATCHING-CRITERION-REF", condition.getMatchingCriterionRef())
+        self.setChildElementOptionalIntegerValue(child_element, "VALUE", condition.getValue())
+
+    def writeVariationPoint(self, element: ET.Element, variation_point: VariationPoint):
+        if variation_point is not None:
+            child_element = ET.SubElement(element, "VARIATION-POINT")
+            self.writeARObjectAttributes(child_element, variation_point)
+            # XSD sequence (AUTOSAR_00046.xsd group AR:VARIATION-POINT, line 99470):
+            # SHORT-LABEL, DESC, BLUEPRINT-CONDITION, [FORMAL-BLUEPRINT-CONDITION obsolete],
+            # FORMAL-BLUEPRINT-GENERATOR, SW-SYSCOND, POST-BUILD-VARIANT-CONDITIONS, SDG.
+            short_label = variation_point.getShortLabel()
+            if short_label is not None:
+                label_element = ET.SubElement(child_element, "SHORT-LABEL")
+                label_element.text = short_label.getValue()
+            self.setMultiLanguageOverviewParagraph(child_element, "DESC", variation_point.getDesc())
+            self.writeDocumentationBlock(child_element, "BLUEPRINT-CONDITION", variation_point.getBlueprintCondition())
+            self.writeBlueprintGenerator(child_element, variation_point.getFormalBlueprintGenerator())
+            self.writeConditionByFormula(child_element, variation_point.getSwSyscond())
+            conditions = variation_point.getPostBuildVariantConditions()
+            if len(conditions) > 0:
+                conditions_element = ET.SubElement(child_element, "POST-BUILD-VARIANT-CONDITIONS")
+                for condition in conditions:
+                    self.writePostBuildVariantCondition(conditions_element, condition)
+            self.setSdg(child_element, variation_point.getSdg())
 
     def writeAdminDataSdgs(self, parent: ET.Element, admin_data: AdminData):
         sdgs = admin_data.getSdgs()
@@ -842,6 +921,8 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.setChildElementOptionalLiteral(element, "CATEGORY", identifiable.getCategory())
         self.writeDocumentationBlock(element, "INTRODUCTION", identifiable.getIntroduction())
         self.setAdminData(element, identifiable.getAdminData())
+        if isinstance(identifiable, Identifiable):
+            self.writeVariationPoint(element, identifiable.getVariationPoint())
 
     def writeARElement(self, parent: ET.Element, ar_element: ARElement):
         self.writeIdentifiable(parent, ar_element)

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -196,10 +196,9 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage, ReferenceBase
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import Collection
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.EngineeringObject import AutosarEngineeringObject, EngineeringObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Enumerations import BindingTimeEnum
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Describable, Identifiable, MultilanguageReferrable, Referrable, ShortNameFragment
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, Identifier, Integer, Limit, RefType, VerbatimString
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, Limit, RefType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import LifeCycleInfo, LifeCycleInfoSet, LifeCyclePeriod
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
     ConditionByFormula,
@@ -557,7 +556,7 @@ from armodel.models.M2.MSR.AsamHdo.ComputationMethod import (
     CompuScales,
 )
 from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import DataConstr, InternalConstrs, PhysConstrs
-from armodel.models.M2.MSR.AsamHdo.SpecialData import Sdg
+from armodel.models.M2.MSR.AsamHdo.SpecialData import Sdg, SdgContents
 from armodel.models.M2.MSR.AsamHdo.Units import PhysicalDimension, Unit
 from armodel.models.M2.MSR.CalibrationData.CalibrationValue import SwValueCont, SwValues
 from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod
@@ -601,7 +600,6 @@ from armodel.models.M2.MSR.Documentation.TextModel.LanguageDataModel import Lang
 from armodel.models.M2.MSR.Documentation.TextModel.MsrQuery import MsrQueryArg, MsrQueryP1, MsrQueryP2, MsrQueryProps
 from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultilanguageLongName, MultiLanguageOverviewParagraph, MultiLanguageParagraph, MultiLanguagePlainText, MultiLanguageVerbatim
 from armodel.writer.abstract_arxml_writer import AbstractARXMLWriter
-
 
 #: Mapping between BindingTimeEnum camelCase values and their XML attribute tokens
 #: (AR:BINDING-TIME-ENUM--SIMPLE).
@@ -647,13 +645,30 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.setChildElementOptionalIntegerValue(child_element, "VEHICLE-SYSTEM", node_name.getVehicleSystem())
             self.setChildElementOptionalIntegerValue(child_element, "VEHICLE-SYSTEM-INSTANCE", node_name.getVehicleSystemInstance())
 
-    def writeSds(self, parent: ET.Element, sdg: Sdg):
-        for sd in sdg.getSds():
+    def writeSds(self, parent: ET.Element, contents: SdgContents):
+        for sd in contents.getSds():
             sd_tag = ET.SubElement(parent, "SD")
             self.writeARObjectAttributes(sd_tag, sd)
-            if sd.gid is not None:
-                sd_tag.attrib["GID"] = sd.gid
-            sd_tag.text = sd.value
+            gid = sd.getGID()
+            if gid is not None:
+                sd_tag.attrib["GID"] = gid.getValue()
+            xml_space = sd.getXmlSpace()
+            if xml_space is not None:
+                sd_tag.attrib["{http://www.w3.org/XML/1998/namespace}space"] = xml_space.getValue()
+            value = sd.getValue()
+            if value is not None:
+                sd_tag.text = value.getValue()
+
+    def writeSdfs(self, parent: ET.Element, contents: SdgContents):
+        for sdf in contents.getSdfs():
+            sdf_tag = ET.SubElement(parent, "SDF")
+            self.writeARObjectAttributes(sdf_tag, sdf)
+            gid = sdf.getGID()
+            if gid is not None:
+                sdf_tag.attrib["GID"] = gid.getValue()
+            value = sdf.getValue()
+            if value is not None:
+                sdf_tag.text = value.getValue()
 
     def writeSdgCaption(self, element: ET.Element, sdg: Sdg):
         caption = sdg.getSdgCaption()
@@ -661,21 +676,30 @@ class ARXMLWriter(AbstractARXMLWriter):
             child_element = ET.SubElement(element, "SDG-CAPTION")
             self.writeMultilanguageReferrable(child_element, caption)
 
-    def writeSdgSdxRefs(self, element: ET.Element, sdg: Sdg):
-        for ref in sdg.getSdxRefs():
+    def writeSdgSdxRefs(self, element: ET.Element, contents: SdgContents):
+        for ref in contents.getSdxRefs():
             self.setChildElementOptionalRefType(element, "SDX-REF", ref)
+
+    def writeSdgSdxfRefs(self, element: ET.Element, contents: SdgContents):
+        for ref in contents.getSdxfRefs():
+            self.setChildElementOptionalRefType(element, "SDXF", ref)
 
     def setSdg(self, element: ET.Element, sdg: Sdg):
         if sdg is not None:
             child_element = ET.SubElement(element, "SDG")
             self.writeARObjectAttributes(child_element, sdg)
-            if sdg.gid is not None and sdg.gid != "":
-                child_element.attrib["GID"] = sdg.gid
+            gid = sdg.getGID()
+            if gid is not None:
+                child_element.attrib["GID"] = gid.getValue()
             self.writeSdgCaption(child_element, sdg)
-            for sdg_item in sdg.getSdgContentsTypes():
-                self.setSdg(child_element, sdg_item)
-            self.writeSds(child_element, sdg)
-            self.writeSdgSdxRefs(child_element, sdg)
+            contents = sdg.getSdgContentsType()
+            if contents is not None:
+                for sdg_item in contents.getSdgs():
+                    self.setSdg(child_element, sdg_item)
+                self.writeSds(child_element, contents)
+                self.writeSdfs(child_element, contents)
+                self.writeSdgSdxRefs(child_element, contents)
+                self.writeSdgSdxfRefs(child_element, contents)
 
     def writeBlueprintGenerator(self, element: ET.Element, generator: BlueprintGenerator):
         if generator is not None:
@@ -699,19 +723,6 @@ class ARXMLWriter(AbstractARXMLWriter):
                     self.notImplemented("Unsupported BINDING-TIME <%s>" % binding_time.getValue())
                 else:
                     child_element.attrib["BINDING-TIME"] = token
-            last_ref = None
-            for item in condition.getFormulaItems():
-                if isinstance(item, str):
-                    if last_ref is None:
-                        child_element.text = item if child_element.text is None else child_element.text + item
-                    else:
-                        last_ref.tail = item if last_ref.tail is None else last_ref.tail + item
-                else:
-                    tag, ref = item
-                    last_ref = ET.SubElement(child_element, tag)
-                    if ref.getDest() is not None:
-                        last_ref.attrib["DEST"] = ref.getDest()
-                    last_ref.text = ref.getValue()
 
     def writePostBuildVariantCondition(self, element: ET.Element, condition: PostBuildVariantCondition):
         child_element = ET.SubElement(element, "POST-BUILD-VARIANT-CONDITION")

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_Enumerations.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_Enumerations.py
@@ -6,6 +6,7 @@ AUTOSAR GenericStructure module.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Enumerations import (
     AutoCollectEnum,
     BindingTimeEnum,
+    XmlSpaceEnum,
 )
 
 
@@ -33,3 +34,21 @@ class TestBindingTimeEnum:
             "preCompileTime",
             "systemDesignTime",
         }
+
+
+class TestXmlSpaceEnum:
+    """
+    Test class for XmlSpaceEnum functionality.
+    """
+
+    def test_members(self):
+        assert XmlSpaceEnum.DEFAULT == "default"
+        assert XmlSpaceEnum.PRESERVE == "preserve"
+
+    def test_enum_values(self):
+        enum = XmlSpaceEnum()
+        assert set(enum.getEnumValues()) == {"default", "preserve"}
+
+    def test_set_value(self):
+        enum = XmlSpaceEnum().setValue(XmlSpaceEnum.PRESERVE)
+        assert enum.getValue() == "preserve"

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_PrimitiveTypes.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_PrimitiveTypes.py
@@ -30,6 +30,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     MacAddressString,
     NameToken,
     NativeDeclarationString,
+    Numerical,
     PositiveInteger,
     PrimitiveIdentifier,
     ReferrableSubtypesEnum,
@@ -40,6 +41,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     TRefType,
     UnlimitedInteger,
     VerbatimString,
+    VerbatimStringPlain,
 )
 
 
@@ -1117,3 +1119,35 @@ class TestIdentifier:
 
         identifier.setNamePattern(None)
         assert identifier.getNamePattern() == name_pattern
+
+
+class TestVerbatimStringPlain:
+    """
+    Test class for VerbatimStringPlain functionality.
+    """
+
+    def test_initialization(self):
+        verbatim = VerbatimStringPlain()
+        assert verbatim is not None
+        assert verbatim._value is None
+
+    def test_set_get_value(self):
+        verbatim = VerbatimStringPlain()
+        assert verbatim.setValue("plain text") is verbatim
+        assert verbatim.getValue() == "plain text"
+
+
+class TestNumerical:
+    """
+    Test class for Numerical functionality.
+    """
+
+    def test_initialization(self):
+        numerical = Numerical()
+        assert numerical is not None
+        assert numerical._value is None
+
+    def test_set_get_value(self):
+        numerical = Numerical()
+        assert numerical.setValue("0x1F") is numerical
+        assert numerical.getValue() == "0x1F"

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py
@@ -13,6 +13,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     ARNumerical,
+    Identifier,
     Integer,
     RefType,
 )
@@ -26,7 +27,10 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import 
     SwSystemconstValue,
     VariationPoint,
 )
+from armodel.models.M2.MSR.AsamHdo.SpecialData import Sdg
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation
+from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
+from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultiLanguageOverviewParagraph
 
 
 def test_sw_systemconst_value_getters_setters_and_chaining():
@@ -155,40 +159,6 @@ def test_post_build_variant_condition_none_values():
 
     assert condition.getMatchingCriterionRef() is None
     assert condition.getValue() is None
-
-
-def test_condition_by_formula_formula_items_ordered():
-    sysc_ref = RefType().setValue("/SwSystemconsts/SY_TURBO").setDest("SW-SYSTEMCONST")
-    string_ref = RefType().setValue("/SwSystemconsts/SY_MODE").setDest("SW-SYSTEMCONST")
-
-    condition = ConditionByFormula()
-
-    assert condition.getFormulaItems() == []
-
-    result_text = condition.addFormulaText("defined(")
-    result_ref = condition.addFormulaRef(sysc_ref)
-    result_tail = condition.addFormulaText(") && ")
-    result_string_ref = condition.addFormulaRef(string_ref, tag="SYSC-STRING-REF")
-
-    items = condition.getFormulaItems()
-    assert items[0] == "defined("
-    assert items[1] == ("SYSC-REF", sysc_ref)
-    assert items[2] == ") && "
-    assert items[3] == ("SYSC-STRING-REF", string_ref)
-    assert len(items) == 4
-    assert result_text is condition
-    assert result_ref is condition
-    assert result_tail is condition
-    assert result_string_ref is condition
-
-
-def test_condition_by_formula_add_none_is_no_op():
-    condition = ConditionByFormula()
-
-    condition.addFormulaText(None)
-    condition.addFormulaRef(None)
-
-    assert condition.getFormulaItems() == []
 
 
 def test_condition_by_formula_getters_and_setters():
@@ -387,6 +357,22 @@ class TestPostBuildVariantCondition:
         assert condition.getMatchingCriterionRef() is None
         assert condition.getValue() is None
 
+    def test_get_set_matching_criterion_ref(self):
+        condition = PostBuildVariantCondition()
+        ref = RefType().setValue("/Criterions/Country").setDest("POST-BUILD-VARIANT-CRITERION")
+        assert condition.setMatchingCriterionRef(ref) is condition
+        assert condition.getMatchingCriterionRef() == ref
+        condition.setMatchingCriterionRef(None)
+        assert condition.getMatchingCriterionRef() == ref
+
+    def test_get_set_value(self):
+        condition = PostBuildVariantCondition()
+        value = Integer().setValue("1")
+        assert condition.setValue(value) is condition
+        assert condition.getValue() == value
+        condition.setValue(None)
+        assert condition.getValue() == value
+
 
 class TestConditionByFormula:
     def test_initialization(self):
@@ -432,3 +418,43 @@ class TestVariationPoint:
         variation_point.setFormalBlueprintGenerator(generator)
         variation_point.setFormalBlueprintGenerator(None)
         assert variation_point.getFormalBlueprintGenerator() == generator
+
+    def test_set_get_blueprint_condition(self):
+        variation_point = VariationPoint()
+        block = DocumentationBlock()
+        assert variation_point.setBlueprintCondition(block) is variation_point
+        assert variation_point.getBlueprintCondition() == block
+        variation_point.setBlueprintCondition(None)
+        assert variation_point.getBlueprintCondition() == block
+
+    def test_set_get_desc(self):
+        variation_point = VariationPoint()
+        desc = MultiLanguageOverviewParagraph()
+        assert variation_point.setDesc(desc) is variation_point
+        assert variation_point.getDesc() == desc
+        variation_point.setDesc(None)
+        assert variation_point.getDesc() == desc
+
+    def test_set_get_sdg(self):
+        variation_point = VariationPoint()
+        sdg = Sdg()
+        assert variation_point.setSdg(sdg) is variation_point
+        assert variation_point.getSdg() == sdg
+        variation_point.setSdg(None)
+        assert variation_point.getSdg() == sdg
+
+    def test_set_get_short_label(self):
+        variation_point = VariationPoint()
+        label = Identifier().setValue("VP_Label")
+        assert variation_point.setShortLabel(label) is variation_point
+        assert variation_point.getShortLabel() == label
+        variation_point.setShortLabel(None)
+        assert variation_point.getShortLabel() == label
+
+    def test_set_get_sw_syscond(self):
+        variation_point = VariationPoint()
+        syscond = ConditionByFormula()
+        assert variation_point.setSwSyscond(syscond) is variation_point
+        assert variation_point.getSwSyscond() == syscond
+        variation_point.setSwSyscond(None)
+        assert variation_point.getSwSyscond() == syscond

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py
@@ -157,6 +157,40 @@ def test_post_build_variant_condition_none_values():
     assert condition.getValue() is None
 
 
+def test_condition_by_formula_formula_items_ordered():
+    sysc_ref = RefType().setValue("/SwSystemconsts/SY_TURBO").setDest("SW-SYSTEMCONST")
+    string_ref = RefType().setValue("/SwSystemconsts/SY_MODE").setDest("SW-SYSTEMCONST")
+
+    condition = ConditionByFormula()
+
+    assert condition.getFormulaItems() == []
+
+    result_text = condition.addFormulaText("defined(")
+    result_ref = condition.addFormulaRef(sysc_ref)
+    result_tail = condition.addFormulaText(") && ")
+    result_string_ref = condition.addFormulaRef(string_ref, tag="SYSC-STRING-REF")
+
+    items = condition.getFormulaItems()
+    assert items[0] == "defined("
+    assert items[1] == ("SYSC-REF", sysc_ref)
+    assert items[2] == ") && "
+    assert items[3] == ("SYSC-STRING-REF", string_ref)
+    assert len(items) == 4
+    assert result_text is condition
+    assert result_ref is condition
+    assert result_tail is condition
+    assert result_string_ref is condition
+
+
+def test_condition_by_formula_add_none_is_no_op():
+    condition = ConditionByFormula()
+
+    condition.addFormulaText(None)
+    condition.addFormulaRef(None)
+
+    assert condition.getFormulaItems() == []
+
+
 def test_condition_by_formula_getters_and_setters():
     binding_time = BindingTimeEnum()
     binding_time.setValue("preCompileTime")

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/test_VariantHandling.py
@@ -360,6 +360,21 @@ class TestConditionByFormula:
         assert condition.getBindingTime() is None
 
 
+def test_identifiable_holds_variation_point():
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage
+
+    parent = ARPackage(None, "Pkg")
+    criterion = PostBuildVariantCriterion(parent, "MyCriterion")
+    variation_point = VariationPoint()
+
+    assert criterion.getVariationPoint() is None
+
+    result = criterion.setVariationPoint(variation_point)
+
+    assert criterion.getVariationPoint() is variation_point
+    assert result is criterion
+
+
 class TestVariationPoint:
     def test_initialization(self):
         variation_point = VariationPoint()

--- a/tests/test_armodel/models/M2/MSR/AsamHdo/test_SpecialData.py
+++ b/tests/test_armodel/models/M2/MSR/AsamHdo/test_SpecialData.py
@@ -3,8 +3,9 @@ This module contains tests for the SpecialData module in MSR.AsamHdo.
 """
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
-from armodel.models.M2.MSR.AsamHdo.SpecialData import Sd, Sdg, SdgCaption
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Enumerations import XmlSpaceEnum
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import NameToken, Numerical, RefType, VerbatimStringPlain
+from armodel.models.M2.MSR.AsamHdo.SpecialData import Sd, Sdf, Sdg, SdgCaption, SdgContents
 from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultiLanguageOverviewParagraph
 
 
@@ -14,26 +15,45 @@ class TestSd:
     def test_sd_initialization(self):
         """Test that an Sd object can be initialized with default values."""
         sd = Sd()
-        assert sd.gid == ""
-        assert sd.value == ""
+        assert sd.getGID() is None
+        assert sd.getValue() is None
+        assert sd.getXmlSpace() is None
 
     def test_sd_gid_methods(self):
         """Test the gid getter and setter."""
         sd = Sd()
-        gid_value = "test_gid"
+        gid_value = NameToken().setValue("test_gid")
 
         result = sd.setGID(gid_value)
         assert sd.getGID() == gid_value
         assert result == sd
 
+        sd.setGID(None)
+        assert sd.getGID() == gid_value
+
     def test_sd_value_methods(self):
         """Test the value getter and setter."""
         sd = Sd()
-        value = "test_value"
+        value = VerbatimStringPlain().setValue("test_value")
 
         result = sd.setValue(value)
         assert sd.getValue() == value
         assert result == sd
+
+        sd.setValue(None)
+        assert sd.getValue() == value
+
+    def test_sd_xml_space_methods(self):
+        """Test the xmlSpace getter and setter."""
+        sd = Sd()
+        xml_space = XmlSpaceEnum().setValue(XmlSpaceEnum.PRESERVE)
+
+        result = sd.setXmlSpace(xml_space)
+        assert sd.getXmlSpace() == xml_space
+        assert result == sd
+
+        sd.setXmlSpace(None)
+        assert sd.getXmlSpace() == xml_space
 
 
 class TestSdgCaption:
@@ -43,7 +63,7 @@ class TestSdgCaption:
         """Test that an SdgCaption object can be initialized with default values."""
         parent_obj = ARPackage(None, "parent_test")  # Using ARPackage as a concrete ARObject subclass
         sdg_caption = SdgCaption(parent_obj, "test_name")
-        assert sdg_caption.desc is None
+        assert sdg_caption.getDesc() is None
 
     def test_sdg_caption_desc_methods(self):
         """Test the desc getter and setter."""
@@ -55,6 +75,9 @@ class TestSdgCaption:
         assert sdg_caption.getDesc() == desc
         assert result == sdg_caption
 
+        sdg_caption.setDesc(None)
+        assert sdg_caption.getDesc() == desc
+
 
 class TestSdg:
     """Test class for Sdg class."""
@@ -62,30 +85,21 @@ class TestSdg:
     def test_sdg_initialization(self):
         """Test that an Sdg object can be initialized with default values."""
         sdg = Sdg()
-        assert sdg.gid == ""
-        assert sdg.sd == []
-        assert sdg.sdgCaption is None
-        assert sdg.sdgContentsTypes == []
-        assert sdg.sdxRefs == []
+        assert sdg.getGID() is None
+        assert sdg.getSdgCaption() is None
+        assert sdg.getSdgContentsType() is None
 
     def test_sdg_gid_methods(self):
         """Test the gid getter and setter."""
         sdg = Sdg()
-        gid_value = "test_gid"
+        gid_value = NameToken().setValue("test_gid")
 
         result = sdg.setGID(gid_value)
         assert sdg.getGID() == gid_value
         assert result == sdg
 
-    def test_sdg_sd_methods(self):
-        """Test adding and getting special data items."""
-        sdg = Sdg()
-        sd_item = Sd()
-
-        result = sdg.addSd(sd_item)
-        sds = sdg.getSds()
-        assert sd_item in sds
-        assert result == sdg
+        sdg.setGID(None)
+        assert sdg.getGID() == gid_value
 
     def test_sdg_caption_methods(self):
         """Test the caption getter and creation."""
@@ -93,27 +107,98 @@ class TestSdg:
         caption = sdg.createSdgCaption("test_caption")
 
         assert sdg.getSdgCaption() == caption
-        assert caption.desc is None
+        assert caption.getDesc() is None
 
         # Test that the caption is properly attached
         assert caption.parent == sdg
         assert caption.short_name == "test_caption"
 
-    def test_sdg_contents_types_methods(self):
-        """Test adding and getting special data group content types."""
+    def test_sdg_contents_type_methods(self):
+        """Test setting and getting the sdg contents type."""
         sdg = Sdg()
-        sdg_content = Sdg()  # Create another Sdg instance
+        contents = SdgContents()
+        contents.addSd(Sd())
 
-        sdg.addSdgContentsType(sdg_content)
-        contents = sdg.getSdgContentsTypes()
-        assert sdg_content in contents
-
-    def test_sdg_refs_methods(self):
-        """Test adding and getting special data extended references."""
-        sdg = Sdg()
-        ref = RefType()
-
-        result = sdg.addSdxRef(ref)
-        refs = sdg.getSdxRefs()
-        assert ref in refs
+        result = sdg.setSdgContentsType(contents)
+        assert sdg.getSdgContentsType() == contents
         assert result == sdg
+
+        sdg.setSdgContentsType(None)
+        assert sdg.getSdgContentsType() == contents
+
+
+class TestSdgContents:
+    """Test class for SdgContents class."""
+
+    def test_initialization(self):
+        contents = SdgContents()
+        assert contents.getSds() == []
+        assert contents.getSdfs() == []
+        assert contents.getSdgs() == []
+        assert contents.getSdxRefs() == []
+        assert contents.getSdxfRefs() == []
+
+    def test_sd_methods(self):
+        contents = SdgContents()
+        sd_item = Sd()
+        assert contents.addSd(sd_item) is contents
+        assert contents.getSds() == [sd_item]
+        contents.addSd(None)
+        assert contents.getSds() == [sd_item]
+
+    def test_sdf_methods(self):
+        contents = SdgContents()
+        sdf_item = Sdf()
+        assert contents.addSdf(sdf_item) is contents
+        assert contents.getSdfs() == [sdf_item]
+        contents.addSdf(None)
+        assert contents.getSdfs() == [sdf_item]
+
+    def test_sdg_methods(self):
+        contents = SdgContents()
+        sdg_item = Sdg()
+        assert contents.addSdg(sdg_item) is contents
+        assert contents.getSdgs() == [sdg_item]
+        contents.addSdg(None)
+        assert contents.getSdgs() == [sdg_item]
+
+    def test_sdx_refs_methods(self):
+        contents = SdgContents()
+        ref = RefType()
+        assert contents.addSdxRef(ref) is contents
+        assert contents.getSdxRefs() == [ref]
+        contents.addSdxRef(None)
+        assert contents.getSdxRefs() == [ref]
+
+    def test_sdxf_refs_methods(self):
+        contents = SdgContents()
+        ref = RefType()
+        assert contents.addSdxfRef(ref) is contents
+        assert contents.getSdxfRefs() == [ref]
+        contents.addSdxfRef(None)
+        assert contents.getSdxfRefs() == [ref]
+
+
+class TestSdf:
+    """Test class for Sdf class."""
+
+    def test_initialization(self):
+        sdf = Sdf()
+        assert sdf.getGID() is None
+        assert sdf.getValue() is None
+
+    def test_gid_methods(self):
+        sdf = Sdf()
+        gid_value = NameToken().setValue("test_gid")
+        assert sdf.setGID(gid_value) is sdf
+        assert sdf.getGID() == gid_value
+        sdf.setGID(None)
+        assert sdf.getGID() == gid_value
+
+    def test_value_methods(self):
+        sdf = Sdf()
+        value = Numerical().setValue("42")
+        assert sdf.setValue(value) is sdf
+        assert sdf.getValue() == value
+        sdf.setValue(None)
+        assert sdf.getValue() == value

--- a/tests/test_armodel/models/M2/MSR/Documentation/TextModel/test_MultilanguageData.py
+++ b/tests/test_armodel/models/M2/MSR/Documentation/TextModel/test_MultilanguageData.py
@@ -54,6 +54,9 @@ class TestMultiLanguageOverviewParagraph:
         assert l_overview_paragraph in l2s
         assert result == multi_lang_overview_paragraph
 
+        multi_lang_overview_paragraph.addL2(None)
+        assert multi_lang_overview_paragraph.getL2s() == [l_overview_paragraph]
+
 
 class TestMultilanguageLongName:
     """Test class for MultilanguageLongName class."""

--- a/tests/test_armodel/parser/data/VariationPoint.arxml
+++ b/tests/test_armodel/parser/data/VariationPoint.arxml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_4-2-2.xsd">
+  <AR-PACKAGES>
+    <AR-PACKAGE>
+      <SHORT-NAME>Demo</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE>
+          <SHORT-NAME>SystemConstants</SHORT-NAME>
+          <ELEMENTS>
+            <SW-SYSTEMCONST>
+              <SHORT-NAME>SY_TURBO</SHORT-NAME>
+            </SW-SYSTEMCONST>
+          </ELEMENTS>
+        </AR-PACKAGE>
+        <AR-PACKAGE>
+          <SHORT-NAME>Criterions</SHORT-NAME>
+          <ELEMENTS>
+            <POST-BUILD-VARIANT-CRITERION>
+              <SHORT-NAME>Country</SHORT-NAME>
+              <VARIATION-POINT>
+                <SHORT-LABEL>VP_Country</SHORT-LABEL>
+              </VARIATION-POINT>
+            </POST-BUILD-VARIANT-CRITERION>
+          </ELEMENTS>
+        </AR-PACKAGE>
+        <AR-PACKAGE>
+          <SHORT-NAME>SwComponents</SHORT-NAME>
+          <ELEMENTS>
+            <APPLICATION-SW-COMPONENT-TYPE>
+              <SHORT-NAME>MySWC</SHORT-NAME>
+              <INTERNAL-BEHAVIORS>
+                <SWC-INTERNAL-BEHAVIOR>
+                  <SHORT-NAME>Ib_MySWC</SHORT-NAME>
+                  <RUNNABLES>
+                    <RUNNABLE-ENTITY>
+                      <SHORT-NAME>Run2</SHORT-NAME>
+                    </RUNNABLE-ENTITY>
+                  </RUNNABLES>
+                  <VARIATION-POINT>
+                    <SHORT-LABEL>VP1</SHORT-LABEL>
+                    <SW-SYSCOND BINDING-TIME="CODE-GENERATION-TIME">defined(<SYSC-REF DEST="SW-SYSTEMCONST">/Demo/SystemConstants/SY_TURBO</SYSC-REF>) &amp;&amp; <SYSC-REF DEST="SW-SYSTEMCONST">/Demo/SystemConstants/SY_TURBO</SYSC-REF> == 0</SW-SYSCOND>
+                    <POST-BUILD-VARIANT-CONDITIONS>
+                      <POST-BUILD-VARIANT-CONDITION>
+                        <MATCHING-CRITERION-REF DEST="POST-BUILD-VARIANT-CRITERION">/Demo/Criterions/Country</MATCHING-CRITERION-REF>
+                        <VALUE>1</VALUE>
+                      </POST-BUILD-VARIANT-CONDITION>
+                    </POST-BUILD-VARIANT-CONDITIONS>
+                  </VARIATION-POINT>
+                </SWC-INTERNAL-BEHAVIOR>
+              </INTERNAL-BEHAVIORS>
+            </APPLICATION-SW-COMPONENT-TYPE>
+          </ELEMENTS>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>

--- a/tests/test_armodel/parser/test_arxml_parser_internals.py
+++ b/tests/test_armodel/parser/test_arxml_parser_internals.py
@@ -24,6 +24,7 @@ from armodel.models import (
     MlFigure,
     RunnableEntity,
     Sdg,
+    SdgContents,
     SwDataDefProps,
 )
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
@@ -697,18 +698,20 @@ class TestSdgDeepHandlers:
             "<SD GID='key1'>value1</SD>",
             root_tag="SDG",
         )
-        sdg = Sdg()
-        parser.readSd(element, sdg)
-        assert len(sdg.getSds()) == 1
+        contents = SdgContents()
+        parser.readSd(element, contents)
+        assert len(contents.getSds()) == 1
+        assert contents.getSds()[0].getGID().getValue() == "key1"
+        assert contents.getSds()[0].getValue().getValue() == "value1"
 
     def test_readSd_multiple(self, parser):
         element = _snip(
             "<SD GID='key1'>value1</SD>" "<SD GID='key2'>value2</SD>",
             root_tag="SDG",
         )
-        sdg = Sdg()
-        parser.readSd(element, sdg)
-        assert len(sdg.getSds()) == 2
+        contents = SdgContents()
+        parser.readSd(element, contents)
+        assert len(contents.getSds()) == 2
 
     def test_readSdgCaption(self, parser):
         element = _snip(
@@ -724,9 +727,9 @@ class TestSdgDeepHandlers:
             "<SDX-REF DEST='ELEMENT'>/path/ref1</SDX-REF>" "<SDX-REF DEST='ELEMENT'>/path/ref2</SDX-REF>",
             root_tag="SDG",
         )
-        sdg = Sdg()
-        parser.readSdgSdxRefs(element, sdg)
-        assert len(sdg.getSdxRefs()) == 2
+        contents = SdgContents()
+        parser.readSdgSdxRefs(element, contents)
+        assert len(contents.getSdxRefs()) == 2
 
     def test_getSdg_with_gid(self, parser):
         element = _snip(
@@ -735,7 +738,7 @@ class TestSdgDeepHandlers:
         )
         element.attrib["GID"] = "MyGroup"
         sdg = parser.getSdg(element)
-        assert sdg.getGID() == "MyGroup"
+        assert sdg.getGID().getValue() == "MyGroup"
 
     def test_readAdminDataSdgs_nested_sdg(self, parser):
         element = _snip(
@@ -745,7 +748,7 @@ class TestSdgDeepHandlers:
         parser.readAdminDataSdgs(element, admin)
         sdgs = admin.getSdgs()
         assert len(sdgs) == 1
-        assert len(sdgs[0].getSdgContentsTypes()) == 1
+        assert len(sdgs[0].getSdgContentsType().getSdgs()) == 1
 
 
 # ==================== Describable Handlers ====================

--- a/tests/test_armodel/parser/test_arxml_parser_variation_point.py
+++ b/tests/test_armodel/parser/test_arxml_parser_variation_point.py
@@ -37,13 +37,13 @@ class TestReadVariationPoint:
         inner = (
             "<VARIATION-POINT>"
             "<SHORT-LABEL>VP_Turbo</SHORT-LABEL>"
-            "<SW-SYSCOND BINDING-TIME=\"CODE-GENERATION-TIME\">"
-            "defined(<SYSC-REF DEST=\"SW-SYSTEMCONST\">/Demo/SystemConstants/SY_TURBO</SYSC-REF>)"
-            " &amp;&amp; <SYSC-STRING-REF DEST=\"SW-SYSTEMCONST\">/Demo/SystemConstants/SY_MODE</SYSC-STRING-REF> == 0"
+            '<SW-SYSCOND BINDING-TIME="CODE-GENERATION-TIME">'
+            'defined(<SYSC-REF DEST="SW-SYSTEMCONST">/Demo/SystemConstants/SY_TURBO</SYSC-REF>)'
+            ' &amp;&amp; <SYSC-STRING-REF DEST="SW-SYSTEMCONST">/Demo/SystemConstants/SY_MODE</SYSC-STRING-REF> == 0'
             "</SW-SYSCOND>"
             "<POST-BUILD-VARIANT-CONDITIONS>"
             "<POST-BUILD-VARIANT-CONDITION>"
-            "<MATCHING-CRITERION-REF DEST=\"POST-BUILD-VARIANT-CRITERION\">/Demo/Criterions/Country</MATCHING-CRITERION-REF>"
+            '<MATCHING-CRITERION-REF DEST="POST-BUILD-VARIANT-CRITERION">/Demo/Criterions/Country</MATCHING-CRITERION-REF>'
             "<VALUE>1</VALUE>"
             "</POST-BUILD-VARIANT-CONDITION>"
             "</POST-BUILD-VARIANT-CONDITIONS>"
@@ -79,7 +79,7 @@ class TestReadVariationPoint:
         inner = (
             "<POST-BUILD-VARIANT-CRITERION>"
             "<SHORT-NAME>Country</SHORT-NAME>"
-            "<COMPU-METHOD-REF DEST=\"COMPU-METHOD\">/Demo/CompuMethods/CountryEnum</COMPU-METHOD-REF>"
+            '<COMPU-METHOD-REF DEST="COMPU-METHOD">/Demo/CompuMethods/CountryEnum</COMPU-METHOD-REF>'
             "<VARIATION-POINT><SHORT-LABEL>VP_Country</SHORT-LABEL></VARIATION-POINT>"
             "</POST-BUILD-VARIANT-CRITERION>"
         )

--- a/tests/test_armodel/parser/test_arxml_parser_variation_point.py
+++ b/tests/test_armodel/parser/test_arxml_parser_variation_point.py
@@ -1,7 +1,6 @@
 """Parser tests for the structural VARIATION-POINT element."""
 
 import os
-import xml.etree.ElementTree as ET
 
 import pytest
 
@@ -56,15 +55,6 @@ class TestReadVariationPoint:
         sw_syscond = vp.getSwSyscond()
         assert isinstance(sw_syscond, ConditionByFormula)
         assert sw_syscond.getBindingTime().getValue() == "codeGenerationTime"
-        items = sw_syscond.getFormulaItems()
-        assert items[0] == "defined("
-        assert items[1][0] == "SYSC-REF"
-        assert items[1][1].getValue() == "/Demo/SystemConstants/SY_TURBO"
-        assert items[1][1].getDest() == "SW-SYSTEMCONST"
-        assert items[2] == ") && "
-        assert items[3][0] == "SYSC-STRING-REF"
-        assert items[3][1].getValue() == "/Demo/SystemConstants/SY_MODE"
-        assert items[4] == " == 0"
 
         conditions = vp.getPostBuildVariantConditions()
         assert len(conditions) == 1
@@ -108,9 +98,7 @@ class TestVariationPointRoundTrip:
         vp = behavior.getVariationPoint()
         assert vp is not None
         assert vp.getShortLabel().getValue() == "VP1"
-        items = vp.getSwSyscond().getFormulaItems()
-        assert items[0] == "defined("
-        assert items[1][1].getValue() == "/Demo/SystemConstants/SY_TURBO"
+        assert vp.getSwSyscond().getBindingTime().getValue() == "codeGenerationTime"
         conditions = vp.getPostBuildVariantConditions()
         assert conditions[0].getMatchingCriterionRef().getValue() == "/Demo/Criterions/Country"
 
@@ -130,11 +118,7 @@ class TestVariationPointRoundTrip:
         vp2 = behavior2.getVariationPoint()
         assert vp2 is not None
         assert vp2.getShortLabel().getValue() == "VP1"
-        items2 = vp2.getSwSyscond().getFormulaItems()
-        assert items2[0] == items[0]
-        assert items2[1][0] == items[1][0]
-        assert items2[1][1].getValue() == items[1][1].getValue()
-        assert items2[1][1].getDest() == items[1][1].getDest()
+        assert vp2.getSwSyscond().getBindingTime().getValue() == "codeGenerationTime"
         conditions2 = vp2.getPostBuildVariantConditions()
         assert conditions2[0].getMatchingCriterionRef().getValue() == "/Demo/Criterions/Country"
         assert conditions2[0].getValue().getValue() == 1

--- a/tests/test_armodel/parser/test_arxml_parser_variation_point.py
+++ b/tests/test_armodel/parser/test_arxml_parser_variation_point.py
@@ -1,16 +1,24 @@
 """Parser tests for the structural VARIATION-POINT element."""
 
+import os
 import xml.etree.ElementTree as ET
 
+import pytest
+
+from armodel.models import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
     ConditionByFormula,
     PostBuildVariantCondition,
     PostBuildVariantCriterion,
     VariationPoint,
 )
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
 from tests.test_armodel.parser._helpers import _snip
 
 NS = "http://autosar.org/schema/r4.0"
+
+VARIATION_POINT_ARXML = os.path.join(os.path.dirname(__file__), "data", "VariationPoint.arxml")
 
 
 class TestReadVariationPoint:
@@ -83,3 +91,54 @@ class TestReadVariationPoint:
         vp = criterion.getVariationPoint()
         assert vp is not None
         assert vp.getShortLabel().getValue() == "VP_Country"
+
+
+@pytest.mark.integration
+class TestVariationPointRoundTrip:
+    def test_parse_write_reparse_preserves_variation_point(self, tmp_path):
+        document = AUTOSAR.getInstance()
+        document.new()
+        document.setARRelease("R23-11")
+        parser = ARXMLParser()
+        parser.load(VARIATION_POINT_ARXML, document)
+
+        swc = document.find("/Demo/SwComponents/MySWC")
+        behavior = swc.getInternalBehavior()
+
+        vp = behavior.getVariationPoint()
+        assert vp is not None
+        assert vp.getShortLabel().getValue() == "VP1"
+        items = vp.getSwSyscond().getFormulaItems()
+        assert items[0] == "defined("
+        assert items[1][1].getValue() == "/Demo/SystemConstants/SY_TURBO"
+        conditions = vp.getPostBuildVariantConditions()
+        assert conditions[0].getMatchingCriterionRef().getValue() == "/Demo/Criterions/Country"
+
+        output = str(tmp_path / "VariationPoint_roundtrip.arxml")
+        writer = ARXMLWriter()
+        writer.save(output, document)
+
+        document2 = AUTOSAR.getInstance()
+        document2.new()
+        document2.setARRelease("R23-11")
+        parser2 = ARXMLParser()
+        parser2.load(output, document2)
+
+        swc2 = document2.find("/Demo/SwComponents/MySWC")
+        behavior2 = swc2.getInternalBehavior()
+
+        vp2 = behavior2.getVariationPoint()
+        assert vp2 is not None
+        assert vp2.getShortLabel().getValue() == "VP1"
+        items2 = vp2.getSwSyscond().getFormulaItems()
+        assert items2[0] == items[0]
+        assert items2[1][0] == items[1][0]
+        assert items2[1][1].getValue() == items[1][1].getValue()
+        assert items2[1][1].getDest() == items[1][1].getDest()
+        conditions2 = vp2.getPostBuildVariantConditions()
+        assert conditions2[0].getMatchingCriterionRef().getValue() == "/Demo/Criterions/Country"
+        assert conditions2[0].getValue().getValue() == 1
+
+        # Criterion element's own variation point also survives
+        criterion2 = document2.find("/Demo/Criterions/Country")
+        assert criterion2.getVariationPoint().getShortLabel().getValue() == "VP_Country"

--- a/tests/test_armodel/parser/test_arxml_parser_variation_point.py
+++ b/tests/test_armodel/parser/test_arxml_parser_variation_point.py
@@ -1,0 +1,85 @@
+"""Parser tests for the structural VARIATION-POINT element."""
+
+import xml.etree.ElementTree as ET
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
+    ConditionByFormula,
+    PostBuildVariantCondition,
+    PostBuildVariantCriterion,
+    VariationPoint,
+)
+from tests.test_armodel.parser._helpers import _snip
+
+NS = "http://autosar.org/schema/r4.0"
+
+
+class TestReadVariationPoint:
+    def test_read_variation_point_minimal(self, parser):
+        element = _snip("<VARIATION-POINT><SHORT-LABEL>VP1</SHORT-LABEL></VARIATION-POINT>")
+        vp_element = element.find("{%s}VARIATION-POINT" % NS)
+
+        vp = parser.readVariationPoint(vp_element, VariationPoint())
+
+        assert vp is not None
+        assert vp.getShortLabel().getValue() == "VP1"
+        assert vp.getSwSyscond() is None
+        assert vp.getPostBuildVariantConditions() == []
+
+    def test_read_variation_point_full(self, parser):
+        inner = (
+            "<VARIATION-POINT>"
+            "<SHORT-LABEL>VP_Turbo</SHORT-LABEL>"
+            "<SW-SYSCOND BINDING-TIME=\"CODE-GENERATION-TIME\">"
+            "defined(<SYSC-REF DEST=\"SW-SYSTEMCONST\">/Demo/SystemConstants/SY_TURBO</SYSC-REF>)"
+            " &amp;&amp; <SYSC-STRING-REF DEST=\"SW-SYSTEMCONST\">/Demo/SystemConstants/SY_MODE</SYSC-STRING-REF> == 0"
+            "</SW-SYSCOND>"
+            "<POST-BUILD-VARIANT-CONDITIONS>"
+            "<POST-BUILD-VARIANT-CONDITION>"
+            "<MATCHING-CRITERION-REF DEST=\"POST-BUILD-VARIANT-CRITERION\">/Demo/Criterions/Country</MATCHING-CRITERION-REF>"
+            "<VALUE>1</VALUE>"
+            "</POST-BUILD-VARIANT-CONDITION>"
+            "</POST-BUILD-VARIANT-CONDITIONS>"
+            "</VARIATION-POINT>"
+        )
+        vp_element = _snip(inner).find("{%s}VARIATION-POINT" % NS)
+
+        vp = parser.readVariationPoint(vp_element, VariationPoint())
+
+        sw_syscond = vp.getSwSyscond()
+        assert isinstance(sw_syscond, ConditionByFormula)
+        assert sw_syscond.getBindingTime().getValue() == "codeGenerationTime"
+        items = sw_syscond.getFormulaItems()
+        assert items[0] == "defined("
+        assert items[1][0] == "SYSC-REF"
+        assert items[1][1].getValue() == "/Demo/SystemConstants/SY_TURBO"
+        assert items[1][1].getDest() == "SW-SYSTEMCONST"
+        assert items[2] == ") && "
+        assert items[3][0] == "SYSC-STRING-REF"
+        assert items[3][1].getValue() == "/Demo/SystemConstants/SY_MODE"
+        assert items[4] == " == 0"
+
+        conditions = vp.getPostBuildVariantConditions()
+        assert len(conditions) == 1
+        assert isinstance(conditions[0], PostBuildVariantCondition)
+        assert conditions[0].getMatchingCriterionRef().getValue() == "/Demo/Criterions/Country"
+        assert conditions[0].getMatchingCriterionRef().getDest() == "POST-BUILD-VARIANT-CRITERION"
+        assert conditions[0].getValue().getValue() == 1
+
+    def test_read_identifiable_picks_up_variation_point(self, parser):
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage
+
+        inner = (
+            "<POST-BUILD-VARIANT-CRITERION>"
+            "<SHORT-NAME>Country</SHORT-NAME>"
+            "<COMPU-METHOD-REF DEST=\"COMPU-METHOD\">/Demo/CompuMethods/CountryEnum</COMPU-METHOD-REF>"
+            "<VARIATION-POINT><SHORT-LABEL>VP_Country</SHORT-LABEL></VARIATION-POINT>"
+            "</POST-BUILD-VARIANT-CRITERION>"
+        )
+        element = _snip(inner).find("{%s}POST-BUILD-VARIANT-CRITERION" % NS)
+
+        criterion = PostBuildVariantCriterion(ARPackage(None, "Pkg"), "Country")
+        parser.readIdentifiable(element, criterion)
+
+        vp = criterion.getVariationPoint()
+        assert vp is not None
+        assert vp.getShortLabel().getValue() == "VP_Country"

--- a/tests/test_armodel/writer/test_arxml_writer.py
+++ b/tests/test_armodel/writer/test_arxml_writer.py
@@ -7,12 +7,22 @@ import xml.etree.cElementTree as ET
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import ConstantReference, NumericalValueSpecification, TextValueSpecification
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Referrable, ShortNameFragment
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARFloat, ARLiteral, DateTime, Identifier, Limit, RefType, RevisionLabelString
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    ARFloat,
+    ARLiteral,
+    DateTime,
+    Identifier,
+    Limit,
+    NameToken,
+    RefType,
+    RevisionLabelString,
+    VerbatimStringPlain,
+)
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
     SwSystemconstValue,
 )
 from armodel.models.M2.MSR.AsamHdo.AdminData import AdminData, DocRevision, Modification
-from armodel.models.M2.MSR.AsamHdo.SpecialData import Sd, Sdg
+from armodel.models.M2.MSR.AsamHdo.SpecialData import Sd, Sdg, SdgContents
 from armodel.models.M2.MSR.DataDictionary.CalibrationParameter import SwCalprmAxisSet
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation
@@ -117,13 +127,13 @@ class TestARXMLWriterSdgMethods:
         writer = ARXMLWriter()
         parent = ET.Element("parent")
 
-        sdg = Sdg()
+        contents = SdgContents()
         sd = Sd()
-        sd.value = "test value"
-        sd.gid = "test-gid"
-        sdg.addSd(sd)
+        sd.setValue(VerbatimStringPlain().setValue("test value"))
+        sd.setGID(NameToken().setValue("test-gid"))
+        contents.addSd(sd)
 
-        writer.writeSds(parent, sdg)
+        writer.writeSds(parent, contents)
 
         assert len(parent) == 1
         sd_tag = parent[0]
@@ -136,15 +146,15 @@ class TestARXMLWriterSdgMethods:
         writer = ARXMLWriter()
         parent = ET.Element("parent")
 
-        sdg = Sdg()
+        contents = SdgContents()
         sd1 = Sd()
-        sd1.value = "value1"
+        sd1.setValue(VerbatimStringPlain().setValue("value1"))
         sd2 = Sd()
-        sd2.value = "value2"
-        sdg.addSd(sd1)
-        sdg.addSd(sd2)
+        sd2.setValue(VerbatimStringPlain().setValue("value2"))
+        contents.addSd(sd1)
+        contents.addSd(sd2)
 
-        writer.writeSds(parent, sdg)
+        writer.writeSds(parent, contents)
 
         assert len(parent) == 2
         assert parent[0].text == "value1"
@@ -169,12 +179,12 @@ class TestARXMLWriterSdgMethods:
         writer = ARXMLWriter()
         parent = ET.Element("parent")
 
-        sdg = Sdg()
+        contents = SdgContents()
         ref = RefType()
         ref.value = "/path/to/ref"
-        sdg.sdxRefs = [ref]
+        contents.addSdxRef(ref)
 
-        writer.writeSdgSdxRefs(parent, sdg)
+        writer.writeSdgSdxRefs(parent, contents)
 
         assert len(parent) == 1
         ref_tag = parent[0]
@@ -187,10 +197,12 @@ class TestARXMLWriterSdgMethods:
         parent = ET.Element("parent")
 
         sdg = Sdg()
-        sdg.gid = "test-gid"
+        sdg.setGID(NameToken().setValue("test-gid"))
         sd = Sd()
-        sd.value = "test value"
-        sdg.addSd(sd)
+        sd.setValue(VerbatimStringPlain().setValue("test value"))
+        contents = SdgContents()
+        contents.addSd(sd)
+        sdg.setSdgContentsType(contents)
 
         writer.setSdg(parent, sdg)
 
@@ -214,10 +226,11 @@ class TestARXMLWriterSdgMethods:
         parent = ET.Element("parent")
 
         sdg = Sdg()
-        sdg.gid = ""
         sd = Sd()
-        sd.value = "test value"
-        sdg.addSd(sd)
+        sd.setValue(VerbatimStringPlain().setValue("test value"))
+        contents = SdgContents()
+        contents.addSd(sd)
+        sdg.setSdgContentsType(contents)
 
         writer.setSdg(parent, sdg)
 
@@ -233,8 +246,10 @@ class TestARXMLWriterSdgMethods:
         admin_data = AdminData()
         sdg = Sdg()
         sd = Sd()
-        sd.value = "test value"
-        sdg.addSd(sd)
+        sd.setValue(VerbatimStringPlain().setValue("test value"))
+        contents = SdgContents()
+        contents.addSd(sd)
+        sdg.setSdgContentsType(contents)
         admin_data.addSdg(sdg)
 
         writer.writeAdminDataSdgs(parent, admin_data)

--- a/tests/test_armodel/writer/test_writer_common_structure.py
+++ b/tests/test_armodel/writer/test_writer_common_structure.py
@@ -21,8 +21,10 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa: E501
     ARLiteral,
     DateTime,
+    NameToken,
     RefType,
     RevisionLabelString,
+    VerbatimStringPlain,
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import (
     ModeDeclarationMapping,
@@ -33,7 +35,7 @@ from armodel.models.M2.MSR.AsamHdo.AdminData import (
     DocRevision,
     Modification,
 )
-from armodel.models.M2.MSR.AsamHdo.SpecialData import Sd, Sdg, SdgCaption
+from armodel.models.M2.MSR.AsamHdo.SpecialData import Sd, Sdg, SdgCaption, SdgContents
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation
 from armodel.models.M2.MSR.Documentation.BlockElements import Caption
 from armodel.models.M2.MSR.Documentation.BlockElements.Figure import (
@@ -107,12 +109,12 @@ class TestSetShortName:
 class TestWriteSds:
     def test_single_sd_with_gid(self, writer):
         parent = _parent()
-        sdg = Sdg()
+        contents = SdgContents()
         sd = Sd()
-        sd.value = "val"
-        sd.gid = "g1"
-        sdg.addSd(sd)
-        writer.writeSds(parent, sdg)
+        sd.setValue(VerbatimStringPlain().setValue("val"))
+        sd.setGID(NameToken().setValue("g1"))
+        contents.addSd(sd)
+        writer.writeSds(parent, contents)
         assert len(parent) == 1
         assert parent[0].tag == "SD"
         assert parent[0].text == "val"
@@ -120,25 +122,24 @@ class TestWriteSds:
 
     def test_multiple_sds(self, writer):
         parent = _parent()
-        sdg = Sdg()
+        contents = SdgContents()
         sd1 = Sd()
-        sd1.value = "v1"
+        sd1.setValue(VerbatimStringPlain().setValue("v1"))
         sd2 = Sd()
-        sd2.value = "v2"
-        sdg.addSd(sd1).addSd(sd2)
-        writer.writeSds(parent, sdg)
+        sd2.setValue(VerbatimStringPlain().setValue("v2"))
+        contents.addSd(sd1).addSd(sd2)
+        writer.writeSds(parent, contents)
         assert len(parent) == 2
         assert parent[0].text == "v1"
         assert parent[1].text == "v2"
 
     def test_sd_without_gid(self, writer):
         parent = _parent()
-        sdg = Sdg()
+        contents = SdgContents()
         sd = Sd()
-        sd.value = "val"
-        sd.gid = None
-        sdg.addSd(sd)
-        writer.writeSds(parent, sdg)
+        sd.setValue(VerbatimStringPlain().setValue("val"))
+        contents.addSd(sd)
+        writer.writeSds(parent, contents)
         assert "GID" not in parent[0].attrib
 
 
@@ -164,12 +165,12 @@ class TestWriteSdgCaption:
 class TestWriteSdgSdxRefs:
     def test_with_refs(self, writer):
         parent = _parent()
-        sdg = Sdg()
+        contents = SdgContents()
         ref = RefType()
         ref.value = "/path"
         ref.dest = "ELEMENT"
-        sdg.addSdxRef(ref)
-        writer.writeSdgSdxRefs(parent, sdg)
+        contents.addSdxRef(ref)
+        writer.writeSdgSdxRefs(parent, contents)
         assert len(parent) == 1
         assert parent[0].tag == "SDX-REF"
         assert parent[0].text == "/path"
@@ -177,8 +178,8 @@ class TestWriteSdgSdxRefs:
 
     def test_without_refs(self, writer):
         parent = _parent()
-        sdg = Sdg()
-        writer.writeSdgSdxRefs(parent, sdg)
+        contents = SdgContents()
+        writer.writeSdgSdxRefs(parent, contents)
         assert len(parent) == 0
 
 
@@ -186,10 +187,12 @@ class TestSetSdg:
     def test_basic_with_gid(self, writer):
         parent = _parent()
         sdg = Sdg()
-        sdg.gid = "gid1"
+        sdg.setGID(NameToken().setValue("gid1"))
         sd = Sd()
-        sd.value = "v"
-        sdg.addSd(sd)
+        sd.setValue(VerbatimStringPlain().setValue("v"))
+        contents = SdgContents()
+        contents.addSd(sd)
+        sdg.setSdgContentsType(contents)
         writer.setSdg(parent, sdg)
         assert parent[0].tag == "SDG"
         assert parent[0].attrib["GID"] == "gid1"
@@ -202,20 +205,21 @@ class TestSetSdg:
         writer.setSdg(parent, None)
         assert len(parent) == 0
 
-    def test_empty_gid_not_written(self, writer):
+    def test_no_gid_not_written(self, writer):
         parent = _parent()
         sdg = Sdg()
-        sdg.gid = ""
         writer.setSdg(parent, sdg)
         assert "GID" not in parent[0].attrib
 
     def test_nested_sdg_contents(self, writer):
         parent = _parent()
         sdg = Sdg()
-        sdg.gid = "outer"
+        sdg.setGID(NameToken().setValue("outer"))
         inner = Sdg()
-        inner.gid = "inner"
-        sdg.addSdgContentsType(inner)
+        inner.setGID(NameToken().setValue("inner"))
+        contents = SdgContents()
+        contents.addSdg(inner)
+        sdg.setSdgContentsType(contents)
         writer.setSdg(parent, sdg)
         outer = parent[0]
         assert outer.tag == "SDG"
@@ -226,11 +230,13 @@ class TestSetSdg:
     def test_sdg_with_caption_and_sdx(self, writer):
         parent = _parent()
         sdg = Sdg()
-        sdg.gid = "g"
+        sdg.setGID(NameToken().setValue("g"))
         sdg.createSdgCaption("Cap")
         ref = RefType()
         ref.value = "/r"
-        sdg.addSdxRef(ref)
+        contents = SdgContents()
+        contents.addSdxRef(ref)
+        sdg.setSdgContentsType(contents)
         writer.setSdg(parent, sdg)
         sdg_tag = parent[0]
         assert sdg_tag.find("SDG-CAPTION") is not None
@@ -242,7 +248,7 @@ class TestWriteAdminDataSdgs:
         parent = _parent()
         admin = AdminData()
         sdg = Sdg()
-        sdg.gid = "g"
+        sdg.setGID(NameToken().setValue("g"))
         admin.addSdg(sdg)
         writer.writeAdminDataSdgs(parent, admin)
         assert parent[0].tag == "SDGS"

--- a/tests/test_armodel/writer/test_writer_variation_point.py
+++ b/tests/test_armodel/writer/test_writer_variation_point.py
@@ -51,9 +51,6 @@ class TestWriteVariationPoint:
 
         syscond = ConditionByFormula()
         syscond.setBindingTime(BindingTimeEnum().setValue("codeGenerationTime"))
-        syscond.addFormulaText("defined(")
-        syscond.addFormulaRef(RefType().setValue("/Demo/SystemConstants/SY_TURBO").setDest("SW-SYSTEMCONST"))
-        syscond.addFormulaText(")")
         vp.setSwSyscond(syscond)
 
         condition = PostBuildVariantCondition()
@@ -80,12 +77,6 @@ class TestWriteVariationPoint:
         syscond_element = vp_element.find("SW-SYSCOND")
         assert syscond_element is not None
         assert syscond_element.attrib["BINDING-TIME"] == "CODE-GENERATION-TIME"
-        assert syscond_element.text == "defined("
-        refs = syscond_element.findall("SYSC-REF")
-        assert len(refs) == 1
-        assert refs[0].attrib["DEST"] == "SW-SYSTEMCONST"
-        assert refs[0].text == "/Demo/SystemConstants/SY_TURBO"
-        assert refs[0].tail == ")"
 
         conditions_wrapper = vp_element.find("POST-BUILD-VARIANT-CONDITIONS")
         condition_element = conditions_wrapper.find("POST-BUILD-VARIANT-CONDITION")

--- a/tests/test_armodel/writer/test_writer_variation_point.py
+++ b/tests/test_armodel/writer/test_writer_variation_point.py
@@ -1,0 +1,131 @@
+"""Writer tests for the structural VARIATION-POINT element."""
+
+import xml.etree.ElementTree as ET
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintGenerator.BlueprintGenerator import (
+    BlueprintGenerator,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Enumerations import (
+    BindingTimeEnum,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    Identifier,
+    Integer,
+    RefType,
+    VerbatimString,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
+    ConditionByFormula,
+    PostBuildVariantCondition,
+    PostBuildVariantCriterion,
+    VariationPoint,
+)
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+def _write_vp_to_element(vp: VariationPoint) -> ET.Element:
+    document = AUTOSAR.getInstance()
+    document.clear()
+    document.setARRelease("R23-11")
+    writer = ARXMLWriter()
+    element = ET.Element("PARENT")
+    writer.writeVariationPoint(element, vp)
+    return element
+
+
+class TestWriteVariationPoint:
+    def test_write_minimal(self):
+        vp = VariationPoint()
+        vp.setShortLabel(Identifier().setValue("VP1"))
+
+        element = _write_vp_to_element(vp)
+
+        vp_element = element.find("VARIATION-POINT")
+        assert vp_element is not None
+        assert vp_element.find("SHORT-LABEL").text == "VP1"
+
+    def test_write_full_roundtrip_content(self):
+        vp = VariationPoint()
+        vp.setShortLabel(Identifier().setValue("VP_Turbo"))
+
+        syscond = ConditionByFormula()
+        syscond.setBindingTime(BindingTimeEnum().setValue("codeGenerationTime"))
+        syscond.addFormulaText("defined(")
+        syscond.addFormulaRef(RefType().setValue("/Demo/SystemConstants/SY_TURBO").setDest("SW-SYSTEMCONST"))
+        syscond.addFormulaText(")")
+        vp.setSwSyscond(syscond)
+
+        condition = PostBuildVariantCondition()
+        condition.setMatchingCriterionRef(RefType().setValue("/Demo/Criterions/Country").setDest("POST-BUILD-VARIANT-CRITERION"))
+        condition.setValue(Integer().setValue("1"))
+        vp.addPostBuildVariantCondition(condition)
+
+        generator = BlueprintGenerator()
+        generator.setExpression(VerbatimString().setValue("LET Name = \"Example\";"))
+        vp.setFormalBlueprintGenerator(generator)
+
+        element = _write_vp_to_element(vp)
+
+        vp_element = element.find("VARIATION-POINT")
+
+        # XSD sequence order: SHORT-LABEL, DESC, BLUEPRINT-CONDITION,
+        # FORMAL-BLUEPRINT-GENERATOR, SW-SYSCOND, POST-BUILD-VARIANT-CONDITIONS, SDG
+        child_tags = [child.tag for child in vp_element]
+        assert child_tags.index("SHORT-LABEL") < child_tags.index("SW-SYSCOND")
+        assert child_tags.index("SW-SYSCOND") < child_tags.index("POST-BUILD-VARIANT-CONDITIONS")
+        assert child_tags.index("FORMAL-BLUEPRINT-GENERATOR") < child_tags.index("SW-SYSCOND")
+        assert vp_element.find("SHORT-LABEL").text == "VP_Turbo"
+
+        syscond_element = vp_element.find("SW-SYSCOND")
+        assert syscond_element is not None
+        assert syscond_element.attrib["BINDING-TIME"] == "CODE-GENERATION-TIME"
+        assert syscond_element.text == "defined("
+        refs = syscond_element.findall("SYSC-REF")
+        assert len(refs) == 1
+        assert refs[0].attrib["DEST"] == "SW-SYSTEMCONST"
+        assert refs[0].text == "/Demo/SystemConstants/SY_TURBO"
+        assert refs[0].tail == ")"
+
+        conditions_wrapper = vp_element.find("POST-BUILD-VARIANT-CONDITIONS")
+        condition_element = conditions_wrapper.find("POST-BUILD-VARIANT-CONDITION")
+        ref_element = condition_element.find("MATCHING-CRITERION-REF")
+        assert ref_element.text == "/Demo/Criterions/Country"
+        assert ref_element.attrib["DEST"] == "POST-BUILD-VARIANT-CRITERION"
+        assert condition_element.find("VALUE").text == "1"
+
+        # XSD BLUEPRINT-GENERATOR sequence: INTRODUCTION before EXPRESSION
+        formal = vp_element.find("FORMAL-BLUEPRINT-GENERATOR")
+        formal_tags = [child.tag for child in formal]
+        assert formal_tags == ["EXPRESSION"]
+        assert formal.find("EXPRESSION").text == "LET Name = \"Example\";"
+
+    def test_write_none_creates_no_element(self):
+        vp = None
+
+        document = AUTOSAR.getInstance()
+        document.clear()
+        document.setARRelease("R23-11")
+        writer = ARXMLWriter()
+        element = ET.Element("PARENT")
+        writer.writeVariationPoint(element, vp)
+
+        assert element.find("VARIATION-POINT") is None
+
+    def test_write_identifiable_emits_variation_point(self):
+        document = AUTOSAR.getInstance()
+        document.clear()
+        document.setARRelease("R23-11")
+
+        criterion = PostBuildVariantCriterion(document, "Country")
+        vp = VariationPoint()
+        vp.setShortLabel(Identifier().setValue("VP_Country"))
+        criterion.setVariationPoint(vp)
+
+        writer = ARXMLWriter()
+        element = ET.Element("POST-BUILD-VARIANT-CRITERION")
+        writer.writeIdentifiable(element, criterion)
+
+        vp_element = element.find("VARIATION-POINT")
+        assert vp_element is not None
+        assert vp_element.find("SHORT-LABEL").text == "VP_Country"

--- a/tests/test_armodel/writer/test_writer_variation_point.py
+++ b/tests/test_armodel/writer/test_writer_variation_point.py
@@ -62,7 +62,7 @@ class TestWriteVariationPoint:
         vp.addPostBuildVariantCondition(condition)
 
         generator = BlueprintGenerator()
-        generator.setExpression(VerbatimString().setValue("LET Name = \"Example\";"))
+        generator.setExpression(VerbatimString().setValue('LET Name = "Example";'))
         vp.setFormalBlueprintGenerator(generator)
 
         element = _write_vp_to_element(vp)
@@ -98,7 +98,7 @@ class TestWriteVariationPoint:
         formal = vp_element.find("FORMAL-BLUEPRINT-GENERATOR")
         formal_tags = [child.tag for child in formal]
         assert formal_tags == ["EXPRESSION"]
-        assert formal.find("EXPRESSION").text == "LET Name = \"Example\";"
+        assert formal.find("EXPRESSION").text == 'LET Name = "Example";'
 
     def test_write_none_creates_no_element(self):
         vp = None


### PR DESCRIPTION
Closes #618

## Summary

Sync the `VariationPoint` model class and its member-type closure to the AUTOSAR spec, stamping with `# Spec verified: R23-11`.

## Changes

- **VariationPoint** (GST Table 7.4): verbatim docstrings, spec-quirk fixes (`with in`), full reader/writer coverage, stamped
- **Member types synced/stamped**: MultiLanguageOverviewParagraph (9.90), BlueprintGenerator (E.12), PostBuildVariantCondition (7.6), ConditionByFormula (7.5 — removed non-spec `formulaItems` XSD content per review)
- **Sdg sub-closure**: Sd (4.22), Sdf (4.23, new), SdgContents (4.20, new), Sdg (4.19, rewritten from whole-class stub), SdgCaption (4.21); new primitives VerbatimStringPlain (4.68), Numerical (E.58), XmlSpaceEnum (XSD-only)
- Reader/writer rewritten for flattened SdgContents structure; real-fixture SDGS blocks round-trip losslessly

## Verification

- 6294 unit + 130 integration tests pass
- flake8, ruff-check, black-check clean