### PR TITLE
sync: align HwElement, HwElementConnector, Describable, String, Numerical to AUTOSAR R23-11 spec

### DIFF
--- a/docs/examples/method_deviation_by_class.md
+++ b/docs/examples/method_deviation_by_class.md
@@ -274,6 +274,15 @@ the aggregation is itself a partial implementation and remains to be wired.
 
 No deviations (multiplicity/type resolved to spec).
 
+## `Describable`
+- **PDF:** `AUTOSAR_FO_TPS_GenericStructureTemplate.pdf`  | **page:** 438
+- **Package:** `M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::Identifiable`
+- **Source:** `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| `removeAdminData` | — | — *(not in spec)* | — | — | added convenience method (resets `adminData` to `None`; used by the admin-data transformer) |
+
 ## `EngineeringObject`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 132
 - **Package:** `M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::EngineeringObject`
@@ -928,6 +937,13 @@ Table 4.6).
 |---|---|---|---|---|---|
 | `symbolProps` | `—` | `symbolProps` | `SymbolProps` | — | type (spec one vs py list) |
 
+## `Integer`
+- **PDF:** *no own spec table*  |  **page:** —
+- **Package:** `M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses`
+- **Source:** `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py`
+
+Class not in markdown/PDF — skipped per user (primitive `Integer` has no dedicated spec table in any rendered PDF; XSD-only, `xml.xsd.customType="INTEGER"`). Left as-is; not part of this sync pass.
+
 ## `NumericalOrText`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 323
 - **Package:** `M2::AUTOSARTemplates::CommonStructure::Constants`
@@ -1526,6 +1542,13 @@ tests, and reader/writer coverage. The aggregated Chapter family lives in
 |---|---|---|---|---|---|
 | — *(missing)* | `—` | `blueprintValue` | `?` | — | missing |
 | — *(missing)* | `—` | `xmlSpace` | `?` | — | missing |
+
+## `XmlSpaceEnum`
+- **PDF:** *no own spec table*  |  **page:** —
+- **Package:** `M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::Enumerations`
+- **Source:** `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Enumerations.py`
+
+Class not in markdown/PDF — skipped per user (enumeration `XmlSpaceEnum` has no dedicated `Enumeration` table in any rendered PDF; XSD-only, used only as an attribute type such as `Sd.xmlSpace`). Left as-is; not part of this sync pass.
 
 ## `HwAttributeValue`
 - **PDF:** `AUTOSAR_CP_TPS_ECUResourceTemplate.pdf`  | **page:** 16
@@ -3096,6 +3119,20 @@ tests, and reader/writer coverage. The aggregated Chapter family lives in
 | — *(missing)* | `—` | `htmlScale` | `?` | — | missing |
 | — *(missing)* | `—` | `htmlWidth` | `?` | — | missing |
 | — *(missing)* | `—` | `notation` | `?` | — | missing |
+
+## `HwElementConnector`
+- **PDF:** `AUTOSAR_CP_TPS_ECUResourceTemplate.pdf`  | **page:** 23
+- **Package:** `M2::AUTOSARTemplates::EcuResourceTemplate`
+- **Source:** `src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/HwElementConnector.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| `hwElementRef` | `RefType` (ref, 0..1) | `hwElement` | `HW-ELEMENT` (ref) | 2× | retained existing single-ref API; spec models two `hwElement` refs (`HW-ELEMENT-REFS`, multiplicity 2). Deferred per bounded-sync decision. |
+| `hwPinRef` | `RefType` (ref, 0..1) | — *(not in spec)* | — | — | convenience ref retained; spec models pin wiring via `hwPinConnection` (aggr `HwPinConnector`\*) and `hwPinGroupConnection` (ref `HwPinGroupConnector`\*), which are not yet modeled. Deferred per bounded-sync decision. |
+| — *(missing)* | `—` | `hwPinConnection` | `HwPinConnector` | aggr\* | not modeled (class `HwPinConnector` does not exist yet) |
+| — *(missing)* | `—` | `hwPinGroupConnection` | `HwPinGroupConnector` | ref\* | not modeled (class `HwPinGroupConnector` does not exist yet) |
+
+> **Note:** Per the bounded-sync decision, the pre-existing `HwElementConnector` API (`hwElementRef`/`hwPinRef`) is retained unchanged and its reader/writer coverage was added for round-trip integrity. No `# Spec verified` marker is applied because the attribute set does not match the spec table. Full spec alignment (introduce `HwPinConnector`/`HwPinGroupConnector`, model `hwElement` as a 2-ref set and the two pin-connection members) is deferred work.
 
 ## `Map`
 - **PDF:** `AUTOSAR_FO_TPS_GenericStructureTemplate.pdf`  | **page:** 305

--- a/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/HwElementConnector.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/HwElementConnector.py
@@ -11,21 +11,22 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 
 class HwElementConnector(Describable):
     """
-    Represents a connection between hardware elements in AUTOSAR hardware descriptions.
-    This class defines the connections that can exist between different hardware elements in the model.
+    This meta-class represents the ability to connect two hardware elements. The details of the connection can be refined by hwPinGroupConnection.
     """
 
     # HwElementConnector method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
-    # [ ] getHwElementRef              [x] impl  [x] docstring  [ ] test
-    # [ ] setHwElementRef              [x] impl  [x] docstring  [ ] test
-    # [ ] getHwPinRef                  [x] impl  [x] docstring  [ ] test
-    # [ ] setHwPinRef                  [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_ECUResourceTemplate.pdf, Table 2.8, p.21
+    # Deviation: source attributes (hwElementRef, hwPinRef) do not match spec
+    #   Table 2.8 (hwElement x2, hwPinConnection aggr, hwPinGroupConnection ref);
+    #   HwPinConnector/HwPinGroupConnector classes not yet modeled. No stamp.
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getHwElementRef              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] setHwElementRef              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHwPinRef                  [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setHwPinRef                  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self):
-        """
-        Initializes the HwElementConnector.
-        """
         super().__init__()
 
         self.hwElementRef: Optional[RefType] = None

--- a/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/__init__.py
@@ -10,80 +10,68 @@ from typing import List, Optional
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer, RefType, String
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Referrable
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwAttributeValue import HwAttributeValue
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementConnector import HwElementConnector
 
 
-class HwDescriptionEntity(ARElement):
+class HwDescriptionEntity(Referrable):
     """
-    Abstract base class for hardware description entities in AUTOSAR.
-    This class defines common properties for hardware elements including attribute values and type references.
+    This meta-class represents the ability to describe a hardware entity.
     """
 
     # HwDescriptionEntity method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
-    # [ ] getHwAttributeValues         [x] impl  [x] docstring  [ ] test
-    # [ ] setHwAttributeValues         [x] impl  [x] docstring  [ ] test
-    # [ ] getHwCategoryRefs            [x] impl  [x] docstring  [ ] test
-    # [ ] addHwCategoryRef             [x] impl  [x] docstring  [ ] test
-    # [ ] getHwTypeRef                 [x] impl  [x] docstring  [ ] test
-    # [ ] setHwTypeRef                 [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_ECUResourceTemplate.pdf, Table 2.1, p.15
+    # Spec verified: R23-11
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addHwAttributeValue          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHwAttributeValues         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addHwCategoryRef             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHwCategoryRefs            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getHwTypeRef                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setHwTypeRef                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent, short_name: str):
-        """
-        Initializes the HwDescriptionEntity with a parent and short name.
-
-        Args:
-            parent: The parent ARObject that contains this hardware description entity
-            short_name: The unique short name of this hardware description entity
-        """
+        if type(self) is HwDescriptionEntity:
+            raise TypeError("HwDescriptionEntity is an abstract class.")
         super().__init__(parent, short_name)
 
+        # This aggregation represents a particular hardware attribute value.
         self.hwAttributeValues: List[HwAttributeValue] = []
+
+        # One of the associations representing one particular category of the hardware entity.
         self.hwCategoryRefs: List[RefType] = []
+
+        # This association is used to assign an optional HwType which contains the common attribute values for all occurences of this HwDescriptionEntity. Note that Hw Types can not be redefined and therefore shall not have a hwType reference.
         self.hwTypeRef: Optional[RefType] = None
 
