### PR TITLE
feat: add TransmissionComSpecProps and ParameterProvideComSpec com spec support

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Constants/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Constants/__init__.py
@@ -35,39 +35,27 @@ class ValueSpecification(ARObject, ABC):
     # [x] setShortLabel                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
-        """
-        Initializes the ValueSpecification base class.
-        Raises TypeError if this abstract class is instantiated directly.
-        """
         if type(self) is ValueSpecification:
             raise TypeError("ValueSpecification is an abstract class.")
 
         super().__init__()
 
-        # The shortLabel of this ValueSpecification.
+        # This can be used to identify particular value specifications for human readers, for example elements of a record type.
         self.shortLabel = None
 
     def getShortLabel(self):
         """
-        Gets the short label for this value specification.
-
-        Returns:
-            The short label
+        This can be used to identify particular value specifications for human readers, for example elements of a record type.
         """
         return self.shortLabel
 
     def setShortLabel(self, value):
         """
-        Sets the short label for this value specification.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The short label to set
-
-        Returns:
-            self for method chaining
+        This can be used to identify particular value specifications for human readers, for example elements of a record type.
+        A None value is a no-op and does not overwrite an existing shortLabel.
         """
-        self.shortLabel = value
+        if value is not None:
+            self.shortLabel = value
         return self
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Filter.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Filter.py
@@ -37,7 +37,7 @@ class DataFilterTypeEnum(AREnum):
         Initializes the DataFilterTypeEnum with all possible values.
         """
         super().__init__(
-            (
+            [
                 DataFilterTypeEnum.MASKED_NEW_DIFFERS_MASKED_OLD,
                 DataFilterTypeEnum.MASKED_NEW_DIFFERS_X,
                 DataFilterTypeEnum.MASKED_NEW_EQUALS_X,
@@ -45,7 +45,7 @@ class DataFilterTypeEnum(AREnum):
                 DataFilterTypeEnum.NEW_IS_OUTSIDE,
                 DataFilterTypeEnum.NEW_IS_WITHIN,
                 DataFilterTypeEnum.ONE_EVERY_N,
-            )
+            ]
         )
 
 
@@ -74,45 +74,39 @@ class DataFilter(ARObject):
     # [x] setX                         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
-        """
-        Initializes the DataFilter with default values.
-        """
         super().__init__()
 
-        # Type of data filtering to apply
+        # This attribute specifies the type of the filter.
         self.dataFilterType: DataFilterTypeEnum = None
-        # Bit mask for masked filtering operations
+
+        # Mask for old and new value.
         self.mask: UnlimitedInteger = None
-        # Maximum threshold value for range-based filtering
+
+        # Value to specify the upper boundary
         self.max: UnlimitedInteger = None
-        # Minimum threshold value for range-based filtering
+
+        # Value to specify the lower boundary
         self.min: UnlimitedInteger = None
-        # Offset value for filtering calculations
+
+        # Specifies the initial number of messages to occur before the first message is passed
         self.offset: PositiveInteger = None
-        # Period for periodic filtering operations (e.g., oneEveryN)
+
+        # Specifies number of messages to occur before the message is passed again
         self.period: PositiveInteger = None
-        # Reference value X used in comparison-based filtering
+
+        # Value to compare with
         self.x: UnlimitedInteger = None
 
     def getDataFilterType(self):
         """
-        Gets the type of data filtering to apply.
-
-        Returns:
-            DataFilterTypeEnum: The data filter type
+        This attribute specifies the type of the filter.
         """
         return self.dataFilterType
 
     def setDataFilterType(self, value):
         """
-        Sets the type of data filtering to apply.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The data filter type to set
-
-        Returns:
-            self for method chaining
+        This attribute specifies the type of the filter.
+        A None value is a no-op and does not overwrite an existing dataFilterType.
         """
         if value is not None:
             self.dataFilterType = value
@@ -120,23 +114,14 @@ class DataFilter(ARObject):
 
     def getMask(self):
         """
-        Gets the bit mask for masked filtering operations.
-
-        Returns:
-            UnlimitedInteger: The bit mask
+        Mask for old and new value.
         """
         return self.mask
 
     def setMask(self, value):
         """
-        Sets the bit mask for masked filtering operations.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The bit mask to set
-
-        Returns:
-            self for method chaining
+        Mask for old and new value.
+        A None value is a no-op and does not overwrite an existing mask.
         """
         if value is not None:
             self.mask = value
@@ -144,23 +129,14 @@ class DataFilter(ARObject):
 
     def getMax(self):
         """
-        Gets the maximum threshold value for range-based filtering.
-
-        Returns:
-            UnlimitedInteger: The maximum threshold
+        Value to specify the upper boundary
         """
         return self.max
 
     def setMax(self, value):
         """
-        Sets the maximum threshold value for range-based filtering.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The maximum threshold to set
-
-        Returns:
-            self for method chaining
+        Value to specify the upper boundary
+        A None value is a no-op and does not overwrite an existing max.
         """
         if value is not None:
             self.max = value
@@ -168,23 +144,14 @@ class DataFilter(ARObject):
 
     def getMin(self):
         """
-        Gets the minimum threshold value for range-based filtering.
-
-        Returns:
-            UnlimitedInteger: The minimum threshold
+        Value to specify the lower boundary
         """
         return self.min
 
     def setMin(self, value):
         """
-        Sets the minimum threshold value for range-based filtering.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The minimum threshold to set
-
-        Returns:
-            self for method chaining
+        Value to specify the lower boundary
+        A None value is a no-op and does not overwrite an existing min.
         """
         if value is not None:
             self.min = value
@@ -192,23 +159,14 @@ class DataFilter(ARObject):
 
     def getOffset(self):
         """
-        Gets the offset value for filtering calculations.
-
-        Returns:
-            PositiveInteger: The offset value
+        Specifies the initial number of messages to occur before the first message is passed
         """
         return self.offset
 
     def setOffset(self, value):
         """
-        Sets the offset value for filtering calculations.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The offset value to set
-
-        Returns:
-            self for method chaining
+        Specifies the initial number of messages to occur before the first message is passed
+        A None value is a no-op and does not overwrite an existing offset.
         """
         if value is not None:
             self.offset = value
@@ -216,23 +174,14 @@ class DataFilter(ARObject):
 
     def getPeriod(self):
         """
-        Gets the period for periodic filtering operations (e.g., oneEveryN).
-
-        Returns:
-            PositiveInteger: The period value
+        Specifies number of messages to occur before the message is passed again
         """
         return self.period
 
     def setPeriod(self, value):
         """
-        Sets the period for periodic filtering operations (e.g., oneEveryN).
-        Only sets the value if it is not None.
-
-        Args:
-            value: The period value to set
-
-        Returns:
-            self for method chaining
+        Specifies number of messages to occur before the message is passed again
+        A None value is a no-op and does not overwrite an existing period.
         """
         if value is not None:
             self.period = value
@@ -240,23 +189,14 @@ class DataFilter(ARObject):
 
     def getX(self):
         """
-        Gets the reference value X used in comparison-based filtering.
-
-        Returns:
-            UnlimitedInteger: The reference value X
+        Value to compare with
         """
         return self.x
 
     def setX(self, value):
         """
-        Sets the reference value X used in comparison-based filtering.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The reference value X to set
-
-        Returns:
-            self for method chaining
+        Value to compare with
+        A None value is a no-op and does not overwrite an existing x.
         """
         if value is not None:
             self.x = value

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Communication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Communication.py
@@ -40,13 +40,14 @@ class HandleInvalidEnum(AREnum):
 
 class PPortComSpec(ARObject, ABC):
     """
-    Communication attributes of a provided PortPrototype. This class will contain attributes
-    that are valid for all kinds of provide ports, independent of client-server or
-    sender-receiver communication patterns.
+    Communication attributes of a provided PortPrototype. This class will contain attributes that are valid for all kinds of provide ports, independent of client-server or sender-receiver communication patterns.
     """
 
     # PPortComSpec method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.58, p.166
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self):
         if type(self) is PPortComSpec:
@@ -234,41 +235,141 @@ class CompositeNetworkRepresentation(ARObject):
         return self
 
 
-class TransmissionAcknowledgementRequest(ARObject):
+class TransmissionModeDefinitionEnum(AREnum):
     """
-    Requests transmission acknowledgement that data has been sent successfully.
-    Success/failure is reported via a SendPoint of a RunnableEntity.
+    This meta-class defines possible settings for the transmission mode.
     """
 
-    # TransmissionAcknowledgementRequest method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getTimeout                   [x] impl  [x] docstring  [ ] test
-    # [ ] setTimeout                   [x] impl  [x] docstring  [ ] test
+    # TransmissionModeDefinitionEnum method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.73, p.181
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods) — enum value form serialized on TransmissionComSpecProps.transmissionMode
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+
+    # The data is assumed to be transmitted in a cyclic manner. The cycle is defined by dataUpdatePeriod. Tags: atp.EnumerationLiteralIndex=0
+    CYCLIC = "cyclic"
+
+    # The data is assumed to be transmitted in a cyclic manner (with cycle time dataUpdatePeriod) and additionally there may be arbitrary transmission if the data value changes (minimumSendInterval to be respected, if defined). Tags: atp.EnumerationLiteralIndex=2
+    CYCLIC_AND_ON_CHANGE = "cyclicAndOnChange"
+
+    # The data is assumed to be transmitted in an arbitrary manner (minimumSendInterval to be respected, if defined). Tags: atp.EnumerationLiteralIndex=1
+    TRIGGERED = "triggered"
+
+    def __init__(self):
+        super().__init__(
+            [
+                TransmissionModeDefinitionEnum.CYCLIC,
+                TransmissionModeDefinitionEnum.CYCLIC_AND_ON_CHANGE,
+                TransmissionModeDefinitionEnum.TRIGGERED,
+            ]
+        )
+
+
+class TransmissionComSpecProps(ARObject):
+    """
+    This meta-class defines a set of transmission attributes which the application software is assumed to implement.
+    """
+
+    # TransmissionComSpecProps method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.70, p.179
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getDataUpdatePeriod     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDataUpdatePeriod     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMinimumSendInterval  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMinimumSendInterval  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTransmissionMode     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTransmissionMode     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.timeout: float = None
+        # This attribute defines the period in which the application is assumed to transmit the respective data.
+        self.dataUpdatePeriod: Optional[TimeValue] = None
 
-    def getTimeout(self):
+        # This attribute defines the minimum interval between two consecutive transmissions of the respective data the application is assumed to ensure.
+        self.minimumSendInterval: Optional[TimeValue] = None
+
+        # The attribute defines the mode in which the application is assumed to transmit the respective data.
+        self.transmissionMode: Optional["TransmissionModeDefinitionEnum"] = None
+
+    def getDataUpdatePeriod(self) -> Optional[TimeValue]:
         """
