### PR TITLE
feat: sync mapping and receiver ComSpec classes to AUTOSAR spec

### DIFF
--- a/docs/examples/method_deviation_by_class.md
+++ b/docs/examples/method_deviation_by_class.md
@@ -1601,7 +1601,7 @@ tests, and reader/writer coverage. The aggregated Chapter family lives in
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| `textTableMappings` | `—` | `textTableMapping` | `TextTableMapping` | — | type (spec one vs py list) |
+| — *(no deviation)* | — | — | — | — | All 6 spec attributes implemented (`firstDataPrototypeRef`, `firstToSecondDataTransformationRef`, `secondDataPrototypeRef`, `secondToFirstDataTransformationRef`, `subElementMappings`, `textTableMappings` with mult `0..2` → list). Reader/writer coverage added (incl. `SUB-ELEMENT-MAPPINGS`/`TEXT-TABLE-MAPPINGS` wrappers). |
 
 ## `ModeDeclarationMapping`
 - **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 132
@@ -1610,33 +1610,25 @@ tests, and reader/writer coverage. The aggregated Chapter family lives in
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| `secondModeRef` | `—` | `secondModeRef` | `Ref (ModeDeclaration)` | Ref | type (spec one vs py list) |
+| — *(no deviation)* | — | — | — | — | `secondModeRef` is `Optional[RefType]` (spec mult `0..1`), `firstModeRefs` is `List[RefType]` (spec mult `*`). |
 
 ## `ReceiverComSpec`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 170
-- **Package:** `M2::AUTOSARTemplates::SWComponentTemplate::Communication`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Communication.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `dataUpdatePeriod` | `TimeValue` | — | missing |
-| — *(missing)* | `—` | `externalReplacementRef` | `Ref (AutosarDataPrototype)` | Ref | missing |
-| `compositeNetworkRepresentation` | `—` | `networkRepresentation` | `SwDataDefProps` | — | type (spec one vs py list) |
-| — *(missing)* | `—` | `receiverIntent` | `ReceiverIntentEnum` | — | missing |
-| — *(missing)* | `—` | `receptionProps` | `ReceptionComSpecProps` | — | missing |
-| — *(missing)* | `—` | `replaceWith` | `VariableAccess` | — | missing |
-| — *(missing)* | `—` | `syncCounterInit` | `PositiveInteger` | — | missing |
-| — *(missing)* | `—` | `transformationComSpecProps` | `EndToEndTransformationComSpecProps` | — | missing |
-
-## `NonqueuedReceiverComSpec`
 - **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 172
 - **Package:** `M2::AUTOSARTemplates::SWComponentTemplate::Communication`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Communication.py`
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| `enableUpdated` | `—` | `enableUpdate` | `Boolean` | — | naming |
-| `timeoutSubstitution` | `—` | `timeoutSubstitutionValue` | `ApplicationAssocMapValueSpecification` | — | naming |
+| — *(no deviation)* | — | — | — | — | All 12 spec attributes implemented (`compositeNetworkRepresentation` mult `*` → list; `dataElement`, `handleOutOfRange`, `handleOutOfRangeStatus`, `maxDeltaCounterInit`, `maxNoNewOrRepeatedData`, `networkRepresentation`, `receptionProps`, `replaceWith`, `syncCounterInit`, `transformationComSpecProps` mult `*` → list, `usesEndToEndProtection`). Reader/writer coverage complete. |
+
+## `NonqueuedReceiverComSpec`
+- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 173
+- **Package:** `M2::AUTOSARTemplates::SWComponentTemplate::Communication`
+- **Source:** `src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Communication.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| — *(no deviation)* | — | — | — | — | All 8 spec attributes implemented; `handleDataStatus` reader/writer coverage added. |
 
 ## `SenderComSpec`
 - **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 178

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Constants/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Constants/__init__.py
@@ -24,17 +24,15 @@ from armodel.models.M2.MSR.DataDictionary.DataDefProperties import ValueList
 
 class ValueSpecification(ARObject, ABC):
     """
-    Abstract base class for expressions leading to a value which can be used to initialize a data object.
-    This class serves as the base for all value specification types in AUTOSAR models.
-    Subclasses include AbstractRuleBasedValueSpecification, ApplicationValueSpecification, CompositeValueSpecification,
-    ConstantReference, NotAvailableValueSpecification, NumericalValueSpecification, ReferenceValueSpecification,
-    and TextValueSpecification.
+    Base class for expressions leading to a value which can be used to initialize a data object.
     """
 
     # ValueSpecification method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
-    # [x] getShortLabel                [x] impl  [x] docstring  [x] test
-    # [x] setShortLabel                [x] impl  [x] docstring  [x] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.109, p.433
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getShortLabel                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setShortLabel                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         """
@@ -46,7 +44,7 @@ class ValueSpecification(ARObject, ABC):
 
         super().__init__()
 
-        # Short label for this value specification
+        # The shortLabel of this ValueSpecification.
         self.shortLabel = None
 
     def getShortLabel(self):

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Filter.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Filter.py
@@ -51,26 +51,27 @@ class DataFilterTypeEnum(AREnum):
 
 class DataFilter(ARObject):
     """
-    Represents a data filter configuration in AUTOSAR models.
-    This class defines conditions and parameters for filtering data updates in AUTOSAR systems.
+    Base class for data filters. The type of the filter is specified in attribute dataFilterType. Some of the filter types require additional arguments which are specified as attributes of this class.
     """
 
     # DataFilter method parity checklist:
-    # [x] __init__                     [x] impl  [x] docstring  [x] test
-    # [x] getDataFilterType            [x] impl  [x] docstring  [x] test
-    # [x] setDataFilterType            [x] impl  [x] docstring  [x] test
-    # [x] getMask                      [x] impl  [x] docstring  [x] test
-    # [x] setMask                      [x] impl  [x] docstring  [x] test
-    # [x] getMax                       [x] impl  [x] docstring  [x] test
-    # [x] setMax                       [x] impl  [x] docstring  [x] test
-    # [x] getMin                       [x] impl  [x] docstring  [x] test
-    # [x] setMin                       [x] impl  [x] docstring  [x] test
-    # [x] getOffset                    [x] impl  [x] docstring  [x] test
-    # [x] setOffset                    [x] impl  [x] docstring  [x] test
-    # [x] getPeriod                    [x] impl  [x] docstring  [x] test
-    # [x] setPeriod                    [x] impl  [x] docstring  [x] test
-    # [x] getX                         [x] impl  [x] docstring  [x] test
-    # [x] setX                         [x] impl  [x] docstring  [x] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.75, p.182
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getDataFilterType            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDataFilterType            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMask                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMask                      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMax                       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMax                       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMin                       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMin                       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getOffset                    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setOffset                    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPeriod                    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setPeriod                    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getX                         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setX                         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         """

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Communication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Communication.py
@@ -6,16 +6,19 @@ and mode switching communications, as well as non-volatile and parameter communi
 """
 
 from abc import ABC
-from typing import List
+from typing import List, Optional
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Describable
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import ValueSpecification
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARNumerical, ARPositiveInteger, Boolean
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARPositiveInteger, Boolean
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger, TimeValue
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface.InstanceRefs import ApplicationCompositeElementInPortInterfaceInstanceRef
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.Filter import DataFilter
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.DataElements import VariableAccess
 
 
 class HandleInvalidEnum(AREnum):
@@ -53,13 +56,14 @@ class PPortComSpec(ARObject, ABC):
 
 class RPortComSpec(ARObject, ABC):
     """
-    Communication attributes of a required PortPrototype. This class will contain attributes
-    that are valid for all kinds of require ports, independent of client-server or
-    sender-receiver communication patterns.
+    Communication attributes of a required PortPrototype. This class will contain attributes that are valid for all kinds of require-ports, independent of client-server or sender-receiver communication patterns.
     """
 
     # RPortComSpec method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.59, p.167
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self):
         if type(self) is RPortComSpec:
@@ -68,68 +72,164 @@ class RPortComSpec(ARObject, ABC):
         super().__init__()
 
 
-class CompositeNetworkRepresentation(ARObject):
+class ReceptionComSpecProps(ARObject):
     """
-    This meta-class is used to define the network representation of leaf elements
-    of composite application data types.
+    This meta-class defines a set of reception attributes which the application software is assumed to implement.
     """
 
-    # CompositeNetworkRepresentation method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getLeafElementIRef           [x] impl  [x] docstring  [ ] test
-    # [ ] setLeafElementIRef           [x] impl  [x] docstring  [ ] test
-    # [ ] getNetworkRepresentation     [x] impl  [x] docstring  [ ] test
-    # [ ] setNetworkRepresentation     [x] impl  [x] docstring  [ ] test
+    # ReceptionComSpecProps method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.64, p.174
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__             [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getDataUpdatePeriod  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDataUpdatePeriod  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTimeout           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTimeout           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.leafElementIRef = None
-        self.networkRepresentation: SwDataDefProps = None
+        # This attribute defines the period in which the application shall check for updated data. This attribute is used for the configuration of the E2E protection, but may also indicate a general data reception period.
+        self.dataUpdatePeriod: Optional[TimeValue] = None
 
-    def getLeafElementIRef(self):
+        # This attribute defines the time interval after which the application shall assume that the to be received data reception has timed out, i.e. the respective data has not been received for that amount of time.
+        self.timeout: Optional[TimeValue] = None
+
+    def getDataUpdatePeriod(self) -> Optional[TimeValue]:
         """
-        Gets the reference to the leaf element of a composite data type.
+        Gets the period in which the application shall check for updated data.
+
+        This attribute defines the period in which the application shall check for updated data. This attribute is used for the configuration of the E2E protection, but may also indicate a general data reception period.
 
         Returns:
-            The leaf element instance reference
+            TimeValue representing the data update period, or None if not set
+        """
+        return self.dataUpdatePeriod
+
+    def setDataUpdatePeriod(self, value: Optional[TimeValue]) -> "ReceptionComSpecProps":
+        """
+        Sets the period in which the application shall check for updated data.
+        A None value is a no-op and does not overwrite an existing data update period.
+
+        This attribute defines the period in which the application shall check for updated data. This attribute is used for the configuration of the E2E protection, but may also indicate a general data reception period.
+
+        Args:
+            value: The data update period TimeValue to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.dataUpdatePeriod = value
+        return self
+
+    def getTimeout(self) -> Optional[TimeValue]:
+        """
+        Gets the time interval after which the application shall assume that the to be received data reception has timed out.
+
+        This attribute defines the time interval after which the application shall assume that the to be received data reception has timed out, i.e. the respective data has not been received for that amount of time.
+
+        Returns:
+            TimeValue representing the timeout, or None if not set
+        """
+        return self.timeout
+
+    def setTimeout(self, value: Optional[TimeValue]) -> "ReceptionComSpecProps":
+        """
+        Sets the time interval after which the application shall assume that the to be received data reception has timed out.
+        A None value is a no-op and does not overwrite an existing timeout.
+
+        This attribute defines the time interval after which the application shall assume that the to be received data reception has timed out, i.e. the respective data has not been received for that amount of time.
+
+        Args:
+            value: The timeout TimeValue to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.timeout = value
+        return self
+
+
+class CompositeNetworkRepresentation(ARObject):
+    """
+    This meta-class is used to define the network representation of leaf elements of composite application data types.
+    """
+
+    # CompositeNetworkRepresentation method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.74, p.181
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                 [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getLeafElementIRef       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setLeafElementIRef       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getNetworkRepresentation [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setNetworkRepresentation [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # This represents that leaf element of an application composite data type. InstanceRef implemented by: ApplicationCompositeElementInPortInterfaceInstanceRef
+        self.leafElementIRef: Optional[ApplicationCompositeElementInPortInterfaceInstanceRef] = None
+
+        # The SwDataDefProps owned by the CompositeNetworkRepresentation are used to define the network representation of the leaf element of an Application CompositeDataType. Stereotypes: atpSplitable Tags: atp.Splitkey=networkRepresentation
+        self.networkRepresentation: Optional[SwDataDefProps] = None
+
+    def getLeafElementIRef(self) -> Optional[ApplicationCompositeElementInPortInterfaceInstanceRef]:
+        """
+        Gets the leaf element of an application composite data type.
+
+        This represents that leaf element of an application composite data type. InstanceRef implemented by: ApplicationCompositeElementInPortInterfaceInstanceRef
+
+        Returns:
+            ApplicationCompositeElementInPortInterfaceInstanceRef, or None if not set
         """
         return self.leafElementIRef
 
-    def setLeafElementIRef(self, value):
+    def setLeafElementIRef(self, value: Optional[ApplicationCompositeElementInPortInterfaceInstanceRef]) -> "CompositeNetworkRepresentation":
         """
-        Sets the reference to the leaf element of a composite data type.
-        Only sets the value if it is not None.
+        Sets the leaf element of an application composite data type.
+        A None value is a no-op and does not overwrite an existing leaf element reference.
+
+        This represents that leaf element of an application composite data type. InstanceRef implemented by: ApplicationCompositeElementInPortInterfaceInstanceRef
 
         Args:
-            value: The leaf element instance reference to set
+            value: The ApplicationCompositeElementInPortInterfaceInstanceRef to set
 
         Returns:
             self for method chaining
         """
-        self.leafElementIRef = value
+        if value is not None:
+            self.leafElementIRef = value
         return self
 
-    def getNetworkRepresentation(self):
+    def getNetworkRepresentation(self) -> Optional[SwDataDefProps]:
         """
-        Gets the network representation of this composite network representation.
+        Gets the SwDataDefProps used to define the network representation of the leaf element of an Application CompositeDataType.
+
+        The SwDataDefProps owned by the CompositeNetworkRepresentation are used to define the network representation of the leaf element of an Application CompositeDataType. Stereotypes: atpSplitable Tags: atp.Splitkey=networkRepresentation
 
         Returns:
-            SwDataDefProps: The network representation
+            SwDataDefProps, or None if not set
         """
         return self.networkRepresentation
 
-    def setNetworkRepresentation(self, value):
+    def setNetworkRepresentation(self, value: Optional[SwDataDefProps]) -> "CompositeNetworkRepresentation":
         """
-        Sets the network representation of this composite network representation.
-        Only sets the value if it is not None.
+        Sets the SwDataDefProps used to define the network representation of the leaf element of an Application CompositeDataType.
+        A None value is a no-op and does not overwrite an existing network representation.
+
+        The SwDataDefProps owned by the CompositeNetworkRepresentation are used to define the network representation of the leaf element of an Application CompositeDataType. Stereotypes: atpSplitable Tags: atp.Splitkey=networkRepresentation
 
         Args:
-            value: The network representation to set
+            value: The SwDataDefProps to set
 
         Returns:
             self for method chaining
         """
+        if value is not None:
+            self.networkRepresentation = value
+        return self
         self.networkRepresentation = value
         return self
 
@@ -667,225 +767,80 @@ class ReceiverComSpec(RPortComSpec, ABC):
     """
 
     # ReceiverComSpec method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getDataElementRef            [x] impl  [x] docstring  [ ] test