-    def getHwAttributeValues(self) -> List[HwAttributeValue]:
+    def addHwAttributeValue(self, value: HwAttributeValue):
         """
-        Gets the list of hardware attribute values for this entity.
+        This aggregation represents a particular hardware attribute value.
 
-        Returns:
-            List of HwAttributeValue instances
-        """
-        return self.hwAttributeValues
-
-    def setHwAttributeValues(self, value: List[HwAttributeValue]):
-        """
-        Sets the list of hardware attribute values for this entity.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The list of hardware attribute values to set
+        A None value is a no-op and does not add an hwAttributeValue.
 
         Returns:
             self for method chaining
         """
         if value is not None:
-            self.hwAttributeValues = value
+            self.hwAttributeValues.append(value)
         return self
 
-    def getHwCategoryRefs(self) -> List[RefType]:
+    def getHwAttributeValues(self) -> List[HwAttributeValue]:
         """
-        Gets the list of hardware category references for this entity.
+        This aggregation represents a particular hardware attribute value.
 
         Returns:
-            List of RefType instances representing hardware category references
+            The list of hwAttributeValues, or an empty list if none are set
         """
-        return self.hwCategoryRefs
+        return self.hwAttributeValues
 
     def addHwCategoryRef(self, value: RefType):
         """
-        Adds a hardware category reference to this entity.
-        Only adds the value if it is not None.
+        One of the associations representing one particular category of the hardware entity.
 
-        Args:
-            value: The hardware category reference to add
+        A None value is a no-op and does not add an hwCategoryRef.
 
         Returns:
             self for method chaining
@@ -92,22 +80,29 @@ class HwDescriptionEntity(ARElement):
             self.hwCategoryRefs.append(value)
         return self
 
-    def getHwTypeRef(self) -> Optional[RefType]:
+    def getHwCategoryRefs(self) -> List[RefType]:
         """
-        Gets the hardware type reference for this entity.
+        One of the associations representing one particular category of the hardware entity.
 
         Returns:
-            RefType representing the hardware type reference, or None if not set
+            The list of hwCategoryRefs, or an empty list if none are set
+        """
+        return self.hwCategoryRefs
+
+    def getHwTypeRef(self) -> Optional[RefType]:
+        """
+        This association is used to assign an optional HwType which contains the common attribute values for all occurences of this HwDescriptionEntity. Note that Hw Types can not be redefined and therefore shall not have a hwType reference.
+
+        Returns:
+            The hwTypeRef, or None if not set
         """
         return self.hwTypeRef
 
-    def setHwTypeRef(self, value: RefType):
+    def setHwTypeRef(self, value: Optional[RefType]):
         """
-        Sets the hardware type reference for this entity.
-        Only sets the value if it is not None.
+        This association is used to assign an optional HwType which contains the common attribute values for all occurences of this HwDescriptionEntity. Note that Hw Types can not be redefined and therefore shall not have a hwType reference.
 
-        Args:
-            value: The hardware type reference to set
+        A None value is a no-op and does not overwrite an existing hwTypeRef.
 
         Returns:
             self for method chaining
@@ -344,58 +339,57 @@ class HwElement(HwDescriptionEntity):
     """
 
     # HwElement method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
-    # [ ] getHwElementConnections      [x] impl  [x] docstring  [ ] test
-    # [ ] setHwElementConnections      [x] impl  [x] docstring  [ ] test
-    # [ ] getHwPinGroups               [x] impl  [x] docstring  [ ] test
-    # [ ] createHwPinGroup             [x] impl  [x] docstring  [ ] test
-    # [ ] getNestedElementRefs         [x] impl  [x] docstring  [ ] test
-    # [ ] setNestedElementRefs         [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_ECUResourceTemplate.pdf, Table 2.4, p.18
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] addHwElementConnection       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHwElementConnections      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createHwPinGroup             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHwPinGroups               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addNestedElementRef          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getNestedElementRefs         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self, parent, short_name: str):
-        """
-        Initializes the HwElement with a parent and short name.
-
-        Args:
-            parent: The parent ARObject that contains this hardware element
-            short_name: The unique short name of this hardware element
-        """
         super().__init__(parent, short_name)
 
+        # This represents one particular connection between two hardware elements.
         self.hwElementConnections: List[HwElementConnector] = []
+
+        # This aggregation is used to describe the connection facilities of a hardware element. Note that hardware element has no pins but only pingroups.
         self.hwPinGroups: List[HwPinGroup] = []
+
+        # This association is used to establish hierarchies of hw elements. Note that one particular HwElement can be target of this association only once. I.e. multiple instantiation of the same HwElement is not supported (at any hierarchy level).
         self.nestedElementRefs: List[RefType] = []
 
     def getHwElementConnections(self) -> List[HwElementConnector]:
         """
-        Gets the list of hardware element connections for this element.
+        This represents one particular connection between two hardware elements.
 
         Returns:
-            List of HwElementConnector instances
+            The list of hwElementConnections, or an empty list if none are set
         """
         return self.hwElementConnections
 
-    def setHwElementConnections(self, value: List[HwElementConnector]):
+    def addHwElementConnection(self, value: HwElementConnector):
         """
-        Sets the list of hardware element connections for this element.
-        Only sets the value if it is not None.
+        This represents one particular connection between two hardware elements.
 
-        Args:
-            value: The list of hardware element connections to set
+        A None value is a no-op and does not add an hwElementConnection.
 
         Returns:
             self for method chaining
         """
         if value is not None:
-            self.hwElementConnections = value
+            self.hwElementConnections.append(value)
         return self
 
     def getHwPinGroups(self) -> List[HwPinGroup]:
         """
-        Gets the list of hardware pin groups for this element.
+        This aggregation is used to describe the connection facilities of a hardware element. Note that hardware element has no pins but only pingroups.
 
         Returns:
-            List of HwPinGroup instances
+            The list of hwPinGroups, or an empty list if none are set
         """
         return self.hwPinGroups
 
@@ -409,32 +403,29 @@ class HwElement(HwDescriptionEntity):
         Returns:
             The created HwPinGroup instance
         """
-        if not self.IsElementExists(short_name):
+        if not any(pin_group.getShortName() == short_name for pin_group in self.hwPinGroups):
             pin_group = HwPinGroup(self, short_name)
-            self.addElement(pin_group)
             self.hwPinGroups.append(pin_group)
-        return self.getElement(short_name)
+        return next(pin_group for pin_group in self.hwPinGroups if pin_group.getShortName() == short_name)
 
     def getNestedElementRefs(self) -> List[RefType]:
         """
-        Gets the list of nested element references for this element.
+        This association is used to establish hierarchies of hw elements. Note that one particular HwElement can be target of this association only once. I.e. multiple instantiation of the same HwElement is not supported (at any hierarchy level).
 
         Returns:
-            List of RefType instances representing nested element references
+            The list of nestedElementRefs, or an empty list if none are set
         """
         return self.nestedElementRefs
 
-    def setNestedElementRefs(self, value: List[RefType]):
+    def addNestedElementRef(self, value: RefType):
         """
-        Sets the list of nested element references for this element.
-        Only sets the value if it is not None.
+        This association is used to establish hierarchies of hw elements. Note that one particular HwElement can be target of this association only once. I.e. multiple instantiation of the same HwElement is not supported (at any hierarchy level).
 
-        Args:
-            value: The list of nested element references to set
+        A None value is a no-op and does not add a nestedElementRef.
 
         Returns:
             self for method chaining
         """
         if value is not None:
-            self.nestedElementRefs = value
+            self.nestedElementRefs.append(value)
         return self

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py
@@ -653,21 +653,23 @@ class ARElement(PackageableElement, ABC):
 
 class Describable(ARObject, ABC):
     """
-    Abstract class for elements that can be described in AUTOSAR models.
-    This class provides basic description functionality for AUTOSAR elements.
+    This meta-class represents the ability to add a descriptive documentation to non identifiable elements.
     """
 
     # Describable method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getDesc                      [x] impl  [x] docstring  [ ] test