-        Gets the timeout value for the transmission acknowledgement.
+        This attribute defines the period in which the application is assumed to transmit the respective data.
+        """
+        return self.dataUpdatePeriod
 
-        Returns:
-            float: The timeout value
+    def setDataUpdatePeriod(self, value: Optional[TimeValue]) -> "TransmissionComSpecProps":
+        """
+        This attribute defines the period in which the application is assumed to transmit the respective data.
+        A None value is a no-op and does not overwrite an existing dataUpdatePeriod.
+        """
+        if value is not None:
+            self.dataUpdatePeriod = value
+        return self
+
+    def getMinimumSendInterval(self) -> Optional[TimeValue]:
+        """
+        This attribute defines the minimum interval between two consecutive transmissions of the respective data the application is assumed to ensure.
+        """
+        return self.minimumSendInterval
+
+    def setMinimumSendInterval(self, value: Optional[TimeValue]) -> "TransmissionComSpecProps":
+        """
+        This attribute defines the minimum interval between two consecutive transmissions of the respective data the application is assumed to ensure.
+        A None value is a no-op and does not overwrite an existing minimumSendInterval.
+        """
+        if value is not None:
+            self.minimumSendInterval = value
+        return self
+
+    def getTransmissionMode(self) -> Optional["TransmissionModeDefinitionEnum"]:
+        """
+        The attribute defines the mode in which the application is assumed to transmit the respective data.
+        """
+        return self.transmissionMode
+
+    def setTransmissionMode(self, value: Optional["TransmissionModeDefinitionEnum"]) -> "TransmissionComSpecProps":
+        """
+        The attribute defines the mode in which the application is assumed to transmit the respective data.
+        A None value is a no-op and does not overwrite an existing transmissionMode.
+        """
+        if value is not None:
+            self.transmissionMode = value
+        return self
+
+
+class TransmissionAcknowledgementRequest(ARObject):
+    """
+    Requests transmission acknowledgement that data has been sent successfully. Success/failure is reported via a SendPoint of a RunnableEntity.
+    """
+
+    # TransmissionAcknowledgementRequest method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.71, p.180
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getTimeout   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTimeout   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # Number of seconds before an error is reported or in case of allowed redundancy, the value is sent again.
+        self.timeout: Optional[TimeValue] = None
+
+    def getTimeout(self) -> Optional[TimeValue]:
+        """
+        Number of seconds before an error is reported or in case of allowed redundancy, the value is sent again.
         """
         return self.timeout
 
-    def setTimeout(self, value):
+    def setTimeout(self, value: Optional[TimeValue]) -> "TransmissionAcknowledgementRequest":
         """
-        Sets the timeout value for the transmission acknowledgement.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The timeout value to set
-
-        Returns:
-            self for method chaining
+        Number of seconds before an error is reported or in case of allowed redundancy, the value is sent again.
+        A None value is a no-op and does not overwrite an existing timeout.
         """
         if value is not None:
             self.timeout = value
@@ -281,19 +382,24 @@ class SenderComSpec(PPortComSpec, ABC):
     """
 
     # SenderComSpec method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] addCompositeNetworkRepresentation [x] impl  [x] docstring  [ ] test