-    # [ ] setDataElementRef            [x] impl  [x] docstring  [ ] test
-    # [ ] getNetworkRepresentation     [x] impl  [x] docstring  [ ] test
-    # [ ] setNetworkRepresentation     [x] impl  [x] docstring  [ ] test
-    # [ ] getHandleOutOfRange          [x] impl  [x] docstring  [ ] test
-    # [ ] setHandleOutOfRange          [x] impl  [x] docstring  [ ] test
-    # [ ] getHandleOutOfRangeStatus    [x] impl  [x] docstring  [ ] test
-    # [ ] setHandleOutOfRangeStatus    [x] impl  [x] docstring  [ ] test
-    # [ ] getMaxDeltaCounterInit       [x] impl  [x] docstring  [ ] test
-    # [ ] setMaxDeltaCounterInit       [x] impl  [x] docstring  [ ] test
-    # [ ] getMaxNoNewOrRepeatedData    [x] impl  [x] docstring  [ ] test
-    # [ ] setMaxNoNewOrRepeatedData    [x] impl  [x] docstring  [ ] test
-    # [ ] getUsesEndToEndProtection    [x] impl  [x] docstring  [ ] test
-    # [ ] setUsesEndToEndProtection    [x] impl  [x] docstring  [ ] test
-    # [ ] addCompositeNetworkRepresentation [x] impl  [x] docstring  [ ] test
-    # [ ] getCompositeNetworkRepresentations [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.60, p.172
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addCompositeNetworkRepresentation [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCompositeNetworkRepresentations [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getDataElementRef            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDataElementRef            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHandleOutOfRange          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setHandleOutOfRange          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHandleOutOfRangeStatus    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setHandleOutOfRangeStatus    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMaxDeltaCounterInit       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMaxDeltaCounterInit       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMaxNoNewOrRepeatedData    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMaxNoNewOrRepeatedData    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getNetworkRepresentation     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setNetworkRepresentation     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getReceptionProps            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setReceptionProps            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getReplaceWith               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setReplaceWith               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSyncCounterInit           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSyncCounterInit           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] addTransformationComSpecProps [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTransformationComSpecProps [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getUsesEndToEndProtection    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setUsesEndToEndProtection    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         if type(self) is ReceiverComSpec:
             raise TypeError("ReceiverComSpec is an abstract class.")
         super().__init__()
 
-        self.compositeNetworkRepresentations = []  # type: List[CompositeNetworkRepresentation]
-        self.dataElementRef = None  # type: RefType
-        self.networkRepresentation = None  # type: SwDataDefProps
-        self.handleOutOfRange = None  # type: HandleOutOfRangeEnum
-        self.handleOutOfRangeStatus = None  # type: HandleOutOfRangeStatusEnum
-        self.maxDeltaCounterInit = None  # type: PositiveInteger
-        self.maxNoNewOrRepeatedData = None  # type: PositiveInteger
-        self.usesEndToEndProtection = None  # type: ARBoolean
+        # This represents a CompositeNetworkRepresentation defined in the context of a ReceiverComSpec. The purpose of this aggregation is to be able to specify the network representation of leaf elements of Application CompositeDataTypes.
+        self.compositeNetworkRepresentations: List[CompositeNetworkRepresentation] = []
 
-    def getDataElementRef(self):
+        # Data element these attributes belong to.
+        self.dataElementRef: Optional[RefType] = None
+
+        # This attribute controls how values that are out of the specified range are handled according to the values of HandleOutOfRangeEnum.
+        self.handleOutOfRange: Optional[HandleOutOfRangeEnum] = None
+
+        # Control the way how return values are created in case of an out-of-range situation.
+        self.handleOutOfRangeStatus: Optional[HandleOutOfRangeStatusEnum] = None
+
+        # Initial maximum allowed gap between two counter values of two consecutively received valid Data, i.e. how many subsequent lost data is accepted. For example, if the receiver gets Data with counter 1 and MaxDeltaCounterInit is 1, then at the next reception the receiver can accept Counters with values 2 and 3, but not 4. Note that if the receiver does not receive new Data at a consecutive read, then the receiver increments the tolerance by 1. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach.
+        self.maxDeltaCounterInit: Optional[PositiveInteger] = None
+
+        # The maximum amount of missing or repeated Data which the receiver does not expect to exceed under normal communication conditions. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach.
+        self.maxNoNewOrRepeatedData: Optional[PositiveInteger] = None
+
+        # A networkRepresentation is used to define how the data Element is mapped to a communication bus.
+        self.networkRepresentation: Optional[SwDataDefProps] = None
+
+        # This aggregation represents the definition transmission props in the context of the enclosing ReceiverComSpec.
+        self.receptionProps: Optional[ReceptionComSpecProps] = None
+
+        # This aggregation is used to identify the AutosarData Prototype to be taken for sourcing an external replacement in the out-of-range and invalidValue handling.
+        self.replaceWith: Optional[VariableAccess] = None
+
+        # Number of Data required for validating the consistency of the counter that shall be received with a valid counter (i.e. counter within the allowed lock-in range) after the detection of an unexpected behavior of a received counter. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach.
+        self.syncCounterInit: Optional[PositiveInteger] = None
+
+        # This references the TransformationComSpecProps which define port-specific configuration for data transformation.
+        self.transformationComSpecProps: List[TransformationComSpecProps] = []
+
+        # This indicates whether the corresponding dataElement shall be transmitted using end-to-end protection. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach.
+        self.usesEndToEndProtection: Optional[ARBoolean] = None
+
+    def addCompositeNetworkRepresentation(self, representation: CompositeNetworkRepresentation) -> "ReceiverComSpec":
         """
-        Gets the data element these attributes belong to.
-
-        Returns:
-            RefType: The data element reference
-        """
-        return self.dataElementRef
-
-    def setDataElementRef(self, value):
-        """
-        Sets the data element these attributes belong to.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The data element reference to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is not None:
-            self.dataElementRef = value
-        return self
-
-    def getNetworkRepresentation(self):
-        """
-        Gets the network representation used to define how the data element is mapped
-        to a communication bus.
-
-        Returns:
-            SwDataDefProps: The network representation
-        """
-        return self.networkRepresentation
-
-    def setNetworkRepresentation(self, value):
-        """
-        Sets the network representation used to define how the data element is mapped
-        to a communication bus.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The network representation to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is not None:
-            self.networkRepresentation = value
-        return self
-
-    def getHandleOutOfRange(self):
-        """
-        Gets how values that are out of the specified range are handled
-        according to the values of HandleOutOfRangeEnum.
-
-        Returns:
-            HandleOutOfRangeEnum: The handle out-of-range setting
-        """
-        return self.handleOutOfRange
-
-    def setHandleOutOfRange(self, value):
-        """
-        Sets how values that are out of the specified range are handled.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The handle out-of-range setting
-
-        Returns:
-            self for method chaining
-        """
-        if value is not None:
-            self.handleOutOfRange = value
-        return self
-
-    def getHandleOutOfRangeStatus(self):
-        """
-        Gets how return values are created in case of an out-of-range situation.
-
-        Returns:
-            HandleOutOfRangeStatusEnum: The out-of-range status handling
-        """
-        return self.handleOutOfRangeStatus
-
-    def setHandleOutOfRangeStatus(self, value):
-        """
-        Sets how return values are created in case of an out-of-range situation.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The out-of-range status handling to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is not None:
-            self.handleOutOfRangeStatus = value
-        return self
-
-    def getMaxDeltaCounterInit(self):
-        """
-        Gets the initial maximum allowed gap between two counter values of two
-        consecutively received valid Data.
-
-        Returns:
-            PositiveInteger: The max delta counter init value
-        """
-        return self.maxDeltaCounterInit
-
-    def setMaxDeltaCounterInit(self, value):
-        """
-        Sets the initial maximum allowed gap between two counter values of two
-        consecutively received valid Data.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The max delta counter init value to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is not None:
-            self.maxDeltaCounterInit = value
-        return self
-
-    def getMaxNoNewOrRepeatedData(self):
-        """
-        Gets the maximum amount of missing or repeated data which the receiver does not
-        expect to exceed under normal communication conditions.
-
-        Returns:
-            PositiveInteger: The max no new or repeated data value
-        """
-        return self.maxNoNewOrRepeatedData
-
-    def setMaxNoNewOrRepeatedData(self, value):
-        """
-        Sets the maximum amount of missing or repeated data which the receiver does not
-        expect to exceed under normal communication conditions.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The max no new or repeated data value to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is not None:
-            self.maxNoNewOrRepeatedData = value
-        return self
-
-    def getUsesEndToEndProtection(self):
-        """
-        Gets whether the corresponding data element shall be transmitted using
-        end-to-end protection.
-
-        Returns:
-            ARBoolean: True if end-to-end protection is used
-        """
-        return self.usesEndToEndProtection
-
-    def setUsesEndToEndProtection(self, value):
-        """
-        Sets whether the corresponding data element shall be transmitted using
-        end-to-end protection.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The end-to-end protection flag
-
-        Returns:
-            self for method chaining
-        """
-        if value is not None:
-            self.usesEndToEndProtection = value
-        return self
-
-    def addCompositeNetworkRepresentation(self, representation: CompositeNetworkRepresentation):
-        """
-        Adds a composite network representation defined in the context of this ReceiverComSpec.
-        Only adds the value if it is not None.
-
-        Args:
-            representation: The composite network representation to add
-
-        Returns:
-            self for method chaining
+        This represents a CompositeNetworkRepresentation defined in the context of a ReceiverComSpec. The purpose of this aggregation is to be able to specify the network representation of leaf elements of Application CompositeDataTypes. Stereotypes: atpSplitable Tags: atp.Splitkey=compositeNetworkRepresentation
+        A None value is a no-op and does not append anything.
         """
         if representation is not None:
             self.compositeNetworkRepresentations.append(representation)
@@ -893,12 +848,174 @@ class ReceiverComSpec(RPortComSpec, ABC):
 
     def getCompositeNetworkRepresentations(self) -> List[CompositeNetworkRepresentation]:
         """
-        Gets the composite network representations defined in the context of this ReceiverComSpec.
-
-        Returns:
-            List[CompositeNetworkRepresentation]: The composite network representations
+        This represents a CompositeNetworkRepresentation defined in the context of a ReceiverComSpec. The purpose of this aggregation is to be able to specify the network representation of leaf elements of Application CompositeDataTypes. Stereotypes: atpSplitable Tags: atp.Splitkey=compositeNetworkRepresentation
         """
         return self.compositeNetworkRepresentations
+
+    def getDataElementRef(self) -> Optional[RefType]:
+        """
+        Data element these attributes belong to.
+        """
+        return self.dataElementRef
+
+    def setDataElementRef(self, value: Optional[RefType]) -> "ReceiverComSpec":
+        """
+        Data element these attributes belong to.
+        A None value is a no-op and does not overwrite an existing dataElementRef.
+        """
+        if value is not None:
+            self.dataElementRef = value
+        return self
+
+    def getHandleOutOfRange(self) -> Optional["HandleOutOfRangeEnum"]:
+        """
+        This attribute controls how values that are out of the specified range are handled according to the values of HandleOutOfRangeEnum.
+        """
+        return self.handleOutOfRange
+
+    def setHandleOutOfRange(self, value: Optional["HandleOutOfRangeEnum"]) -> "ReceiverComSpec":
+        """
+        This attribute controls how values that are out of the specified range are handled according to the values of HandleOutOfRangeEnum.
+        A None value is a no-op and does not overwrite an existing handleOutOfRange.
+        """
+        if value is not None:
+            self.handleOutOfRange = value
+        return self
+
+    def getHandleOutOfRangeStatus(self) -> Optional["HandleOutOfRangeStatusEnum"]:
+        """
+        Control the way how return values are created in case of an out-of-range situation.
+        """
+        return self.handleOutOfRangeStatus
+
+    def setHandleOutOfRangeStatus(self, value: Optional["HandleOutOfRangeStatusEnum"]) -> "ReceiverComSpec":
+        """
+        Control the way how return values are created in case of an out-of-range situation.
+        A None value is a no-op and does not overwrite an existing handleOutOfRangeStatus.
+        """
+        if value is not None:
+            self.handleOutOfRangeStatus = value
+        return self
+
+    def getMaxDeltaCounterInit(self) -> Optional[PositiveInteger]:
+        """
+        Initial maximum allowed gap between two counter values of two consecutively received valid Data, i.e. how many subsequent lost data is accepted. For example, if the receiver gets Data with counter 1 and MaxDeltaCounterInit is 1, then at the next reception the receiver can accept Counters with values 2 and 3, but not 4. Note that if the receiver does not receive new Data at a consecutive read, then the receiver increments the tolerance by 1. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach. Stereotypes: atpVariation
+        """
+        return self.maxDeltaCounterInit
+
+    def setMaxDeltaCounterInit(self, value: Optional[PositiveInteger]) -> "ReceiverComSpec":
+        """
+        Initial maximum allowed gap between two counter values of two consecutively received valid Data, i.e. how many subsequent lost data is accepted. For example, if the receiver gets Data with counter 1 and MaxDeltaCounterInit is 1, then at the next reception the receiver can accept Counters with values 2 and 3, but not 4. Note that if the receiver does not receive new Data at a consecutive read, then the receiver increments the tolerance by 1. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach. Stereotypes: atpVariation
+        A None value is a no-op and does not overwrite an existing maxDeltaCounterInit.
+        """
+        if value is not None:
+            self.maxDeltaCounterInit = value
+        return self
+
+    def getMaxNoNewOrRepeatedData(self) -> Optional[PositiveInteger]:
+        """
+        The maximum amount of missing or repeated Data which the receiver does not expect to exceed under normal communication conditions. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach.
+        """
+        return self.maxNoNewOrRepeatedData
+
+    def setMaxNoNewOrRepeatedData(self, value: Optional[PositiveInteger]) -> "ReceiverComSpec":
+        """
+        The maximum amount of missing or repeated Data which the receiver does not expect to exceed under normal communication conditions. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach.
+        A None value is a no-op and does not overwrite an existing maxNoNewOrRepeatedData.
+        """
+        if value is not None:
+            self.maxNoNewOrRepeatedData = value
+        return self
+
+    def getNetworkRepresentation(self) -> Optional[SwDataDefProps]:
+        """
+        A networkRepresentation is used to define how the data Element is mapped to a communication bus. Stereotypes: atpSplitable Tags: atp.Splitkey=networkRepresentation
+        """
+        return self.networkRepresentation
+
+    def setNetworkRepresentation(self, value: Optional[SwDataDefProps]) -> "ReceiverComSpec":
+        """
+        A networkRepresentation is used to define how the data Element is mapped to a communication bus. Stereotypes: atpSplitable Tags: atp.Splitkey=networkRepresentation
+        A None value is a no-op and does not overwrite an existing networkRepresentation.
+        """
+        if value is not None:
+            self.networkRepresentation = value
+        return self
+
+    def getReceptionProps(self) -> Optional["ReceptionComSpecProps"]:
+        """
+        This aggregation represents the definition transmission props in the context of the enclosing ReceiverComSpec.
+        """
+        return self.receptionProps
+
+    def setReceptionProps(self, value: Optional["ReceptionComSpecProps"]) -> "ReceiverComSpec":
+        """
+        This aggregation represents the definition transmission props in the context of the enclosing ReceiverComSpec.
+        A None value is a no-op and does not overwrite an existing receptionProps.
+        """
+        if value is not None:
+            self.receptionProps = value
+        return self
+
+    def getReplaceWith(self) -> Optional["VariableAccess"]:
+        """
+        This aggregation is used to identify the AutosarData Prototype to be taken for sourcing an external replacement in the out-of-range and invalidValue handling.
+        """
+        return self.replaceWith
+
+    def setReplaceWith(self, value: Optional["VariableAccess"]) -> "ReceiverComSpec":
+        """
+        This aggregation is used to identify the AutosarData Prototype to be taken for sourcing an external replacement in the out-of-range and invalidValue handling.
+        A None value is a no-op and does not overwrite an existing replaceWith.
+        """
+        if value is not None:
+            self.replaceWith = value
+        return self
+
+    def getSyncCounterInit(self) -> Optional[PositiveInteger]:
+        """
+        Number of Data required for validating the consistency of the counter that shall be received with a valid counter (i.e. counter within the allowed lock-in range) after the detection of an unexpected behavior of a received counter. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach.
+        """
+        return self.syncCounterInit
+
+    def setSyncCounterInit(self, value: Optional[PositiveInteger]) -> "ReceiverComSpec":
+        """
+        Number of Data required for validating the consistency of the counter that shall be received with a valid counter (i.e. counter within the allowed lock-in range) after the detection of an unexpected behavior of a received counter. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach.
+        A None value is a no-op and does not overwrite an existing syncCounterInit.
+        """
+        if value is not None:
+            self.syncCounterInit = value
+        return self
+
+    def addTransformationComSpecProps(self, value: Optional["TransformationComSpecProps"]) -> "ReceiverComSpec":
+        """
+        This references the TransformationComSpecProps which define port-specific configuration for data transformation.
+        A None value is a no-op and does not append anything.
+        """
+        if value is not None:
+            self.transformationComSpecProps.append(value)
+        return self
+
+    def getTransformationComSpecProps(self) -> List["TransformationComSpecProps"]:
+        """
+        This references the TransformationComSpecProps which define port-specific configuration for data transformation.
+        """
+        return self.transformationComSpecProps
+
+    def getUsesEndToEndProtection(self) -> Optional[ARBoolean]:
+        """
+        This indicates whether the corresponding dataElement shall be transmitted using end-to-end protection. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
+        """
+        return self.usesEndToEndProtection
+
+    def setUsesEndToEndProtection(self, value: Optional[ARBoolean]) -> "ReceiverComSpec":
+        """
+        This indicates whether the corresponding dataElement shall be transmitted using end-to-end protection. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
+        A None value is a no-op and does not overwrite an existing usesEndToEndProtection.
+        """
+        if value is not None:
+            self.usesEndToEndProtection = value
+        return self
 
 
 class ModeSwitchedAckRequest(ARObject):
@@ -1073,12 +1190,13 @@ class ParameterProvideComSpec(PPortComSpec):
 
 class TransformationComSpecProps(Describable, ABC):
     """
-    TransformationComSpecProps holds all the attributes for transformers that are
-    port specific.
+    TransformationComSpecProps holds all the attributes for transformers that are port specific.
     """
 
     # TransformationComSpecProps method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.86, p.197
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self):
         if type(self) is TransformationComSpecProps:
@@ -1779,229 +1897,172 @@ class NonqueuedReceiverComSpec(ReceiverComSpec):
     """
 
     # NonqueuedReceiverComSpec method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getAliveTimeout              [x] impl  [x] docstring  [ ] test
-    # [ ] setAliveTimeout              [x] impl  [x] docstring  [ ] test
-    # [ ] getEnableUpdated             [x] impl  [x] docstring  [ ] test
-    # [ ] setEnableUpdated             [x] impl  [x] docstring  [ ] test
-    # [ ] getFilter                    [x] impl  [x] docstring  [ ] test
-    # [ ] setFilter                    [x] impl  [x] docstring  [ ] test
-    # [ ] getHandleDataStatus          [x] impl  [x] docstring  [ ] test
-    # [ ] setHandleDataStatus          [x] impl  [x] docstring  [ ] test
-    # [ ] getHandleNeverReceived       [x] impl  [x] docstring  [ ] test
-    # [ ] setHandleNeverReceived       [x] impl  [x] docstring  [ ] test
-    # [ ] getHandleTimeoutType         [x] impl  [x] docstring  [ ] test
-    # [ ] setHandleTimeoutType         [x] impl  [x] docstring  [ ] test
-    # [ ] getInitValue                 [x] impl  [x] docstring  [ ] test
-    # [ ] setInitValue                 [x] impl  [x] docstring  [ ] test
-    # [ ] getTimeoutSubstitution       [x] impl  [x] docstring  [ ] test
-    # [ ] setTimeoutSubstitution       [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.62, p.173
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getAliveTimeout              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setAliveTimeout              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getEnableUpdate              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setEnableUpdate              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFilter                    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFilter                    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHandleDataStatus          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setHandleDataStatus          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHandleNeverReceived       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setHandleNeverReceived       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHandleTimeoutType         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setHandleTimeoutType         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getInitValue                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setInitValue                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTimeoutSubstitutionValue  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTimeoutSubstitutionValue  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.aliveTimeout: ARNumerical = None
-        self.enableUpdated: ARBoolean = None
-        self.filter = None
-        self.handleDataStatus: ARBoolean = None
-        self.handleNeverReceived: ARBoolean = None
-        self.handleTimeoutType: str = ""
-        self.initValue: ValueSpecification = None
-        self.timeoutSubstitution: ValueSpecification = None
+        # Specify the amount of time (in seconds) after which the software component (via the RTE) needs to be notified if the corresponding data item have not been received according to the specified timing description. If the aliveTimeout attribute is 0 no timeout monitoring shall be performed.
+        self.aliveTimeout: Optional[TimeValue] = None
 
-    def getAliveTimeout(self):
+        # This attribute controls whether application code is entitled to check whether the value of the corresponding Variable DataPrototype has been updated.
+        self.enableUpdate: Optional[ARBoolean] = None
+
+        # The applicable filter algorithm for filtering the value of the corresponding dataElement.
+        self.filter: Optional[DataFilter] = None
+
+        # If this attribute is set to true, then the Rte_IStatus API shall exist. If the attribute does not exist or is set to false, then the Rte_IStatus API may still exist in response to the existence of further conditions.
+        self.handleDataStatus: Optional[ARBoolean] = None
+
+        # This attribute specifies whether for the corresponding VariableDataPrototype the "never received" flag is available. If yes, the RTE is supposed to assume that initially the VariableDataPrototype has not been received before. After the first reception of the corresponding VariableDataPrototype the flag is cleared. • If the value of this attribute is set to "true" the flag is required. • If set to "false", the RTE shall not support the "never received" functionality for the corresponding Variable DataPrototype.
+        self.handleNeverReceived: Optional[ARBoolean] = None
+
+        # This attribute controls the behavior with respect to the handling of timeouts.
+        self.handleTimeoutType: Optional["HandleTimeoutEnum"] = None
+
+        # Initial value to be used in case the sending component is not yet initialized. If the sender also specifies an initial value, then the receiver's value will be used.
+        self.initValue: Optional[ValueSpecification] = None
+
+        # This attribute represents the substitution value applicable in the case of a timeout.
+        self.timeoutSubstitutionValue: Optional[ValueSpecification] = None
+
+    def getAliveTimeout(self) -> Optional[TimeValue]:
         """
-        Gets the amount of time (in seconds) after which the software component
-        (via the RTE) needs to be notified if the corresponding data item has not
-        been received. If aliveTimeout is 0, no timeout monitoring shall be performed.
-
-        Returns:
-            ARNumerical: The alive timeout value
+        Specify the amount of time (in seconds) after which the software component (via the RTE) needs to be notified if the corresponding data item have not been received according to the specified timing description. If the aliveTimeout attribute is 0 no timeout monitoring shall be performed.
         """
         return self.aliveTimeout
 
-    def setAliveTimeout(self, value):
+    def setAliveTimeout(self, value: Optional[TimeValue]) -> "NonqueuedReceiverComSpec":
         """
-        Sets the amount of time (in seconds) after which the software component
-        needs to be notified.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The alive timeout value to set
-
-        Returns:
-            self for method chaining
+        Specify the amount of time (in seconds) after which the software component (via the RTE) needs to be notified if the corresponding data item have not been received according to the specified timing description. If the aliveTimeout attribute is 0 no timeout monitoring shall be performed.
+        A None value is a no-op and does not overwrite an existing aliveTimeout.
         """
-        self.aliveTimeout = value
+        if value is not None:
+            self.aliveTimeout = value
         return self
 
-    def getEnableUpdated(self):
+    def getEnableUpdate(self) -> Optional[ARBoolean]:
         """
-        Gets whether application code is entitled to check whether the value
-        of the corresponding VariableDataPrototype has been updated.
-
-        Returns:
-            ARBoolean: True if update check is enabled
+        This attribute controls whether application code is entitled to check whether the value of the corresponding Variable DataPrototype has been updated.
         """
-        return self.enableUpdated
+        return self.enableUpdate
 
-    def setEnableUpdated(self, value):
+    def setEnableUpdate(self, value: Optional[ARBoolean]) -> "NonqueuedReceiverComSpec":
         """
-        Sets whether application code is entitled to check whether the value
-        of the corresponding VariableDataPrototype has been updated.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The enable updated flag
-
-        Returns:
-            self for method chaining
+        This attribute controls whether application code is entitled to check whether the value of the corresponding Variable DataPrototype has been updated.
+        A None value is a no-op and does not overwrite an existing enableUpdate.
         """
-        self.enableUpdated = value
+        if value is not None:
+            self.enableUpdate = value
         return self
 
-    def getFilter(self):
+    def getFilter(self) -> Optional[DataFilter]:
         """
-        Gets the applicable filter algorithm for filtering the value
-        of the corresponding dataElement.
-
-        Returns:
-            The filter algorithm
+        The applicable filter algorithm for filtering the value of the corresponding dataElement.
         """
         return self.filter
 
-    def setFilter(self, value):
+    def setFilter(self, value: Optional[DataFilter]) -> "NonqueuedReceiverComSpec":
         """
-        Sets the applicable filter algorithm for filtering the value
-        of the corresponding dataElement.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The filter algorithm to set
-
-        Returns:
-            self for method chaining
+        The applicable filter algorithm for filtering the value of the corresponding dataElement.
+        A None value is a no-op and does not overwrite an existing filter.
         """
-        self.filter = value
+        if value is not None:
+            self.filter = value
         return self
 
-    def getHandleDataStatus(self):
+    def getHandleDataStatus(self) -> Optional[ARBoolean]:
         """
-        Gets whether the Rte_IStatus API shall exist.
-
-        Returns:
-            ARBoolean: True if handle data status is enabled
+        If this attribute is set to true, then the Rte_IStatus API shall exist. If the attribute does not exist or is set to false, then the Rte_IStatus API may still exist in response to the existence of further conditions.
         """
         return self.handleDataStatus
 
-    def setHandleDataStatus(self, value):
+    def setHandleDataStatus(self, value: Optional[ARBoolean]) -> "NonqueuedReceiverComSpec":
         """
-        Sets whether the Rte_IStatus API shall exist.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The handle data status flag
-
-        Returns:
-            self for method chaining
+        If this attribute is set to true, then the Rte_IStatus API shall exist. If the attribute does not exist or is set to false, then the Rte_IStatus API may still exist in response to the existence of further conditions.
+        A None value is a no-op and does not overwrite an existing handleDataStatus.
         """
-        self.handleDataStatus = value
+        if value is not None:
+            self.handleDataStatus = value
         return self
 
-    def getHandleNeverReceived(self):
+    def getHandleNeverReceived(self) -> Optional[ARBoolean]:
         """
-        Gets whether the 'never received' flag is available for the corresponding
-        VariableDataPrototype.
-
-        Returns:
-            ARBoolean: True if never received flag is available
+        This attribute specifies whether for the corresponding VariableDataPrototype the "never received" flag is available. If yes, the RTE is supposed to assume that initially the VariableDataPrototype has not been received before. After the first reception of the corresponding VariableDataPrototype the flag is cleared. • If the value of this attribute is set to "true" the flag is required. • If set to "false", the RTE shall not support the "never received" functionality for the corresponding Variable DataPrototype.
         """
         return self.handleNeverReceived
 
-    def setHandleNeverReceived(self, value):
+    def setHandleNeverReceived(self, value: Optional[ARBoolean]) -> "NonqueuedReceiverComSpec":
         """
-        Sets whether the 'never received' flag is available for the corresponding
-        VariableDataPrototype.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The handle never received flag
-
-        Returns:
-            self for method chaining
+        This attribute specifies whether for the corresponding VariableDataPrototype the "never received" flag is available. If yes, the RTE is supposed to assume that initially the VariableDataPrototype has not been received before. After the first reception of the corresponding VariableDataPrototype the flag is cleared. • If the value of this attribute is set to "true" the flag is required. • If set to "false", the RTE shall not support the "never received" functionality for the corresponding Variable DataPrototype.
+        A None value is a no-op and does not overwrite an existing handleNeverReceived.
         """
-        self.handleNeverReceived = value
+        if value is not None:
+            self.handleNeverReceived = value
         return self
 
-    def getHandleTimeoutType(self):
+    def getHandleTimeoutType(self) -> Optional["HandleTimeoutEnum"]:
         """
-        Gets the behavior with respect to the handling of timeouts.
-
-        Returns:
-            str: The handle timeout type
+        This attribute controls the behavior with respect to the handling of timeouts.
         """
         return self.handleTimeoutType
 
-    def setHandleTimeoutType(self, value):
+    def setHandleTimeoutType(self, value: Optional["HandleTimeoutEnum"]) -> "NonqueuedReceiverComSpec":
         """
-        Sets the behavior with respect to the handling of timeouts.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The handle timeout type to set
-
-        Returns:
-            self for method chaining
+        This attribute controls the behavior with respect to the handling of timeouts.
+        A None value is a no-op and does not overwrite an existing handleTimeoutType.
         """
-        self.handleTimeoutType = value
+        if value is not None:
+            self.handleTimeoutType = value
         return self
 
-    def getInitValue(self):
+    def getInitValue(self) -> Optional[ValueSpecification]:
         """
-        Gets the initial value to be used in case the sending component
-        is not yet initialized.
-
-        Returns:
-            ValueSpecification: The initial value
+        Initial value to be used in case the sending component is not yet initialized. If the sender also specifies an initial value, then the receiver's value will be used.
         """
         return self.initValue
 
-    def setInitValue(self, value):
+    def setInitValue(self, value: Optional[ValueSpecification]) -> "NonqueuedReceiverComSpec":
         """
-        Sets the initial value to be used in case the sending component
-        is not yet initialized.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The initial value to set
-
-        Returns:
-            self for method chaining
+        Initial value to be used in case the sending component is not yet initialized. If the sender also specifies an initial value, then the receiver's value will be used.
+        A None value is a no-op and does not overwrite an existing initValue.
         """
-        self.initValue = value
+        if value is not None:
+            self.initValue = value
         return self
 
-    def getTimeoutSubstitution(self):
+    def getTimeoutSubstitutionValue(self) -> Optional[ValueSpecification]:
         """
-        Gets the substitution value applicable in the case of a timeout.
-
-        Returns:
-            ValueSpecification: The timeout substitution value
+        This attribute represents the substitution value applicable in the case of a timeout.
         """
-        return self.timeoutSubstitution
+        return self.timeoutSubstitutionValue
 
-    def setTimeoutSubstitution(self, value):
+    def setTimeoutSubstitutionValue(self, value: Optional[ValueSpecification]) -> "NonqueuedReceiverComSpec":
         """
-        Sets the substitution value applicable in the case of a timeout.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The timeout substitution value to set
-
-        Returns:
-            self for method chaining
+        This attribute represents the substitution value applicable in the case of a timeout.
+        A None value is a no-op and does not overwrite an existing timeoutSubstitutionValue.
         """
-        self.timeoutSubstitution = value
+        if value is not None:
+            self.timeoutSubstitutionValue = value
         return self
 
 
@@ -2074,55 +2135,71 @@ class HandleOutOfRangeEnum(AREnum):
 
     def __init__(self):
         super().__init__(
-            (
+            [
                 HandleOutOfRangeEnum.DEFAULT,
                 HandleOutOfRangeEnum.EXTERNAL_REPLACEMENT,
                 HandleOutOfRangeEnum.IGNORE,
                 HandleOutOfRangeEnum.INVALID,
                 HandleOutOfRangeEnum.NONE,
                 HandleOutOfRangeEnum.SATURATE,
-            )
+            ]
         )
 
 
 class HandleOutOfRangeStatusEnum(AREnum):
     """
-    Enumeration for handle out of range status.
+    This enumeration defines how the RTE handles values that are out of range.
     """
 
     # HandleOutOfRangeStatusEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.61, p.172
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods) — enum value form serialized on ReceiverComSpec.handleOutOfRangeStatus
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
-    SET_STATUS = "set-status"
-    DO_NOT_SET_STATUS = "do-not-set-status"
+    # The RTE sets the return status to RTE_E_OUT_OF_RANGE if the received value is out of range and the attribute handleOutOfRange is not set to "none" or "invalid". Tags: atp.EnumerationLiteralIndex=0
+    INDICATE = "indicate"
+
+    # The RTE sets the return status to RTE_E_OK Tags: atp.EnumerationLiteralIndex=1
+    SILENT = "silent"
 
     def __init__(self):
         super().__init__(
-            (
-                HandleOutOfRangeStatusEnum.SET_STATUS,
-                HandleOutOfRangeStatusEnum.DO_NOT_SET_STATUS,
-            )
+            [
+                HandleOutOfRangeStatusEnum.INDICATE,
+                HandleOutOfRangeStatusEnum.SILENT,
+            ]
         )
 
 
 class HandleTimeoutEnum(AREnum):
     """
-    Enumeration for handle timeout behavior.
+    Strategies of handling a reception timeout violation.
     """
 
     # HandleTimeoutEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.65, p.174
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods) — enum value form serialized on NonqueuedReceiverComSpec.handleTimeoutType
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
-    KEEP_OLD_VALUE = "keep-old-value"
-    REPLACE_WITH_DEFAULT = "replace-with-default"
-    INVALIDATE = "invalidate"
+    # If set to none no replacement shall take place. Tags: atp.EnumerationLiteralIndex=0
+    NONE = "none"
+
+    # If set to replace, the replacement value shall be the ComInitValue. Tags: atp.EnumerationLiteralIndex=1
+    REPLACE = "replace"
+
+    # If set to replace, the replacement value shall be the timeout substitution value. Tags: atp.EnumerationLiteralIndex=2
+    REPLACE_BY_TIMEOUT_SUBSTITUTION_VALUE = "replaceByTimeoutSubstitutionValue"
 
     def __init__(self):
         super().__init__(
             (
-                HandleTimeoutEnum.KEEP_OLD_VALUE,
-                HandleTimeoutEnum.REPLACE_WITH_DEFAULT,
-                HandleTimeoutEnum.INVALIDATE,
+                HandleTimeoutEnum.NONE,
+                HandleTimeoutEnum.REPLACE,
+                HandleTimeoutEnum.REPLACE_BY_TIMEOUT_SUBSTITUTION_VALUE,
             )
         )
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/__init__.py
@@ -27,6 +27,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     RefType,
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.DataPrototypes import AutosarDataPrototype, ParameterDataPrototype, VariableDataPrototype
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface.InstanceRefs import ApplicationCompositeElementInPortInterfaceInstanceRef
 
 
 class PortInterface(AtpType, ABC):
@@ -876,73 +877,252 @@ class ClientServerOperationMapping(ARObject):
         return self
 
 
-class DataPrototypeMapping(ARObject):
-    # DataPrototypeMapping method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getFirstDataPrototypeRef     [x] impl  [ ] docstring  [ ] test
-    # [ ] setFirstDataPrototypeRef     [x] impl  [ ] docstring  [ ] test
-    # [ ] getFirstToSecondDataTransformationRef [x] impl  [ ] docstring  [ ] test
-    # [ ] setFirstToSecondDataTransformationRef [x] impl  [ ] docstring  [ ] test
-    # [ ] getSecondDataPrototypeRef    [x] impl  [ ] docstring  [ ] test
-    # [ ] setSecondDataPrototypeRef    [x] impl  [ ] docstring  [ ] test
-    # [ ] getSecondToFirstDataTransformationRef [x] impl  [ ] docstring  [ ] test
-    # [ ] setSecondToFirstDataTransformationRef [x] impl  [ ] docstring  [ ] test
-    # [ ] getSubElementMappings        [x] impl  [ ] docstring  [ ] test
-    # [ ] setSubElementMappings        [x] impl  [ ] docstring  [ ] test
-    # [ ] getTextTableMappings         [x] impl  [ ] docstring  [ ] test
-    # [ ] setTextTableMappings         [x] impl  [ ] docstring  [ ] test
+class SubElementMapping(ARObject):
+    """
+    This meta-class allows for the definition of mappings of elements of a composite data type.
+    """
+
+    # SubElementMapping method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.32, p.137
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__             [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getFirstElement      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFirstElement      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSecondElement     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSecondElement     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] addTextTableMapping  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTextTableMappings [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self):
         super().__init__()
 
-        self.firstDataPrototypeRef: RefType = None
-        self.firstToSecondDataTransformationRef: RefType = None
-        self.secondDataPrototypeRef: RefType = None
-        self.secondToFirstDataTransformationRef: RefType = None
-        self.subElementMappings = []
+        # This represents the first element referenced in the scope of the mapping. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=firstElement, firstElement.variationPoint.shortLabel vh.latestBindingTime=preCompileTime
+        self.firstElement: Optional[ApplicationCompositeElementInPortInterfaceInstanceRef] = None
+
+        # This represents the second element referenced in the scope of the mapping. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=secondElement, secondElement.variationPoint.shortLabel vh.latestBindingTime=preCompileTime
+        self.secondElement: Optional[ApplicationCompositeElementInPortInterfaceInstanceRef] = None
+
+        # This allows for the text-table translation of individual elements of a composite data type.
         self.textTableMappings: List["TextTableMapping"] = []
 
-    def getFirstDataPrototypeRef(self):
-        return self.firstDataPrototypeRef
+    def getFirstElement(self) -> Optional[ApplicationCompositeElementInPortInterfaceInstanceRef]:
+        """
+        Gets the first element referenced in the scope of the mapping.
 
-    def setFirstDataPrototypeRef(self, value):
-        self.firstDataPrototypeRef = value
+        This represents the first element referenced in the scope of the mapping. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=firstElement, firstElement.variationPoint.shortLabel vh.latestBindingTime=preCompileTime
+
+        Returns:
+            ApplicationCompositeElementInPortInterfaceInstanceRef, or None if not set
+        """
+        return self.firstElement
+
+    def setFirstElement(self, value: Optional[ApplicationCompositeElementInPortInterfaceInstanceRef]) -> "SubElementMapping":
+        """
+        Sets the first element referenced in the scope of the mapping.
+        A None value is a no-op and does not overwrite an existing first element.
+
+        This represents the first element referenced in the scope of the mapping. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=firstElement, firstElement.variationPoint.shortLabel vh.latestBindingTime=preCompileTime
+
+        Args:
+            value: The ApplicationCompositeElementInPortInterfaceInstanceRef to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.firstElement = value
         return self
 
-    def getFirstToSecondDataTransformationRef(self):
-        return self.firstToSecondDataTransformationRef
+    def getSecondElement(self) -> Optional[ApplicationCompositeElementInPortInterfaceInstanceRef]:
+        """
+        Gets the second element referenced in the scope of the mapping.
 
-    def setFirstToSecondDataTransformationRef(self, value):
-        self.firstToSecondDataTransformationRef = value
+        This represents the second element referenced in the scope of the mapping. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=secondElement, secondElement.variationPoint.shortLabel vh.latestBindingTime=preCompileTime
+
+        Returns:
+            ApplicationCompositeElementInPortInterfaceInstanceRef, or None if not set
+        """
+        return self.secondElement
+
+    def setSecondElement(self, value: Optional[ApplicationCompositeElementInPortInterfaceInstanceRef]) -> "SubElementMapping":
+        """
+        Sets the second element referenced in the scope of the mapping.
+        A None value is a no-op and does not overwrite an existing second element.
+
+        This represents the second element referenced in the scope of the mapping. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=secondElement, secondElement.variationPoint.shortLabel vh.latestBindingTime=preCompileTime
+
+        Args:
+            value: The ApplicationCompositeElementInPortInterfaceInstanceRef to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.secondElement = value
         return self
 
-    def getSecondDataPrototypeRef(self):
-        return self.secondDataPrototypeRef
+    def addTextTableMapping(self, value: Optional["TextTableMapping"]) -> "SubElementMapping":
+        """
+        Adds a TextTableMapping allowing for the text-table translation of individual elements of a composite data type.
+        A None value is a no-op and does not append anything.
 
-    def setSecondDataPrototypeRef(self, value):
-        self.secondDataPrototypeRef = value
+        This allows for the text-table translation of individual elements of a composite data type.
+
+        Args:
+            value: The TextTableMapping to add
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.textTableMappings.append(value)
         return self
 
-    def getSecondToFirstDataTransformationRef(self):
-        return self.secondToFirstDataTransformationRef
+    def getTextTableMappings(self) -> List["TextTableMapping"]:
+        """
+        Gets the TextTableMappings allowing for the text-table translation of individual elements of a composite data type.
 
-    def setSecondToFirstDataTransformationRef(self, value):
-        self.secondToFirstDataTransformationRef = value
-        return self
+        This allows for the text-table translation of individual elements of a composite data type.
 
-    def getSubElementMappings(self):
-        return self.subElementMappings
-
-    def setSubElementMappings(self, value):
-        self.subElementMappings = value
-        return self
-
-    def getTextTableMappings(self):
+        Returns:
+            List of TextTableMapping instances
+        """
         return self.textTableMappings
 
-    def setTextTableMappings(self, value):
-        self.textTableMappings = value
+
+class DataPrototypeMapping(ARObject):
+    """
+    Defines the mapping of two particular VariableDataPrototypes, ParameterDataPrototypes or Argument DataPrototypes with non-equal shortNames, non-equal structure (specific condition is described by [constr_1187]), and/or non-equal semantic (resolution or range) in context of two different Sender ReceiverInterface, NvDataInterface or ParameterInterface or Operations. If the semantic is unequal, the following rules apply: The textTableMapping is only applicable if the referred DataPrototypes are typed by AutosarDataType referring to CompuMethods of category TEXTTABLE, SCALE_LINEAR_AND_TEXTTABLE or BITFIELD_TEXTTABLE. In the case that the DataPrototypes are typed by AutosarDataType either referring to CompuMethods of category LINEAR, IDENTICAL or referring to no CompuMethod (which is similar as IDENTICAL) the linear conversion factor is calculated out of the factorSiToUnit and offsetSiToUnit attributes of the referred Units and the CompuRationalCoeffs of a compuInternalToPhys of the referred CompuMethods.
+    """
+
+    # DataPrototypeMapping method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.22, p.125
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getFirstDataPrototypeRef     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFirstDataPrototypeRef     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFirstToSecondDataTransformationRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFirstToSecondDataTransformationRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSecondDataPrototypeRef    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSecondDataPrototypeRef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSecondToFirstDataTransformationRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSecondToFirstDataTransformationRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] addSubElementMapping         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSubElementMappings        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addTextTableMapping          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTextTableMappings         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # First to be mapped DataPrototype in context of a Sender ReceiverInterface, NvDataInterface, ParameterInterface or Operation.
+        self.firstDataPrototypeRef: Optional[RefType] = None
+
+        # This reference defines the need to execute the Data Transformation <Mip>_<transformerId> functions of the transformation chain when communicating from the Data PrototypeMapping.firstDataPrototype to the Data PrototypeMapping.secondDataPrototype. This reference also specifies the reverse Data Transformation <Mip>_Inv_<transformerId> functions of the transformation chain (i.e. from the DataPrototype Mapping.secondDataPrototype to the DataPrototype Mapping.firstDataPrototype) if the referenced Data Transformation is symmetric, i.e. attribute Data Transformation.dataTransformationKind is set to symmetric.
+        self.firstToSecondDataTransformationRef: Optional[RefType] = None
+
+        # Second to be mapped DataPrototype in context of a SenderReceiverInterface, NvDataInterface, Parameter Interface or Operation.
+        self.secondDataPrototypeRef: Optional[RefType] = None
+
+        # This defines the need to execute the reverse Data Transformation <Mip>_Inv_<transformerId> functions of the transformation chain when communicating from the DataPrototypeMapping.secondDataPrototype to the Data PrototypeMapping.firstDataPrototype.
+        self.secondToFirstDataTransformationRef: Optional[RefType] = None
+
+        # This represents the owned SubelementMapping.
+        self.subElementMappings: List[SubElementMapping] = []
+
+        # Applied TextTableMapping(s)
+        self.textTableMappings: List["TextTableMapping"] = []
+
+    def getFirstDataPrototypeRef(self) -> Optional[RefType]:
+        """
+        First to be mapped DataPrototype in context of a Sender ReceiverInterface, NvDataInterface, ParameterInterface or Operation.
+        """
+        return self.firstDataPrototypeRef
+
+    def setFirstDataPrototypeRef(self, value: Optional[RefType]) -> "DataPrototypeMapping":
+        """
+        First to be mapped DataPrototype in context of a Sender ReceiverInterface, NvDataInterface, ParameterInterface or Operation.
+        A None value is a no-op and does not overwrite an existing firstDataPrototypeRef.
+        """
+        if value is not None:
+            self.firstDataPrototypeRef = value
         return self
+
+    def getFirstToSecondDataTransformationRef(self) -> Optional[RefType]:
+        """
+        This reference defines the need to execute the Data Transformation <Mip>_<transformerId> functions of the transformation chain when communicating from the Data PrototypeMapping.firstDataPrototype to the Data PrototypeMapping.secondDataPrototype. This reference also specifies the reverse Data Transformation <Mip>_Inv_<transformerId> functions of the transformation chain (i.e. from the DataPrototype Mapping.secondDataPrototype to the DataPrototype Mapping.firstDataPrototype) if the referenced Data Transformation is symmetric, i.e. attribute Data Transformation.dataTransformationKind is set to symmetric.
+        """
+        return self.firstToSecondDataTransformationRef
+
+    def setFirstToSecondDataTransformationRef(self, value: Optional[RefType]) -> "DataPrototypeMapping":
+        """
+        This reference defines the need to execute the Data Transformation <Mip>_<transformerId> functions of the transformation chain when communicating from the Data PrototypeMapping.firstDataPrototype to the Data PrototypeMapping.secondDataPrototype. This reference also specifies the reverse Data Transformation <Mip>_Inv_<transformerId> functions of the transformation chain (i.e. from the DataPrototype Mapping.secondDataPrototype to the DataPrototype Mapping.firstDataPrototype) if the referenced Data Transformation is symmetric, i.e. attribute Data Transformation.dataTransformationKind is set to symmetric.
+        A None value is a no-op and does not overwrite an existing firstToSecondDataTransformationRef.
+        """
+        if value is not None:
+            self.firstToSecondDataTransformationRef = value
+        return self
+
+    def getSecondDataPrototypeRef(self) -> Optional[RefType]:
+        """
+        Second to be mapped DataPrototype in context of a SenderReceiverInterface, NvDataInterface, Parameter Interface or Operation.
+        """
+        return self.secondDataPrototypeRef
+
+    def setSecondDataPrototypeRef(self, value: Optional[RefType]) -> "DataPrototypeMapping":
+        """
+        Second to be mapped DataPrototype in context of a SenderReceiverInterface, NvDataInterface, Parameter Interface or Operation.
+        A None value is a no-op and does not overwrite an existing secondDataPrototypeRef.
+        """
+        if value is not None:
+            self.secondDataPrototypeRef = value
+        return self
+
+    def getSecondToFirstDataTransformationRef(self) -> Optional[RefType]:
+        """
+        This defines the need to execute the reverse Data Transformation <Mip>_Inv_<transformerId> functions of the transformation chain when communicating from the DataPrototypeMapping.secondDataPrototype to the Data PrototypeMapping.firstDataPrototype.
+        """
+        return self.secondToFirstDataTransformationRef
+
+    def setSecondToFirstDataTransformationRef(self, value: Optional[RefType]) -> "DataPrototypeMapping":
+        """
+        This defines the need to execute the reverse Data Transformation <Mip>_Inv_<transformerId> functions of the transformation chain when communicating from the DataPrototypeMapping.secondDataPrototype to the Data PrototypeMapping.firstDataPrototype.
+        A None value is a no-op and does not overwrite an existing secondToFirstDataTransformationRef.
+        """
+        if value is not None:
+            self.secondToFirstDataTransformationRef = value
+        return self
+
+    def addSubElementMapping(self, value: Optional[SubElementMapping]) -> "DataPrototypeMapping":
+        """
+        This represents the owned SubelementMapping.
+        A None value is a no-op and does not append anything.
+        """
+        if value is not None:
+            self.subElementMappings.append(value)
+        return self
+
+    def getSubElementMappings(self) -> List[SubElementMapping]:
+        """
+        This represents the owned SubelementMapping.
+        """
+        return self.subElementMappings
+
+    def addTextTableMapping(self, value: Optional["TextTableMapping"]) -> "DataPrototypeMapping":
+        """
+        Applied TextTableMapping(s)
+        A None value is a no-op and does not append anything.
+        """
+        if value is not None:
+            self.textTableMappings.append(value)
+        return self
+
+    def getTextTableMappings(self) -> List["TextTableMapping"]:
+        """
+        Applied TextTableMapping(s)
+        """
+        return self.textTableMappings
 
 
 class ClientServerInterfaceMapping(PortInterfaceMapping):
@@ -1036,31 +1216,55 @@ class TriggerInterfaceMapping(PortInterfaceMapping):
 
 
 class ModeDeclarationMapping(AtpStructureElement):
+    """
+    This meta-class implements a concrete mapping of two ModeDeclarations.
+    """
+
     # ModeDeclarationMapping method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getFirstModeRefs             [x] impl  [ ] docstring  [ ] test
-    # [ ] addFirstModeRef              [x] impl  [ ] docstring  [ ] test
-    # [ ] getSecondModeRef             [x] impl  [ ] docstring  [ ] test
-    # [ ] setSecondModeRef             [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.29, p.132
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__             [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getFirstModeRefs     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addFirstModeRef      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSecondModeRef     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSecondModeRef     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
+        # This represents the first ModeDeclaration of the Mode DeclarationMapping. This reference has the multiplicity 1 .. * to support use cases where e.g. one mode of the mode user is mapped to several modes of the mode manager.
         self.firstModeRefs: List[RefType] = []
-        self.secondModeRef: RefType = []
+
+        # This represents the second ModeDeclaration of the Mode DeclarationMapping.
+        self.secondModeRef: Optional[RefType] = None
 
     def getFirstModeRefs(self) -> List[RefType]:
+        """
+        This represents the first ModeDeclaration of the Mode DeclarationMapping. This reference has the multiplicity 1 .. * to support use cases where e.g. one mode of the mode user is mapped to several modes of the mode manager.
+        """
         return self.firstModeRefs
 
-    def addFirstModeRef(self, value: "RefType"):
+    def addFirstModeRef(self, value: Optional[RefType]) -> "ModeDeclarationMapping":
+        """
+        This represents the first ModeDeclaration of the Mode DeclarationMapping. This reference has the multiplicity 1 .. * to support use cases where e.g. one mode of the mode user is mapped to several modes of the mode manager.
+        A None value is a no-op and does not append anything.
+        """
         if value is not None:
             self.firstModeRefs.append(value)
         return self
 
-    def getSecondModeRef(self) -> RefType:
+    def getSecondModeRef(self) -> Optional[RefType]:
+        """
+        This represents the second ModeDeclaration of the Mode DeclarationMapping.
+        """
         return self.secondModeRef
 
-    def setSecondModeRef(self, value: RefType):
+    def setSecondModeRef(self, value: Optional[RefType]) -> "ModeDeclarationMapping":
+        """
+        This represents the second ModeDeclaration of the Mode DeclarationMapping.
+        A None value is a no-op and does not overwrite an existing secondModeRef.
+        """
         if value is not None:
             self.secondModeRef = value
         return self
@@ -1135,64 +1339,179 @@ class PortInterfaceMappingSet(AtpBlueprintable):
 
 
 class TextTableMapping(ARObject):
+    """
+    Defines the mapping of two DataPrototypes typed by AutosarDataTypes that refer to CompuMethods of category TEXTTABLE, SCALE_LINEAR_AND_TEXTTABLE or BITFIELD_TEXTTABLE.
+    """
+
     # TextTableMapping method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getBitfieldTextTableMaskFirst [x] impl  [ ] docstring  [ ] test
-    # [ ] setBitfieldTextTableMaskFirst [x] impl  [ ] docstring  [ ] test
-    # [ ] getBitfieldTextTableMaskSecond [x] impl  [ ] docstring  [ ] test
-    # [ ] setBitfieldTextTableMaskSecond [x] impl  [ ] docstring  [ ] test
-    # [ ] getIdenticalMapping          [x] impl  [ ] docstring  [ ] test
-    # [ ] setIdenticalMapping          [x] impl  [ ] docstring  [ ] test
-    # [ ] getMappingDirection          [x] impl  [ ] docstring  [ ] test
-    # [ ] setMappingDirection          [x] impl  [ ] docstring  [ ] test
-    # [ ] getValuePairs                [x] impl  [ ] docstring  [ ] test
-    # [ ] setValuePairs                [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.36, p.145
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBitfieldTextTableMaskFirst [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBitfieldTextTableMaskFirst [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getBitfieldTextTableMaskSecond [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBitfieldTextTableMaskSecond [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getIdenticalMapping          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIdenticalMapping          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMappingDirection          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMappingDirection          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] addValuePair                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getValuePairs                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self):
         super().__init__()
 
-        self.bitfieldTextTableMaskFirst: PositiveInteger = None
-        self.bitfieldTextTableMaskSecond: PositiveInteger = None
-        self.identicalMapping: Boolean = None
-        self.mappingDirection = None
-        self.valuePairs = []
+        # This attribute can be used to support the mapping of bit field to bit field, boolean values to bit fields, and vice versa. The attribute defines the bit mask for the first element of the TextTableMapping. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
+        self.bitfieldTextTableMaskFirst: Optional[PositiveInteger] = None
 
-    def getBitfieldTextTableMaskFirst(self):
+        # This attribute can be used to support the mapping of bit field to bit field, boolean values to bit fields, and vice versa. The attribute defines the bit mask for the second element of the TextTableMapping. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
+        self.bitfieldTextTableMaskSecond: Optional[PositiveInteger] = None
+
+        # If identicalMapping is set == true the values of the two referenced DataPrototypes do not need any conversion of the values.
+        self.identicalMapping: Optional[Boolean] = None
+
+        # Specifies the conversion direction for which the TextTableMapping is applicable.
+        self.mappingDirection = None
+
+        # Defines a pair of values which are translated into each other.
+        self.valuePairs: List = []
+
+    def getBitfieldTextTableMaskFirst(self) -> Optional[PositiveInteger]:
+        """
+        Gets the bit mask for the first element of the TextTableMapping.
+
+        This attribute can be used to support the mapping of bit field to bit field, boolean values to bit fields, and vice versa. The attribute defines the bit mask for the first element of the TextTableMapping. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
+
+        Returns:
+            PositiveInteger, or None if not set
+        """
         return self.bitfieldTextTableMaskFirst
 
-    def setBitfieldTextTableMaskFirst(self, value):
+    def setBitfieldTextTableMaskFirst(self, value: Optional[PositiveInteger]) -> "TextTableMapping":
+        """
+        Sets the bit mask for the first element of the TextTableMapping.
+        A None value is a no-op and does not overwrite an existing bit mask.
+
+        This attribute can be used to support the mapping of bit field to bit field, boolean values to bit fields, and vice versa. The attribute defines the bit mask for the first element of the TextTableMapping. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
+
+        Args:
+            value: The bit mask to set
+
+        Returns:
+            self for method chaining
+        """
         if value is not None:
             self.bitfieldTextTableMaskFirst = value
         return self
 
-    def getBitfieldTextTableMaskSecond(self):
+    def getBitfieldTextTableMaskSecond(self) -> Optional[PositiveInteger]:
+        """
+        Gets the bit mask for the second element of the TextTableMapping.
+
+        This attribute can be used to support the mapping of bit field to bit field, boolean values to bit fields, and vice versa. The attribute defines the bit mask for the second element of the TextTableMapping. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
+
+        Returns:
+            PositiveInteger, or None if not set
+        """
         return self.bitfieldTextTableMaskSecond
 
-    def setBitfieldTextTableMaskSecond(self, value):
+    def setBitfieldTextTableMaskSecond(self, value: Optional[PositiveInteger]) -> "TextTableMapping":
+        """
+        Sets the bit mask for the second element of the TextTableMapping.
+        A None value is a no-op and does not overwrite an existing bit mask.
+
+        This attribute can be used to support the mapping of bit field to bit field, boolean values to bit fields, and vice versa. The attribute defines the bit mask for the second element of the TextTableMapping. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
+
+        Args:
+            value: The bit mask to set
+
+        Returns:
+            self for method chaining
+        """
         if value is not None:
             self.bitfieldTextTableMaskSecond = value
         return self
 
-    def getIdenticalMapping(self):
+    def getIdenticalMapping(self) -> Optional[Boolean]:
+        """
+        Gets whether the values of the two referenced DataPrototypes need any conversion of the values.
+
+        If identicalMapping is set == true the values of the two referenced DataPrototypes do not need any conversion of the values.
+
+        Returns:
+            Boolean, or None if not set
+        """
         return self.identicalMapping
 
-    def setIdenticalMapping(self, value):
+    def setIdenticalMapping(self, value: Optional[Boolean]) -> "TextTableMapping":
+        """
+        Sets whether the values of the two referenced DataPrototypes need any conversion of the values.
+        A None value is a no-op and does not overwrite an existing identicalMapping.
+
+        If identicalMapping is set == true the values of the two referenced DataPrototypes do not need any conversion of the values.
+
+        Args:
+            value: The identicalMapping flag to set
+
+        Returns:
+            self for method chaining
+        """
         if value is not None:
             self.identicalMapping = value
         return self
 
     def getMappingDirection(self):
+        """
+        Gets the conversion direction for which the TextTableMapping is applicable.
+
+        Specifies the conversion direction for which the TextTableMapping is applicable.
+
+        Returns:
+            The mapping direction, or None if not set
+        """
         return self.mappingDirection
 
     def setMappingDirection(self, value):
+        """
+        Sets the conversion direction for which the TextTableMapping is applicable.
+        A None value is a no-op and does not overwrite an existing mapping direction.
+
+        Specifies the conversion direction for which the TextTableMapping is applicable.
+
+        Args:
+            value: The mapping direction to set
+
+        Returns:
+            self for method chaining
+        """
         if value is not None:
             self.mappingDirection = value
         return self
 
-    def getValuePairs(self):
-        return self.valuePairs
+    def addValuePair(self, value):
+        """
+        Adds a pair of values which are translated into each other.
+        A None value is a no-op and does not append anything.
 
-    def setValuePairs(self, value):
+        Defines a pair of values which are translated into each other.
+
+        Args:
+            value: The TextTableValuePair to add
+
+        Returns:
+            self for method chaining
+        """
         if value is not None:
-            self.valuePairs = value
+            self.valuePairs.append(value)
         return self
+
+    def getValuePairs(self) -> List:
+        """
+        Gets the pairs of values which are translated into each other.
+
+        Defines a pair of values which are translated into each other.
+
+        Returns:
+            List of TextTableValuePair instances
+        """
+        return self.valuePairs

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements.py
@@ -9,6 +9,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
+from typing import Optional
 
 
 class ParameterAccess(AbstractAccessPoint):
@@ -77,38 +78,47 @@ class ParameterAccess(AbstractAccessPoint):
 
 class VariableAccess(AbstractAccessPoint):
     """
-    A VariableAccess represents the access to a variable data prototype
-    within the internal behavior of an atomic software component.
+    The presence of a VariableAccess implies that a RunnableEntity needs access to a VariableDataPrototype. The kind of access is specified by the role in which the class is used.
     """
 
     # VariableAccess method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getAccessedVariableRef       [x] impl  [x] docstring  [ ] test
-    # [ ] setAccessedVariableRef       [x] impl  [x] docstring  [ ] test
-    # [ ] getScope                     [x] impl  [x] docstring  [ ] test
-    # [ ] setScope                     [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 7.33, p.567
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getAccessedVariableRef       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setAccessedVariableRef       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getScope                     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setScope                     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name):
         super().__init__(parent, short_name)
 
-        self.accessedVariableRef: "AutosarVariableRef" = None
-        self.scope: ARLiteral = None
+        # This denotes the accessed variable.
+        self.accessedVariableRef: Optional["AutosarVariableRef"] = None
 
-    def getAccessedVariableRef(self) -> "AutosarVariableRef":
+        # This attribute allows for constraining the scope of the corresponding communication. For example, it possible to express whether the communication is intended to cross the boundary of an ECU or whether it is intended not to cross the boundary of a single partition.
+        self.scope: Optional[ARLiteral] = None
+
+    def getAccessedVariableRef(self) -> Optional["AutosarVariableRef"]:
         """
-        Gets the accessed variable reference.
+        Gets the accessed variable.
+
+        This denotes the accessed variable.
 
         Returns:
-            AutosarVariableRef: The accessed variable reference
+            AutosarVariableRef, or None if not set
         """
         return self.accessedVariableRef
 
-    def setAccessedVariableRef(self, value: "AutosarVariableRef"):
+    def setAccessedVariableRef(self, value: Optional["AutosarVariableRef"]) -> "VariableAccess":
         """
-        Sets the accessed variable reference.
+        Sets the accessed variable.
+        A None value is a no-op and does not overwrite an existing accessed variable.
+
+        This denotes the accessed variable.
 
         Args:
-            value: The accessed variable reference to set
+            value: The AutosarVariableRef to set
 
         Returns:
             self for method chaining
@@ -117,24 +127,30 @@ class VariableAccess(AbstractAccessPoint):
             self.accessedVariableRef = value
         return self
 
-    def getScope(self):
+    def getScope(self) -> Optional[ARLiteral]:
         """
-        Gets the scope of the variable access.
+        Gets the scope of the corresponding communication.
+
+        This attribute allows for constraining the scope of the corresponding communication. For example, it possible to express whether the communication is intended to cross the boundary of an ECU or whether it is intended not to cross the boundary of a single partition.
 
         Returns:
-            The scope
+            ARLiteral, or None if not set
         """
         return self.scope
 
-    def setScope(self, value):
+    def setScope(self, value: Optional[ARLiteral]) -> "VariableAccess":
         """
-        Sets the scope of the variable access.
+        Sets the scope of the corresponding communication.
+        A None value is a no-op and does not overwrite an existing scope.
+
+        This attribute allows for constraining the scope of the corresponding communication. For example, it possible to express whether the communication is intended to cross the boundary of an ECU or whether it is intended not to cross the boundary of a single partition.
 
         Args:
-            value: The scope to set
+            value: The ARLiteral to set
 
         Returns:
             self for method chaining
         """
-        self.scope = value
+        if value is not None:
+            self.scope = value
         return self

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -239,6 +239,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttribute
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import (
     ClientComSpec,
     CompositeNetworkRepresentation,
+    EndToEndTransformationComSpecProps,
     ModeSwitchedAckRequest,
     ModeSwitchReceiverComSpec,
     ModeSwitchSenderComSpec,
@@ -251,6 +252,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import
     QueuedReceiverComSpec,
     QueuedSenderComSpec,
     ReceiverComSpec,
+    ReceptionComSpecProps,
     RPortComSpec,
     SenderComSpec,
     ServerComSpec,
@@ -354,6 +356,8 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import
     PortInterface,
     PortInterfaceMappingSet,
     SenderReceiverInterface,
+    SubElementMapping,
+    TextTableMapping,
     TriggerInterface,
     VariableAndParameterInterfaceMapping,
 )
@@ -366,7 +370,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation im
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior import ExternalTriggeringPoint, RunnableEntity, RunnableEntityArgument, SwcExclusiveAreaPolicy, SwcInternalBehavior
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AccessCount import AccessCount, AccessCountSet
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AutosarVariableRef import AutosarVariableRef
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.DataElements import ParameterAccess
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.DataElements import ParameterAccess, VariableAccess
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.IncludedDataTypes import IncludedDataTypeSet
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.InstanceRefsUsage import AutosarParameterRef, ParameterInAtomicSWCTypeInstanceRef, VariableInAtomicSWCTypeInstanceRef
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.InstantiationDataDefProps import InstantiationDataDefProps
@@ -3768,6 +3772,48 @@ class ARXMLParser(AbstractARXMLParser):
         com_spec.setMaxDeltaCounterInit(self.getChildElementOptionalPositiveInteger(element, "MAX-DELTA-COUNTER-INIT"))
         com_spec.setMaxNoNewOrRepeatedData(self.getChildElementOptionalPositiveInteger(element, "MAX-NO-NEW-OR-REPEATED-DATA"))
         com_spec.setUsesEndToEndProtection(self.getChildElementOptionalBooleanValue(element, "USES-END-TO-END-PROTECTION"))
+        reception_props = self.getReceptionComSpecProps(element, "RECEPTION-PROPS")
+        if reception_props is not None:
+            com_spec.setReceptionProps(reception_props)
+        replace_with = self.find(element, "REPLACE-WITH")
+        if replace_with is not None:
+            variable_access = VariableAccess(None, self.getShortName(replace_with))
+            self.readVariableAccess(replace_with, variable_access)
+            com_spec.setReplaceWith(variable_access)
+        com_spec.setSyncCounterInit(self.getChildElementOptionalPositiveInteger(element, "SYNC-COUNTER-INIT"))
+        for child_element in self.findall(element, "TRANSFORMATION-COM-SPEC-PROPSS/TRANSFORMATION-COM-SPEC-PROPS"):
+            com_spec.addTransformationComSpecProps(self.getTransformationComSpecProps(child_element))
+
+    def getReceptionComSpecProps(self, element: ET.Element, key: str) -> ReceptionComSpecProps:
+        child_element = self.find(element, key)
+        if child_element is None:
+            return None
+        props = ReceptionComSpecProps()
+        self.readARObjectAttributes(child_element, props)
+        props.setDataUpdatePeriod(self.getChildElementOptionalTimeValue(child_element, "DATA-UPDATE-PERIOD"))
+        props.setTimeout(self.getChildElementOptionalTimeValue(child_element, "TIMEOUT"))
+        return props
+
+    def readVariableAccess(self, element: ET.Element, access: VariableAccess):
+        self.readIdentifiable(element, access)
+        access.setAccessedVariableRef(self.getAutosarVariableRef(element, "ACCESSED-VARIABLE"))
+        access.setScope(self.getChildElementOptionalLiteral(element, "SCOPE"))
+
+    def getTransformationComSpecProps(self, element: ET.Element) -> TransformationComSpecProps:
+        child = self.find(element, "*")
+        if child is None:
+            return None
+        tag_name = self.getTagName(child)
+        if tag_name == "END-TO-END-TRANSFORMATION-COM-SPEC-PROPS":
+            props = EndToEndTransformationComSpecProps()
+            self.readTransformationComSpecProps(child, props)
+            return props
+        elif tag_name == "USER-DEFINED-TRANSFORMATION-COM-SPEC-PROPS":
+            props = UserDefinedTransformationComSpecProps()
+            self.readUserDefinedTransformationComSpecProps(child, props)
+            return props
+        self.notImplemented("Unsupported TransformationComSpecProps <%s>" % tag_name)
+        return None
 
     def getSwValues(self, element: ET.Element, key: str) -> SwValues:
         child_element = self.find(element, key)
@@ -3862,11 +3908,13 @@ class ARXMLParser(AbstractARXMLParser):
         self.readARObjectAttributes(element, com_spec)
         self.readReceiverComSpec(element, com_spec)
         com_spec.setAliveTimeout(self.getChildElementOptionalFloatValue(element, "ALIVE-TIMEOUT"))
-        com_spec.setEnableUpdated(self.getChildElementOptionalBooleanValue(element, "ENABLE-UPDATE"))
+        com_spec.setEnableUpdate(self.getChildElementOptionalBooleanValue(element, "ENABLE-UPDATE"))
+        com_spec.setHandleDataStatus(self.getChildElementOptionalBooleanValue(element, "HANDLE-DATA-STATUS"))
         com_spec.setHandleNeverReceived(self.getChildElementOptionalBooleanValue(element, "HANDLE-NEVER-RECEIVED"))
         com_spec.setFilter(self.getDataFilter(element, "FILTER"))
         com_spec.setHandleTimeoutType(self.getChildElementOptionalLiteral(element, "HANDLE-TIMEOUT-TYPE"))
         com_spec.setInitValue(self.getInitValue(element))
+        com_spec.setTimeoutSubstitutionValue(self.getChildValueSpecification(element, "TIMEOUT-SUBSTITUTION-VALUE"))
         return com_spec
 
     def readRequiredComSpec(self, element: ET.Element, parent: RPortPrototype):
@@ -8093,9 +8141,39 @@ class ARXMLParser(AbstractARXMLParser):
         for child_element in self.findall(element, "%s/DATA-PROTOTYPE-MAPPING" % key):
             mapping = DataPrototypeMapping()
             mapping.setFirstDataPrototypeRef(self.getChildElementOptionalRefType(child_element, "FIRST-DATA-PROTOTYPE-REF"))
+            mapping.setFirstToSecondDataTransformationRef(self.getChildElementOptionalRefType(child_element, "FIRST-TO-SECOND-DATA-TRANSFORMATION-REF"))
             mapping.setSecondDataPrototypeRef(self.getChildElementOptionalRefType(child_element, "SECOND-DATA-PROTOTYPE-REF"))
+            mapping.setSecondToFirstDataTransformationRef(self.getChildElementOptionalRefType(child_element, "SECOND-TO-FIRST-DATA-TRANSFORMATION-REF"))
+            for sub_element in self.findall(child_element, "SUB-ELEMENT-MAPPINGS/SUB-ELEMENT-MAPPING"):
+                mapping.addSubElementMapping(self.getSubElementMapping(sub_element))
+            for text_table in self.findall(child_element, "TEXT-TABLE-MAPPINGS/TEXT-TABLE-MAPPING"):
+                mapping.addTextTableMapping(self.getTextTableMapping(text_table))
             mappings.append(mapping)
         return mappings
+
+    def getSubElementMapping(self, element: ET.Element) -> SubElementMapping:
+        mapping = SubElementMapping()
+        for ref_element in self.findall(element, "FIRST-ELEMENTS/*"):
+            if self.getTagName(ref_element) == "APPLICATION-COMPOSITE-DATA-TYPE-SUB-ELEMENT-REF":
+                mapping.setFirstElement(self.getApplicationCompositeElementInPortInterfaceInstanceRef(ref_element, "APPLICATION-COMPOSITE-ELEMENT-IREF"))
+            else:
+                self.notImplemented("Unsupported firstElement SubElementRef <%s>" % self.getTagName(ref_element))
+        for ref_element in self.findall(element, "SECOND-ELEMENTS/*"):
+            if self.getTagName(ref_element) == "APPLICATION-COMPOSITE-DATA-TYPE-SUB-ELEMENT-REF":
+                mapping.setSecondElement(self.getApplicationCompositeElementInPortInterfaceInstanceRef(ref_element, "APPLICATION-COMPOSITE-ELEMENT-IREF"))
+            else:
+                self.notImplemented("Unsupported secondElement SubElementRef <%s>" % self.getTagName(ref_element))
+        for text_table in self.findall(element, "TEXT-TABLE-MAPPINGS/TEXT-TABLE-MAPPING"):
+            mapping.addTextTableMapping(self.getTextTableMapping(text_table))
+        return mapping
+
+    def getTextTableMapping(self, element: ET.Element) -> TextTableMapping:
+        mapping = TextTableMapping()
+        mapping.setBitfieldTextTableMaskFirst(self.getChildElementOptionalPositiveInteger(element, "BITFIELD-TEXT-TABLE-MASK-FIRST"))
+        mapping.setBitfieldTextTableMaskSecond(self.getChildElementOptionalPositiveInteger(element, "BITFIELD-TEXT-TABLE-MASK-SECOND"))
+        mapping.setIdenticalMapping(self.getChildElementOptionalBooleanValue(element, "IDENTICAL-MAPPING"))
+        mapping.setMappingDirection(self.getChildElementOptionalLiteral(element, "MAPPING-DIRECTION"))
+        return mapping
 
     def readVariableAndParameterInterfaceMapping(self, element: ET.Element, mapping: VariableAndParameterInterfaceMapping):
         # self.logger.debug("Read VariableAndParameterInterfaceMapping %s" % mapping.getShortName())

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -222,6 +222,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttribute
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import (
     ClientComSpec,
     CompositeNetworkRepresentation,
+    EndToEndTransformationComSpecProps,
     ModeSwitchedAckRequest,
     ModeSwitchReceiverComSpec,
     ModeSwitchSenderComSpec,
@@ -234,6 +235,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import
     QueuedReceiverComSpec,
     QueuedSenderComSpec,
     ReceiverComSpec,
+    ReceptionComSpecProps,
     RPortComSpec,
     SenderComSpec,
     ServerComSpec,
@@ -336,6 +338,8 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import
     PortInterface,
     PortInterfaceMappingSet,
     SenderReceiverInterface,
+    SubElementMapping,
+    TextTableMapping,
     TriggerInterface,
     VariableAndParameterInterfaceMapping,
 )
@@ -1032,8 +1036,8 @@ class ARXMLWriter(AbstractARXMLWriter):
     def setApplicationCompositeElementInPortInterfaceInstanceRef(self, element: ET.Element, key: str, iref: ApplicationCompositeElementInPortInterfaceInstanceRef):  # noqa E501
         if iref is not None:
             child_element = ET.SubElement(element, key)
-            self.setChildElementOptionalRefType(child_element, "ROOT-DATA-PROTOTYPE-REF", iref.root_data_prototype_ref)
-            self.setChildElementOptionalRefType(child_element, "TARGET-DATA-PROTOTYPE-REF", iref.target_data_prototype_ref)
+            self.setChildElementOptionalRefType(child_element, "ROOT-DATA-PROTOTYPE-REF", iref.getRootDataPrototypeRef())
+            self.setChildElementOptionalRefType(child_element, "TARGET-DATA-PROTOTYPE-REF", iref.getTargetDataPrototypeRef())
         return iref
 
     def writeCompositeNetworkRepresentation(self, element: ET.Element, representation: CompositeNetworkRepresentation):
@@ -1056,6 +1060,34 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.setChildElementOptionalPositiveInteger(element, "MAX-DELTA-COUNTER-INIT", com_spec.getMaxDeltaCounterInit())
         self.setChildElementOptionalPositiveInteger(element, "MAX-NO-NEW-OR-REPEATED-DATA", com_spec.getMaxNoNewOrRepeatedData())
         self.setChildElementOptionalBooleanValue(element, "USES-END-TO-END-PROTECTION", com_spec.getUsesEndToEndProtection())
+        self.writeReceptionComSpecProps(element, "RECEPTION-PROPS", com_spec.getReceptionProps())
+        self.writeReceiverReplaceWith(element, "REPLACE-WITH", com_spec.getReplaceWith())
+        self.setChildElementOptionalPositiveInteger(element, "SYNC-COUNTER-INIT", com_spec.getSyncCounterInit())
+        props = com_spec.getTransformationComSpecProps()
+        if len(props) > 0:
+            props_tag = ET.SubElement(element, "TRANSFORMATION-COM-SPEC-PROPSS")
+            for prop in props:
+                if isinstance(prop, EndToEndTransformationComSpecProps):
+                    child = ET.SubElement(props_tag, "END-TO-END-TRANSFORMATION-COM-SPEC-PROPS")
+                    self.writeTransformationComSpecProps(child, prop)
+                elif isinstance(prop, UserDefinedTransformationComSpecProps):
+                    self.writeUserDefinedTransformationComSpecProps(props_tag, prop)
+                else:
+                    self.notImplemented("Unsupported TransformationComSpecProps %s" % type(prop))
+
+    def writeReceptionComSpecProps(self, element: ET.Element, key: str, props: ReceptionComSpecProps):
+        if props is not None:
+            child_element = ET.SubElement(element, key)
+            self.writeARObjectAttributes(child_element, props)
+            self.setChildElementOptionalTimeValue(child_element, "DATA-UPDATE-PERIOD", props.getDataUpdatePeriod())
+            self.setChildElementOptionalTimeValue(child_element, "TIMEOUT", props.getTimeout())
+
+    def writeReceiverReplaceWith(self, element: ET.Element, key: str, access: VariableAccess):
+        if access is not None:
+            child_element = ET.SubElement(element, key)
+            self.writeIdentifiable(child_element, access)
+            self.setAutosarVariableRef(child_element, "ACCESSED-VARIABLE", access.getAccessedVariableRef())
+            self.setChildElementOptionalLiteral(child_element, "SCOPE", access.getScope())
 
     def setSwValues(self, element: ET.Element, key: str, sw_values: SwValues):
         if sw_values is not None:
@@ -1148,12 +1180,14 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.writeARObjectAttributes(child_element, com_spec)
         self.writeReceiverComSpec(child_element, com_spec)
         self.setChildElementOptionalFloatValue(child_element, "ALIVE-TIMEOUT", com_spec.getAliveTimeout())
-        self.setChildElementOptionalBooleanValue(child_element, "ENABLE-UPDATE", com_spec.getEnableUpdated())
+        self.setChildElementOptionalBooleanValue(child_element, "ENABLE-UPDATE", com_spec.getEnableUpdate())
         self.setDataFilter(child_element, "FILTER", com_spec.getFilter())
+        self.setChildElementOptionalBooleanValue(child_element, "HANDLE-DATA-STATUS", com_spec.getHandleDataStatus())
         self.setChildElementOptionalBooleanValue(child_element, "HANDLE-NEVER-RECEIVED", com_spec.getHandleNeverReceived())
         self.setChildElementOptionalLiteral(child_element, "HANDLE-TIMEOUT-TYPE", com_spec.getHandleTimeoutType())
 
         self.setChildValueSpecification(child_element, "INIT-VALUE", com_spec.getInitValue())
+        self.setChildValueSpecification(child_element, "TIMEOUT-SUBSTITUTION-VALUE", com_spec.getTimeoutSubstitutionValue())
 
     def writeQueuedReceiverComSpec(self, element: ET.Element, com_spec: QueuedReceiverComSpec):
         child_element = ET.SubElement(element, "QUEUED-RECEIVER-COM-SPEC")
@@ -7367,7 +7401,44 @@ class ARXMLWriter(AbstractARXMLWriter):
     def setDataPrototypeMapping(self, element: ET.Element, mapping: DataPrototypeMapping):
         child_element = ET.SubElement(element, "DATA-PROTOTYPE-MAPPING")
         self.setChildElementOptionalRefType(child_element, "FIRST-DATA-PROTOTYPE-REF", mapping.getFirstDataPrototypeRef())
+        self.setChildElementOptionalRefType(child_element, "FIRST-TO-SECOND-DATA-TRANSFORMATION-REF", mapping.getFirstToSecondDataTransformationRef())
         self.setChildElementOptionalRefType(child_element, "SECOND-DATA-PROTOTYPE-REF", mapping.getSecondDataPrototypeRef())
+        self.setChildElementOptionalRefType(child_element, "SECOND-TO-FIRST-DATA-TRANSFORMATION-REF", mapping.getSecondToFirstDataTransformationRef())
+        sub_elements = mapping.getSubElementMappings()
+        if len(sub_elements) > 0:
+            sub_tag = ET.SubElement(child_element, "SUB-ELEMENT-MAPPINGS")
+            for sub_element in sub_elements:
+                self.setSubElementMapping(sub_tag, sub_element)
+        text_tables = mapping.getTextTableMappings()
+        if len(text_tables) > 0:
+            text_tag = ET.SubElement(child_element, "TEXT-TABLE-MAPPINGS")
+            for text_table in text_tables:
+                self.setTextTableMapping(text_tag, text_table)
+
+    def setSubElementMapping(self, element: ET.Element, mapping: SubElementMapping):
+        child_element = ET.SubElement(element, "SUB-ELEMENT-MAPPING")
+        first = mapping.getFirstElement()
+        if first is not None:
+            first_tag = ET.SubElement(child_element, "FIRST-ELEMENTS")
+            iref_tag = ET.SubElement(first_tag, "APPLICATION-COMPOSITE-DATA-TYPE-SUB-ELEMENT-REF")
+            self.setApplicationCompositeElementInPortInterfaceInstanceRef(iref_tag, "APPLICATION-COMPOSITE-ELEMENT-IREF", first)
+        second = mapping.getSecondElement()
+        if second is not None:
+            second_tag = ET.SubElement(child_element, "SECOND-ELEMENTS")
+            iref_tag = ET.SubElement(second_tag, "APPLICATION-COMPOSITE-DATA-TYPE-SUB-ELEMENT-REF")
+            self.setApplicationCompositeElementInPortInterfaceInstanceRef(iref_tag, "APPLICATION-COMPOSITE-ELEMENT-IREF", second)
+        text_tables = mapping.getTextTableMappings()
+        if len(text_tables) > 0:
+            text_tag = ET.SubElement(child_element, "TEXT-TABLE-MAPPINGS")
+            for text_table in text_tables:
+                self.setTextTableMapping(text_tag, text_table)
+
+    def setTextTableMapping(self, element: ET.Element, mapping: TextTableMapping):
+        child_element = ET.SubElement(element, "TEXT-TABLE-MAPPING")
+        self.setChildElementOptionalPositiveInteger(child_element, "BITFIELD-TEXT-TABLE-MASK-FIRST", mapping.getBitfieldTextTableMaskFirst())
+        self.setChildElementOptionalPositiveInteger(child_element, "BITFIELD-TEXT-TABLE-MASK-SECOND", mapping.getBitfieldTextTableMaskSecond())
+        self.setChildElementOptionalBooleanValue(child_element, "IDENTICAL-MAPPING", mapping.getIdenticalMapping())
+        self.setChildElementOptionalLiteral(child_element, "MAPPING-DIRECTION", mapping.getMappingDirection())
 
     def setDataPrototypeMappings(self, element: ET.Element, key: str, mappings: List[DataPrototypeMapping]):
         if len(mappings) > 0:

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/test_PortInterface_Comprehensive.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/test_PortInterface_Comprehensive.py
@@ -6,7 +6,7 @@ Tests cover all classes and methods in the PortInterface module files to achieve
 import pytest
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, ARLiteral, PositiveInteger, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, Boolean, PositiveInteger, RefType
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import (
     ClientServerApplicationErrorMapping,
     ClientServerInterfaceMapping,
@@ -21,7 +21,6 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import
     ModeSwitchInterface,
     PortInterfaceMapping,
     PortInterfaceMappingSet,
-    TextTableMapping,
     TriggerInterface,
     TriggerInterfaceMapping,
     VariableAndParameterInterfaceMapping,
@@ -252,6 +251,168 @@ class TestDataPrototypeMapping:
         mapping.setSecondDataPrototypeRef(second_ref)
         assert mapping.getSecondDataPrototypeRef() == second_ref
 
+    def test_first_data_prototype_ref_none_noop(self):
+        """Test setFirstDataPrototypeRef with None is a no-op."""
+        mapping = DataPrototypeMapping()
+        ref = RefType()
+        ref.setValue("/Test/FirstData")
+        mapping.setFirstDataPrototypeRef(ref)
+        mapping.setFirstDataPrototypeRef(None)
+        assert mapping.getFirstDataPrototypeRef() == ref
+
+    def test_first_to_second_data_transformation_ref(self):
+        """Test firstToSecondDataTransformationRef getter and setter with None no-op."""
+        mapping = DataPrototypeMapping()
+        assert mapping.getFirstToSecondDataTransformationRef() is None
+        ref = RefType()
+        ref.setValue("/Test/Transform")
+        mapping.setFirstToSecondDataTransformationRef(ref)
+        assert mapping.getFirstToSecondDataTransformationRef() == ref
+        mapping.setFirstToSecondDataTransformationRef(None)
+        assert mapping.getFirstToSecondDataTransformationRef() == ref
+
+    def test_second_to_first_data_transformation_ref(self):
+        """Test secondToFirstDataTransformationRef getter and setter with None no-op."""
+        mapping = DataPrototypeMapping()
+        assert mapping.getSecondToFirstDataTransformationRef() is None
+        ref = RefType()
+        ref.setValue("/Test/Transform2")
+        mapping.setSecondToFirstDataTransformationRef(ref)
+        assert mapping.getSecondToFirstDataTransformationRef() == ref
+        mapping.setSecondToFirstDataTransformationRef(None)
+        assert mapping.getSecondToFirstDataTransformationRef() == ref
+
+    def test_add_sub_element_mapping(self):
+        """Test addSubElementMapping and getSubElementMappings with None no-op."""
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import SubElementMapping
+
+        mapping = DataPrototypeMapping()
+        assert mapping.getSubElementMappings() == []
+        sub = SubElementMapping()
+        result = mapping.addSubElementMapping(sub)
+        assert result is mapping
+        assert mapping.getSubElementMappings() == [sub]
+        mapping.addSubElementMapping(None)
+        assert mapping.getSubElementMappings() == [sub]
+
+    def test_add_text_table_mapping(self):
+        """Test addTextTableMapping and getTextTableMappings with None no-op."""
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import TextTableMapping
+
+        mapping = DataPrototypeMapping()
+        assert mapping.getTextTableMappings() == []
+        text_map = TextTableMapping()
+        result = mapping.addTextTableMapping(text_map)
+        assert result is mapping
+        assert mapping.getTextTableMappings() == [text_map]
+        mapping.addTextTableMapping(None)
+        assert mapping.getTextTableMappings() == [text_map]
+
+
+class TestSubElementMapping:
+    """Test class for SubElementMapping class."""
+
+    def test_sub_element_mapping_initialization(self):
+        """Test SubElementMapping initialization."""
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import SubElementMapping
+
+        mapping = SubElementMapping()
+        assert mapping.getFirstElement() is None
+        assert mapping.getSecondElement() is None
+        assert mapping.getTextTableMappings() == []
+
+    def test_get_set_first_element(self):
+        """Test firstElement getter and setter with None no-op."""
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import SubElementMapping
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface.InstanceRefs import ApplicationCompositeElementInPortInterfaceInstanceRef
+
+        mapping = SubElementMapping()
+        iref = ApplicationCompositeElementInPortInterfaceInstanceRef()
+        result = mapping.setFirstElement(iref)
+        assert result is mapping
+        assert mapping.getFirstElement() == iref
+        mapping.setFirstElement(None)
+        assert mapping.getFirstElement() == iref
+
+    def test_get_set_second_element(self):
+        """Test secondElement getter and setter with None no-op."""
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import SubElementMapping
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface.InstanceRefs import ApplicationCompositeElementInPortInterfaceInstanceRef
+
+        mapping = SubElementMapping()
+        iref = ApplicationCompositeElementInPortInterfaceInstanceRef()
+        result = mapping.setSecondElement(iref)
+        assert result is mapping
+        assert mapping.getSecondElement() == iref
+        mapping.setSecondElement(None)
+        assert mapping.getSecondElement() == iref
+
+    def test_add_text_table_mapping(self):
+        """Test addTextTableMapping and getTextTableMappings with None no-op."""
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import SubElementMapping, TextTableMapping
+
+        mapping = SubElementMapping()
+        assert mapping.getTextTableMappings() == []
+        text_map = TextTableMapping()
+        result = mapping.addTextTableMapping(text_map)
+        assert result is mapping
+        assert mapping.getTextTableMappings() == [text_map]
+        mapping.addTextTableMapping(None)
+        assert mapping.getTextTableMappings() == [text_map]
+
+
+class TestTextTableMapping:
+    """Test class for TextTableMapping class."""
+
+    def test_text_table_mapping_initialization(self):
+        """Test TextTableMapping initialization."""
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import TextTableMapping
+
+        mapping = TextTableMapping()
+        assert mapping.getBitfieldTextTableMaskFirst() is None
+        assert mapping.getBitfieldTextTableMaskSecond() is None
+        assert mapping.getIdenticalMapping() is None
+        assert mapping.getValuePairs() == []
+
+    def test_get_set_bitfield_text_table_mask_first(self):
+        """Test bitfieldTextTableMaskFirst getter and setter with None no-op."""
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import TextTableMapping
+
+        mapping = TextTableMapping()
+        mask = PositiveInteger()
+        mask.setValue(255)
+        result = mapping.setBitfieldTextTableMaskFirst(mask)
+        assert result is mapping
+        assert mapping.getBitfieldTextTableMaskFirst() == mask
+        mapping.setBitfieldTextTableMaskFirst(None)
+        assert mapping.getBitfieldTextTableMaskFirst() == mask
+
+    def test_get_set_bitfield_text_table_mask_second(self):
+        """Test bitfieldTextTableMaskSecond getter and setter with None no-op."""
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import TextTableMapping
+
+        mapping = TextTableMapping()
+        mask = PositiveInteger()
+        mask.setValue(255)
+        result = mapping.setBitfieldTextTableMaskSecond(mask)
+        assert result is mapping
+        assert mapping.getBitfieldTextTableMaskSecond() == mask
+        mapping.setBitfieldTextTableMaskSecond(None)
+        assert mapping.getBitfieldTextTableMaskSecond() == mask
+
+    def test_get_set_identical_mapping(self):
+        """Test identicalMapping getter and setter with None no-op."""
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import TextTableMapping
+
+        mapping = TextTableMapping()
+        flag = Boolean()
+        flag.setValue(True)
+        result = mapping.setIdenticalMapping(flag)
+        assert result is mapping
+        assert mapping.getIdenticalMapping() == flag
+        mapping.setIdenticalMapping(None)
+        assert mapping.getIdenticalMapping() == flag
+
 
 class TestClientServerInterfaceMapping:
     """Test class for ClientServerInterfaceMapping class."""
@@ -350,7 +511,7 @@ class TestModeDeclarationMapping:
         mapping = ModeDeclarationMapping(ar_root, "TestModeDeclarationMapping")
 
         assert mapping.getFirstModeRefs() == []
-        assert mapping.getSecondModeRef() == []
+        assert mapping.getSecondModeRef() is None
         assert mapping.parent == ar_root
         assert mapping.short_name == "TestModeDeclarationMapping"
 
@@ -364,6 +525,18 @@ class TestModeDeclarationMapping:
         second_ref.setValue("/Test/SecondMode")
         mapping.setSecondModeRef(second_ref)  # Fixed to take single ref, not list
         assert second_ref == mapping.getSecondModeRef()
+
+        # Test None no-op on secondModeRef
+        mapping.setSecondModeRef(None)
+        assert second_ref == mapping.getSecondModeRef()
+
+    def test_add_first_mode_ref_none_noop(self):
+        """Test addFirstModeRef with None is a no-op."""
+        document = AUTOSAR.getInstance()
+        ar_root = document.createARPackage("AUTOSAR")
+        mapping = ModeDeclarationMapping(ar_root, "TestModeDeclarationMapping")
+        mapping.addFirstModeRef(None)
+        assert mapping.getFirstModeRefs() == []
 
 
 class TestModeDeclarationMappingSet:
@@ -412,32 +585,3 @@ class TestPortInterfaceMappingSet:
         assert trigger_mapping is not None
 
         assert len(mapping_set.getPortInterfaceMappings()) == 4
-
-
-class TestTextTableMapping:
-    """Test class for TextTableMapping class."""
-
-    def test_text_table_mapping_initialization(self):
-        """Test TextTableMapping initialization and methods."""
-        mapping = TextTableMapping()
-        assert mapping.bitfieldTextTableMaskFirst is None
-        assert mapping.bitfieldTextTableMaskSecond is None
-        assert mapping.identicalMapping is None
-        assert mapping.mappingDirection is None
-        assert mapping.valuePairs == []
-
-        # Test setters and getters
-        first_mask = PositiveInteger()
-        first_mask.setValue(15)
-        mapping.setBitfieldTextTableMaskFirst(first_mask)
-        assert mapping.getBitfieldTextTableMaskFirst() == first_mask
-
-        second_mask = PositiveInteger()
-        second_mask.setValue(31)
-        mapping.setBitfieldTextTableMaskSecond(second_mask)
-        assert mapping.getBitfieldTextTableMaskSecond() == second_mask
-
-        identical = ARBoolean()
-        identical.setValue(True)
-        mapping.setIdenticalMapping(identical)
-        assert mapping.getIdenticalMapping() == identical

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_Communication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_Communication.py
@@ -5,12 +5,14 @@ Tests cover all classes and methods in the Communication.py file to achieve 100%
 
 import pytest
 
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, ARNumerical, ARPositiveInteger, PositiveInteger, RefType, TimeValue
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, ARPositiveInteger, PositiveInteger, RefType, TimeValue
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import (
     ClientComSpec,
     CompositeNetworkRepresentation,
     EndToEndTransformationComSpecProps,
     HandleInvalidEnum,
+    HandleOutOfRangeStatusEnum,
+    HandleTimeoutEnum,
     ModeSwitchedAckRequest,
     ModeSwitchReceiverComSpec,
     ModeSwitchSenderComSpec,
@@ -24,6 +26,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import
     QueuedReceiverComSpec,
     QueuedSenderComSpec,
     ReceiverComSpec,
+    ReceptionComSpecProps,
     RPortComSpec,
     SenderComSpec,
     ServerComSpec,
@@ -309,6 +312,61 @@ class TestReceiverComSpec:
         receiver.addCompositeNetworkRepresentation(comp_rep)
         assert comp_rep in receiver.getCompositeNetworkRepresentations()
 
+    def test_reception_props(self):
+        """Test receptionProps getter and setter with round-trip and None no-op."""
+        receiver = NonqueuedReceiverComSpec()
+        assert receiver.getReceptionProps() is None
+
+        props = ReceptionComSpecProps()
+        result = receiver.setReceptionProps(props)
+        assert result is receiver
+        assert receiver.getReceptionProps() == props
+
+        receiver.setReceptionProps(None)
+        assert receiver.getReceptionProps() == props
+
+    def test_replace_with(self):
+        """Test replaceWith getter and setter with round-trip and None no-op."""
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.DataElements import VariableAccess
+
+        receiver = NonqueuedReceiverComSpec()
+        assert receiver.getReplaceWith() is None
+
+        access = VariableAccess(None, "TestAccess")
+        result = receiver.setReplaceWith(access)
+        assert result is receiver
+        assert receiver.getReplaceWith() == access
+
+        receiver.setReplaceWith(None)
+        assert receiver.getReplaceWith() == access
+
+    def test_sync_counter_init(self):
+        """Test syncCounterInit getter and setter with round-trip and None no-op."""
+        receiver = NonqueuedReceiverComSpec()
+        assert receiver.getSyncCounterInit() is None
+
+        value = PositiveInteger()
+        value.setValue(3)
+        result = receiver.setSyncCounterInit(value)
+        assert result is receiver
+        assert receiver.getSyncCounterInit() == value
+
+        receiver.setSyncCounterInit(None)
+        assert receiver.getSyncCounterInit() == value
+
+    def test_transformation_com_spec_props(self):
+        """Test transformationComSpecProps add and get with None no-op."""
+        receiver = NonqueuedReceiverComSpec()
+        assert receiver.getTransformationComSpecProps() == []
+
+        props = EndToEndTransformationComSpecProps()
+        result = receiver.addTransformationComSpecProps(props)
+        assert result is receiver
+        assert receiver.getTransformationComSpecProps() == [props]
+
+        receiver.addTransformationComSpecProps(None)
+        assert receiver.getTransformationComSpecProps() == [props]
+
 
 class TestModeSwitchedAckRequest:
     """Test class for ModeSwitchedAckRequest class."""
@@ -549,27 +607,29 @@ class TestNonqueuedReceiverComSpec:
     def test_nonqueued_receiver_com_spec_initialization(self):
         """Test NonqueuedReceiverComSpec initialization and methods."""
         receiver = NonqueuedReceiverComSpec()
-        assert receiver.aliveTimeout is None
-        assert receiver.enableUpdated is None
-        assert receiver.filter is None
-        assert receiver.handleDataStatus is None
-        assert receiver.handleNeverReceived is None
-        assert receiver.handleTimeoutType == ""
-        assert receiver.initValue is None
-        assert receiver.timeoutSubstitution is None
+        assert receiver.getAliveTimeout() is None
+        assert receiver.getEnableUpdate() is None
+        assert receiver.getFilter() is None
+        assert receiver.getHandleDataStatus() is None
+        assert receiver.getHandleNeverReceived() is None
+        assert receiver.getHandleTimeoutType() is None
+        assert receiver.getInitValue() is None
+        assert receiver.getTimeoutSubstitutionValue() is None
 
         # Test setters and getters
-        alive_timeout = ARNumerical()
+        alive_timeout = TimeValue()
         alive_timeout.setValue("10.5")
         receiver.setAliveTimeout(alive_timeout)
         assert receiver.getAliveTimeout() == alive_timeout
 
         enable_updated = ARBoolean()
         enable_updated.setValue(True)
-        receiver.setEnableUpdated(enable_updated)
-        assert receiver.getEnableUpdated() == enable_updated
+        receiver.setEnableUpdate(enable_updated)
+        assert receiver.getEnableUpdate() == enable_updated
 
-        filter_value = "test_filter"
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.Filter import DataFilter
+
+        filter_value = DataFilter()
         receiver.setFilter(filter_value)
         assert receiver.getFilter() == filter_value
 
@@ -583,7 +643,8 @@ class TestNonqueuedReceiverComSpec:
         receiver.setHandleNeverReceived(handle_never)
         assert receiver.getHandleNeverReceived() == handle_never
 
-        timeout_type = "test_timeout"
+        timeout_type = HandleTimeoutEnum()
+        timeout_type.setValue(HandleTimeoutEnum.REPLACE)
         receiver.setHandleTimeoutType(timeout_type)
         assert receiver.getHandleTimeoutType() == timeout_type
 
@@ -594,8 +655,73 @@ class TestNonqueuedReceiverComSpec:
         assert receiver.getInitValue() == init_value
 
         timeout_sub = TextValueSpecification()
-        receiver.setTimeoutSubstitution(timeout_sub)
-        assert receiver.getTimeoutSubstitution() == timeout_sub
+        receiver.setTimeoutSubstitutionValue(timeout_sub)
+        assert receiver.getTimeoutSubstitutionValue() == timeout_sub
+
+    def test_alive_timeout_none_noop(self):
+        """Test setAliveTimeout with None is a no-op."""
+        receiver = NonqueuedReceiverComSpec()
+        alive_timeout = TimeValue()
+        alive_timeout.setValue("10.5")
+        receiver.setAliveTimeout(alive_timeout)
+        receiver.setAliveTimeout(None)
+        assert receiver.getAliveTimeout() == alive_timeout
+
+    def test_enable_update_none_noop(self):
+        """Test setEnableUpdate with None is a no-op."""
+        receiver = NonqueuedReceiverComSpec()
+        enable = ARBoolean()
+        enable.setValue(True)
+        receiver.setEnableUpdate(enable)
+        receiver.setEnableUpdate(None)
+        assert receiver.getEnableUpdate() == enable
+
+    def test_handle_timeout_type_none_noop(self):
+        """Test setHandleTimeoutType with None is a no-op."""
+        receiver = NonqueuedReceiverComSpec()
+        timeout_type = HandleTimeoutEnum()
+        timeout_type.setValue(HandleTimeoutEnum.NONE)
+        receiver.setHandleTimeoutType(timeout_type)
+        receiver.setHandleTimeoutType(None)
+        assert receiver.getHandleTimeoutType() == timeout_type
+
+    def test_timeout_substitution_value_none_noop(self):
+        """Test setTimeoutSubstitutionValue with None is a no-op."""
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure import TextValueSpecification
+
+        receiver = NonqueuedReceiverComSpec()
+        timeout_sub = TextValueSpecification()
+        receiver.setTimeoutSubstitutionValue(timeout_sub)
+        receiver.setTimeoutSubstitutionValue(None)
+        assert receiver.getTimeoutSubstitutionValue() == timeout_sub
+
+
+class TestHandleOutOfRangeStatusEnum:
+    """Test cases for HandleOutOfRangeStatusEnum class."""
+
+    def test_members(self):
+        """Test HandleOutOfRangeStatusEnum member values."""
+        enum = HandleOutOfRangeStatusEnum()
+        values = enum.getEnumValues()
+        assert HandleOutOfRangeStatusEnum.INDICATE == "indicate"
+        assert HandleOutOfRangeStatusEnum.SILENT == "silent"
+        assert HandleOutOfRangeStatusEnum.INDICATE in values
+        assert HandleOutOfRangeStatusEnum.SILENT in values
+
+
+class TestHandleTimeoutEnum:
+    """Test cases for HandleTimeoutEnum class."""
+
+    def test_members(self):
+        """Test HandleTimeoutEnum member values."""
+        enum = HandleTimeoutEnum()
+        values = enum.getEnumValues()
+        assert HandleTimeoutEnum.NONE == "none"
+        assert HandleTimeoutEnum.REPLACE == "replace"
+        assert HandleTimeoutEnum.REPLACE_BY_TIMEOUT_SUBSTITUTION_VALUE == "replaceByTimeoutSubstitutionValue"
+        assert HandleTimeoutEnum.NONE in values
+        assert HandleTimeoutEnum.REPLACE in values
+        assert HandleTimeoutEnum.REPLACE_BY_TIMEOUT_SUBSTITUTION_VALUE in values
 
 
 class TestQueuedReceiverComSpec:

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_PortInterface.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_PortInterface.py
@@ -516,13 +516,15 @@ class TestDataPrototypeMapping:
         assert data_mapping.getSecondToFirstDataTransformationRef() == second_transform_ref
 
         # Test subElementMappings methods
-        sub_element = "test_sub_element"
-        data_mapping.setSubElementMappings(sub_element)
-        assert data_mapping.getSubElementMappings() == sub_element
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import SubElementMapping
+
+        sub_element = SubElementMapping()
+        data_mapping.addSubElementMapping(sub_element)
+        assert data_mapping.getSubElementMappings() == [sub_element]
 
         # Test textTableMappings methods
         text_table_mapping = TextTableMapping()
-        data_mapping.setTextTableMappings([text_table_mapping])
+        data_mapping.addTextTableMapping(text_table_mapping)
         assert text_table_mapping in data_mapping.getTextTableMappings()
 
 
@@ -624,7 +626,7 @@ class TestModeDeclarationMapping:
         assert mode_decl_mapping.parent == ar_root
         assert mode_decl_mapping.short_name == "TestModeDeclarationMapping"
         assert mode_decl_mapping.firstModeRefs == []
-        assert mode_decl_mapping.secondModeRef == []
+        assert mode_decl_mapping.secondModeRef is None
 
         # Test firstModeRefs methods
         from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
@@ -637,8 +639,8 @@ class TestModeDeclarationMapping:
         # Test secondModeRef methods
         second_ref = RefType()
         second_ref.setValue("/Second/Mode/Ref")
-        mode_decl_mapping.setSecondModeRef([second_ref])
-        assert second_ref in mode_decl_mapping.getSecondModeRef()
+        mode_decl_mapping.setSecondModeRef(second_ref)
+        assert second_ref == mode_decl_mapping.getSecondModeRef()
 
 
 class TestModeDeclarationMappingSet:
@@ -738,5 +740,5 @@ class TestTextTableMapping:
 
         # Test valuePairs methods
         value_pair = "test_value_pair"
-        text_mapping.setValuePairs([value_pair])
+        text_mapping.addValuePair(value_pair)
         assert value_pair in text_mapping.getValuePairs()

--- a/tests/test_armodel/parser/test_arxml_parser_comspec.py
+++ b/tests/test_armodel/parser/test_arxml_parser_comspec.py
@@ -146,6 +146,7 @@ class TestGetNonqueuedReceiverComSpec:
             <DATA-ELEMENT-REF DEST="VARIABLE-DATA-PROTOTYPE">/vdp/Elem</DATA-ELEMENT-REF>
             <ALIVE-TIMEOUT>0.5</ALIVE-TIMEOUT>
             <ENABLE-UPDATE>true</ENABLE-UPDATE>
+            <HANDLE-DATA-STATUS>true</HANDLE-DATA-STATUS>
             <HANDLE-NEVER-RECEIVED>false</HANDLE-NEVER-RECEIVED>
             <HANDLE-TIMEOUT-TYPE>REPLACE</HANDLE-TIMEOUT-TYPE>
             """,
@@ -156,7 +157,9 @@ class TestGetNonqueuedReceiverComSpec:
         assert result.getDataElementRef() is not None
         assert result.getDataElementRef().getDest() == "VARIABLE-DATA-PROTOTYPE"
         assert result.getAliveTimeout() is not None
-        assert result.getEnableUpdated() is not None
+        assert result.getEnableUpdate() is not None
+        assert result.getHandleDataStatus() is not None
+        assert result.getHandleDataStatus().getValue() is True
         assert result.getHandleNeverReceived() is not None
         assert result.getHandleTimeoutType() is not None
 

--- a/tests/test_armodel/parser/test_arxml_parser_orchestrators.py
+++ b/tests/test_armodel/parser/test_arxml_parser_orchestrators.py
@@ -1884,6 +1884,61 @@ class TestPortInterfaceMappingHandlers:
         parser.readVariableAndParameterInterfaceMapping(element, mapping)
         assert len(mapping.getDataMappings()) == 1
 
+    def test_readDataPrototypeMapping_full(self, parser):
+        element = _snip(
+            "<DATA-MAPPINGS>"
+            "<DATA-PROTOTYPE-MAPPING>"
+            "<FIRST-DATA-PROTOTYPE-REF DEST='VARIABLE-DATA-PROTOTYPE'>/first</FIRST-DATA-PROTOTYPE-REF>"
+            "<FIRST-TO-SECOND-DATA-TRANSFORMATION-REF DEST='DATA-TRANSFORMATION'>/t1</FIRST-TO-SECOND-DATA-TRANSFORMATION-REF>"
+            "<SECOND-DATA-PROTOTYPE-REF DEST='VARIABLE-DATA-PROTOTYPE'>/second</SECOND-DATA-PROTOTYPE-REF>"
+            "<SECOND-TO-FIRST-DATA-TRANSFORMATION-REF DEST='DATA-TRANSFORMATION'>/t2</SECOND-TO-FIRST-DATA-TRANSFORMATION-REF>"
+            "<SUB-ELEMENT-MAPPINGS>"
+            "<SUB-ELEMENT-MAPPING>"
+            "<FIRST-ELEMENTS>"
+            "<APPLICATION-COMPOSITE-DATA-TYPE-SUB-ELEMENT-REF>"
+            "<APPLICATION-COMPOSITE-ELEMENT-IREF>"
+            "<ROOT-DATA-PROTOTYPE-REF DEST='VARIABLE-DATA-PROTOTYPE'>/root</ROOT-DATA-PROTOTYPE-REF>"
+            "<TARGET-DATA-PROTOTYPE-REF DEST='VARIABLE-DATA-PROTOTYPE'>/target</TARGET-DATA-PROTOTYPE-REF>"
+            "</APPLICATION-COMPOSITE-ELEMENT-IREF>"
+            "</APPLICATION-COMPOSITE-DATA-TYPE-SUB-ELEMENT-REF>"
+            "</FIRST-ELEMENTS>"
+            "</SUB-ELEMENT-MAPPING>"
+            "</SUB-ELEMENT-MAPPINGS>"
+            "<TEXT-TABLE-MAPPINGS>"
+            "<TEXT-TABLE-MAPPING>"
+            "<BITFIELD-TEXT-TABLE-MASK-FIRST>1</BITFIELD-TEXT-TABLE-MASK-FIRST>"
+            "<BITFIELD-TEXT-TABLE-MASK-SECOND>2</BITFIELD-TEXT-TABLE-MASK-SECOND>"
+            "<IDENTICAL-MAPPING>true</IDENTICAL-MAPPING>"
+            "<MAPPING-DIRECTION>BIDIRECTIONAL</MAPPING-DIRECTION>"
+            "</TEXT-TABLE-MAPPING>"
+            "</TEXT-TABLE-MAPPINGS>"
+            "</DATA-PROTOTYPE-MAPPING>"
+            "</DATA-MAPPINGS>",
+            root_tag="PARENT",
+        )
+        mappings = parser.getDataPrototypeMappings(element, "DATA-MAPPINGS")
+        assert len(mappings) == 1
+        parsed = mappings[0]
+        assert parsed.getFirstDataPrototypeRef().getValue() == "/first"
+        assert parsed.getFirstToSecondDataTransformationRef().getValue() == "/t1"
+        assert parsed.getSecondDataPrototypeRef().getValue() == "/second"
+        assert parsed.getSecondToFirstDataTransformationRef().getValue() == "/t2"
+        assert len(parsed.getSubElementMappings()) == 1
+        sub = parsed.getSubElementMappings()[0]
+        assert sub.getFirstElement() is not None
+        assert sub.getFirstElement().getRootDataPrototypeRef().getValue() == "/root"
+        assert len(parsed.getTextTableMappings()) == 1
+        text = parsed.getTextTableMappings()[0]
+        assert text.getBitfieldTextTableMaskFirst().getValue() == 1
+        assert text.getBitfieldTextTableMaskSecond().getValue() == 2
+        assert text.getIdenticalMapping().getValue() is True
+        assert text.getMappingDirection().getValue() == "BIDIRECTIONAL"
+
+    def test_readDataPrototypeMapping_minimal(self, parser):
+        element = _snip("<DATA-MAPPINGS></DATA-MAPPINGS>", root_tag="PARENT")
+        mappings = parser.getDataPrototypeMappings(element, "DATA-MAPPINGS")
+        assert len(mappings) == 0
+
     def test_readClientServerInterfaceMapping_full(self, parser):
         from armodel.models import PortInterfaceMappingSet
 

--- a/tests/test_armodel/writer/test_writer_sw_component.py
+++ b/tests/test_armodel/writer/test_writer_sw_component.py
@@ -403,8 +403,8 @@ class TestWriteCompositeNetworkRepresentation:
     def test_set_app_composite_iref(self, writer):
         parent = _parent()
         iref = ApplicationCompositeElementInPortInterfaceInstanceRef()
-        iref.root_data_prototype_ref = _ref()
-        iref.target_data_prototype_ref = _ref()
+        iref.setRootDataPrototypeRef(_ref())
+        iref.setTargetDataPrototypeRef(_ref())
         writer.setApplicationCompositeElementInPortInterfaceInstanceRef(parent, "LEAF-ELEMENT-IREF", iref)
         assert parent[0].tag == "LEAF-ELEMENT-IREF"
         assert parent[0].find("ROOT-DATA-PROTOTYPE-REF") is not None
@@ -444,8 +444,9 @@ class TestWriteReceiverComSpec:
         com_spec = NonqueuedReceiverComSpec()
         com_spec.setDataElementRef(_ref())
         com_spec.setAliveTimeout(_time_value(0.5))
-        com_spec.setEnableUpdated(_boolean(True))
+        com_spec.setEnableUpdate(_boolean(True))
         com_spec.setFilter(DataFilter())
+        com_spec.setHandleDataStatus(_boolean(True))
         com_spec.setHandleNeverReceived(_boolean(False))
         com_spec.setHandleTimeoutType(_literal("keep-old-value"))
         com_spec.setInitValue(TextValueSpecification())
@@ -455,6 +456,7 @@ class TestWriteReceiverComSpec:
         assert parent[0].find("ALIVE-TIMEOUT") is not None
         assert parent[0].find("ENABLE-UPDATE") is not None
         assert parent[0].find("FILTER") is not None
+        assert parent[0].find("HANDLE-DATA-STATUS") is not None
         assert parent[0].find("HANDLE-NEVER-RECEIVED") is not None
         assert parent[0].find("HANDLE-TIMEOUT-TYPE") is not None
         assert parent[0].find("INIT-VALUE") is not None

--- a/tests/test_armodel/writer/test_writer_system_mapping.py
+++ b/tests/test_armodel/writer/test_writer_system_mapping.py
@@ -15,8 +15,10 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     AnyInstanceRef,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa: E501
+    ARBoolean,
     ARLiteral,
     ARNumerical,
+    ARPositiveInteger,
     RefType,
     RevisionLabelString,
 )
@@ -86,6 +88,18 @@ def _revision(value):
     r = RevisionLabelString()
     r.setValue(value)
     return r
+
+
+def _boolean(val=True):
+    b = ARBoolean()
+    b.setValue(val)
+    return b
+
+
+def _positive_int(val=1):
+    i = ARPositiveInteger()
+    i.setValue(str(val))
+    return i
 
 
 def _pkg():
@@ -593,13 +607,71 @@ class TestWriterSetDataPrototypeMapping:
     def test_full(self, writer):
         mapping = DataPrototypeMapping()
         mapping.setFirstDataPrototypeRef(_ref("/f", "VARIABLE-DATA-PROTOTYPE"))
+        mapping.setFirstToSecondDataTransformationRef(_ref("/t1", "DATA-TRANSFORMATION"))
         mapping.setSecondDataPrototypeRef(_ref("/s", "VARIABLE-DATA-PROTOTYPE"))
+        mapping.setSecondToFirstDataTransformationRef(_ref("/t2", "DATA-TRANSFORMATION"))
         parent = _parent()
         writer.setDataPrototypeMapping(parent, mapping)
         m = parent[0]
         assert m.tag == "DATA-PROTOTYPE-MAPPING"
         assert m.find("FIRST-DATA-PROTOTYPE-REF") is not None
+        assert m.find("FIRST-TO-SECOND-DATA-TRANSFORMATION-REF") is not None
         assert m.find("SECOND-DATA-PROTOTYPE-REF") is not None
+        assert m.find("SECOND-TO-FIRST-DATA-TRANSFORMATION-REF") is not None
+
+    def test_with_sub_element_and_text_table_mappings(self, writer):
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import (
+            SubElementMapping,
+            TextTableMapping,
+        )
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface.InstanceRefs import (
+            ApplicationCompositeElementInPortInterfaceInstanceRef,
+        )
+
+        mapping = DataPrototypeMapping()
+        sub = SubElementMapping()
+        iref = ApplicationCompositeElementInPortInterfaceInstanceRef()
+        iref.setRootDataPrototypeRef(_ref("/root", "VARIABLE-DATA-PROTOTYPE"))
+        iref.setTargetDataPrototypeRef(_ref("/target", "VARIABLE-DATA-PROTOTYPE"))
+        sub.setFirstElement(iref)
+        mapping.addSubElementMapping(sub)
+        text = TextTableMapping()
+        text.setBitfieldTextTableMaskFirst(_positive_int(1))
+        text.setBitfieldTextTableMaskSecond(_positive_int(2))
+        text.setIdenticalMapping(_boolean(True))
+        text.setMappingDirection(_literal("BIDIRECTIONAL"))
+        mapping.addTextTableMapping(text)
+        parent = _parent()
+        writer.setDataPrototypeMapping(parent, mapping)
+        m = parent[0]
+        sub_elements = m.find("SUB-ELEMENT-MAPPINGS")
+        assert sub_elements is not None
+        sub_mapping = sub_elements.find("SUB-ELEMENT-MAPPING")
+        first_elements = sub_mapping.find("FIRST-ELEMENTS")
+        assert first_elements is not None
+        sub_ref = first_elements.find("APPLICATION-COMPOSITE-DATA-TYPE-SUB-ELEMENT-REF")
+        assert sub_ref is not None
+        iref_elem = sub_ref.find("APPLICATION-COMPOSITE-ELEMENT-IREF")
+        assert iref_elem is not None
+        assert iref_elem.find("ROOT-DATA-PROTOTYPE-REF") is not None
+        text_elements = m.find("TEXT-TABLE-MAPPINGS")
+        assert text_elements is not None
+        text_mapping = text_elements.find("TEXT-TABLE-MAPPING")
+        assert text_mapping is not None
+        assert text_mapping.find("BITFIELD-TEXT-TABLE-MASK-FIRST") is not None
+        assert text_mapping.find("BITFIELD-TEXT-TABLE-MASK-SECOND") is not None
+        assert text_mapping.find("IDENTICAL-MAPPING") is not None
+        assert text_mapping.find("MAPPING-DIRECTION") is not None
+
+    def test_empty_wrapper_lists_not_emitted(self, writer):
+        mapping = DataPrototypeMapping()
+        parent = _parent()
+        writer.setDataPrototypeMapping(parent, mapping)
+        m = parent[0]
+        assert m.find("SUB-ELEMENT-MAPPINGS") is None
+        assert m.find("TEXT-TABLE-MAPPINGS") is None
+        assert m.find("FIRST-TO-SECOND-DATA-TRANSFORMATION-REF") is None
+        assert m.find("SECOND-TO-FIRST-DATA-TRANSFORMATION-REF") is None
 
 
 class TestWriterSetDataPrototypeMappings:


### PR DESCRIPTION
Closes #622

## Summary
Sync 7 model classes in SWComponentTemplate to AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf (R23-11), all stamped `# Spec verified: R23-11`:
- **DataPrototypeMapping** (Table 4.22) — reader/writer for firstToSecondDataTransformationRef, secondToFirstDataTransformationRef, subElementMappings, textTableMappings
- **NonqueuedReceiverComSpec** (Table 4.62) — reader/writer for handleDataStatus
- **ModeDeclarationMapping** (4.29), **ReceiverComSpec** (4.60 abstract), **RPortComSpec** (4.59), **HandleOutOfRangeStatusEnum** (4.61), **HandleTimeoutEnum** (4.65) — verbatim docstrings, spec-order members, typed accessors

Also: latent writer bug fix in `setApplicationCompositeElementInPortInterfaceInstanceRef`, stale deviation rows removed, round-trip tests asserting field values.

## Verification
- 6327 unit tests, 130/130 integration round-trip, flake8, ruff, black-check all green