-    # [ ] setDesc                      [x] impl  [x] docstring  [ ] test
-    # [ ] getCategory                  [x] impl  [x] docstring  [ ] test
-    # [ ] setCategory                  [x] impl  [x] docstring  [ ] test
-    # [ ] getAdminData                 [x] impl  [x] docstring  [ ] test
-    # [ ] setAdminData                 [x] impl  [x] docstring  [ ] test
-    # [ ] removeAdminData              [x] impl  [x] docstring  [ ] test
-    # [ ] getIntroduction              [x] impl  [x] docstring  [ ] test
-    # [ ] setIntroduction              [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table E.25, p.438
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getAdminData                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setAdminData                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] removeAdminData              [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getCategory                  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCategory                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDesc                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDesc                      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getIntroduction              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIntroduction              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         if type(self) is Describable:
@@ -675,72 +677,27 @@ class Describable(ARObject, ABC):
 
         super().__init__()
 
-        self.desc = None
-        self.category = None
-        self.adminData = None
-        self.introduction = None
+        # This represents the administrative data for the describable object. Stereotypes: atpSplitable Tags: atp.Splitkey=adminData xml.sequenceOffset=-20
+        self.adminData: Optional[AdminData] = None
 
-    def getDesc(self) -> Optional[MultiLanguageOverviewParagraph]:
-        """
-        Gets the description for this describable element.
+        # The category is a keyword that specializes the semantics of the Describable. It affects the expected existence of attributes and the applicability of constraints. Tags: xml.sequenceOffset=-50
+        self.category: Optional[CategoryString] = None
 
-        Returns:
-            MultiLanguageOverviewParagraph instance, or None if not set
-        """
-        return self.desc
+        # This represents a general but brief (one paragraph) description what the object in question is about. It is only one paragraph! Desc is intended to be collected into overview tables. This property helps a human reader to identify the object in question. More elaborate documentation, (in particular how the object is built or used) should go to "introduction". Tags: xml.sequenceOffset=-60
+        self.desc: Optional[MultiLanguageOverviewParagraph] = None
 
-    def setDesc(self, value: MultiLanguageOverviewParagraph):
-        """
-        Sets the description for this describable element.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The description to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is not None:
-            self.desc = value
-        return self
-
-    def getCategory(self) -> Optional[CategoryString]:
-        """
-        Gets the category for this describable element.
-
-        Returns:
-            CategoryString instance, or None if not set
-        """
-        return self.category
-
-    def setCategory(self, value: CategoryString):
-        """
-        Sets the category for this describable element.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The category to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is not None:
-            self.category = value
-        return self
+        # This represents more information about how the object in question is built or is used. Therefore it is a DocumentationBlock. Tags: xml.sequenceOffset=-30
+        self.introduction: Optional[DocumentationBlock] = None
 
     def getAdminData(self) -> Optional[AdminData]:
         """
-        Gets the administrative data for this describable element.
-
-        Returns:
-            AdminData instance, or None if not set
+        This represents the administrative data for the describable object. Stereotypes: atpSplitable Tags: atp.Splitkey=adminData xml.sequenceOffset=-20
         """
         return self.adminData
 
-    def setAdminData(self, value: AdminData):
+    def setAdminData(self, value: Optional[AdminData]):
         """
-        Sets the administrative data for this describable element.
-        Only sets the value if it is not None.
+        This represents the administrative data for the describable object. Stereotypes: atpSplitable Tags: atp.Splitkey=adminData xml.sequenceOffset=-20
 
         Args:
             value: The administrative data to set
@@ -758,19 +715,55 @@ class Describable(ARObject, ABC):
         """
         self.adminData = None
 
-    def getIntroduction(self) -> Optional[DocumentationBlock]:
+    def getCategory(self) -> Optional[CategoryString]:
         """
-        Gets the introduction documentation for this describable element.
+        The category is a keyword that specializes the semantics of the Describable. It affects the expected existence of attributes and the applicability of constraints. Tags: xml.sequenceOffset=-50
+        """
+        return self.category
+
+    def setCategory(self, value: Optional[CategoryString]):
+        """
+        The category is a keyword that specializes the semantics of the Describable. It affects the expected existence of attributes and the applicability of constraints. Tags: xml.sequenceOffset=-50
+
+        Args:
+            value: The category to set
 
         Returns:
-            DocumentationBlock instance, or None if not set
+            self for method chaining
+        """
+        if value is not None:
+            self.category = value
+        return self
+
+    def getDesc(self) -> Optional[MultiLanguageOverviewParagraph]:
+        """
+        This represents a general but brief (one paragraph) description what the object in question is about. It is only one paragraph! Desc is intended to be collected into overview tables. This property helps a human reader to identify the object in question. More elaborate documentation, (in particular how the object is built or used) should go to "introduction". Tags: xml.sequenceOffset=-60
+        """
+        return self.desc
+
+    def setDesc(self, value: Optional[MultiLanguageOverviewParagraph]):
+        """
+        This represents a general but brief (one paragraph) description what the object in question is about. It is only one paragraph! Desc is intended to be collected into overview tables. This property helps a human reader to identify the object in question. More elaborate documentation, (in particular how the object is built or used) should go to "introduction". Tags: xml.sequenceOffset=-60
+
+        Args:
+            value: The description to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is not None:
+            self.desc = value
+        return self
+
+    def getIntroduction(self) -> Optional[DocumentationBlock]:
+        """
+        This represents more information about how the object in question is built or is used. Therefore it is a DocumentationBlock. Tags: xml.sequenceOffset=-30
         """
         return self.introduction
 
-    def setIntroduction(self, value: DocumentationBlock):
+    def setIntroduction(self, value: Optional[DocumentationBlock]):
         """
-        Sets the introduction documentation for this describable element.
-        Only sets the value if it is not None.
+        This represents more information about how the object in question is built or is used. Therefore it is a DocumentationBlock. Tags: xml.sequenceOffset=-30
 
         Args:
             value: The introduction documentation to set

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
@@ -351,12 +351,18 @@ class AREnum(ARLiteral):
 
 class String(ARLiteral):
     """
-    Represents a string AUTOSAR type.
-    This class provides functionality for string values in AUTOSAR models.
+    This represents a String in which white-space shall be normalized before processing. For example: in order to compare two Strings: • leading and trailing white-space needs to be removed • consecutive white-space (blank, cr, lf, tab) needs to be replaced by one blank.
+
+    Tags:
+        * xml.xsd.customType=STRING
+        * xml.xsd.type=string
     """
 
     # String method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [x] test
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.63, p.113
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self):
         super().__init__()
@@ -1306,14 +1312,17 @@ class McdIdentifier(ARLiteral):
 
 class Numerical(ARLiteral):
     """
-    This primitive specifies a numerical value. It can be denoted in different formats
-    such as Decimal, Octal, Hexadecimal, Float. See the xsd pattern for details. The
-    value can be expressed in octal, hexadecimal, binary representation. Negative
-    numbers can only be expressed in decimal or float notation.
+    This primitive specifies a numerical value. It can be denoted in different formats such as Decimal, Octal, Hexadecimal, Float. See the xsd pattern for details. The value can be expressed in octal, hexadecimal, binary representation. Negative numbers can only be expressed in decimal or float notation.
+
+    Tags:
+        * xml.xsd.customType=NUMERICAL-VALUE
+        * xml.xsd.pattern=(0[xX][0-9a-fA-F]+)|(0[0-7]+)|(0[bB][0-1]+)|(([+\\-]?[1-9][0-9]+(\\.[0-9]+)?|[+\\-]?[0-9](\\.[0-9]+)?)([eE]([+\\-]?)[0-9]+)?)|\\.0|INF|-INF|NaN
+        * xml.xsd.type=string
     """
 
     # Numerical method parity checklist:
-    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table E.58, p.92
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table E.58, p.457
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -199,7 +199,8 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucValidationCondition,
     EcucValueConfigurationClass,
 )
-from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwDescriptionEntity, HwElement, HwPinGroup
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwDescriptionEntity, HwElement, HwElementConnector, HwPinGroup
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwAttributeValue import HwAttributeValue
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwAttributeDef, HwCategory, HwType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import Documentation, DocumentationContext
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import AnyInstanceRef
@@ -5969,9 +5970,21 @@ class ARXMLParser(AbstractARXMLParser):
         for ref in self.getChildElementRefTypeList(element, "HW-CATEGORY-REFS/HW-CATEGORY-REF"):
             entity.addHwCategoryRef(ref)
 