-    # [ ] getCompositeNetworkRepresentations [x] impl  [x] docstring  [ ] test
-    # [ ] getDataElementRef            [x] impl  [x] docstring  [ ] test
-    # [ ] setDataElementRef            [x] impl  [x] docstring  [ ] test
-    # [ ] getNetworkRepresentation     [x] impl  [x] docstring  [ ] test
-    # [ ] setNetworkRepresentation     [x] impl  [x] docstring  [ ] test
-    # [ ] getHandleOutOfRange          [x] impl  [x] docstring  [ ] test
-    # [ ] setHandleOutOfRange          [x] impl  [x] docstring  [ ] test
-    # [ ] getTransmissionAcknowledge   [x] impl  [x] docstring  [ ] test
-    # [ ] setTransmissionAcknowledge   [x] impl  [x] docstring  [ ] test
-    # [ ] getUsesEndToEndProtection    [x] impl  [x] docstring  [ ] test
-    # [ ] setUsesEndToEndProtection    [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.67, p.178
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addCompositeNetworkRepresentation [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCompositeNetworkRepresentations [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getDataElementRef          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDataElementRef          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHandleOutOfRange        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setHandleOutOfRange        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getNetworkRepresentation   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setNetworkRepresentation   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTransmissionAcknowledge [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTransmissionAcknowledge [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTransmissionProps       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTransmissionProps       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getUsesEndToEndProtection  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setUsesEndToEndProtection  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         if type(self) is SenderComSpec:
@@ -301,145 +407,130 @@ class SenderComSpec(PPortComSpec, ABC):
 
         super().__init__()
 
+        # This represents a CompositeNetworkRepresentation defined in the context of a SenderComSpec. Stereotypes: atpSplitable Tags: atp.Splitkey=compositeNetworkRepresentation
         self.compositeNetworkRepresentations: List[CompositeNetworkRepresentation] = []
-        self.dataElementRef: RefType = None
-        self.networkRepresentation: SwDataDefProps = None
-        self.handleOutOfRange: str = None
-        self.transmissionAcknowledge: TransmissionAcknowledgementRequest = None
-        self.usesEndToEndProtection: ARBoolean = None
 
-    def addCompositeNetworkRepresentation(self, representation: CompositeNetworkRepresentation):
+        # Data element these quality of service attributes apply to.
+        self.dataElementRef: Optional[RefType] = None
+
+        # This attribute controls how out-of-range values shall be dealt with.
+        self.handleOutOfRange: Optional[HandleOutOfRangeEnum] = None
+
+        # A networkRepresentation is used to define how the data Element is mapped to a communication bus. Stereotypes: atpSplitable Tags: atp.Splitkey=networkRepresentation
+        self.networkRepresentation: Optional[SwDataDefProps] = None
+
+        # Requested transmission acknowledgement for data element.
+        self.transmissionAcknowledge: Optional[TransmissionAcknowledgementRequest] = None
+
+        # This aggregation represents the definition transmission props in the context of the enclosing SenderComSpec.
+        self.transmissionProps: Optional[TransmissionComSpecProps] = None
+
+        # This indicates whether the corresponding dataElement shall be transmitted using end-to-end protection. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
+        self.usesEndToEndProtection: Optional[Boolean] = None
+
+    def addCompositeNetworkRepresentation(self, representation: Optional[CompositeNetworkRepresentation]) -> "SenderComSpec":
         """
-        Adds a composite network representation defined in the context of this SenderComSpec.
+        This represents a CompositeNetworkRepresentation defined in the context of a SenderComSpec. Stereotypes: atpSplitable Tags: atp.Splitkey=compositeNetworkRepresentation
+        A None value is a no-op and does not append anything.
         """
-        self.compositeNetworkRepresentations.append(representation)
+        if representation is not None:
+            self.compositeNetworkRepresentations.append(representation)
+        return self
 
     def getCompositeNetworkRepresentations(self) -> List[CompositeNetworkRepresentation]:
         """
-        Gets the composite network representations defined in the context of this SenderComSpec.
-
-        Returns:
-            List[CompositeNetworkRepresentation]: The composite network representations
+        This represents a CompositeNetworkRepresentation defined in the context of a SenderComSpec. Stereotypes: atpSplitable Tags: atp.Splitkey=compositeNetworkRepresentation
         """
         return self.compositeNetworkRepresentations
 
-    def getDataElementRef(self):
+    def getDataElementRef(self) -> Optional[RefType]:
         """
-        Gets the data element these quality of service attributes apply to.
-
-        Returns:
-            RefType: The data element reference
+        Data element these quality of service attributes apply to.
         """
         return self.dataElementRef
 
-    def setDataElementRef(self, value):
+    def setDataElementRef(self, value: Optional[RefType]) -> "SenderComSpec":
         """
-        Sets the data element these quality of service attributes apply to.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The data element reference to set
-
-        Returns:
-            self for method chaining
+        Data element these quality of service attributes apply to.
+        A None value is a no-op and does not overwrite an existing dataElementRef.
         """
-        self.dataElementRef = value
+        if value is not None:
+            self.dataElementRef = value
         return self
 
-    def getNetworkRepresentation(self):
+    def getHandleOutOfRange(self) -> Optional["HandleOutOfRangeEnum"]:
         """
-        Gets the network representation used to define how the data element is mapped
-        to a communication bus.
-
-        Returns:
-            SwDataDefProps: The network representation
-        """
-        return self.networkRepresentation
-
-    def setNetworkRepresentation(self, value):
-        """
-        Sets the network representation used to define how the data element is mapped
-        to a communication bus.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The network representation to set
-
-        Returns:
-            self for method chaining
-        """
-        self.networkRepresentation = value
-        return self
-
-    def getHandleOutOfRange(self):
-        """
-        Gets the strategy for handling out-of-range values.
-
-        Returns:
-            str: The handle out-of-range setting
+        This attribute controls how out-of-range values shall be dealt with.
         """
         return self.handleOutOfRange
 
-    def setHandleOutOfRange(self, value):
+    def setHandleOutOfRange(self, value: Optional["HandleOutOfRangeEnum"]) -> "SenderComSpec":
         """
-        Sets the strategy for handling out-of-range values.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The handle out-of-range setting
-
-        Returns:
-            self for method chaining
+        This attribute controls how out-of-range values shall be dealt with.
+        A None value is a no-op and does not overwrite an existing handleOutOfRange.
         """
-        self.handleOutOfRange = value
+        if value is not None:
+            self.handleOutOfRange = value
         return self
 
-    def getTransmissionAcknowledge(self):
+    def getNetworkRepresentation(self) -> Optional[SwDataDefProps]:
         """
-        Gets the transmission acknowledgement request for this sender com spec.
+        A networkRepresentation is used to define how the data Element is mapped to a communication bus. Stereotypes: atpSplitable Tags: atp.Splitkey=networkRepresentation
+        """
+        return self.networkRepresentation
 
-        Returns:
-            TransmissionAcknowledgementRequest: The transmission acknowledgement
+    def setNetworkRepresentation(self, value: Optional[SwDataDefProps]) -> "SenderComSpec":
+        """
+        A networkRepresentation is used to define how the data Element is mapped to a communication bus. Stereotypes: atpSplitable Tags: atp.Splitkey=networkRepresentation
+        A None value is a no-op and does not overwrite an existing networkRepresentation.
+        """
+        if value is not None:
+            self.networkRepresentation = value
+        return self
+
+    def getTransmissionAcknowledge(self) -> Optional[TransmissionAcknowledgementRequest]:
+        """
+        Requested transmission acknowledgement for data element.
         """
         return self.transmissionAcknowledge
 
-    def setTransmissionAcknowledge(self, value):
+    def setTransmissionAcknowledge(self, value: Optional[TransmissionAcknowledgementRequest]) -> "SenderComSpec":
         """
-        Sets the transmission acknowledgement request for this sender com spec.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The transmission acknowledgement request to set
-
-        Returns:
-            self for method chaining
+        Requested transmission acknowledgement for data element.
+        A None value is a no-op and does not overwrite an existing transmissionAcknowledge.
         """
-        self.transmissionAcknowledge = value
+        if value is not None:
+            self.transmissionAcknowledge = value
         return self
 
-    def getUsesEndToEndProtection(self):
+    def getTransmissionProps(self) -> Optional[TransmissionComSpecProps]:
         """
-        Gets whether the corresponding data element shall be transmitted using
-        end-to-end protection.
+        This aggregation represents the definition transmission props in the context of the enclosing SenderComSpec.
+        """
+        return self.transmissionProps
 
-        Returns:
-            ARBoolean: True if end-to-end protection is used
+    def setTransmissionProps(self, value: Optional[TransmissionComSpecProps]) -> "SenderComSpec":
+        """
+        This aggregation represents the definition transmission props in the context of the enclosing SenderComSpec.
+        A None value is a no-op and does not overwrite an existing transmissionProps.
+        """
+        if value is not None:
+            self.transmissionProps = value
+        return self
+
+    def getUsesEndToEndProtection(self) -> Optional[Boolean]:
+        """
+        This indicates whether the corresponding dataElement shall be transmitted using end-to-end protection. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
         """
         return self.usesEndToEndProtection
 
-    def setUsesEndToEndProtection(self, value):
+    def setUsesEndToEndProtection(self, value: Optional[Boolean]) -> "SenderComSpec":
         """
-        Sets whether the corresponding data element shall be transmitted using
-        end-to-end protection.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The end-to-end protection flag
-
-        Returns:
-            self for method chaining
+        This indicates whether the corresponding dataElement shall be transmitted using end-to-end protection. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
+        A None value is a no-op and does not overwrite an existing usesEndToEndProtection.
         """
-        self.usesEndToEndProtection = value
+        if value is not None:
+            self.usesEndToEndProtection = value
         return self
 
 
@@ -458,42 +549,56 @@ class QueuedSenderComSpec(SenderComSpec):
 
 class NonqueuedSenderComSpec(SenderComSpec):
     """
-    Communication attributes for non-queued sender/receiver communication (sender side).
+    Communication attributes for non-queued sender/receiver communication (sender side)
     """
 
     # NonqueuedSenderComSpec method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getInitValue                 [x] impl  [x] docstring  [ ] test
-    # [ ] setInitValue                 [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.69, p.179
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getDataFilter  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDataFilter  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getInitValue  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setInitValue  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.initValue: ValueSpecification = None
+        # The applicable filter algorithm for filtering the value of the corresponding dataElement.
+        self.dataFilter: Optional[DataFilter] = None
 
-    def getInitValue(self):
+        # Initial value to be sent if sender component is not yet fully initialized, but receiver needs data already.
+        self.initValue: Optional[ValueSpecification] = None
+
+    def getDataFilter(self) -> Optional[DataFilter]:
         """
-        Gets the initial value to be sent if sender component is not yet fully initialized,
-        but receiver needs data already.
+        The applicable filter algorithm for filtering the value of the corresponding dataElement.
+        """
+        return self.dataFilter
 
-        Returns:
-            ValueSpecification: The initial value
+    def setDataFilter(self, value: Optional[DataFilter]) -> "NonqueuedSenderComSpec":
+        """
+        The applicable filter algorithm for filtering the value of the corresponding dataElement.
+        A None value is a no-op and does not overwrite an existing dataFilter.
+        """
+        if value is not None:
+            self.dataFilter = value
+        return self
+
+    def getInitValue(self) -> Optional[ValueSpecification]:
+        """
+        Initial value to be sent if sender component is not yet fully initialized, but receiver needs data already.
         """
         return self.initValue
 
-    def setInitValue(self, value):
+    def setInitValue(self, value: Optional[ValueSpecification]) -> "NonqueuedSenderComSpec":
         """
-        Sets the initial value to be sent if sender component is not yet fully initialized,
-        but receiver needs data already.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The initial value to set
-
-        Returns:
-            self for method chaining
+        Initial value to be sent if sender component is not yet fully initialized, but receiver needs data already.
+        A None value is a no-op and does not overwrite an existing initValue.
         """
-        self.initValue = value
+        if value is not None:
+            self.initValue = value
         return self
 
 
@@ -503,37 +608,73 @@ class ClientComSpec(RPortComSpec):
     """
 
     # ClientComSpec method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getOperationRef              [x] impl  [x] docstring  [ ] test
-    # [ ] setOperationRef              [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.77, p.187
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getEndToEndCallResponseTimeout  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setEndToEndCallResponseTimeout  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getOperationRef  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setOperationRef  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] addTransformationComSpecProps  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTransformationComSpecProps  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self):
         super().__init__()
 
-        self.operationRef: RefType = None
+        # This attribute defines the maximum time interval in which the application shall expect the servers's response (time between the sending of the call invocation until the arrival of the server's response).
+        self.endToEndCallResponseTimeout: Optional[TimeValue] = None
 
-    def getOperationRef(self):
+        # This represents the corresponding ClientServerOperation.
+        self.operationRef: Optional[RefType] = None
+
+        # This references the TransformationComSpecProps which define port-specific configuration for data transformation.
+        self.transformationComSpecProps: List[TransformationComSpecProps] = []
+
+    def getEndToEndCallResponseTimeout(self) -> Optional[TimeValue]:
         """
-        Gets the reference to the operation these communication attributes apply to.
+        This attribute defines the maximum time interval in which the application shall expect the servers's response (time between the sending of the call invocation until the arrival of the server's response).
+        """
+        return self.endToEndCallResponseTimeout
 
-        Returns:
-            RefType: The operation reference
+    def setEndToEndCallResponseTimeout(self, value: Optional[TimeValue]) -> "ClientComSpec":
+        """
+        This attribute defines the maximum time interval in which the application shall expect the servers's response (time between the sending of the call invocation until the arrival of the server's response).
+        A None value is a no-op and does not overwrite an existing endToEndCallResponseTimeout.
+        """
+        if value is not None:
+            self.endToEndCallResponseTimeout = value
+        return self
+
+    def getOperationRef(self) -> Optional[RefType]:
+        """
+        This represents the corresponding ClientServerOperation.
         """
         return self.operationRef
 
-    def setOperationRef(self, value):
+    def setOperationRef(self, value: Optional[RefType]) -> "ClientComSpec":
         """
-        Sets the reference to the operation these communication attributes apply to.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The operation reference to set
-
-        Returns:
-            self for method chaining
+        This represents the corresponding ClientServerOperation.
+        A None value is a no-op and does not overwrite an existing operationRef.
         """
-        self.operationRef = value
+        if value is not None:
+            self.operationRef = value
         return self
+
+    def addTransformationComSpecProps(self, value: Optional["TransformationComSpecProps"]) -> "ClientComSpec":
+        """
+        This references the TransformationComSpecProps which define port-specific configuration for data transformation.
+        A None value is a no-op and does not append anything.
+        """
+        if value is not None:
+            self.transformationComSpecProps.append(value)
+        return self
+
+    def getTransformationComSpecProps(self) -> List["TransformationComSpecProps"]:
+        """
+        This references the TransformationComSpecProps which define port-specific configuration for data transformation.
+        """
+        return self.transformationComSpecProps
 
 
 class ModeSwitchReceiverComSpec(RPortComSpec):
@@ -1177,15 +1318,57 @@ class ModeSwitchSenderComSpec(PPortComSpec):
 
 class ParameterProvideComSpec(PPortComSpec):
     """
-    \"Communication\" specification that applies to parameters on the provided side
-    of a connection.
+    "Communication" specification that applies to parameters on the provided side of a connection.
     """
 
     # ParameterProvideComSpec method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.82, p.192
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getInitValue  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setInitValue  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getParameterRef  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setParameterRef  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
+
+        # The initial value applicable for the corresponding ParameterDataPrototype.
+        self.initValue: Optional[ValueSpecification] = None
+
+        # The ParameterDataPrototype to which the Parameter ComSpec applies.
+        self.parameterRef: Optional[RefType] = None
+
+    def getInitValue(self) -> Optional[ValueSpecification]:
+        """
+        The initial value applicable for the corresponding ParameterDataPrototype.
+        """
+        return self.initValue
+
+    def setInitValue(self, value: Optional[ValueSpecification]) -> "ParameterProvideComSpec":
+        """
+        The initial value applicable for the corresponding ParameterDataPrototype.
+        A None value is a no-op and does not overwrite an existing initValue.
+        """
+        if value is not None:
+            self.initValue = value
+        return self
+
+    def getParameterRef(self) -> Optional[RefType]:
+        """
+        The ParameterDataPrototype to which the Parameter ComSpec applies.
+        """
+        return self.parameterRef
+
+    def setParameterRef(self, value: Optional[RefType]) -> "ParameterProvideComSpec":
+        """
+        The ParameterDataPrototype to which the Parameter ComSpec applies.
+        A None value is a no-op and does not overwrite an existing parameterRef.
+        """
+        if value is not None:
+            self.parameterRef = value
+        return self
 
 
 class TransformationComSpecProps(Describable, ABC):
@@ -1195,6 +1378,7 @@ class TransformationComSpecProps(Describable, ABC):
 
     # TransformationComSpecProps method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.86, p.197
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
@@ -1707,93 +1891,73 @@ class ServerComSpec(PPortComSpec):
     """
 
     # ServerComSpec method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getOperationRef              [x] impl  [x] docstring  [ ] test
-    # [ ] setOperationRef              [x] impl  [x] docstring  [ ] test
-    # [ ] getQueueLength               [x] impl  [x] docstring  [ ] test
-    # [ ] setQueueLength               [x] impl  [x] docstring  [ ] test
-    # [ ] getTransformationComSpecProps [x] impl  [x] docstring  [ ] test
-    # [ ] addTransformationComSpecProps [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.78, p.188
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getOperationRef  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setOperationRef  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getQueueLength  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setQueueLength  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] addTransformationComSpecProps  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTransformationComSpecProps  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self):
         super().__init__()
 