+    def readHwAttributeValue(self, element: ET.Element, attribute_value: HwAttributeValue):
+        self.readARObjectAttributes(element, attribute_value)
+        attribute_value.setHwAttributeDefRef(self.getChildElementOptionalRefType(element, "HW-ATTRIBUTE-DEF-REF"))
+
+    def readHwDescriptionEntityHwAttributeValues(self, element: ET.Element, entity: HwDescriptionEntity):
+        for child_element in self.findall(element, "HW-ATTRIBUTE-VALUES/HW-ATTRIBUTE-VALUE"):
+            attribute_value = HwAttributeValue()
+            self.readHwAttributeValue(child_element, attribute_value)
+            entity.addHwAttributeValue(attribute_value)
+
     def readHwDescriptionEntity(self, element: ET.Element, entity: HwDescriptionEntity):
-        self.readARElement(element, entity)
+        self.readReferrable(element, entity)
+        entity.setHwTypeRef(self.getChildElementOptionalRefType(element, "HW-TYPE-REF"))
         self.readHwDescriptionEntityHwCategoryRefs(element, entity)
+        self.readHwDescriptionEntityHwAttributeValues(element, entity)
 
     def readHwPinGroup(self, element: ET.SubElement, pin_group: HwPinGroup):
         self.readHwDescriptionEntity(element, pin_group)
@@ -5985,10 +5998,30 @@ class ARXMLParser(AbstractARXMLParser):
             else:
                 self.notImplemented("Unsupported Hw Pin Group <%s>" % tag_name)
 
+    def readHwElementConnector(self, element: ET.Element, connector: HwElementConnector):
+        self.readDescribable(element, connector)
+        connector.setHwElementRef(self.getChildElementOptionalRefType(element, "HW-ELEMENT-REF"))
+        connector.setHwPinRef(self.getChildElementOptionalRefType(element, "HW-PIN-REF"))
+
+    def readHwElementHwElementConnections(self, element: ET.Element, hw_element: HwElement):
+        for child_element in self.findall(element, "HW-ELEMENT-CONNECTIONS/HW-ELEMENT-CONNECTOR"):
+            connector = HwElementConnector()
+            self.readHwElementConnector(child_element, connector)
+            hw_element.addHwElementConnection(connector)
+
+    def readHwElementHwNestedElementRefs(self, element: ET.Element, hw_element: HwElement):
+        refs = self.getChildElementRefTypeList(element, "NESTED-ELEMENTS/HW-ELEMENT-REF-CONDITIONAL/HW-ELEMENT-REF")
+        if len(refs) == 0:
+            refs = self.getChildElementRefTypeList(element, "NESTED-ELEMENTS/HW-ELEMENT-REF")
+        for ref in refs:
+            hw_element.addNestedElementRef(ref)
+
     def readHwElement(self, element: ET.Element, hw_element: HwElement):
         self.logger.debug("Read HwElement <%s>" % hw_element.getShortName())
         self.readHwDescriptionEntity(element, hw_element)
         self.readHwElementHwPinGroups(element, hw_element)
+        self.readHwElementHwElementConnections(element, hw_element)
+        self.readHwElementHwNestedElementRefs(element, hw_element)
 
     def readHwAttributeDef(self, element: ET.Element, attribute_def: HwAttributeDef):
         self.readIdentifiable(element, attribute_def)
@@ -6010,7 +6043,7 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readHwType(self, element: ET.Element, type: HwType):
         self.logger.debug("Read HwType <%s>" % type.getShortName())
-        self.readARElement(element, type)
+        self.readReferrable(element, type)
 
     def readPduToFrameMappings(self, element: ET.Element, parent: Frame):
         for child_element in self.findall(element, "PDU-TO-FRAME-MAPPINGS/PDU-TO-FRAME-MAPPING"):
@@ -6515,6 +6548,11 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readDescribable(self, element: ET.Element, desc: Describable):
         self.readARObjectAttributes(element, desc)
+
+        desc.setDesc(self.getMultiLanguageOverviewParagraph(element, "DESC"))
+        desc.setCategory(self.getChildElementOptionalLiteral(element, "CATEGORY"))
+        desc.setIntroduction(self.getDocumentationBlock(element, "INTRODUCTION"))
+        desc.setAdminData(self.getAdminData(element, "ADMIN-DATA"))
 
     def readTransformationDescription(self, element: ET.Element, desc: TransformationDescription):
         self.readDescribable(element, desc)

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -189,7 +189,8 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucValidationCondition,
     EcucValueConfigurationClass,
 )
-from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwDescriptionEntity, HwElement, HwPinGroup
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwDescriptionEntity, HwElement, HwElementConnector, HwPinGroup
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwAttributeValue import HwAttributeValue
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwAttributeDef, HwCategory, HwType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import Documentation, DocumentationContext
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import AnyInstanceRef
@@ -8115,9 +8116,23 @@ class ARXMLWriter(AbstractARXMLWriter):
             for ref in refs:
                 self.setChildElementOptionalRefType(child_element, "HW-CATEGORY-REF", ref)
 
+    def writeHwAttributeValue(self, element: ET.Element, attribute_value: HwAttributeValue):
+        child_element = ET.SubElement(element, "HW-ATTRIBUTE-VALUE")
+        self.writeARObjectAttributes(child_element, attribute_value)
+        self.setChildElementOptionalRefType(child_element, "HW-ATTRIBUTE-DEF-REF", attribute_value.getHwAttributeDefRef())
+
+    def writeHwDescriptionEntityHwAttributeValues(self, element: ET.Element, entity: HwDescriptionEntity):
+        attribute_values = entity.getHwAttributeValues()
+        if len(attribute_values) > 0:
+            child_element = ET.SubElement(element, "HW-ATTRIBUTE-VALUES")
+            for attribute_value in attribute_values:
+                self.writeHwAttributeValue(child_element, attribute_value)
+
     def writeHwDescriptionEntity(self, element: ET.Element, entity: HwDescriptionEntity):
-        self.writeARElement(element, entity)
+        self.writeReferrable(element, entity)
+        self.setChildElementOptionalRefType(element, "HW-TYPE-REF", entity.getHwTypeRef())
         self.writeHwDescriptionEntityHwCategoryRefs(element, entity)
+        self.writeHwDescriptionEntityHwAttributeValues(element, entity)
 
     def writeHwPinGroup(self, element: ET.SubElement, pin_group: HwPinGroup):
         if pin_group is not None:
@@ -8134,12 +8149,38 @@ class ARXMLWriter(AbstractARXMLWriter):
                 else:
                     self.notImplemented("Unsupported Hw Pin Group <%s>" % type(pin_group))
 
+    def writeHwElementConnector(self, parent: ET.Element, connector: HwElementConnector):
+        child_element = ET.SubElement(parent, "HW-ELEMENT-CONNECTOR")
+        self.writeDescribable(child_element, connector)
+        self.setChildElementOptionalRefType(child_element, "HW-ELEMENT-REF", connector.getHwElementRef())
+        self.setChildElementOptionalRefType(child_element, "HW-PIN-REF", connector.getHwPinRef())
+
+    def writeHwElementHwElementConnections(self, element: ET.Element, hw_element: HwElement):
+        connections = hw_element.getHwElementConnections()
+        if len(connections) > 0:
+            child_element = ET.SubElement(element, "HW-ELEMENT-CONNECTIONS")
+            for connector in connections:
+                if isinstance(connector, HwElementConnector):
+                    self.writeHwElementConnector(child_element, connector)
+                else:
+                    self.notImplemented("Unsupported Hw Element Connector <%s>" % type(connector))
+
+    def writeHwElementHwNestedElementRefs(self, element: ET.Element, hw_element: HwElement):
+        nested_element_refs = hw_element.getNestedElementRefs()
+        if len(nested_element_refs) > 0:
+            child_element = ET.SubElement(element, "NESTED-ELEMENTS")
+            for ref in nested_element_refs:
+                conditional = ET.SubElement(child_element, "HW-ELEMENT-REF-CONDITIONAL")
+                self.setChildElementOptionalRefType(conditional, "HW-ELEMENT-REF", ref)
+
     def writeHwElement(self, element: ET.Element, hw_element: HwElement):
         if hw_element is not None:
             self.logger.debug("Write HwElement <%s>" % hw_element.getShortName())
             child_element = ET.SubElement(element, "HW-ELEMENT")
             self.writeHwDescriptionEntity(child_element, hw_element)
             self.writeHwElementHwPinGroups(child_element, hw_element)
+            self.writeHwElementHwElementConnections(child_element, hw_element)
+            self.writeHwElementHwNestedElementRefs(child_element, hw_element)
 
     def writeHwAttributeDef(self, element: ET.Element, attribute_def: HwAttributeDef):
         if attribute_def is not None:
@@ -8166,7 +8207,7 @@ class ARXMLWriter(AbstractARXMLWriter):
     def writeHwType(self, element: ET.Element, type: HwType):
         self.logger.debug("Write HwType <%s>" % type.getShortName())
         child_element = ET.SubElement(element, "HW-TYPE")
-        self.writeARElement(child_element, type)
+        self.writeReferrable(child_element, type)
 
     def writeLinCommunicationController(self, element: ET.Element, controller: LinCommunicationController):
         self.writeCommunicationController(element, controller)
@@ -8344,6 +8385,10 @@ class ARXMLWriter(AbstractARXMLWriter):
 
     def writeDescribable(self, element: ET.Element, desc: Describable):
         self.writeARObjectAttributes(element, desc)
+        self.setMultiLanguageOverviewParagraph(element, "DESC", desc.getDesc())
+        self.setChildElementOptionalLiteral(element, "CATEGORY", desc.getCategory())
+        self.writeDocumentationBlock(element, "INTRODUCTION", desc.getIntroduction())
+        self.setAdminData(element, desc.getAdminData())
 
     def writeTransformationDescription(self, element: ET.Element, desc: TransformationDescription):
         self.writeDescribable(element, desc)

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/test_EcuResourceTemplate.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/test_EcuResourceTemplate.py
@@ -3,76 +3,9 @@ Test cases for the EcuResourceTemplate __init__.py module.
 These tests ensure 100% code coverage for the HwDescriptionEntity, HwPin, HwPinGroupContent, HwPinGroup, and HwElement classes.
 """
 
-from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwDescriptionEntity, HwElement, HwPin, HwPinGroup, HwPinGroupContent
-from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwAttributeValue import HwAttributeValue
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwElement, HwPin, HwPinGroup, HwPinGroupContent
 from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementConnector import HwElementConnector
-
-
-def test_hw_description_entity_init():
-    """
-    Test initialization of HwDescriptionEntity class.
-
-    Test Steps:
-    1. Create a HwDescriptionEntity instance with parent and short_name
-    2. Verify default attributes are set correctly
-    """
-    # Create a mock parent object
-    parent = object()
-
-    # Initialize HwDescriptionEntity
-    hw_desc_entity = HwDescriptionEntity(parent, "test_hw_desc_entity")
-
-    # Verify initial values
-    assert hw_desc_entity.parent == parent
-    assert hw_desc_entity.short_name == "test_hw_desc_entity"
-    assert hw_desc_entity.hwAttributeValues == []
-    assert hw_desc_entity.hwCategoryRefs == []
-    assert hw_desc_entity.hwTypeRef is None
-
-
-def test_hw_description_entity_getters_and_setters():
-    """
-    Test all getter and setter methods of HwDescriptionEntity class.
-
-    Test Steps:
-    1. Create a HwDescriptionEntity instance
-    2. Test setting and getting hwAttributeValues
-    3. Test adding and getting hwCategoryRefs
-    4. Test setting and getting hwTypeRef
-    5. Verify method chaining (return self)
-    """
-    hw_desc_entity = HwDescriptionEntity(None, "test_hw_desc_entity")
-
-    # Test hwAttributeValues setter and getter
-    test_attr_values = [HwAttributeValue(), HwAttributeValue()]
-    return_value = hw_desc_entity.setHwAttributeValues(test_attr_values)
-    assert return_value == hw_desc_entity  # Verify method chaining
-    assert hw_desc_entity.getHwAttributeValues() == test_attr_values
-
-    # Test addHwCategoryRef and getHwCategoryRefs
-    test_category_ref = "test_category_ref"
-    return_value = hw_desc_entity.addHwCategoryRef(test_category_ref)
-    assert return_value == hw_desc_entity  # Verify method chaining
-    assert test_category_ref in hw_desc_entity.getHwCategoryRefs()
-
-    # Test hwTypeRef setter and getter
-    test_type_ref = "test_type_ref"
-    return_value = hw_desc_entity.setHwTypeRef(test_type_ref)
-    assert return_value == hw_desc_entity  # Verify method chaining
-    assert hw_desc_entity.getHwTypeRef() == test_type_ref
-
-    # Test with None values (should not set/add)
-    original_attr_values = hw_desc_entity.getHwAttributeValues()
-    hw_desc_entity.setHwAttributeValues(None)
-    assert hw_desc_entity.getHwAttributeValues() == original_attr_values  # Should remain unchanged
-
-    original_type_ref = hw_desc_entity.getHwTypeRef()
-    hw_desc_entity.setHwTypeRef(None)
-    assert hw_desc_entity.getHwTypeRef() == original_type_ref  # Should remain unchanged
-
-    original_category_refs_count = len(hw_desc_entity.getHwCategoryRefs())
-    hw_desc_entity.addHwCategoryRef(None)
-    assert len(hw_desc_entity.getHwCategoryRefs()) == original_category_refs_count  # Should remain unchanged
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
 
 
 def test_hw_pin_init():
@@ -275,19 +208,29 @@ def test_hw_element_getters_and_setters():
 
     Test Steps:
     1. Create a HwElement instance
-    2. Test setting and getting hwElementConnections
+    2. Test adding and getting hwElementConnections
     3. Test createHwPinGroup method
-    4. Test setting and getting nestedElementRefs
-    5. Verify method chaining (return self)
+    4. Test adding and getting nestedElementRefs
+    5. Verify method chaining (return self) and None no-op
     """
 
     hw_element = HwElement(None, "test_hw_element")
 
-    # Test hwElementConnections setter and getter
-    test_connections = [HwElementConnector(), HwElementConnector()]
-    return_value = hw_element.setHwElementConnections(test_connections)
+    # Test hwElementConnections adder and getter
+    connection1 = HwElementConnector()
+    ref1 = RefType()
+    ref1.setDest("HW-ELEMENT")
+    ref1.setValue("/pkg/elem1")
+    connection1.setHwElementRef(ref1)
+    connection2 = HwElementConnector()
+    ref2 = RefType()
+    ref2.setDest("HW-PIN")
+    ref2.setValue("/pkg/elem1/pinA")
+    connection2.setHwPinRef(ref2)
+    return_value = hw_element.addHwElementConnection(connection1)
     assert return_value == hw_element  # Verify method chaining
-    assert hw_element.getHwElementConnections() == test_connections
+    hw_element.addHwElementConnection(connection2)
+    assert hw_element.getHwElementConnections() == [connection1, connection2]
 
     # Test createHwPinGroup
     new_pin_group = hw_element.createHwPinGroup("new_pin_group")
@@ -295,25 +238,29 @@ def test_hw_element_getters_and_setters():
     assert new_pin_group.short_name == "new_pin_group"
     assert new_pin_group in hw_element.getHwPinGroups()
 
-    # Test nestedElementRefs setter and getter
-    test_nested_refs = ["ref1", "ref2", "ref3"]
-    return_value = hw_element.setNestedElementRefs(test_nested_refs)
+    # Test nestedElementRefs adder and getter
+    ref1 = RefType()
+    ref1.setDest("HW-ELEMENT")
+    ref1.setValue("/pkg/elem2")
+    ref2 = RefType()
+    ref2.setDest("HW-ELEMENT")
+    ref2.setValue("/pkg/elem3")
+    return_value = hw_element.addNestedElementRef(ref1)
     assert return_value == hw_element  # Verify method chaining
-    assert hw_element.getNestedElementRefs() == test_nested_refs
+    hw_element.addNestedElementRef(ref2)
+    assert hw_element.getNestedElementRefs() == [ref1, ref2]
 
-    # Test with None values (should not set)
+    # Test with None values (should not add)
     original_connections = hw_element.getHwElementConnections()
-    hw_element.setHwElementConnections(None)
+    hw_element.addHwElementConnection(None)
     assert hw_element.getHwElementConnections() == original_connections  # Should remain unchanged
 
     original_nested_refs = hw_element.getNestedElementRefs()
-    hw_element.setNestedElementRefs(None)
+    hw_element.addNestedElementRef(None)
     assert hw_element.getNestedElementRefs() == original_nested_refs  # Should remain unchanged
 
 
 if __name__ == "__main__":