-        self.operationRef: RefType = None
-        self.queueLength: PositiveInteger = None
+        # Operation these communication attributes apply to.
+        self.operationRef: Optional[RefType] = None
+
+        # Length of call queue on the server side. The queue is implemented by the RTE. The value shall be greater or equal to 1. Setting the value of queueLength to 1 implies that incoming requests are rejected while another request that arrived earlier is being processed.
+        self.queueLength: Optional[PositiveInteger] = None
+
+        # This references the TransformationComSpecProps which define port-specific configuration for data transformation.
         self.transformationComSpecProps: List[TransformationComSpecProps] = []
 
-    def getOperationRef(self):
+    def getOperationRef(self) -> Optional[RefType]:
         """
-        Gets the operation these communication attributes apply to.
-
-        Returns:
-            RefType: The operation reference
+        Operation these communication attributes apply to.
         """
         return self.operationRef
 
-    def setOperationRef(self, value):
+    def setOperationRef(self, value: Optional[RefType]) -> "ServerComSpec":
         """
-        Sets the operation these communication attributes apply to.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The operation reference to set
-
-        Returns:
-            self for method chaining
+        Operation these communication attributes apply to.
+        A None value is a no-op and does not overwrite an existing operationRef.
         """
-        self.operationRef = value
+        if value is not None:
+            self.operationRef = value
         return self
 
-    def getQueueLength(self):
+    def getQueueLength(self) -> Optional[PositiveInteger]:
         """
-        Gets the length of call queue on the server side.
-        The queue is implemented by the RTE.
-
-        Returns:
-            PositiveInteger: The queue length
+        Length of call queue on the server side. The queue is implemented by the RTE. The value shall be greater or equal to 1. Setting the value of queueLength to 1 implies that incoming requests are rejected while another request that arrived earlier is being processed.
         """
         return self.queueLength
 
-    def setQueueLength(self, value):
+    def setQueueLength(self, value: Optional[PositiveInteger]) -> "ServerComSpec":
         """
-        Sets the length of call queue on the server side.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The queue length to set
-
-        Returns:
-            self for method chaining
+        Length of call queue on the server side. The queue is implemented by the RTE. The value shall be greater or equal to 1. Setting the value of queueLength to 1 implies that incoming requests are rejected while another request that arrived earlier is being processed.
+        A None value is a no-op and does not overwrite an existing queueLength.
         """
-        self.queueLength = value
+        if value is not None:
+            self.queueLength = value
         return self
 
-    def getTransformationComSpecProps(self) -> List[TransformationComSpecProps]:
+    def addTransformationComSpecProps(self, value: Optional["TransformationComSpecProps"]) -> "ServerComSpec":
         """
-        Gets the TransformationComSpecProps which define port-specific configuration
-        for data transformation.
+        This references the TransformationComSpecProps which define port-specific configuration for data transformation.
+        A None value is a no-op and does not append anything.
+        """
+        if value is not None:
+            self.transformationComSpecProps.append(value)
+        return self
 
-        Returns:
-            List[TransformationComSpecProps]: The transformation com spec props
+    def getTransformationComSpecProps(self) -> List["TransformationComSpecProps"]:
+        """
+        This references the TransformationComSpecProps which define port-specific configuration for data transformation.
         """
         return self.transformationComSpecProps
-
-    def addTransformationComSpecProps(self, transformationComSpecProps: TransformationComSpecProps):
-        """
-        Adds a TransformationComSpecProps which defines port-specific configuration
-        for data transformation.
-        Only adds the value if it is not None.
-
-        Args:
-            transformationComSpecProps: The transformation com spec props to add
-
-        Returns:
-            self for method chaining
-        """
-        if transformationComSpecProps is not None:
-            self.transformationComSpecProps.append(transformationComSpecProps)
-        return self
 
 
 class NvProvideComSpec(PPortComSpec):
@@ -2200,29 +2364,5 @@ class HandleTimeoutEnum(AREnum):
                 HandleTimeoutEnum.NONE,
                 HandleTimeoutEnum.REPLACE,
                 HandleTimeoutEnum.REPLACE_BY_TIMEOUT_SUBSTITUTION_VALUE,
-            )
-        )
-
-
-class TransmissionModeDefinitionEnum(AREnum):
-    """
-    Enumeration for transmission mode definition.
-    """
-
-    # TransmissionModeDefinitionEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-
-    PERIODIC = "periodic"
-    ON_CHANGE = "on-change"
-    DIRECT = "direct"
-    MIXED = "mixed"
-
-    def __init__(self):
-        super().__init__(
-            (
-                TransmissionModeDefinitionEnum.PERIODIC,
-                TransmissionModeDefinitionEnum.ON_CHANGE,
-                TransmissionModeDefinitionEnum.DIRECT,
-                TransmissionModeDefinitionEnum.MIXED,
             )
         )

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
@@ -22,7 +22,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     RefType,
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import ClientComSpec, ModeSwitchReceiverComSpec, ModeSwitchSenderComSpec
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import NonqueuedReceiverComSpec, NonqueuedSenderComSpec, PPortComSpec
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import NonqueuedReceiverComSpec, NonqueuedSenderComSpec, NvProvideComSpec, ParameterProvideComSpec, PPortComSpec
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import ParameterRequireComSpec, QueuedReceiverComSpec, QueuedSenderComSpec
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import RPortComSpec, ServerComSpec
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
@@ -319,6 +319,10 @@ class AbstractProvidedPortPrototype(PortPrototype):
         elif isinstance(com_spec, QueuedSenderComSpec):
             pass
         elif isinstance(com_spec, ModeSwitchSenderComSpec):
+            pass
+        elif isinstance(com_spec, NvProvideComSpec):
+            pass
+        elif isinstance(com_spec, ParameterProvideComSpec):
             pass
         else:
             raise ValueError("Unsupported com spec")

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -247,6 +247,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import
     NonqueuedSenderComSpec,
     NvProvideComSpec,
     NvRequireComSpec,
+    ParameterProvideComSpec,
     ParameterRequireComSpec,
     PPortComSpec,
     QueuedReceiverComSpec,
@@ -258,6 +259,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import
     ServerComSpec,
     TransformationComSpecProps,
     TransmissionAcknowledgementRequest,