-    test_hw_description_entity_init()
-    test_hw_description_entity_getters_and_setters()
     test_hw_pin_init()
     test_hw_pin_getters_and_setters()
     test_hw_pin_group_content_init()

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/test_HwDescriptionEntity.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/test_HwDescriptionEntity.py
@@ -1,0 +1,69 @@
+import pytest
+
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import (
+    HwDescriptionEntity,
+    HwElement,
+)
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwAttributeValue import HwAttributeValue
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+
+
+class TestHwDescriptionEntity:
+    def test_abstract_class_cannot_be_instantiated(self):
+        """Test that HwDescriptionEntity abstract class cannot be instantiated directly"""
+        with pytest.raises(TypeError, match="HwDescriptionEntity is an abstract class"):
+            HwDescriptionEntity(None, "TestEntity")
+
+    def test_concrete_subclass_initialization(self):
+        """Test that a concrete subclass of HwDescriptionEntity can be instantiated"""
+        element = HwElement(None, "TestElement")
+        assert element is not None
+        assert element.getShortName() == "TestElement"
+        assert element.getHwAttributeValues() == []
+        assert element.getHwCategoryRefs() == []
+        assert element.getHwTypeRef() is None
+
+    def test_add_hw_attribute_value(self):
+        """Test addHwAttributeValue method"""
+        entity = HwElement(None, "TestEntity")
+        value = HwAttributeValue()
+        result = entity.addHwAttributeValue(value)
+        assert result is entity
+        assert entity.getHwAttributeValues() == [value]
+
+    def test_add_hw_attribute_value_none(self):
+        """Test addHwAttributeValue with None value"""
+        entity = HwElement(None, "TestEntity")
+        result = entity.addHwAttributeValue(None)
+        assert result is entity
+        assert entity.getHwAttributeValues() == []
+
+    def test_add_hw_category_ref(self):
+        """Test addHwCategoryRef method"""
+        entity = HwElement(None, "TestEntity")
+        ref = RefType()
+        result = entity.addHwCategoryRef(ref)
+        assert result is entity
+        assert entity.getHwCategoryRefs() == [ref]
+
+    def test_add_hw_category_ref_none(self):
+        """Test addHwCategoryRef with None value"""
+        entity = HwElement(None, "TestEntity")
+        result = entity.addHwCategoryRef(None)
+        assert result is entity
+        assert entity.getHwCategoryRefs() == []
+
+    def test_set_hw_type_ref(self):
+        """Test setHwTypeRef method"""
+        entity = HwElement(None, "TestEntity")
+        ref = RefType()
+        result = entity.setHwTypeRef(ref)
+        assert result is entity
+        assert entity.getHwTypeRef() == ref
+
+    def test_set_hw_type_ref_none(self):
+        """Test setHwTypeRef with None value"""
+        entity = HwElement(None, "TestEntity")
+        result = entity.setHwTypeRef(None)
+        assert result is entity
+        assert entity.getHwTypeRef() is None

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_Identifiable.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_Identifiable.py
@@ -14,7 +14,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     Referrable,
     ShortNameFragment,
 )
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Identifier
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import CategoryString, Identifier
 from armodel.models.M2.MSR.AsamHdo.AdminData import AdminData
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
@@ -824,9 +824,9 @@ class TestDescribable:
         except TypeError:
             pass  # Expected behavior
 
-    def test_get_set_desc_describable(self):
+    def test_initialization(self):
         """
-        Test getDesc and setDesc methods for Describable.
+        Test that Describable initializes all fields to None.
         """
 
         class ConcreteDescribable(Describable):
@@ -835,13 +835,10 @@ class TestDescribable:
 
         obj = ConcreteDescribable()
 
-        # Initially should be None
+        assert obj.getAdminData() is None
+        assert obj.getCategory() is None
         assert obj.getDesc() is None
-
-        # Set description
-        desc = MultiLanguageOverviewParagraph()
-        obj.setDesc(desc)
-        assert obj.getDesc() is desc
+        assert obj.getIntroduction() is None
 
     def test_get_set_admin_data_describable(self):
         """
@@ -854,13 +851,16 @@ class TestDescribable:
 
         obj = ConcreteDescribable()
 
-        # Initially should be None
         assert obj.getAdminData() is None
 
-        # Set admin data
         admin_data = AdminData()
-        obj.setAdminData(admin_data)
+        result = obj.setAdminData(admin_data)
+        assert result is obj  # method chaining
         assert obj.getAdminData() is admin_data
+
+        result = obj.setAdminData(None)
+        assert result is obj  # method chaining with None
+        assert obj.getAdminData() is admin_data  # None is a no-op
 
     def test_remove_admin_data_describable(self):
         """
@@ -873,18 +873,16 @@ class TestDescribable:
 
         obj = ConcreteDescribable()
 
-        # Set admin data
         admin_data = AdminData()
         obj.setAdminData(admin_data)
         assert obj.getAdminData() is admin_data
 
-        # Remove admin data
         obj.removeAdminData()
         assert obj.getAdminData() is None
 
     def test_get_set_category_describable(self):
         """
-        Test getCategory and setCategory methods in Describable class to cover lines 435, 448-450.
+        Test getCategory and setCategory methods in Describable class.
         """
 
         class ConcreteDescribable(Describable):
@@ -893,24 +891,38 @@ class TestDescribable:
 
         obj = ConcreteDescribable()
 
-        # Test initial value is None (covers line 435)
         assert obj.getCategory() is None
 
-        # Test setCategory with a value (covers lines 448, 449, 450)
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import CategoryString
-
         category = CategoryString().setValue("TestDescribableCategory")
-        result = obj.setCategory(category)  # Should return self (line 450)
-        assert result is obj  # Verify method chaining
-
-        # Verify the category was set (covers line 435 again)
+        result = obj.setCategory(category)
+        assert result is obj  # method chaining
         assert obj.getCategory() is category
 
-        # Test setCategory with None to test the if condition path
-        obj2 = ConcreteDescribable()
-        result2 = obj2.setCategory(None)  # Should still return self
-        assert result2 is obj2  # Method chaining still works with None input
-        assert obj2.getCategory() is None  # Category remains None
+        result = obj.setCategory(None)
+        assert result is obj  # method chaining with None
+        assert obj.getCategory() is category  # None is a no-op
+
+    def test_get_set_desc_describable(self):
+        """
+        Test getDesc and setDesc methods for Describable.
+        """
+
+        class ConcreteDescribable(Describable):
+            def __init__(self):
+                super().__init__()
+
+        obj = ConcreteDescribable()
+
+        assert obj.getDesc() is None
+
+        desc = MultiLanguageOverviewParagraph()
+        result = obj.setDesc(desc)
+        assert result is obj  # method chaining
+        assert obj.getDesc() is desc
+
+        result = obj.setDesc(None)
+        assert result is obj  # method chaining with None
+        assert obj.getDesc() is desc  # None is a no-op
 
     def test_get_set_introduction_describable(self):
         """
@@ -923,10 +935,13 @@ class TestDescribable:
 
         obj = ConcreteDescribable()
 
-        # Initially should be None
         assert obj.getIntroduction() is None
 
-        # Set introduction
         intro = DocumentationBlock()
-        obj.setIntroduction(intro)
+        result = obj.setIntroduction(intro)
+        assert result is obj  # method chaining
         assert obj.getIntroduction() is intro
+
+        result = obj.setIntroduction(None)
+        assert result is obj  # method chaining with None
+        assert obj.getIntroduction() is intro  # None is a no-op

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_PrimitiveTypes.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_PrimitiveTypes.py
@@ -362,6 +362,13 @@ class TestString:
         assert string_val is not None
         assert string_val._value is None
 
+    def test_set_value(self):
+        """
+        Test String value assignment.
+        """
+        string_val = String().setValue("Hello World")
+        assert string_val.getValue() == "Hello World"
+
 
 class TestAlignmentType:
     """

--- a/tests/test_armodel/parser/test_arxml_parser_hw_description_entity.py
+++ b/tests/test_armodel/parser/test_arxml_parser_hw_description_entity.py
@@ -1,0 +1,119 @@
+import xml.etree.ElementTree as ET
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSARDoc
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwElement
+from armodel.parser.arxml_parser import ARXMLParser
+
+
+class TestReadHwDescriptionEntity:
+    def test_read_hw_element_attributes(self):
+        xml_content = """
+            <HW-ELEMENT>
+              <SHORT-NAME>TestElement</SHORT-NAME>
+              <HW-TYPE-REF DEST="HW-TYPE">/HwTypes/TestType</HW-TYPE-REF>
+              <HW-CATEGORY-REFS>
+                <HW-CATEGORY-REF DEST="HW-CATEGORY">/HwCategories/Cat1</HW-CATEGORY-REF>
+                <HW-CATEGORY-REF DEST="HW-CATEGORY">/HwCategories/Cat2</HW-CATEGORY-REF>
+              </HW-CATEGORY-REFS>
+              <HW-ATTRIBUTE-VALUES>
+                <HW-ATTRIBUTE-VALUE>
+                  <HW-ATTRIBUTE-DEF-REF DEST="HW-ATTRIBUTE-DEF">/HwCategories/Cat1/AttrDef</HW-ATTRIBUTE-DEF-REF>
+                </HW-ATTRIBUTE-VALUE>
+              </HW-ATTRIBUTE-VALUES>
+            </HW-ELEMENT>
+        """
+        element = ET.fromstring(xml_content)
+        document = AUTOSARDoc()
+        parser = ARXMLParser()
+        parser.nsmap = {"xmlns": ""}
+
+        hw_element = HwElement(document, "TestElement")
+        parser.readHwElement(element, hw_element)
+
+        assert hw_element.getShortName() == "TestElement"
+        assert hw_element.getHwTypeRef() is not None
+        assert hw_element.getHwTypeRef().getValue() == "/HwTypes/TestType"
+        assert hw_element.getHwTypeRef().getDest() == "HW-TYPE"
+
+        category_refs = hw_element.getHwCategoryRefs()
+        assert len(category_refs) == 2
+        assert category_refs[0].getValue() == "/HwCategories/Cat1"
+        assert category_refs[0].getDest() == "HW-CATEGORY"
+        assert category_refs[1].getValue() == "/HwCategories/Cat2"
+
+        attribute_values = hw_element.getHwAttributeValues()
+        assert len(attribute_values) == 1
+        assert attribute_values[0].getHwAttributeDefRef().getValue() == "/HwCategories/Cat1/AttrDef"
+
+    def test_read_hw_element_empty_wrappers(self):
+        xml_content = """
+            <HW-ELEMENT>
+              <SHORT-NAME>TestElement</SHORT-NAME>
+            </HW-ELEMENT>
+        """
+        element = ET.fromstring(xml_content)
+        document = AUTOSARDoc()
+        parser = ARXMLParser()
+        parser.nsmap = {"xmlns": ""}
+
+        hw_element = HwElement(document, "TestElement")
+        parser.readHwElement(element, hw_element)
+
+        assert hw_element.getHwTypeRef() is None
+        assert hw_element.getHwCategoryRefs() == []
+        assert hw_element.getHwAttributeValues() == []
+
+    def test_read_hw_element_connections_and_nested(self):
+        xml_content = """
+            <HW-ELEMENT>
+              <SHORT-NAME>TestElement</SHORT-NAME>
+              <HW-ELEMENT-CONNECTIONS>
+                <HW-ELEMENT-CONNECTOR>
+                  <HW-ELEMENT-REF DEST="HW-ELEMENT">/Elements/ElemA</HW-ELEMENT-REF>
+                  <HW-PIN-REF DEST="HW-PIN">/Elements/ElemA/Pin1</HW-PIN-REF>
+                </HW-ELEMENT-CONNECTOR>
+              </HW-ELEMENT-CONNECTIONS>
+              <NESTED-ELEMENTS>
+                <HW-ELEMENT-REF DEST="HW-ELEMENT">/Elements/ElemB</HW-ELEMENT-REF>
+                <HW-ELEMENT-REF DEST="HW-ELEMENT">/Elements/ElemC</HW-ELEMENT-REF>
+              </NESTED-ELEMENTS>
+            </HW-ELEMENT>
+        """
+        element = ET.fromstring(xml_content)
+        document = AUTOSARDoc()
+        parser = ARXMLParser()
+        parser.nsmap = {"xmlns": ""}
+
+        hw_element = HwElement(document, "TestElement")
+        parser.readHwElement(element, hw_element)
+
+        connections = hw_element.getHwElementConnections()
+        assert len(connections) == 1
+        assert connections[0].getHwElementRef().getValue() == "/Elements/ElemA"
+        assert connections[0].getHwElementRef().getDest() == "HW-ELEMENT"
+        assert connections[0].getHwPinRef().getValue() == "/Elements/ElemA/Pin1"
+        assert connections[0].getHwPinRef().getDest() == "HW-PIN"
+
+        nested = hw_element.getNestedElementRefs()
+        assert len(nested) == 2
+        assert [ref.getValue() for ref in nested] == ["/Elements/ElemB", "/Elements/ElemC"]
+        assert all(ref.getDest() == "HW-ELEMENT" for ref in nested)
+
+    def test_read_hw_element_connector_refs(self):
+        xml_content = """
+            <HW-ELEMENT-CONNECTOR>
+              <HW-ELEMENT-REF DEST="HW-ELEMENT">/Elements/ElemA</HW-ELEMENT-REF>
+              <HW-PIN-REF DEST="HW-PIN">/Elements/ElemA/Pin1</HW-PIN-REF>
+            </HW-ELEMENT-CONNECTOR>
+        """
+        element = ET.fromstring(xml_content)
+        parser = ARXMLParser()
+        parser.nsmap = {"xmlns": ""}
+
+        from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementConnector import HwElementConnector
+
+        connector = HwElementConnector()
+        parser.readHwElementConnector(element, connector)
+
+        assert connector.getHwElementRef().getValue() == "/Elements/ElemA"
+        assert connector.getHwPinRef().getValue() == "/Elements/ElemA/Pin1"

--- a/tests/test_armodel/parser/test_arxml_parser_internals.py
+++ b/tests/test_armodel/parser/test_arxml_parser_internals.py
@@ -756,9 +756,20 @@ class TestSdgDeepHandlers:
 
 class TestDescribableHandlers:
     def test_readDescribable(self, parser):
-        element = _snip("", root_tag="DESC")
+        element = _snip(
+            "<DESC><L-2 L='en'>Desc</L-2></DESC>" "<CATEGORY>MyCategory</CATEGORY>" "<INTRODUCTION><P><L-1 L='en'>Intro</L-1></P></INTRODUCTION>" "<ADMIN-DATA><LANGUAGE>en</LANGUAGE></ADMIN-DATA>",
+            root_tag="DESC",
+        )
         desc = EndToEndTransformationDescription()
         parser.readDescribable(element, desc)
+        assert desc.getDesc() is not None
+        assert desc.getDesc().getL2s()[0].getValue() == "Desc"
+        assert desc.getCategory() is not None
+        assert desc.getCategory().getValue() == "MyCategory"
+        assert desc.getIntroduction() is not None
+        assert desc.getIntroduction().getPs()[0].getL1s()[0].getValue() == "Intro"
+        assert desc.getAdminData() is not None
+        assert desc.getAdminData().getLanguage().getValue() == "en"
 
     def test_readTransformationDescription(self, parser):
         element = _snip("", root_tag="TRANS-DESC")

--- a/tests/test_armodel/writer/test_writer_common_structure.py
+++ b/tests/test_armodel/writer/test_writer_common_structure.py
@@ -20,6 +20,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa: E501
     ARLiteral,
+    CategoryString,
     DateTime,
     NameToken,
     RefType,
@@ -1078,3 +1079,30 @@ class TestWriteDescribable:
         desc.timestamp = "2024-01-01T00:00:00"
         writer.writeDescribable(parent, desc)
         assert parent.attrib["T"] == "2024-01-01T00:00:00"
+
+    def test_writes_full_describable(self, writer):
+        parent = _parent()
+        desc = ConcreteDescribable()
+        desc_desc = MultiLanguageOverviewParagraph()
+        l2 = LOverviewParagraph()
+        l2.l = "en"
+        l2.value = "Desc"
+        desc_desc.addL2(l2)
+        desc.setDesc(desc_desc)
+        desc.setCategory(CategoryString().setValue("MyCategory"))
+        intro = DocumentationBlock()
+        para = MultiLanguageParagraph()
+        l1 = LLongName()
+        l1.l = "en"
+        l1.value = "Intro"
+        para.addL1(l1)
+        intro.addP(para)
+        desc.setIntroduction(intro)
+        desc.setAdminData(AdminData())
+        writer.writeDescribable(parent, desc)
+        assert parent.find("DESC") is not None
+        assert parent.find("DESC/L-2").text == "Desc"
+        assert parent.find("CATEGORY").text == "MyCategory"
+        assert parent.find("INTRODUCTION") is not None
+        assert parent.find("INTRODUCTION/P/L-1").text == "Intro"
+        assert parent.find("ADMIN-DATA") is not None