+    TransmissionComSpecProps,
     UserDefinedTransformationComSpecProps,
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import (
@@ -3871,7 +3873,9 @@ class ARXMLParser(AbstractARXMLParser):
     def getClientComSpec(self, element: ET.Element) -> ClientComSpec:
         com_spec = ClientComSpec()
         self.readRPortComSpec(element, com_spec)
-        com_spec.operationRef = self.getChildElementOptionalRefType(element, "OPERATION-REF")
+        com_spec.setEndToEndCallResponseTimeout(self.getChildElementOptionalTimeValue(element, "END-TO-END-CALL-RESPONSE-TIMEOUT"))
+        com_spec.setOperationRef(self.getChildElementOptionalRefType(element, "OPERATION-REF"))
+        self.readTransformationComSpecPropss(element, com_spec)
         return com_spec
 
     def getParameterRequireComSpec(self, element: ET.Element) -> ParameterRequireComSpec:
@@ -4033,8 +4037,19 @@ class ARXMLParser(AbstractARXMLParser):
         if child_element is not None:
             acknowledge = TransmissionAcknowledgementRequest()
             self.readARObjectAttributes(child_element, acknowledge)
-            acknowledge.timeout = self.getChildElementOptionalFloatValue(child_element, "TIMEOUT")
+            acknowledge.setTimeout(self.getChildElementOptionalTimeValue(child_element, "TIMEOUT"))
             return acknowledge
+        return None
+
+    def getTransmissionComSpecProps(self, element: ET.Element, key: str) -> TransmissionComSpecProps:
+        child_element = self.find(element, key)
+        if child_element is not None:
+            props = TransmissionComSpecProps()
+            self.readARObjectAttributes(child_element, props)
+            props.setDataUpdatePeriod(self.getChildElementOptionalTimeValue(child_element, "DATA-UPDATE-PERIOD"))
+            props.setMinimumSendInterval(self.getChildElementOptionalTimeValue(child_element, "MINIMUM-SEND-INTERVAL"))
+            props.setTransmissionMode(self.getChildElementOptionalLiteral(child_element, "TRANSMISSION-MODE"))
+            return props
         return None
 
     def readSenderComSpec(self, element: ET.Element, com_spec: SenderComSpec):
@@ -4042,14 +4057,16 @@ class ARXMLParser(AbstractARXMLParser):
         for child_element in self.findall(element, "COMPOSITE-NETWORK-REPRESENTATIONS/COMPOSITE-NETWORK-REPRESENTATION"):
             com_spec.addCompositeNetworkRepresentation(self.getCompositeNetworkRepresentation(child_element))
         com_spec.setDataElementRef(self.getChildElementOptionalRefType(element, "DATA-ELEMENT-REF"))
-        com_spec.setNetworkRepresentation(self.getSwDataDefProps(element, "NETWORK-REPRESENTATION"))
         com_spec.setHandleOutOfRange(self.getChildElementOptionalLiteral(element, "HANDLE-OUT-OF-RANGE"))
+        com_spec.setNetworkRepresentation(self.getSwDataDefProps(element, "NETWORK-REPRESENTATION"))
         com_spec.setTransmissionAcknowledge(self.readTransmissionAcknowledgementRequest(element))
+        com_spec.setTransmissionProps(self.getTransmissionComSpecProps(element, "TRANSMISSION-PROPS"))
         com_spec.setUsesEndToEndProtection(self.getChildElementOptionalBooleanValue(element, "USES-END-TO-END-PROTECTION"))
 
     def getNonqueuedSenderComSpec(self, element: ET.Element) -> NonqueuedSenderComSpec:
         com_spec = NonqueuedSenderComSpec()
         self.readSenderComSpec(element, com_spec)
+        com_spec.setDataFilter(self.getDataFilter(element, "DATA-FILTER"))
         com_spec.setInitValue(self.getInitValue(element))
         return com_spec
 
@@ -4059,10 +4076,17 @@ class ARXMLParser(AbstractARXMLParser):
     def readUserDefinedTransformationComSpecProps(self, element: ET.Element, props: UserDefinedTransformationComSpecProps):
         self.readTransformationComSpecProps(element, props)
 
-    def readServerComSpecTransformationComSpecProps(self, element: ET.Element, com_spec: ServerComSpec):
+    def readEndToEndTransformationComSpecProps(self, element: ET.Element, props: EndToEndTransformationComSpecProps):
+        self.readTransformationComSpecProps(element, props)
+
+    def readTransformationComSpecPropss(self, element: ET.Element, com_spec):
         for child_element in self.findall(element, "TRANSFORMATION-COM-SPEC-PROPSS/*"):
             tag_name = self.getTagName(child_element)
-            if tag_name == "USER-DEFINED-TRANSFORMATION-COM-SPEC-PROPS":
+            if tag_name == "END-TO-END-TRANSFORMATION-COM-SPEC-PROPS":
+                props = EndToEndTransformationComSpecProps()
+                self.readEndToEndTransformationComSpecProps(child_element, props)
+                com_spec.addTransformationComSpecProps(props)
+            elif tag_name == "USER-DEFINED-TRANSFORMATION-COM-SPEC-PROPS":
                 props = UserDefinedTransformationComSpecProps()
                 self.readUserDefinedTransformationComSpecProps(child_element, props)
                 com_spec.addTransformationComSpecProps(props)
@@ -4076,8 +4100,15 @@ class ARXMLParser(AbstractARXMLParser):
         com_spec = ServerComSpec()
         self.readPPortComSpec(element, com_spec)
         com_spec.setOperationRef(self.getChildElementOptionalRefType(element, "OPERATION-REF"))
-        com_spec.setQueueLength(self.getChildElementOptionalNumericalValue(element, "QUEUE-LENGTH"))
-        self.readServerComSpecTransformationComSpecProps(element, com_spec)
+        com_spec.setQueueLength(self.getChildElementOptionalPositiveInteger(element, "QUEUE-LENGTH"))
+        self.readTransformationComSpecPropss(element, com_spec)
+        return com_spec
+
+    def getParameterProvideComSpec(self, element: ET.Element) -> ParameterProvideComSpec:
+        com_spec = ParameterProvideComSpec()
+        self.readPPortComSpec(element, com_spec)
+        com_spec.setInitValue(self.getInitValue(element))
+        com_spec.setParameterRef(self.getChildElementOptionalRefType(element, "PARAMETER-REF"))
         return com_spec
 
     def getQueuedSenderComSpec(self, element: ET.Element) -> QueuedSenderComSpec:
@@ -4121,6 +4152,8 @@ class ARXMLParser(AbstractARXMLParser):
                 parent.addProvidedComSpec(self.getModeSwitchSenderComSpec(child_element))
             elif tag_name == "NV-PROVIDE-COM-SPEC":
                 parent.addProvidedComSpec(self.getNvProvideComSpec(child_element))
+            elif tag_name == "PARAMETER-PROVIDE-COM-SPEC":
+                parent.addProvidedComSpec(self.getParameterProvideComSpec(child_element))
             else:
                 self.raiseError("Unsupported RequiredComSpec <%s>" % tag_name)
 

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -230,6 +230,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import
     NonqueuedSenderComSpec,
     NvProvideComSpec,
     NvRequireComSpec,
+    ParameterProvideComSpec,
     ParameterRequireComSpec,
     PPortComSpec,
     QueuedReceiverComSpec,
@@ -241,6 +242,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import
     ServerComSpec,
     TransformationComSpecProps,
     TransmissionAcknowledgementRequest,
+    TransmissionComSpecProps,
     UserDefinedTransformationComSpecProps,
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import (
@@ -946,8 +948,15 @@ class ARXMLWriter(AbstractARXMLWriter):
         if acknowledge is not None:
             child_element = ET.SubElement(element, "TRANSMISSION-ACKNOWLEDGE")
             self.writeARObjectAttributes(child_element, acknowledge)
-            if acknowledge.timeout is not None:
-                self.setChildElementOptionalFloatValue(child_element, "TIMEOUT", acknowledge.timeout)
+            self.setChildElementOptionalTimeValue(child_element, "TIMEOUT", acknowledge.getTimeout())
+
+    def writeTransmissionComSpecProps(self, element: ET.Element, props: TransmissionComSpecProps):
+        if props is not None:
+            child_element = ET.SubElement(element, "TRANSMISSION-PROPS")
+            self.writeARObjectAttributes(child_element, props)
+            self.setChildElementOptionalTimeValue(child_element, "DATA-UPDATE-PERIOD", props.getDataUpdatePeriod())
+            self.setChildElementOptionalTimeValue(child_element, "MINIMUM-SEND-INTERVAL", props.getMinimumSendInterval())
+            self.setChildElementOptionalLiteral(child_element, "TRANSMISSION-MODE", props.getTransmissionMode())
 
     def writeSenderComSpec(self, element: ET.Element, com_spec: SenderComSpec):
         representations = com_spec.getCompositeNetworkRepresentations()
@@ -956,15 +965,17 @@ class ARXMLWriter(AbstractARXMLWriter):
             for representation in representations:
                 self.writeCompositeNetworkRepresentation(child_element, representation)
         self.setChildElementOptionalRefType(element, "DATA-ELEMENT-REF", com_spec.getDataElementRef())
-        self.setSwDataDefProps(element, "NETWORK-REPRESENTATION", com_spec.getNetworkRepresentation())
         self.setChildElementOptionalLiteral(element, "HANDLE-OUT-OF-RANGE", com_spec.getHandleOutOfRange())
+        self.setSwDataDefProps(element, "NETWORK-REPRESENTATION", com_spec.getNetworkRepresentation())
         self.writeTransmissionAcknowledgementRequest(element, com_spec.getTransmissionAcknowledge())
+        self.writeTransmissionComSpecProps(element, com_spec.getTransmissionProps())
         self.setChildElementOptionalBooleanValue(element, "USES-END-TO-END-PROTECTION", com_spec.getUsesEndToEndProtection())
 
     def writeNonqueuedSenderComSpec(self, element: ET.Element, com_spec: NonqueuedSenderComSpec):
         child_element = ET.SubElement(element, "NONQUEUED-SENDER-COM-SPEC")
         self.writeARObjectAttributes(child_element, com_spec)
         self.writeSenderComSpec(child_element, com_spec)
+        self.setDataFilter(child_element, "DATA-FILTER", com_spec.getDataFilter())
         self.setChildValueSpecification(child_element, "INIT-VALUE", com_spec.getInitValue())
 
     def writeTransformationComSpecProps(self, element: ET.Element, prop: TransformationComSpecProps):
@@ -977,20 +988,13 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeTransformationComSpecProps(child_element, prop)
 
     def writeServerComSpecTransformationComSpecProps(self, element: ET.Element, com_spec: ServerComSpec):
-        props = com_spec.getTransformationComSpecProps()
-        if len(props) > 0:
-            child_element = ET.SubElement(element, "TRANSFORMATION-COM-SPEC-PROPSS")
-            for prop in props:
-                if isinstance(prop, UserDefinedTransformationComSpecProps):
-                    self.writeUserDefinedTransformationComSpecProps(child_element, prop)
-                else:
-                    self.notImplemented("Unsupported TransformationComSpecProps %s" % type(prop))
+        self.writeTransformationComSpecPropss(element, com_spec.getTransformationComSpecProps())
 
     def writeServerComSpec(self, element: ET.Element, com_spec: ServerComSpec):
         child_element = ET.SubElement(element, "SERVER-COM-SPEC")
         self.writeARObjectAttributes(child_element, com_spec)
         self.setChildElementOptionalRefType(child_element, "OPERATION-REF", com_spec.getOperationRef())
-        self.setChildElementOptionalNumericalValue(child_element, "QUEUE-LENGTH", com_spec.getQueueLength())
+        self.setChildElementOptionalPositiveInteger(child_element, "QUEUE-LENGTH", com_spec.getQueueLength())
         self.writeServerComSpecTransformationComSpecProps(child_element, com_spec)
 
     def writeQueuedSenderComSpec(self, element: ET.Element, com_spec: QueuedSenderComSpec):
@@ -1030,6 +1034,8 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeModeSwitchSenderComSpec(com_specs_tag, com_spec)
         elif isinstance(com_spec, NvProvideComSpec):
             self.writeNvProvideComSpec(com_specs_tag, com_spec)
+        elif isinstance(com_spec, ParameterProvideComSpec):
+            self.writeParameterProvideComSpec(com_specs_tag, com_spec)
         else:
             self.notImplemented("Unsupported PPortComSpec %s" % type(com_spec))
 
@@ -1199,7 +1205,25 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.logger.debug("writeClientComSpec")
         child_element = ET.SubElement(element, "CLIENT-COM-SPEC")
         self.writeARObjectAttributes(child_element, com_spec)
+        self.setChildElementOptionalTimeValue(child_element, "END-TO-END-CALL-RESPONSE-TIMEOUT", com_spec.getEndToEndCallResponseTimeout())
         self.setChildElementOptionalRefType(child_element, "OPERATION-REF", com_spec.getOperationRef())
+        self.writeTransformationComSpecPropss(child_element, com_spec.getTransformationComSpecProps())
+
+    def writeTransformationComSpecPropss(self, element: ET.Element, props):
+        if len(props) > 0:
+            child_element = ET.SubElement(element, "TRANSFORMATION-COM-SPEC-PROPSS")
+            for prop in props:
+                if isinstance(prop, UserDefinedTransformationComSpecProps):
+                    self.writeUserDefinedTransformationComSpecProps(child_element, prop)
+                else:
+                    self.notImplemented("Unsupported TransformationComSpecProps %s" % type(prop))
+
+    def writeParameterProvideComSpec(self, element: ET.Element, com_spec: ParameterProvideComSpec):
+        self.logger.debug("writeParameterProvideComSpec")
+        child_element = ET.SubElement(element, "PARAMETER-PROVIDE-COM-SPEC")
+        self.writeARObjectAttributes(child_element, com_spec)
+        self.setChildValueSpecification(child_element, "INIT-VALUE", com_spec.getInitValue())
+        self.setChildElementOptionalRefType(child_element, "PARAMETER-REF", com_spec.getParameterRef())
 
     def writeParameterRequireComSpec(self, element: ET.Element, com_spec: ParameterRequireComSpec):
         self.logger.debug("writeParameterRequireComSpec")

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_Communication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_Communication.py
@@ -5,12 +5,15 @@ Tests cover all classes and methods in the Communication.py file to achieve 100%
 
 import pytest
 
+from armodel.models.M2.AUTOSARTemplates.CommonStructure import TextValueSpecification
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.Filter import DataFilter
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, ARPositiveInteger, PositiveInteger, RefType, TimeValue
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import (
     ClientComSpec,
     CompositeNetworkRepresentation,
     EndToEndTransformationComSpecProps,
     HandleInvalidEnum,
+    HandleOutOfRangeEnum,
     HandleOutOfRangeStatusEnum,
     HandleTimeoutEnum,
     ModeSwitchedAckRequest,
@@ -32,6 +35,8 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import
     ServerComSpec,
     TransformationComSpecProps,
     TransmissionAcknowledgementRequest,
+    TransmissionComSpecProps,
+    TransmissionModeDefinitionEnum,
     UserDefinedTransformationComSpecProps,
 )
 
@@ -92,19 +97,87 @@ class TestCompositeNetworkRepresentation:
 class TestTransmissionAcknowledgementRequest:
     """Test class for TransmissionAcknowledgementRequest class."""
 
-    def test_transmission_acknowledgement_request_initialization(self):
-        """Test TransmissionAcknowledgementRequest initialization."""
+    def test_initialization(self):
+        """Test TransmissionAcknowledgementRequest field defaults."""
         request = TransmissionAcknowledgementRequest()
         assert request.timeout is None
+        assert request.getTimeout() is None
+
+    def test_get_set_timeout(self):
+        """Test setTimeout returns self, value round-trips, None is a no-op."""
+        request = TransmissionAcknowledgementRequest()
+        timeout = TimeValue()
+        timeout.setValue("0.5")
+        assert request.setTimeout(timeout) is request
+        assert request.getTimeout() is timeout
+        request.setTimeout(None)
+        assert request.getTimeout() is timeout
 
 
 class TestSenderComSpec:
-    """Test class for SenderComSpec abstract class."""
+    """Test class for SenderComSpec abstract class (base accessors via NonqueuedSenderComSpec)."""
 
     def test_sender_com_spec_abstract(self):
-        """Test that SenderComSpec is an abstract class that raises NotImplementedError when instantiated."""
+        """Test that SenderComSpec is an abstract class that raises TypeError when instantiated."""
         with pytest.raises(TypeError):
             SenderComSpec()
+
+    def test_sender_com_spec_base_properties(self):
+        """Test all SenderComSpec base accessors through a concrete subclass."""
+        sender = NonqueuedSenderComSpec()
+        assert sender.compositeNetworkRepresentations == []
+        assert sender.dataElementRef is None
+        assert sender.handleOutOfRange is None
+        assert sender.networkRepresentation is None
+        assert sender.transmissionAcknowledge is None
+        assert sender.transmissionProps is None
+        assert sender.usesEndToEndProtection is None
+
+        from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
+
+        representation = CompositeNetworkRepresentation()
+        assert sender.addCompositeNetworkRepresentation(representation) is sender
+        assert sender.getCompositeNetworkRepresentations() == [representation]
+        sender.addCompositeNetworkRepresentation(None)
+        assert len(sender.getCompositeNetworkRepresentations()) == 1
+
+        ref = RefType()
+        ref.setValue("/if/DataElement")
+        assert sender.setDataElementRef(ref) is sender
+        assert sender.getDataElementRef() is ref
+        sender.setDataElementRef(None)
+        assert sender.getDataElementRef() is ref
+
+        handle_out_of_range = HandleOutOfRangeEnum().setValue(HandleOutOfRangeEnum.NONE)
+        assert sender.setHandleOutOfRange(handle_out_of_range) is sender
+        assert sender.getHandleOutOfRange() is handle_out_of_range
+        sender.setHandleOutOfRange(None)
+        assert sender.getHandleOutOfRange() is handle_out_of_range
+
+        network_representation = SwDataDefProps()
+        assert sender.setNetworkRepresentation(network_representation) is sender
+        assert sender.getNetworkRepresentation() is network_representation
+        sender.setNetworkRepresentation(None)
+        assert sender.getNetworkRepresentation() is network_representation
+
+        acknowledge = TransmissionAcknowledgementRequest()
+        assert sender.setTransmissionAcknowledge(acknowledge) is sender
+        assert sender.getTransmissionAcknowledge() is acknowledge
+        sender.setTransmissionAcknowledge(None)
+        assert sender.getTransmissionAcknowledge() is acknowledge
+
+        transmission_props = TransmissionComSpecProps()
+        assert sender.setTransmissionProps(transmission_props) is sender
+        assert sender.getTransmissionProps() is transmission_props
+        sender.setTransmissionProps(None)
+        assert sender.getTransmissionProps() is transmission_props
+
+        uses_e2e = ARBoolean()
+        uses_e2e.setValue(True)
+        assert sender.setUsesEndToEndProtection(uses_e2e) is sender
+        assert sender.getUsesEndToEndProtection() is uses_e2e
+        sender.setUsesEndToEndProtection(None)
+        assert sender.getUsesEndToEndProtection() is uses_e2e
 
 
 class TestQueuedSenderComSpec:
@@ -146,9 +219,10 @@ class TestQueuedSenderComSpec:
         assert sender.getNetworkRepresentation() == network_rep
         assert sender == sender.setNetworkRepresentation(network_rep)  # Test method chaining
 
-        sender.setHandleOutOfRange("handle_out")
-        assert sender.getHandleOutOfRange() == "handle_out"
-        assert sender == sender.setHandleOutOfRange("handle_out")  # Test method chaining
+        handle_out_of_range = HandleOutOfRangeEnum().setValue(HandleOutOfRangeEnum.SATURATE)
+        sender.setHandleOutOfRange(handle_out_of_range)
+        assert sender.getHandleOutOfRange() == handle_out_of_range
+        assert sender == sender.setHandleOutOfRange(handle_out_of_range)  # Test method chaining
 
 
 class TestNonqueuedSenderComSpec:
@@ -157,13 +231,26 @@ class TestNonqueuedSenderComSpec:
     def test_nonqueued_sender_com_spec_initialization(self):
         """Test NonqueuedSenderComSpec initialization and methods."""
         sender = NonqueuedSenderComSpec()
-        assert sender.compositeNetworkRepresentations == []
-        assert sender.dataElementRef is None
-        assert sender.networkRepresentation is None
-        assert sender.handleOutOfRange is None
-        assert sender.transmissionAcknowledge is None
-        assert sender.usesEndToEndProtection is None
+        assert sender.dataFilter is None
         assert sender.initValue is None
+
+    def test_get_set_data_filter(self):
+        """Test dataFilter accessor pair and None no-op."""
+        sender = NonqueuedSenderComSpec()
+        data_filter = DataFilter()
+        assert sender.setDataFilter(data_filter) is sender
+        assert sender.getDataFilter() is data_filter
+        sender.setDataFilter(None)
+        assert sender.getDataFilter() is data_filter
+
+    def test_get_set_init_value(self):
+        """Test initValue accessor pair and None no-op."""
+        sender = NonqueuedSenderComSpec()
+        init_value = TextValueSpecification()
+        assert sender.setInitValue(init_value) is sender
+        assert sender.getInitValue() is init_value
+        sender.setInitValue(None)
+        assert sender.getInitValue() is init_value
 
 
 class TestClientComSpec:
@@ -172,13 +259,38 @@ class TestClientComSpec:
     def test_client_com_spec_initialization(self):
         """Test ClientComSpec initialization and methods."""
         client = ClientComSpec()
+        assert client.endToEndCallResponseTimeout is None
         assert client.operationRef is None
+        assert client.transformationComSpecProps == []
 
-        # Test setters and getters
+    def test_get_set_end_to_end_call_response_timeout(self):
+        """Test endToEndCallResponseTimeout accessor pair and None no-op."""
+        client = ClientComSpec()
+        timeout = TimeValue()
+        timeout.setValue("1.0")
+        assert client.setEndToEndCallResponseTimeout(timeout) is client
+        assert client.getEndToEndCallResponseTimeout() is timeout
+        client.setEndToEndCallResponseTimeout(None)
+        assert client.getEndToEndCallResponseTimeout() is timeout
+
+    def test_get_set_operation_ref(self):
+        """Test operationRef accessor pair and None no-op."""
+        client = ClientComSpec()
         ref = RefType()
         ref.setValue("/Test/Operation")
-        client.setOperationRef(ref)
-        assert client.getOperationRef() == ref
+        assert client.setOperationRef(ref) is client
+        assert client.getOperationRef() is ref
+        client.setOperationRef(None)
+        assert client.getOperationRef() is ref
+
+    def test_add_transformation_com_spec_props(self):
+        """Test transformationComSpecProps add/get and None no-op."""
+        client = ClientComSpec()
+        props = UserDefinedTransformationComSpecProps()
+        assert client.addTransformationComSpecProps(props) is client
+        assert client.getTransformationComSpecProps() == [props]
+        client.addTransformationComSpecProps(None)
+        assert len(client.getTransformationComSpecProps()) == 1
 
 
 class TestModeSwitchReceiverComSpec:
@@ -419,9 +531,91 @@ class TestParameterProvideComSpec:
     """Test class for ParameterProvideComSpec class."""
 
     def test_parameter_provide_com_spec_initialization(self):
-        """Test ParameterProvideComSpec initialization."""
-        _param_prov = ParameterProvideComSpec()
-        # Just verify it can be initialized
+        """Test ParameterProvideComSpec field defaults."""
+        com_spec = ParameterProvideComSpec()
+        assert com_spec.initValue is None
+        assert com_spec.parameterRef is None
+
+    def test_get_set_init_value(self):
+        """Test initValue accessor pair and None no-op."""
+        com_spec = ParameterProvideComSpec()
+        init_value = TextValueSpecification()
+        assert com_spec.setInitValue(init_value) is com_spec
+        assert com_spec.getInitValue() is init_value
+        com_spec.setInitValue(None)
+        assert com_spec.getInitValue() is init_value
+
+    def test_get_set_parameter_ref(self):
+        """Test parameterRef accessor pair and None no-op."""
+        com_spec = ParameterProvideComSpec()
+        ref = RefType()
+        ref.setValue("/if/Parameter")
+        assert com_spec.setParameterRef(ref) is com_spec
+        assert com_spec.getParameterRef() is ref
+        com_spec.setParameterRef(None)
+        assert com_spec.getParameterRef() is ref
+
+
+class TestTransmissionComSpecProps:
+    """Test class for TransmissionComSpecProps class."""
+
+    def test_initialization(self):
+        """Test TransmissionComSpecProps field defaults."""
+        props = TransmissionComSpecProps()
+        assert props.dataUpdatePeriod is None
+        assert props.minimumSendInterval is None
+        assert props.transmissionMode is None
+
+    def test_get_set_data_update_period(self):
+        """Test dataUpdatePeriod accessor pair and None no-op."""
+        props = TransmissionComSpecProps()
+        period = TimeValue()
+        period.setValue("0.01")
+        assert props.setDataUpdatePeriod(period) is props
+        assert props.getDataUpdatePeriod() is period
+        props.setDataUpdatePeriod(None)
+        assert props.getDataUpdatePeriod() is period
+
+    def test_get_set_minimum_send_interval(self):
+        """Test minimumSendInterval accessor pair and None no-op."""
+        props = TransmissionComSpecProps()
+        interval = TimeValue()
+        interval.setValue("0.1")
+        assert props.setMinimumSendInterval(interval) is props
+        assert props.getMinimumSendInterval() is interval
+        props.setMinimumSendInterval(None)
+        assert props.getMinimumSendInterval() is interval
+
+    def test_get_set_transmission_mode(self):
+        """Test transmissionMode accessor pair and None no-op."""
+        props = TransmissionComSpecProps()
+        mode = TransmissionModeDefinitionEnum().setValue(TransmissionModeDefinitionEnum.TRIGGERED)
+        assert props.setTransmissionMode(mode) is props
+        assert props.getTransmissionMode() is mode
+        props.setTransmissionMode(None)
+        assert props.getTransmissionMode() is mode
+
+
+class TestTransmissionModeDefinitionEnum:
+    """Test class for TransmissionModeDefinitionEnum class."""
+
+    def test_members(self):
+        """Test TransmissionModeDefinitionEnum member values."""
+        enum = TransmissionModeDefinitionEnum()
+        values = enum.getEnumValues()
+        assert TransmissionModeDefinitionEnum.CYCLIC == "cyclic"
+        assert TransmissionModeDefinitionEnum.CYCLIC_AND_ON_CHANGE == "cyclicAndOnChange"
+        assert TransmissionModeDefinitionEnum.TRIGGERED == "triggered"
+        assert TransmissionModeDefinitionEnum.CYCLIC in values
+        assert TransmissionModeDefinitionEnum.CYCLIC_AND_ON_CHANGE in values
+        assert TransmissionModeDefinitionEnum.TRIGGERED in values
+        assert len(values) == 3
+
+    def test_instantiable(self):
+        """Test that the enum can be instantiated and hold a value."""
+        enum = TransmissionModeDefinitionEnum()
+        enum.setValue(TransmissionModeDefinitionEnum.CYCLIC_AND_ON_CHANGE)
+        assert enum.getValue() == "cyclicAndOnChange"
 
 
 class TestTransformationComSpecProps:
@@ -572,6 +766,14 @@ class TestServerComSpec:
         e2e_props = EndToEndTransformationComSpecProps()
         server.addTransformationComSpecProps(e2e_props)
         assert e2e_props in server.getTransformationComSpecProps()
+
+        # None no-op checks
+        server.setOperationRef(None)
+        assert server.getOperationRef() is ref
+        server.setQueueLength(None)
+        assert server.getQueueLength() is queue_len
+        server.addTransformationComSpecProps(None)
+        assert len(server.getTransformationComSpecProps()) == 1
 
 
 class TestNvProvideComSpec:

--- a/tests/test_armodel/parser/test_arxml_parser_comspec.py
+++ b/tests/test_armodel/parser/test_arxml_parser_comspec.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from armodel.models import AUTOSAR, ApplicationSwComponentType
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import UserDefinedTransformationComSpecProps
 from tests.test_armodel.parser._helpers import _autosar_root, _snip
 
 
@@ -58,6 +59,134 @@ class TestGetClientComSpec:
         result = parser.getClientComSpec(element)
         assert result is not None
         assert result.getOperationRef() is None
+
+    def test_with_end_to_end_call_response_timeout(self, parser):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        element = _snip(
+            """
+            <END-TO-END-CALL-RESPONSE-TIMEOUT>1.5</END-TO-END-CALL-RESPONSE-TIMEOUT>
+            """,
+            root_tag="CLIENT-COM-SPEC",
+        )
+        result = parser.getClientComSpec(element)
+        assert result.getEndToEndCallResponseTimeout() is not None
+        assert result.getEndToEndCallResponseTimeout().getValue() == 1.5
+
+    def test_with_transformation_com_spec_props(self, parser):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        element = _snip(
+            """
+            <TRANSFORMATION-COM-SPEC-PROPSS>
+                <USER-DEFINED-TRANSFORMATION-COM-SPEC-PROPS></USER-DEFINED-TRANSFORMATION-COM-SPEC-PROPS>
+            </TRANSFORMATION-COM-SPEC-PROPSS>
+            """,
+            root_tag="CLIENT-COM-SPEC",
+        )
+        result = parser.getClientComSpec(element)
+        assert len(result.getTransformationComSpecProps()) == 1
+        assert isinstance(result.getTransformationComSpecProps()[0], UserDefinedTransformationComSpecProps)
+
+
+class TestGetNonqueuedSenderComSpec:
+    """Tests for getNonqueuedSenderComSpec."""
+
+    def test_with_data_filter(self, parser):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        element = _snip(
+            """
+            <DATA-ELEMENT-REF DEST="VARIABLE-DATA-PROTOTYPE">/if/De</DATA-ELEMENT-REF>
+            <DATA-FILTER>
+                <DATA-FILTER-TYPE>ONE-EVERY-N</DATA-FILTER-TYPE>
+            </DATA-FILTER>
+            """,
+            root_tag="NONQUEUED-SENDER-COM-SPEC",
+        )
+        result = parser.getNonqueuedSenderComSpec(element)
+        assert result.getDataFilter() is not None
+        assert result.getDataFilter().getDataFilterType() is not None
+        assert result.getDataElementRef().getValue() == "/if/De"
+
+    def test_with_transmission_props(self, parser):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        element = _snip(
+            """
+            <TRANSMISSION-PROPS>
+                <DATA-UPDATE-PERIOD>0.01</DATA-UPDATE-PERIOD>
+                <MINIMUM-SEND-INTERVAL>0.1</MINIMUM-SEND-INTERVAL>
+                <TRANSMISSION-MODE>triggered</TRANSMISSION-MODE>
+            </TRANSMISSION-PROPS>
+            <TRANSMISSION-ACKNOWLEDGE>
+                <TIMEOUT>0.5</TIMEOUT>
+            </TRANSMISSION-ACKNOWLEDGE>
+            """,
+            root_tag="NONQUEUED-SENDER-COM-SPEC",
+        )
+        result = parser.getNonqueuedSenderComSpec(element)
+        props = result.getTransmissionProps()
+        assert props is not None
+        assert props.getDataUpdatePeriod().getValue() == 0.01
+        assert props.getMinimumSendInterval().getValue() == 0.1
+        assert props.getTransmissionMode().getValue() == "triggered"
+        assert result.getTransmissionAcknowledge() is not None
+        assert result.getTransmissionAcknowledge().getTimeout().getValue() == 0.5
+
+    def test_without_transmission_props(self, parser):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        element = _snip("", root_tag="NONQUEUED-SENDER-COM-SPEC")
+        result = parser.getNonqueuedSenderComSpec(element)
+        assert result.getTransmissionProps() is None
+        assert result.getTransmissionAcknowledge() is None
+
+
+class TestGetServerComSpec:
+    """Tests for getServerComSpec."""
+
+    def test_with_queue_length_and_props(self, parser):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        element = _snip(
+            """
+            <OPERATION-REF DEST="CLIENT-SERVER-OPERATION">/if/Op</OPERATION-REF>
+            <QUEUE-LENGTH>4</QUEUE-LENGTH>
+            <TRANSFORMATION-COM-SPEC-PROPSS>
+                <USER-DEFINED-TRANSFORMATION-COM-SPEC-PROPS></USER-DEFINED-TRANSFORMATION-COM-SPEC-PROPS>
+            </TRANSFORMATION-COM-SPEC-PROPSS>
+            """,
+            root_tag="SERVER-COM-SPEC",
+        )
+        result = parser.getServerComSpec(element)
+        assert result.getOperationRef().getValue() == "/if/Op"
+        assert result.getQueueLength().getValue() == 4
+        assert len(result.getTransformationComSpecProps()) == 1
+
+
+class TestGetParameterProvideComSpec:
+    """Tests for getParameterProvideComSpec."""
+
+    def test_with_init_value_and_parameter_ref(self, parser):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        element = _snip(
+            """
+            <INIT-VALUE>
+                <TEXT-VALUE-SPECIFICATION>
+                    <VALUE>init</VALUE>
+                </TEXT-VALUE-SPECIFICATION>
+            </INIT-VALUE>
+            <PARAMETER-REF DEST="PARAMETER-DATA-PROTOTYPE">/if/Param</PARAMETER-REF>
+            """,
+            root_tag="PARAMETER-PROVIDE-COM-SPEC",
+        )
+        result = parser.getParameterProvideComSpec(element)
+        assert result.getInitValue() is not None
+        assert result.getParameterRef() is not None
+        assert result.getParameterRef().getValue() == "/if/Param"
+        assert result.getParameterRef().getDest() == "PARAMETER-DATA-PROTOTYPE"
+
+    def test_empty(self, parser):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        element = _snip("", root_tag="PARAMETER-PROVIDE-COM-SPEC")
+        result = parser.getParameterProvideComSpec(element)
+        assert result.getInitValue() is None
+        assert result.getParameterRef() is None
 
 
 class TestGetParameterRequireComSpec:
@@ -373,6 +502,23 @@ class TestReadProvidedComSpec:
         specs = p_port.getProvidedComSpecs()
         assert len(specs) == 1
 
+    def test_parameter_provide_branch(self, parser):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        p_port = _make_p_port()
+        element = _snip(
+            """
+            <PROVIDED-COM-SPECS>
+                <PARAMETER-PROVIDE-COM-SPEC>
+                    <PARAMETER-REF DEST="PARAMETER-DATA-PROTOTYPE">/if/Param</PARAMETER-REF>
+                </PARAMETER-PROVIDE-COM-SPEC>
+            </PROVIDED-COM-SPECS>
+            """
+        )
+        parser.readProvidedComSpec(element, p_port)
+        specs = p_port.getProvidedComSpecs()
+        assert len(specs) == 1
+        assert specs[0].getParameterRef().getValue() == "/if/Param"
+
     def test_nv_provide_branch_with_mock_parent(self, parser):
         AUTOSAR.getInstance().setARRelease("R23-11")
         mock_parent = MagicMock()
@@ -504,7 +650,7 @@ class TestTransformationComSpecProps:
 
         com_spec = ServerComSpec()
         element = _snip("<TRANSFORMATION-COM-SPEC-PROPSS>" "<USER-DEFINED-TRANSFORMATION-COM-SPEC-PROPS/>" "</TRANSFORMATION-COM-SPEC-PROPSS>")
-        parser.readServerComSpecTransformationComSpecProps(element, com_spec)
+        parser.readTransformationComSpecPropss(element, com_spec)
         assert len(com_spec.getTransformationComSpecProps()) == 1
 
     def test_readServerComSpecTransformationComSpecProps_unsupported_warns(self, warning_parser, caplog):
@@ -513,7 +659,7 @@ class TestTransformationComSpecProps:
         com_spec = ServerComSpec()
         element = _snip("<TRANSFORMATION-COM-SPEC-PROPSS><BAD/></TRANSFORMATION-COM-SPEC-PROPSS>")
         with caplog.at_level(logging.ERROR):
-            warning_parser.readServerComSpecTransformationComSpecProps(element, com_spec)
+            warning_parser.readTransformationComSpecPropss(element, com_spec)
         assert any("Unsupported TransformationComSpecProps" in r.getMessage() for r in caplog.records)
 
 

--- a/tests/test_armodel/writer/test_writer_sw_component.py
+++ b/tests/test_armodel/writer/test_writer_sw_component.py
@@ -29,6 +29,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import (
     ClientComSpec,
     CompositeNetworkRepresentation,
+    HandleOutOfRangeEnum,
     ModeSwitchedAckRequest,
     ModeSwitchReceiverComSpec,
     ModeSwitchSenderComSpec,
@@ -36,6 +37,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import
     NonqueuedSenderComSpec,
     NvProvideComSpec,
     NvRequireComSpec,
+    ParameterProvideComSpec,
     ParameterRequireComSpec,
     PPortComSpec,
     QueuedReceiverComSpec,
@@ -44,6 +46,8 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import
     ServerComSpec,
     TransformationComSpecProps,
     TransmissionAcknowledgementRequest,
+    TransmissionComSpecProps,
+    TransmissionModeDefinitionEnum,
     UserDefinedTransformationComSpecProps,
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs import (  # noqa: E501
@@ -200,7 +204,7 @@ class TestWriteSenderComSpec:
         props = SwDataDefProps()
         props.setSwCalprmAxisSet(SwCalprmAxisSet())
         com_spec.setNetworkRepresentation(props)
-        com_spec.setHandleOutOfRange(_literal("keep"))
+        com_spec.setHandleOutOfRange(HandleOutOfRangeEnum().setValue(HandleOutOfRangeEnum.SATURATE))
         com_spec.setTransmissionAcknowledge(TransmissionAcknowledgementRequest())
         com_spec.setUsesEndToEndProtection(_boolean(False))
         parent = _parent()
@@ -227,6 +231,28 @@ class TestWriteSenderComSpec:
         writer.writeNonqueuedSenderComSpec(parent, com_spec)
         assert parent[0].tag == "NONQUEUED-SENDER-COM-SPEC"
         assert parent[0].find("INIT-VALUE") is not None
+
+    def test_write_sender_comspec_with_transmission_props(self, writer):
+        com_spec = NonqueuedSenderComSpec()
+        props = TransmissionComSpecProps()
+        props.setDataUpdatePeriod(_time_value(0.01))
+        props.setMinimumSendInterval(_time_value(0.1))
+        props.setTransmissionMode(TransmissionModeDefinitionEnum().setValue(TransmissionModeDefinitionEnum.TRIGGERED))
+        com_spec.setTransmissionProps(props)
+        parent = _parent()
+        writer.writeSenderComSpec(parent, com_spec)
+        transmission_props = parent.find("TRANSMISSION-PROPS")
+        assert transmission_props is not None
+        assert transmission_props.find("DATA-UPDATE-PERIOD") is not None
+        assert transmission_props.find("MINIMUM-SEND-INTERVAL") is not None
+        assert transmission_props.find("TRANSMISSION-MODE").text == "triggered"
+
+    def test_write_nonqueued_sender_comspec_with_data_filter(self, writer):
+        com_spec = NonqueuedSenderComSpec()
+        com_spec.setDataFilter(DataFilter())
+        parent = _parent()
+        writer.writeNonqueuedSenderComSpec(parent, com_spec)
+        assert parent[0].find("DATA-FILTER") is not None
 
     def test_write_queued_sender_comspec(self, writer):
         com_spec = QueuedSenderComSpec()
@@ -286,6 +312,46 @@ class TestWriteServerComSpec:
         assert parent[0].find("OPERATION-REF") is not None
         assert parent[0].find("QUEUE-LENGTH") is not None
         assert parent[0].find("TRANSFORMATION-COM-SPEC-PROPSS") is not None
+
+
+class TestWriteClientComSpec:
+    def test_write_client_comspec(self, writer):
+        com_spec = ClientComSpec()
+        com_spec.setEndToEndCallResponseTimeout(_time_value(1.5))
+        com_spec.setOperationRef(_ref(value="/if/Op", dest="CLIENT-SERVER-OPERATION"))
+        com_spec.addTransformationComSpecProps(UserDefinedTransformationComSpecProps())
+        parent = _parent()
+        writer.writeClientComSpec(parent, com_spec)
+        assert parent[0].tag == "CLIENT-COM-SPEC"
+        assert parent[0].find("END-TO-END-CALL-RESPONSE-TIMEOUT") is not None
+        assert parent[0].find("OPERATION-REF") is not None
+        assert parent[0].find("TRANSFORMATION-COM-SPEC-PROPSS") is not None
+
+    def test_write_client_comspec_empty(self, writer):
+        com_spec = ClientComSpec()
+        parent = _parent()
+        writer.writeClientComSpec(parent, com_spec)
+        assert parent[0].find("END-TO-END-CALL-RESPONSE-TIMEOUT") is None
+        assert parent[0].find("TRANSFORMATION-COM-SPEC-PROPSS") is None
+
+
+class TestWriteParameterProvideComSpec:
+    def test_write_parameter_provide_comspec(self, writer):
+        com_spec = ParameterProvideComSpec()
+        com_spec.setInitValue(TextValueSpecification())
+        com_spec.setParameterRef(_ref(value="/if/Param", dest="PARAMETER-DATA-PROTOTYPE"))
+        parent = _parent()
+        writer.writeParameterProvideComSpec(parent, com_spec)
+        assert parent[0].tag == "PARAMETER-PROVIDE-COM-SPEC"
+        assert parent[0].find("INIT-VALUE") is not None
+        assert parent[0].find("PARAMETER-REF") is not None
+
+    def test_write_parameter_provide_comspec_empty(self, writer):
+        com_spec = ParameterProvideComSpec()
+        parent = _parent()
+        writer.writeParameterProvideComSpec(parent, com_spec)
+        assert parent[0].find("INIT-VALUE") is None
+        assert parent[0].find("PARAMETER-REF") is None
 
 
 class TestWriteModeSwitchSenderComSpec:
@@ -372,6 +438,12 @@ class TestWritePPortComSpec:
         parent = _parent()
         writer.writePPortComSpec(parent, com_spec)
         assert parent.find("NV-PROVIDE-COM-SPEC") is not None
+
+    def test_dispatches_parameter_provide(self, writer):
+        com_spec = ParameterProvideComSpec()
+        parent = _parent()
+        writer.writePPortComSpec(parent, com_spec)
+        assert parent.find("PARAMETER-PROVIDE-COM-SPEC") is not None
 
 
 class TestWriteCompositeNetworkRepresentation:


### PR DESCRIPTION
Closes #624

## Summary

Add missing SW-component communication spec classes and wire them through the parser/writer to match the AUTOSAR R23-11 spec.

## Changes

- **New classes**
  - `TransmissionModeDefinitionEnum` (cyclic / cyclicAndOnChange / triggered) — spec Table 4.73
  - `TransmissionComSpecProps` (dataUpdatePeriod, minimumSendInterval, transmissionMode) — spec Table 4.70
  - `ParameterProvideComSpec` — provided parameter port com spec
- **Extended classes**
  - `ClientComSpec`: add `endToEndCallResponseTimeout` and `transformationComSpecProps`
  - `ServerComSpec`: support `EndToEndTransformationComSpecProps`; `queueLength` typed as `PositiveInteger`
  - `NonqueuedSenderComSpec`: add `dataFilter`
- **Parser/writer**
  - Rename `readServerComSpecTransformationComSpecProps` → `readTransformationComSpecPropss`; now handles both EndToEnd and UserDefined transformation props
  - Wire read/write paths for every new attribute and new com spec element
- **Spec sync**
  - Class checklist comments and per-attribute docstrings synced to R23-11 (Tables 4.58, 4.70, 4.73)

## Tests

- New/extended tests in `test_Communication.py`, `test_arxml_parser_comspec.py`, `test_writer_sw_component.py`
- Full suite: 6359 unit + 1 integration, all passing
- flake8 (E9, F63, F7, F82) clean

## Files (9)

```
src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Constants/__init__.py
src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Filter.py
src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Communication.py
src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
src/armodel/parser/arxml_parser.py
src/armodel/writer/arxml_writer.py
tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_Communication.py
tests/test_armodel/parser/test_arxml_parser_comspec.py
tests/test_armodel/writer/test_writer_sw_component.py
```