--- a/tests/test_armodel/writer/test_writer_hw_description_entity.py
+++ b/tests/test_armodel/writer/test_writer_hw_description_entity.py
@@ -1,0 +1,134 @@
+"""Tests for reading and writing HwDescriptionEntity attributes."""
+
+import os
+import tempfile
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwElement
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwAttributeValue import HwAttributeValue
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementConnector import HwElementConnector
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+def make_ref(value: str, dest: str) -> RefType:
+    ref = RefType()
+    ref.setValue(value)
+    ref.setDest(dest)
+    return ref
+
+
+def _build_document(element: HwElement):
+    AUTOSAR.getInstance().setARRelease("R23-11")
+    document = AUTOSAR.getInstance()
+    document.clear()
+    ar_root = document.createARPackage("AUTOSAR")
+    ar_root.addElement(element)
+    return document
+
+
+def _reload(file_path):
+    document_2 = AUTOSAR.getInstance()
+    document_2.clear()
+    ARXMLParser().load(file_path, document_2)
+    package = document_2.getARPackages()[0]
+    return next(element for element in package.elements if isinstance(element, HwElement))
+
+
+class TestWriteHwDescriptionEntity:
+    def test_round_trip_populated(self):
+        """Test parse -> write -> re-parse of populated hwTypeRef, hwCategoryRefs, hwAttributeValues."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        element = HwElement(ar_root, "TestElement")
+
+        element.setHwTypeRef(make_ref("/HwTypes/TestType", "HW-TYPE"))
+        element.addHwCategoryRef(make_ref("/HwCategories/Cat1", "HW-CATEGORY"))
+        element.addHwCategoryRef(make_ref("/HwCategories/Cat2", "HW-CATEGORY"))
+
+        attribute_value = HwAttributeValue()
+        attribute_value.setHwAttributeDefRef(make_ref("/HwCategories/Cat1/AttrDef", "HW-ATTRIBUTE-DEF"))
+        element.addHwAttributeValue(attribute_value)
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, _build_document(element))
+            element_2 = _reload(file_path)
+            assert element_2.getShortName() == "TestElement"
+            assert element_2.getHwTypeRef().getValue() == "/HwTypes/TestType"
+            assert element_2.getHwTypeRef().getDest() == "HW-TYPE"
+            category_refs = element_2.getHwCategoryRefs()
+            assert len(category_refs) == 2
+            assert [r.getValue() for r in category_refs] == ["/HwCategories/Cat1", "/HwCategories/Cat2"]
+            attribute_values = element_2.getHwAttributeValues()
+            assert len(attribute_values) == 1
+            assert attribute_values[0].getHwAttributeDefRef().getValue() == "/HwCategories/Cat1/AttrDef"
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+    def test_round_trip_unset_emits_no_wrappers(self):
+        """Test empty refs/lists round-trip to no wrapper elements."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        element = HwElement(ar_root, "TestElement")
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, _build_document(element))
+            with open(file_path, "r", encoding="utf-8") as file_handle:
+                content = file_handle.read()
+            assert "HW-TYPE-REF" not in content
+            assert "HW-CATEGORY-REFS" not in content
+            assert "HW-ATTRIBUTE-VALUES" not in content
+            assert "HW-ELEMENT-CONNECTIONS" not in content
+            assert "NESTED-ELEMENTS" not in content
+
+            element_2 = _reload(file_path)
+            assert element_2.getShortName() == "TestElement"
+            assert element_2.getHwTypeRef() is None
+            assert element_2.getHwCategoryRefs() == []
+            assert element_2.getHwAttributeValues() == []
+            assert element_2.getHwElementConnections() == []
+            assert element_2.getNestedElementRefs() == []
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+    def test_round_trip_connections_and_nested(self):
+        """Test parse -> write -> re-parse of hwElementConnection and nestedElement."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        element = HwElement(ar_root, "TestElement")
+
+        connector = HwElementConnector()
+        connector.setHwElementRef(make_ref("/Elements/ElemA", "HW-ELEMENT"))
+        connector.setHwPinRef(make_ref("/Elements/ElemA/Pin1", "HW-PIN"))
+        element.addHwElementConnection(connector)
+        element.addNestedElementRef(make_ref("/Elements/ElemB", "HW-ELEMENT"))
+        element.addNestedElementRef(make_ref("/Elements/ElemC", "HW-ELEMENT"))
+
+        file_path = tempfile.mktemp(suffix=".arxml")
+        try:
+            ARXMLWriter().save(file_path, _build_document(element))
+            with open(file_path, "r", encoding="utf-8") as file_handle:
+                content = file_handle.read()
+            assert "HW-ELEMENT-CONNECTIONS" in content
+            assert "HW-ELEMENT-CONNECTOR" in content
+            assert "NESTED-ELEMENTS" in content
+
+            element_2 = _reload(file_path)
+            connections = element_2.getHwElementConnections()
+            assert len(connections) == 1
+            assert connections[0].getHwElementRef().getValue() == "/Elements/ElemA"
+            assert connections[0].getHwElementRef().getDest() == "HW-ELEMENT"
+            assert connections[0].getHwPinRef().getValue() == "/Elements/ElemA/Pin1"
+            assert connections[0].getHwPinRef().getDest() == "HW-PIN"
+            nested = element_2.getNestedElementRefs()
+            assert len(nested) == 2
+            assert [ref.getValue() for ref in nested] == ["/Elements/ElemB", "/Elements/ElemC"]
+            assert all(ref.getDest() == "HW-ELEMENT" for ref in nested)
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)


### PR DESCRIPTION
## Summary
Sync the model classes modified in the staged changes to their canonical AUTOSAR R23-11 spec tables, per the `sync-autosar-class` TDD workflow (Rules 0001–0016). Field-to-spec parity verified against XSD `AUTOSAR_00046.xsd` and the PDF Notes, with a genuine Step 9b confirmation gate before any `# Spec verified` marker.

## Changes
- **HwElement** (ECUResourceTemplate Table 2.4): added reader/writer for `hwElementConnection` (`HW-ELEMENT-CONNECTIONS/HW-ELEMENT-CONNECTOR`) and `nestedElement` (`NESTED-ELEMENTS/HW-ELEMENT-REF-CONDITIONAL/HW-ELEMENT-REF`); switched `setXxx` → `addXxx` typed-list accessors; verbatim docstrings.
- **HwElementConnector** (Table 2.8): retained existing `hwElementRef`/`hwPinRef` API (bounded sync); added reader/writer for round-trip integrity. Recorded as a deviation (API does not match spec `hwElement`×2 + `hwPinConnection` + `hwPinGroupConnection`).
- **Describable** (FO GenericStructureTemplate Table E.25): fixed spec citation (was wrongly pointing at ECUResourceTemplate Table E.4).
- **String / Numerical** (FO GenericStructureTemplate Tables 4.63 / E.58): verbatim Notes/Tags; fixed ruff W605 invalid-escape sequences in `Numerical` docstring.
- **HwDescriptionEntity** (Table 2.1): confirmed compliant.

## Files Modified
- `src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/__init__.py`
- `src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/HwElementConnector.py`
- `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py`
- `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py`
- `src/armodel/parser/arxml_parser.py`
- `src/armodel/writer/arxml_writer.py`
- `docs/examples/method_deviation_by_class.md`
- tests (model / parser / writer)

## Test Coverage
Added/updated unit tests for HwElement getter/setter + round-trip, HwElementConnector reader, and NESTED-ELEMENTS / HW-ELEMENT-CONNECTIONS parsing & writing. Full suite: 6310 passed (incl. integration round-trip). `ruff check` and `black --check` clean; `flake8` (E9/F63/F7/F82) clean.

## Requirements
Source of truth: XSD `AUTOSAR_00046.xsd` + PDF spec tables (R23-11).

Closes #626