### PR TITLE
refactor: sync BswModuleEntry & BswModuleDescription to AUTOSAR R23-11

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py
@@ -5,7 +5,6 @@ including dependencies, module entries, and client-server interfaces.
 """
 
 from typing import List, Optional
-from enum import Enum
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpBlueprintable
 from armodel.models.M2.MSR.DataDictionary.ServiceProcessTask import SwServiceArg
@@ -15,72 +14,116 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger, AREnum
 
 
-class BswEntryKindEnum(str, Enum):
+class BswEntryKindEnum(AREnum):
     """
-    Enumeration for BSW Entry Kind values.
-    Defines the types of entries that can exist in BSW modules.
+    Denotes the mechanism by which the entry into the Bsw module shall be called.
     """
 
     # BswEntryKindEnum method parity checklist:
-    # (no methods)
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 4.2, p.34
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods) — enum value form serialized on BswModuleEntry.bswEntryKind
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
-    # Function entry type for BSW module entries
-    FUNCTION = "FUNCTION"
+    # This BswModuleEntry specifies an abstract signature of C-functions. The signature needs to be implemented by concrete BswModuleEntrys Tags: atp.EnumerationLiteralIndex=0
+    ABSTRACT = "abstract"
+
+    # This BswModuleEntry specifies a concrete C-function with its signature. Tags: atp.EnumerationLiteralIndex=1
+    CONCRETE = "concrete"
+
+    def __init__(self):
+        super().__init__([BswEntryKindEnum.ABSTRACT, BswEntryKindEnum.CONCRETE])
 
 
-class BswCallType(str, Enum):
+class BswCallType(AREnum):
     """
-    Enumeration for BSW Call Type values.
-    Defines how BSW module entries can be called (synchronously or asynchronously).
+    Denotes the mechanism by which the entry into the Bsw module shall be called.
     """
 
     # BswCallType method parity checklist:
-    # (no methods)
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 4.4, p.36
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods) — enum value form serialized on BswModuleEntry.callType
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
-    # Synchronous call type - caller waits for completion
-    SYNCHRONOUS = "SYNCHRONOUS"
-    # Asynchronous call type - caller does not wait for completion
-    ASYNCHRONOUS = "ASYNCHRONOUS"
+    # Callback (i.e. the caller specifies the signature) Tags: atp.EnumerationLiteralIndex=0
+    CALLBACK = "callback"
+
+    # Callout - provide defined means to extend the functionality of an existing module. In this case caller specifies the signature. Tags: atp.EnumerationLiteralIndex=4
+    CALLOUT = "callout"
+
+    # Interrupt routine Tags: atp.EnumerationLiteralIndex=1
+    INTERRUPT = "interrupt"
+
+    # Regular API call Tags: atp.EnumerationLiteralIndex=2
+    REGULAR = "regular"
+
+    # Called by the scheduler Tags: atp.EnumerationLiteralIndex=3
+    SCHEDULED = "scheduled"
+
+    def __init__(self):
+        super().__init__([BswCallType.CALLBACK, BswCallType.CALLOUT, BswCallType.INTERRUPT, BswCallType.REGULAR, BswCallType.SCHEDULED])
 
 
-class BswExecutionContext(str, Enum):
+class BswExecutionContext(AREnum):
     """
-    Enumeration for BSW Execution Context values.
-    Defines where BSW module entries can execute in the system.
+    Specifies the execution context required or guaranteed for the call associated with this service.
     """
 
     # BswExecutionContext method parity checklist:
-    # (no methods)
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 4.3, p.34
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods) — enum value form serialized on BswModuleEntry.executionContext
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
-    # Execution in a hook function context
-    HOOK = "HOOK"
-    # Execution in interrupt category 1 context (high priority)
-    INTERRUPT_CAT_1 = "INTERRUPT-CAT-1"
-    # Execution in interrupt category 2 context (medium priority)
-    INTERRUPT_CAT_2 = "INTERRUPT-CAT-2"
-    # Execution in a task context
-    TASK = "TASK"
-    # Execution context is unspecified
-    UNSPECIFIED = "UNSPECIFIED"
+    # Context of an OS "hook" routine always Tags: atp.EnumerationLiteralIndex=0
+    HOOK = "hook"
+
+    # CAT1 interrupt context always Tags: atp.EnumerationLiteralIndex=1
+    INTERRUPT_CAT_1 = "interruptCat1"
+
+    # CAT2 interrupt context always Tags: atp.EnumerationLiteralIndex=2
+    INTERRUPT_CAT_2 = "interruptCat2"
+
+    # Task context always Tags: atp.EnumerationLiteralIndex=3
+    TASK = "task"
+
+    # The execution context is not specified by the API Tags: atp.EnumerationLiteralIndex=4
+    UNSPECIFIED = "unspecified"
+
+    def __init__(self):
+        super().__init__([BswExecutionContext.HOOK, BswExecutionContext.INTERRUPT_CAT_1, BswExecutionContext.INTERRUPT_CAT_2, BswExecutionContext.TASK, BswExecutionContext.UNSPECIFIED])
 
 
-class SwServiceImplPolicyEnum(str, Enum):
+class SwServiceImplPolicyEnum(AREnum):
     """
-    Enumeration for SW Service Implementation Policy values.
-    Defines how software service implementations should be generated in code.
+    This specifies the legal values for the implementation policies for services (in AUTOSAR: BswModule Entry-s).
     """
 
     # SwServiceImplPolicyEnum method parity checklist:
-    # (no methods)
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 4.5, p.36
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods) — enum value form serialized on BswModuleEntry.swServiceImplPolicy
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
-    # Implementation should be inlined
-    INLINE = "INLINE"
-    # Implementation should be inlined conditionally based on configuration
-    INLINE_CONDITIONAL = "INLINE-CONDITIONAL"
-    # Implementation should be generated as a macro
-    MACRO = "MACRO"
-    # Standard implementation (not inlined)
-    STANDARD = "STANDARD"
+    # inline service definition. Tags: atp.EnumerationLiteralIndex=0
+    INLINE = "inline"
+
+    # The service (in AUTOSAR: BswModuleEntry) is implemented in a way that it either resolves to an inline function or to a standard function depending on conditions set at a later point in time. The following two values are standardized (to be used for code sections only and exclusively to each other): • INLINE - The code section is declared with the keyword "inline". • LOCAL_INLINE - The code section is declared with the keyword "static inline". In both cases (INLINE and LOCAL_INLINE) the inline expansion depends on the compiler. Depending on this, the code section either corresponds to an actual section in memory or is put into the section of the caller. Tags: atp.EnumerationLiteralIndex=1
+    INLINE_CONDITIONAL = "inlineConditional"
+
+    # macro service definition. Tags: atp.EnumerationLiteralIndex=2
+    MACRO = "macro"
+
+    # Standard service and default value, if nothing is defined. Tags: atp.EnumerationLiteralIndex=3
+    STANDARD = "standard"
+
+    def __init__(self):
+        super().__init__([SwServiceImplPolicyEnum.INLINE, SwServiceImplPolicyEnum.INLINE_CONDITIONAL, SwServiceImplPolicyEnum.MACRO, SwServiceImplPolicyEnum.STANDARD])
 
 
 class BswModuleDependency(Identifiable):
@@ -164,107 +207,82 @@ class BswModuleDependency(Identifiable):
 
 class BswModuleEntry(AtpBlueprintable):
     """
-    Represents a single API entry (C-function prototype) into the BSW module or cluster.
-    The name of the C-function is equal to the short name of this element.
+    This class represents a single API entry (C-function prototype) into the BSW module or cluster. The name of the C-function is equal to the short name of this element with one exception: In case of multiple instances of a module on the same CPU, special rules for "infixes" apply, see description of class BswImplementation.
     """
 
     # BswModuleEntry method parity checklist:
-    # [x] __init__                     [x] impl  [x] docstring  [x] test
-    # [x] getArguments                 [x] impl  [x] docstring  [x] test
-    # [x] createArgument               [x] impl  [x] docstring  [x] test
-    # [x] getBswEntryKind              [x] impl  [x] docstring  [x] test
-    # [x] setBswEntryKind              [x] impl  [x] docstring  [x] test
-    # [x] getCallType                  [x] impl  [x] docstring  [x] test
-    # [x] setCallType                  [x] impl  [x] docstring  [x] test
-    # [x] getExecutionContext          [x] impl  [x] docstring  [x] test
-    # [x] setExecutionContext          [x] impl  [x] docstring  [x] test
-    # [x] getFunctionPrototypeEmitter  [x] impl  [x] docstring  [x] test
-    # [x] setFunctionPrototypeEmitter  [x] impl  [x] docstring  [x] test
-    # [x] getIsReentrant               [x] impl  [x] docstring  [x] test
-    # [x] setIsReentrant               [x] impl  [x] docstring  [x] test
-    # [x] getIsSynchronous             [x] impl  [x] docstring  [x] test
-    # [x] setIsSynchronous             [x] impl  [x] docstring  [x] test
-    # [x] getReturnType                [x] impl  [x] docstring  [x] test
-    # [x] createReturnType             [x] impl  [x] docstring  [x] test
-    # [x] getRole                      [x] impl  [x] docstring  [x] test
-    # [x] setRole                      [x] impl  [x] docstring  [x] test
-    # [x] getServiceId                 [x] impl  [x] docstring  [x] test
-    # [x] setServiceId                 [x] impl  [x] docstring  [x] test
-    # [x] getSwServiceImplPolicy       [x] impl  [x] docstring  [x] test
-    # [x] setSwServiceImplPolicy       [x] impl  [x] docstring  [x] test
-    # [x] __str__                      [x] impl  [x] docstring  [x] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 4.1, p.33
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] createArgument               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getArguments                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBswEntryKind              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getBswEntryKind              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCallType                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCallType                  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setExecutionContext          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getExecutionContext          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFunctionPrototypeEmitter  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFunctionPrototypeEmitter  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIsReentrant               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getIsReentrant               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIsSynchronous             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getIsSynchronous             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createReturnType             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getReturnType                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setRole                      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRole                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setServiceId                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getServiceId                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwServiceImplPolicy        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwServiceImplPolicy        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self, parent: ARObject, short_name: str):
-        """
-        Initializes the BSW module entry with a parent and short name.
-
-        Args:
-            parent: The parent ARObject that contains this entry
-            short_name: The unique short name of this entry
-        """
         super().__init__(parent, short_name)
 
         # An argument belonging to this BswModuleEntry.
         self.arguments: List[SwServiceArg] = []
 
-        # This describes whether the entry is concrete or abstract.
-        # If the attribute is missing the entry is considered as concrete.
-        self.bswEntryKind: BswEntryKindEnum = None
+        # This describes whether the entry is concrete or abstract. If the attribute is missing the entry is considered as concrete.
+        self.bswEntryKind: Optional[BswEntryKindEnum] = None
 
         # The type of call associated with this service.
-        self.callType: BswCallType = None
+        self.callType: Optional[BswCallType] = None
 
-        # Specifies the execution context which is required (in case of entries into this
-        # module) or guaranteed (in case of entries called from this module) for this service.
-        self.executionContext: BswExecutionContext = None
+        # Specifies the execution context which is required (in case of entries into this module) or guaranteed (in case of entries called from this module) for this service.
+        self.executionContext: Optional[BswExecutionContext] = None
 
-        # This attribute is used to control the generation of function prototypes.
-        # If set to "RTE", the RTE generates the function prototypes in the Module
-        # Interlink Header File.
-        self.functionPrototypeEmitter: NameToken = None
+        # This attribute is used to control the generation of function prototypes. If set to "RTE", the RTE generates the function prototypes in the Module Interlink Header File.
+        self.functionPrototypeEmitter: Optional[NameToken] = None
 
-        # Reentrancy from the viewpoint of function callers:
-        # - true: Enables the service to be invoked again, before the service has finished.
-        # - false: It is prohibited to invoke the service again before it has finished.
-        self.isReentrant: Boolean = None
+        # Reentrancy from the viewpoint of function callers: • true: Enables the service to be invoked again, before the service has finished. • false: It is prohibited to invoke the service again before is has finished.
+        self.isReentrant: Optional[Boolean] = None
 
-        # Synchronicity from the viewpoint of function callers:
-        # - true: This calls a synchronous service, i.e. the service is completed when the
-        #   call returns.
-        # - false: The service (on semantical level) may not be complete when the call
-        #   returns.
-        self.isSynchronous: Boolean = None
+        # Synchronicity from the viewpoint of function callers: • true: This calls a synchronous service, i.e. the service is completed when the call returns. • false: The service (on semantical level) may not be complete when the call returns.
+        self.isSynchronous: Optional[Boolean] = None
 
-        # The return type belonging to this BswModuleEntry.
-        self.returnType: SwServiceArg = None
+        # The return type belonging to this bswModuleEntry.
+        self.returnType: Optional[SwServiceArg] = None
 
-        # Specifies the role of the entry in the given context. It shall be equal to the
-        # standardized name of the service call, especially in cases where no
-        # ServiceIdentifier is specified, e.g. for callbacks.
-        self.role: Identifier = None
+        # Specifies the role of the entry in the given context. It shall be equal to the standardized name of the service call, especially in cases where no ServiceIdentifier is specified, e.g. for callbacks. Note that the ShortName is not always sufficient because it maybe vendor specific (e.g. for callbacks which can have more than one instance).
+        self.role: Optional[Identifier] = None
 
-        # Refers to the service identifier of the Standardized Interfaces of AUTOSAR basic
-        # software. For non-standardized interfaces, it can optionally be used for
-        # proprietary identification.
-        self.serviceId: ARNumerical = None
+        # Refers to the service identifier of the Standardized Interfaces of AUTOSAR basic software. For non-standardized interfaces, it can optionally be used for proprietary identification.
+        self.serviceId: Optional[PositiveInteger] = None
 
-        # Denotes the implementation policy as a standard function call, inline function
-        # or macro. This has to be specified on interface level because it determines the
-        # signature of the call.
-        self.swServiceImplPolicy: SwServiceImplPolicyEnum = None
+        # Denotes the implementation policy as a standard function call, inline function or macro. This has to be specified on interface level because it determines the signature of the call.
+        self.swServiceImplPolicy: Optional[SwServiceImplPolicyEnum] = None
 
     def getArguments(self) -> List[SwServiceArg]:
         """
-        Gets the list of arguments belonging to this BswModuleEntry.
-
-        Returns:
-            List of SwServiceArg instances
+        An argument belonging to this BswModuleEntry.
         """
         return self.arguments
 
     def createArgument(self, short_name: str) -> SwServiceArg:
         """
-        Creates and adds an argument to this module entry.
+        An argument belonging to this BswModuleEntry.
 
         Args:
             short_name: The short name for the new argument
@@ -280,25 +298,14 @@ class BswModuleEntry(AtpBlueprintable):
 
     def getBswEntryKind(self) -> Optional[BswEntryKindEnum]:
         """
-        Gets whether the entry is concrete or abstract.
-        If the attribute is missing the entry is considered as concrete.
-
-        Returns:
-            BswEntryKindEnum value
+        This describes whether the entry is concrete or abstract. If the attribute is missing the entry is considered as concrete.
         """
         return self.bswEntryKind
 
-    def setBswEntryKind(self, value: BswEntryKindEnum) -> "BswModuleEntry":
+    def setBswEntryKind(self, value: Optional[BswEntryKindEnum]) -> "BswModuleEntry":
         """
-        Sets whether the entry is concrete or abstract.
-        If the attribute is missing the entry is considered as concrete.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The BswEntryKindEnum value to set
-
-        Returns:
-            self for method chaining
+        This describes whether the entry is concrete or abstract. If the attribute is missing the entry is considered as concrete.
+        A None value is a no-op and does not overwrite an existing bswEntryKind.
         """
         if value is not None:
             self.bswEntryKind = value
@@ -306,23 +313,14 @@ class BswModuleEntry(AtpBlueprintable):
 
     def getCallType(self) -> Optional[BswCallType]:
         """
-        Gets the type of call associated with this service.
-
-        Returns:
-            BswCallType value
+        The type of call associated with this service.
         """
         return self.callType
 
-    def setCallType(self, value: BswCallType) -> "BswModuleEntry":
+    def setCallType(self, value: Optional[BswCallType]) -> "BswModuleEntry":
         """
-        Sets the type of call associated with this service.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The BswCallType value to set
-
-        Returns:
-            self for method chaining
+        The type of call associated with this service.
+        A None value is a no-op and does not overwrite an existing callType.
         """
         if value is not None:
             self.callType = value
@@ -330,59 +328,29 @@ class BswModuleEntry(AtpBlueprintable):
 
     def getExecutionContext(self) -> Optional[BswExecutionContext]:
         """
-        Gets the execution context which is required (in case of entries into this module)
-        or guaranteed (in case of entries called from this module) for this service.
-
-        Returns:
-            BswExecutionContext value
+        Specifies the execution context which is required (in case of entries into this module) or guaranteed (in case of entries called from this module) for this service.
         """
         return self.executionContext
 
-    def setExecutionContext(self, value: BswExecutionContext) -> "BswModuleEntry":
+    def setExecutionContext(self, value: Optional[BswExecutionContext]) -> "BswModuleEntry":
         """
-        Sets the execution context which is required (in case of entries into this module)
-        or guaranteed (in case of entries called from this module) for this service.
-        Validates that the value is one of the allowed execution contexts.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The BswExecutionContext value to set
-
-        Returns:
-            self for method chaining
-
-        Raises:
-            ValueError: If the execution context is not valid
+        Specifies the execution context which is required (in case of entries into this module) or guaranteed (in case of entries called from this module) for this service.
+        A None value is a no-op and does not overwrite an existing executionContext.
         """
         if value is not None:
-            if value.upper() not in ("HOOK", "INTERRUPT-CAT-1", "INTERRUPT-CAT-2", "TASK", "UNSPECIFIED"):
-                raise ValueError("Invalid execution context <%s> of BswModuleEntry <%s>" % (value, self.short_name))
             self.executionContext = value
         return self
 
     def getFunctionPrototypeEmitter(self) -> Optional[NameToken]:
         """
-        Gets the function prototype emitter used to control the generation of function
-        prototypes. If set to "RTE", the RTE generates the function prototypes in the
-        Module Interlink Header File.
-
-        Returns:
-            NameToken for the function prototype emitter
+        This attribute is used to control the generation of function prototypes. If set to "RTE", the RTE generates the function prototypes in the Module Interlink Header File.
         """
         return self.functionPrototypeEmitter
 
-    def setFunctionPrototypeEmitter(self, value: NameToken) -> "BswModuleEntry":
+    def setFunctionPrototypeEmitter(self, value: Optional[NameToken]) -> "BswModuleEntry":
         """
-        Sets the function prototype emitter used to control the generation of function
-        prototypes. If set to "RTE", the RTE generates the function prototypes in the
-        Module Interlink Header File.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The NameToken to set
-
-        Returns:
-            self for method chaining
+        This attribute is used to control the generation of function prototypes. If set to "RTE", the RTE generates the function prototypes in the Module Interlink Header File.
+        A None value is a no-op and does not overwrite an existing functionPrototypeEmitter.
         """
         if value is not None:
             self.functionPrototypeEmitter = value
@@ -390,23 +358,14 @@ class BswModuleEntry(AtpBlueprintable):
 
     def getIsReentrant(self) -> Optional[Boolean]:
         """
-        Gets the reentrancy flag from the viewpoint of function callers.
-
-        Returns:
-            Boolean indicating if this entry is reentrant
+        Reentrancy from the viewpoint of function callers: • true: Enables the service to be invoked again, before the service has finished. • false: It is prohibited to invoke the service again before is has finished.
         """
         return self.isReentrant
 
-    def setIsReentrant(self, value: Boolean) -> "BswModuleEntry":
+    def setIsReentrant(self, value: Optional[Boolean]) -> "BswModuleEntry":
         """
-        Sets the reentrancy flag from the viewpoint of function callers.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The reentrant flag to set
-
-        Returns:
-            self for method chaining
+        Reentrancy from the viewpoint of function callers: • true: Enables the service to be invoked again, before the service has finished. • false: It is prohibited to invoke the service again before is has finished.
+        A None value is a no-op and does not overwrite an existing isReentrant.
         """
         if value is not None:
             self.isReentrant = value
@@ -414,23 +373,14 @@ class BswModuleEntry(AtpBlueprintable):
 
     def getIsSynchronous(self) -> Optional[Boolean]:
         """
-        Gets the synchronicity flag from the viewpoint of function callers.
-
-        Returns:
-            Boolean indicating if this entry is synchronous
+        Synchronicity from the viewpoint of function callers: • true: This calls a synchronous service, i.e. the service is completed when the call returns. • false: The service (on semantical level) may not be complete when the call returns.
         """
         return self.isSynchronous
 
-    def setIsSynchronous(self, value: Boolean) -> "BswModuleEntry":
+    def setIsSynchronous(self, value: Optional[Boolean]) -> "BswModuleEntry":
         """
-        Sets the synchronicity flag from the viewpoint of function callers.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The synchronous flag to set
-
-        Returns:
-            self for method chaining
+        Synchronicity from the viewpoint of function callers: • true: This calls a synchronous service, i.e. the service is completed when the call returns. • false: The service (on semantical level) may not be complete when the call returns.
+        A None value is a no-op and does not overwrite an existing isSynchronous.
         """
         if value is not None:
             self.isSynchronous = value
@@ -438,16 +388,13 @@ class BswModuleEntry(AtpBlueprintable):
 
     def getReturnType(self) -> Optional[SwServiceArg]:
         """
-        Gets the return type belonging to this BswModuleEntry.
-
-        Returns:
-            SwServiceArg instance representing the return type
+        The return type belonging to this bswModuleEntry.
         """
         return self.returnType
 
     def createReturnType(self, short_name: str) -> SwServiceArg:
         """
-        Creates and sets the return type for this module entry.
+        The return type belonging to this bswModuleEntry.
 
         Args:
             short_name: The short name for the new return type
@@ -463,53 +410,29 @@ class BswModuleEntry(AtpBlueprintable):
 
     def getRole(self) -> Optional[Identifier]:
         """
-        Gets the role of the entry in the given context.
-        It shall be equal to the standardized name of the service call.
-
-        Returns:
-            Identifier for the role
+        Specifies the role of the entry in the given context. It shall be equal to the standardized name of the service call, especially in cases where no ServiceIdentifier is specified, e.g. for callbacks. Note that the ShortName is not always sufficient because it maybe vendor specific (e.g. for callbacks which can have more than one instance).
         """
         return self.role
 
-    def setRole(self, value: Identifier) -> "BswModuleEntry":
+    def setRole(self, value: Optional[Identifier]) -> "BswModuleEntry":
         """
-        Sets the role of the entry in the given context.
-        It shall be equal to the standardized name of the service call.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The role identifier to set
-
-        Returns:
-            self for method chaining
+        Specifies the role of the entry in the given context. It shall be equal to the standardized name of the service call, especially in cases where no ServiceIdentifier is specified, e.g. for callbacks. Note that the ShortName is not always sufficient because it maybe vendor specific (e.g. for callbacks which can have more than one instance).
+        A None value is a no-op and does not overwrite an existing role.
         """
         if value is not None:
             self.role = value
         return self
 
-    def getServiceId(self) -> Optional[ARNumerical]:
+    def getServiceId(self) -> Optional[PositiveInteger]:
         """
-        Gets the service identifier of the Standardized Interfaces of AUTOSAR basic
-        software. For non-standardized interfaces, it can optionally be used for
-        proprietary identification.
-
-        Returns:
-            ARNumerical representing the service ID
+        Refers to the service identifier of the Standardized Interfaces of AUTOSAR basic software. For non-standardized interfaces, it can optionally be used for proprietary identification.
         """
         return self.serviceId
 
-    def setServiceId(self, value: ARNumerical) -> "BswModuleEntry":
+    def setServiceId(self, value: Optional[PositiveInteger]) -> "BswModuleEntry":
         """
-        Sets the service identifier of the Standardized Interfaces of AUTOSAR basic
-        software. For non-standardized interfaces, it can optionally be used for
-        proprietary identification.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The service ID to set
-
-        Returns:
-            self for method chaining
+        Refers to the service identifier of the Standardized Interfaces of AUTOSAR basic software. For non-standardized interfaces, it can optionally be used for proprietary identification.
+        A None value is a no-op and does not overwrite an existing serviceId.
         """
         if value is not None:
             self.serviceId = value
@@ -517,63 +440,21 @@ class BswModuleEntry(AtpBlueprintable):
 
     def getSwServiceImplPolicy(self) -> Optional[SwServiceImplPolicyEnum]:
         """
-        Gets the implementation policy as a standard function call, inline function or
-        macro. This has to be specified on interface level because it determines the
-        signature of the call.
-
-        Returns:
-            SwServiceImplPolicyEnum value
+        Denotes the implementation policy as a standard function call, inline function or macro. This has to be specified on interface level because it determines the signature of the call.
         """
         return self.swServiceImplPolicy
 
-    def setSwServiceImplPolicy(self, value: SwServiceImplPolicyEnum) -> "BswModuleEntry":
+    def setSwServiceImplPolicy(self, value: Optional[SwServiceImplPolicyEnum]) -> "BswModuleEntry":
         """
-        Sets the implementation policy as a standard function call, inline function or
-        macro. This has to be specified on interface level because it determines the
-        signature of the call.
-        Validates that the value is one of the allowed implementation policies.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The SwServiceImplPolicyEnum value to set
-
-        Returns:
-            self for method chaining
-
-        Raises:
-            ValueError: If the implementation policy is not valid
+        Denotes the implementation policy as a standard function call, inline function or macro. This has to be specified on interface level because it determines the signature of the call.
+        A None value is a no-op and does not overwrite an existing swServiceImplPolicy.
         """
         if value is not None:
-            if value.upper() not in ("INLINE", "INLINE-CONDITIONAL", "MACRO", "STANDARD"):
-                raise ValueError("Invalid SwServiceImplPolicy <%s> of BswModuleEntry <%s>" % (value, self.short_name))
             self.swServiceImplPolicy = value
         return self
 
     def __str__(self) -> str:
-        """
-        Returns a string representation of this BSW module entry.
-        Shows the key properties of the entry in a formatted way.
-
-        Returns:
-            Formatted string representation of the BSW module entry
-        """
-        result = []
-
-        result.append("short_name             : %s" % self.short_name)
-        if self.serviceId is not None:
-            result.append("service_id             : %d" % self.serviceId.getValue())
-        if self.isReentrant is not None:
-            result.append("is_reentrant           : %s" % self.isReentrant)
-        if self.isSynchronous is not None:
-            result.append("is_synchronous         : %s" % self.isSynchronous)
-        if self.callType is not None:
-            result.append("call_type              : %s" % self.callType)
-        if self.executionContext is not None:
-            result.append("execution_context      : %s" % self.executionContext)
-        if self.swServiceImplPolicy is not None:
-            result.append("sw_service_impl_policy : %s" % self.swServiceImplPolicy)
-
-        return "\n".join(result)
+        return "BswModuleEntry(%s)" % self.short_name
 
 
 class BswModuleClientServerEntry(Referrable):

--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py
@@ -10,7 +10,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure impor
 from armodel.models.M2.MSR.DataDictionary.ServiceProcessTask import SwServiceArg
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, Referrable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARNumerical, Boolean, Identifier, NameToken, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, Identifier, NameToken, RefType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger, AREnum
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/__init__.py
@@ -18,162 +18,137 @@ from typing import List, Optional
 
 class BswModuleDescription(AtpStructureElement):
     """
-    Represents the description of a single BSW module or BSW cluster in AUTOSAR.
-    In case it describes a BSW module, the short name of this element equals the name of the BSW module.
-    This is the root element for describing BSW module structure, interfaces, and behavior.
+    Root element for the description of a single BSW module or BSW cluster. In case it describes a BSW module, the short name of this element equals the name of the BSW module.
     """
 
     # BswModuleDescription method parity checklist:
-    # [x] __init__                     [x] impl  [x] docstring  [x] test
-    # [x] getBswModuleDependencies     [x] impl  [x] docstring  [x] test
-    # [x] setBswModuleDependencies     [x] impl  [x] docstring  [x] test
-    # [x] getBswModuleDocumentation    [x] impl  [x] docstring  [x] test
-    # [x] setBswModuleDocumentation    [x] impl  [x] docstring  [x] test
-    # [x] getExpectedEntryRefs         [x] impl  [x] docstring  [x] test
-    # [x] setExpectedEntryRefs         [x] impl  [x] docstring  [x] test
-    # [x] getImplementedEntryRefs      [x] impl  [x] docstring  [x] test
-    # [x] addImplementedEntryRef       [x] impl  [x] docstring  [x] test
-    # [x] getInternalBehaviors         [x] impl  [x] docstring  [x] test
-    # [x] setInternalBehaviors         [x] impl  [x] docstring  [x] test
-    # [x] createBswInternalBehavior    [x] impl  [x] docstring  [x] test
-    # [x] getModuleId                  [x] impl  [x] docstring  [x] test
-    # [x] setModuleId                  [x] impl  [x] docstring  [x] test
-    # [x] getProvidedClientServerEntries [x] impl  [x] docstring  [x] test
-    # [x] createProvidedClientServerEntry [x] impl  [x] docstring  [x] test
-    # [x] getProvidedDatas             [x] impl  [x] docstring  [x] test
-    # [x] createProvidedData           [x] impl  [x] docstring  [x] test
-    # [x] getProvidedModeGroups        [x] impl  [x] docstring  [x] test
-    # [x] createProvidedModeGroup      [x] impl  [x] docstring  [x] test
-    # [x] getReleasedTriggers          [x] impl  [x] docstring  [x] test
-    # [x] createReleasedTrigger        [x] impl  [x] docstring  [x] test
-    # [x] getRequiredClientServerEntries [x] impl  [x] docstring  [x] test
-    # [x] createRequiredClientServerEntry [x] impl  [x] docstring  [x] test
-    # [x] getRequiredDatas             [x] impl  [x] docstring  [x] test
-    # [x] createRequiredData           [x] impl  [x] docstring  [x] test
-    # [x] getRequiredModeGroups        [x] impl  [x] docstring  [x] test
-    # [x] createRequiredModeGroup      [x] impl  [x] docstring  [x] test
-    # [x] getRequiredTriggers          [x] impl  [x] docstring  [x] test
-    # [x] createRequiredTrigger        [x] impl  [x] docstring  [x] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 3.1, p.29
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init                        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBswModuleDependencies      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createBswModuleDependency     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] addBswModuleDependency        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBswModuleDocumentation     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBswModuleDocumentation      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getExpectedEntryRefs          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setExpectedEntryRefs          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] addExpectedEntryRef           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getImplementedEntryRefs       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addImplementedEntryRef        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getInternalBehaviors          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setInternalBehaviors          [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] createBswInternalBehavior     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getModuleId                   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setModuleId                   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getProvidedClientServerEntries [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createProvidedClientServerEntry [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getProvidedDatas              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createProvidedData            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getProvidedModeGroups         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createProvidedModeGroup       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getReleasedTriggers           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createReleasedTrigger         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRequiredClientServerEntries [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createRequiredClientServerEntry [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRequiredDatas              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createRequiredData            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRequiredModeGroups         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createRequiredModeGroup       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRequiredTriggers           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createRequiredTrigger         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
-        """
-        Initializes the BSW module description with a parent and short name.
-
-        Args:
-            parent: The parent ARObject that contains this BSW module description
-            short_name: The unique short name of this BSW module (equals the module name)
-        """
         super().__init__(parent, short_name)
 
-        # Describes the dependency to another BSW module
+        # Describes the dependency to another BSW module.
         self.bswModuleDependencies: List[BswModuleDependency] = []
 
-        # This adds a documentation to the BSW module
-        self.bswModuleDocumentation: SwComponentDocumentation = None
+        # This adds a documentation to the BSW module.
+        self.bswModuleDocumentation: Optional[SwComponentDocumentation] = None
 
-        # Indicates an entry which is required by this module.
-        # Replacement of outgoingCallback / requiredEntry.
+        # Indicates an entry which is required by this module. Replacement of outgoingCallback / requiredEntry.
         self.expectedEntryRefs: List[RefType] = []
 
-        # Specifies an entry provided by this module which can be called by other modules.
-        # This includes "main" functions, interrupt routines, and callbacks.
-        # Replacement of providedEntry / expectedCallback.
+        # Specifies an entry provided by this module which can be called by other modules. This includes "main" functions, interrupt routines, and callbacks. Replacement of providedEntry / expectedCallback.
         self.implementedEntryRefs: List[RefType] = []
 
-        # The various BswInternalBehaviors associated with a BswModuleDescription
-        # can be distributed over several physical files (<<atpSplitable>>).
+        # The various BswInternalBehaviors associated with a BswModuleDescription can be distributed over several physical files. Therefore the aggregation is <<atpSplitable>>.
         self.internalBehaviors: List[BswInternalBehavior] = []
 
-        # Refers to the BSW Module Identifier defined by the AUTOSAR standard.
-        # For non-standardized modules, a proprietary identifier can be optionally chosen.
-        self.moduleId: PositiveInteger = None
+        # Refers to the BSW Module Identifier defined by the AUTOSAR standard. For non-standardized modules, a proprietary identifier can be optionally chosen.
+        self.moduleId: Optional[PositiveInteger] = None
 
-        # Specifies that this module provides a client server entry which can be called
-        # from another partition or core. This entry is declared locally to this context
-        # and will be connected to the requiredClientServerEntry of another or the same
-        # module via the configuration of the BSW Scheduler.
+        # Specifies that this module provides a client server entry which can be called from another partition or core. This entry is declared locally to this context and will be connected to the requiredClientServerEntry of another or the same module via the configuration of the BSW Scheduler.
         self.providedClientServerEntries: List[BswModuleClientServerEntry] = []
 
-        # Specifies a data prototype provided by this module in order to be read from
-        # another partition or core. The providedData is declared locally to this context
-        # and will be connected to the requiredData of another or the same module via
-        # the configuration of the BSW Scheduler.
+        # Specifies a data prototype provided by this module in order to be read from another partition or core. The providedData is declared locally to this context and will be connected to the requiredData of another or the same module via the configuration of the BSW Scheduler.
         self.providedDatas: List[VariableDataPrototype] = []
 
-        # A set of modes which is owned and provided by this module or cluster. It can be
-        # connected to the requiredModeGroups of other modules or clusters via the
-        # configuration of the BswScheduler. It can also be synchronized with modes provided
-        # via ports by an associated ServiceSwComponentType, EcuAbstractionSwComponentType
-        # or ComplexDeviceDriverSwComponentType.
+        # A set of modes which is owned and provided by this module or cluster. It can be connected to the requiredModeGroups of other modules or clusters via the configuration of the BswScheduler. It can also be synchronized with modes provided via ports by an associated ServiceSwComponentType, EcuAbstractionSwComponentType or ComplexDeviceDriverSwComponentType.
         self.providedModeGroups: List[ModeDeclarationGroupPrototype] = []
 
-        # A Trigger released by this module or cluster. It can be connected to the
-        # requiredTriggers of other modules or clusters via the configuration of the
-        # BswScheduler. It can also be synchronized with Triggers provided via ports by an
-        # associated ServiceSwComponentType, EcuAbstractionSwComponentType or
-        # ComplexDeviceDriverSwComponentType.
+        # A Trigger released by this module or cluster. It can be connected to the requiredTriggers of other modules or clusters via the configuration of the BswScheduler. It can also be synchronized with Triggers provided via ports by an associated ServiceSwComponentType, EcuAbstractionSwComponentType or ComplexDeviceDriverSwComponentType.
         self.releasedTriggers: List[Trigger] = []
 
-        # Specifies that this module requires a client server entry which can be implemented
-        # on another partition or core. This entry is declared locally to this context and
-        # will be connected to the providedClientServerEntry of another or the same module
-        # via the configuration of the BSW Scheduler.
+        # Specifies that this module requires a client server entry which can be implemented on another partition or core. This entry is declared locally to this context and will be connected to the providedClientServerEntry of another or the same module via the configuration of the BSW Scheduler.
         self.requiredClientServerEntries: List[BswModuleClientServerEntry] = []
 
-        # Specifies a data prototype required by this module in order to be provided from
-        # another partition or core. The requiredData is declared locally to this context
-        # and will be connected to the providedData of another or the same module via the
-        # configuration of the BswScheduler.
+        # Specifies a data prototype required by this module in order to be provided from another partition or core. The requiredData is declared locally to this context and will be connected to the providedData of another or the same module via the configuration of the BswScheduler.
         self.requiredDatas: List[VariableDataPrototype] = []
 
-        # Specifies that this module or cluster depends on a certain mode group. The
-        # requiredModeGroup is local to this context and will be connected to the
-        # providedModeGroup of another module or cluster via the configuration of the
-        # BswScheduler.
+        # Specifies that this module or cluster depends on a certain mode group. The requiredModeGroup is local to this context and will be connected to the providedModeGroup of another module or cluster via the configuration of the BswScheduler.
         self.requiredModeGroups: List[ModeDeclarationGroupPrototype] = []
 
-        # Specifies that this module or cluster reacts upon an external trigger. This
-        # requiredTrigger is declared locally to this context and will be connected to the
-        # providedTrigger of another module or cluster via the configuration of the
-        # BswScheduler.
+        # Specifies that this module or cluster reacts upon an external trigger. This requiredTrigger is declared locally to this context and will be connected to the providedTrigger of another module or cluster via the configuration of the BswScheduler.
         self.requiredTriggers: List[Trigger] = []
 
     def getBswModuleDependencies(self) -> List[BswModuleDependency]:
         """
-        Gets the list of dependencies to other BSW modules.
-
-        Returns:
-            List of BswModuleDependency instances
+        Describes the dependency to another BSW module.
         """
         return self.bswModuleDependencies
 
-    def setBswModuleDependencies(self, value: List[BswModuleDependency]) -> "BswModuleDescription":
+    def createBswModuleDependency(self, short_name: str) -> BswModuleDependency:
         """
-        Sets the list of dependencies to other BSW modules.
-        Only sets the value if it is not None.
+        Describes the dependency to another BSW module.
 
         Args:
-            value: List of BswModuleDependency instances to set
+            short_name: The short name for the new BSW module dependency
+
+        Returns:
+            The created BswModuleDependency instance
+        """
+        if not self.IsElementExists(short_name):
+            dependency = BswModuleDependency(self, short_name)
+            self.addElement(dependency)
+            self.bswModuleDependencies.append(dependency)
+        return self.getElement(short_name)
+
+    def addBswModuleDependency(self, value: BswModuleDependency) -> "BswModuleDescription":
+        """
+        Describes the dependency to another BSW module.
+        Only adds the value if it is not None.
+
+        Args:
+            value: BswModuleDependency instance to add
 
         Returns:
             self for method chaining
         """
         if value is not None:
-            self.bswModuleDependencies = value
+            self.bswModuleDependencies.append(value)
         return self
 
     def getBswModuleDocumentation(self) -> Optional[SwComponentDocumentation]:
         """
-        Gets the documentation attached to this BSW module.
-
-        Returns:
-            SwComponentDocumentation instance containing module documentation
+        This adds a documentation to the BSW module.
         """
         return self.bswModuleDocumentation
 
     def setBswModuleDocumentation(self, value: SwComponentDocumentation) -> "BswModuleDescription":
         """
-        Sets the documentation attached to this BSW module.
+        This adds a documentation to the BSW module.
         Only sets the value if it is not None.
 
         Args:
@@ -188,18 +163,13 @@ class BswModuleDescription(AtpStructureElement):
 
     def getExpectedEntryRefs(self) -> List[RefType]:
         """
-        Gets the list of expected entry references that this module requires.
-        These are entries required by this module
-        (replacement of outgoingCallback / requiredEntry).
-
-        Returns:
-            List of RefType to expected entries
+        Indicates an entry which is required by this module. Replacement of outgoingCallback / requiredEntry.
         """
         return self.expectedEntryRefs
 
     def setExpectedEntryRefs(self, value: List[RefType]) -> "BswModuleDescription":
         """
-        Sets the list of expected entry references that this module requires.
+        Indicates an entry which is required by this module. Replacement of outgoingCallback / requiredEntry.
         Only sets the value if it is not None.
 
         Args:
@@ -212,22 +182,30 @@ class BswModuleDescription(AtpStructureElement):
             self.expectedEntryRefs = value
         return self
 
-    def getImplementedEntryRefs(self) -> List[RefType]:
+    def addExpectedEntryRef(self, value: RefType) -> "BswModuleDescription":
         """
-        Gets the list of implemented entry references that this module provides.
-        These are entries provided by this module which can be called by other modules,
-        including "main" functions, interrupt routines, and callbacks
-        (replacement of providedEntry / expectedCallback).
+        Indicates an entry which is required by this module. Replacement of outgoingCallback / requiredEntry.
+        Only adds the value if it is not None.
+
+        Args:
+            value: RefType to an expected entry to add
 
         Returns:
-            List of RefType to implemented entries
+            self for method chaining
+        """
+        if value is not None:
+            self.expectedEntryRefs.append(value)
+        return self
+
+    def getImplementedEntryRefs(self) -> List[RefType]:
+        """
+        Specifies an entry provided by this module which can be called by other modules. This includes "main" functions, interrupt routines, and callbacks. Replacement of providedEntry / expectedCallback.
         """
         return self.implementedEntryRefs
 
     def addImplementedEntryRef(self, value: RefType) -> "BswModuleDescription":
         """
-        Adds an implemented entry reference to this module's list.
-        These are entries provided by this module which can be called by other modules.
+        Specifies an entry provided by this module which can be called by other modules. This includes "main" functions, interrupt routines, and callbacks. Replacement of providedEntry / expectedCallback.
         Only adds the value if it is not None.
 
         Args:
@@ -242,18 +220,13 @@ class BswModuleDescription(AtpStructureElement):
 
     def getInternalBehaviors(self) -> List[BswInternalBehavior]:
         """
-        Gets the list of internal behaviors of this BSW module.
-        The various BswInternalBehaviors can be distributed over several physical files.
-
-        Returns:
-            List of BswInternalBehavior instances
+        The various BswInternalBehaviors associated with a BswModuleDescription can be distributed over several physical files. Therefore the aggregation is <<atpSplitable>>.
         """
         return self.internalBehaviors
 
     def setInternalBehaviors(self, value: List[BswInternalBehavior]) -> "BswModuleDescription":
         """
-        Sets the list of internal behaviors of this BSW module.
-        The various BswInternalBehaviors can be distributed over several physical files.
+        The various BswInternalBehaviors associated with a BswModuleDescription can be distributed over several physical files. Therefore the aggregation is <<atpSplitable>>.
         Only sets the value if it is not None.
 
         Args:
@@ -268,8 +241,7 @@ class BswModuleDescription(AtpStructureElement):
 
     def createBswInternalBehavior(self, short_name: str) -> BswInternalBehavior:
         """
-        Creates and adds a BSW internal behavior to this module description.
-        This defines how the module behaves internally, including its events and entities.
+        The various BswInternalBehaviors associated with a BswModuleDescription can be distributed over several physical files. Therefore the aggregation is <<atpSplitable>>.
 
         Args:
             short_name: The short name for the new internal behavior
@@ -285,18 +257,13 @@ class BswModuleDescription(AtpStructureElement):
 
     def getModuleId(self) -> Optional[PositiveInteger]:
         """
-        Gets the BSW Module Identifier defined by the AUTOSAR standard.
-        For non-standardized modules, a proprietary identifier can be optionally chosen.
-
-        Returns:
-            Positive integer representing the module ID
+        Refers to the BSW Module Identifier defined by the AUTOSAR standard. For non-standardized modules, a proprietary identifier can be optionally chosen.
         """
         return self.moduleId
 
     def setModuleId(self, value: PositiveInteger) -> "BswModuleDescription":
         """
-        Sets the BSW Module Identifier defined by the AUTOSAR standard.
-        For non-standardized modules, a proprietary identifier can be optionally chosen.
+        Refers to the BSW Module Identifier defined by the AUTOSAR standard. For non-standardized modules, a proprietary identifier can be optionally chosen.
         Only sets the value if it is not None.
 
         Args:
@@ -311,19 +278,13 @@ class BswModuleDescription(AtpStructureElement):
 
     def getProvidedClientServerEntries(self) -> List[BswModuleClientServerEntry]:
         """
-        Gets the list of client-server entries that this module provides.
-        These are entries which can be called from another partition or core, connected to
-        the requiredClientServerEntry of another or the same module via the BSW Scheduler.
-
-        Returns:
-            List of BswModuleClientServerEntry instances
+        Specifies that this module provides a client server entry which can be called from another partition or core. This entry is declared locally to this context and will be connected to the requiredClientServerEntry of another or the same module via the configuration of the BSW Scheduler.
         """
         return self.providedClientServerEntries
 
     def createProvidedClientServerEntry(self, short_name: str) -> BswModuleClientServerEntry:
         """
-        Creates and adds a client-server entry that this module provides to others.
-        This is a service interface that this module offers to other modules.
+        Specifies that this module provides a client server entry which can be called from another partition or core. This entry is declared locally to this context and will be connected to the requiredClientServerEntry of another or the same module via the configuration of the BSW Scheduler.
 
         Args:
             short_name: The short name for the new provided client-server entry
@@ -339,20 +300,13 @@ class BswModuleDescription(AtpStructureElement):
 
     def getProvidedDatas(self) -> List[VariableDataPrototype]:
         """
-        Gets the list of data prototypes that this module provides.
-        These are data prototypes provided by this module to be read from another partition
-        or core, connected to the requiredData of another or the same module via the
-        BSW Scheduler.
-
-        Returns:
-            List of VariableDataPrototype instances
+        Specifies a data prototype provided by this module in order to be read from another partition or core. The providedData is declared locally to this context and will be connected to the requiredData of another or the same module via the configuration of the BSW Scheduler.
         """
         return self.providedDatas
 
     def createProvidedData(self, short_name: str) -> VariableDataPrototype:
         """
-        Creates and adds a data prototype that this module provides to others.
-        This is a data interface that this module offers to other modules.
+        Specifies a data prototype provided by this module in order to be read from another partition or core. The providedData is declared locally to this context and will be connected to the requiredData of another or the same module via the configuration of the BSW Scheduler.
 
         Args:
             short_name: The short name for the new provided data prototype
@@ -368,19 +322,13 @@ class BswModuleDescription(AtpStructureElement):
 
     def getProvidedModeGroups(self) -> List[ModeDeclarationGroupPrototype]:
         """
-        Gets the list of mode group prototypes that this module provides.
-        These are a set of modes owned and provided by this module or cluster, connected to
-        the requiredModeGroups of other modules or clusters via the BswScheduler.
-
-        Returns:
-            List of ModeDeclarationGroupPrototype instances
+        A set of modes which is owned and provided by this module or cluster. It can be connected to the requiredModeGroups of other modules or clusters via the configuration of the BswScheduler. It can also be synchronized with modes provided via ports by an associated ServiceSwComponentType, EcuAbstractionSwComponentType or ComplexDeviceDriverSwComponentType.
         """
         return self.providedModeGroups
 
     def createProvidedModeGroup(self, short_name: str) -> ModeDeclarationGroupPrototype:
         """
-        Creates and adds a mode group prototype that this module provides to others.
-        This is a mode interface that this module offers to other modules for mode management.
+        A set of modes which is owned and provided by this module or cluster. It can be connected to the requiredModeGroups of other modules or clusters via the configuration of the BswScheduler. It can also be synchronized with modes provided via ports by an associated ServiceSwComponentType, EcuAbstractionSwComponentType or ComplexDeviceDriverSwComponentType.
 
         Args:
             short_name: The short name for the new provided mode group
@@ -396,19 +344,13 @@ class BswModuleDescription(AtpStructureElement):
 
     def getReleasedTriggers(self) -> List[Trigger]:
         """
-        Gets the list of triggers that this module releases.
-        These are triggers released by this module or cluster, connected to the
-        requiredTriggers of other modules or clusters via the BswScheduler.
-
-        Returns:
-            List of Trigger instances
+        A Trigger released by this module or cluster. It can be connected to the requiredTriggers of other modules or clusters via the configuration of the BswScheduler. It can also be synchronized with Triggers provided via ports by an associated ServiceSwComponentType, EcuAbstractionSwComponentType or ComplexDeviceDriverSwComponentType.
         """
         return self.releasedTriggers
 
     def createReleasedTrigger(self, short_name: str) -> Trigger:
         """
-        Creates and adds a trigger that this module releases to others.
-        This is a trigger interface that this module can send to other modules.
+        A Trigger released by this module or cluster. It can be connected to the requiredTriggers of other modules or clusters via the configuration of the BswScheduler. It can also be synchronized with Triggers provided via ports by an associated ServiceSwComponentType, EcuAbstractionSwComponentType or ComplexDeviceDriverSwComponentType.
 
         Args:
             short_name: The short name for the new released trigger
@@ -424,19 +366,13 @@ class BswModuleDescription(AtpStructureElement):
 
     def getRequiredClientServerEntries(self) -> List[BswModuleClientServerEntry]:
         """
-        Gets the list of client-server entries that this module requires.
-        These are entries which can be implemented on another partition or core, connected
-        to the providedClientServerEntry of another or the same module via the BSW Scheduler.
-
-        Returns:
-            List of BswModuleClientServerEntry instances
+        Specifies that this module requires a client server entry which can be implemented on another partition or core. This entry is declared locally to this context and will be connected to the providedClientServerEntry of another or the same module via the configuration of the BSW Scheduler.
         """
         return self.requiredClientServerEntries
 
     def createRequiredClientServerEntry(self, short_name: str) -> BswModuleClientServerEntry:
         """
-        Creates and adds a client-server entry that this module requires from others.
-        This is a service interface that this module needs from other modules.
+        Specifies that this module requires a client server entry which can be implemented on another partition or core. This entry is declared locally to this context and will be connected to the providedClientServerEntry of another or the same module via the configuration of the BSW Scheduler.
 
         Args:
             short_name: The short name for the new required client-server entry
@@ -452,20 +388,13 @@ class BswModuleDescription(AtpStructureElement):
 
     def getRequiredDatas(self) -> List[VariableDataPrototype]:
         """
-        Gets the list of data prototypes that this module requires.
-        These are data prototypes required by this module to be provided from another
-        partition or core, connected to the providedData of another or the same module via
-        the BSW Scheduler.
-
-        Returns:
-            List of VariableDataPrototype instances
+        Specifies a data prototype required by this module in order to be provided from another partition or core. The requiredData is declared locally to this context and will be connected to the providedData of another or the same module via the configuration of the BswScheduler.
         """
         return self.requiredDatas
 
     def createRequiredData(self, short_name: str) -> VariableDataPrototype:
         """
-        Creates and adds a data prototype that this module requires from others.
-        This is a data interface that this module needs from other modules.
+        Specifies a data prototype required by this module in order to be provided from another partition or core. The requiredData is declared locally to this context and will be connected to the providedData of another or the same module via the configuration of the BswScheduler.
 
         Args:
             short_name: The short name for the new required data prototype
@@ -481,19 +410,13 @@ class BswModuleDescription(AtpStructureElement):
 
     def getRequiredModeGroups(self) -> List[ModeDeclarationGroupPrototype]:
         """
-        Gets the list of mode group prototypes that this module requires.
-        These indicate a dependency on a certain mode group, connected to the
-        providedModeGroup of another module or cluster via the BswScheduler.
-
-        Returns:
-            List of ModeDeclarationGroupPrototype instances
+        Specifies that this module or cluster depends on a certain mode group. The requiredModeGroup is local to this context and will be connected to the providedModeGroup of another module or cluster via the configuration of the BswScheduler.
         """
         return self.requiredModeGroups
 
     def createRequiredModeGroup(self, short_name: str) -> ModeDeclarationGroupPrototype:
         """
-        Creates and adds a mode group prototype that this module requires from others.
-        This is a mode interface that this module needs from other modules for mode management.
+        Specifies that this module or cluster depends on a certain mode group. The requiredModeGroup is local to this context and will be connected to the providedModeGroup of another module or cluster via the configuration of the BswScheduler.
 
         Args:
             short_name: The short name for the new required mode group
@@ -509,19 +432,13 @@ class BswModuleDescription(AtpStructureElement):
 
     def getRequiredTriggers(self) -> List[Trigger]:
         """
-        Gets the list of triggers that this module requires.
-        These indicate that this module or cluster reacts upon an external trigger,
-        connected to the providedTrigger of another module or cluster via the BswScheduler.
-
-        Returns:
-            List of Trigger instances
+        Specifies that this module or cluster reacts upon an external trigger. This requiredTrigger is declared locally to this context and will be connected to the providedTrigger of another module or cluster via the configuration of the BswScheduler.
         """
         return self.requiredTriggers
 
     def createRequiredTrigger(self, short_name: str) -> Trigger:
         """
-        Creates and adds a trigger that this module requires from others.
-        This is a trigger interface that this module needs from other modules.
+        Specifies that this module or cluster reacts upon an external trigger. This requiredTrigger is declared locally to this context and will be connected to the providedTrigger of another module or cluster via the configuration of the BswScheduler.
 
         Args:
             short_name: The short name for the new required trigger

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -35,7 +35,7 @@ from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswBehavior import (
     RoleBasedBswModuleEntryAssignment,
 )
 from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import BswImplementation
-from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleClientServerEntry, BswModuleDependency, BswModuleEntry
+from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleClientServerEntry, BswModuleEntry
 from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import BswModuleDescription
 from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview.InstanceRefs import ModeInBswModuleDescriptionInstanceRef
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import (

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -35,7 +35,7 @@ from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswBehavior import (
     RoleBasedBswModuleEntryAssignment,
 )
 from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import BswImplementation
-from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleClientServerEntry, BswModuleEntry
+from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleClientServerEntry, BswModuleDependency, BswModuleEntry
 from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import BswModuleDescription
 from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview.InstanceRefs import ModeInBswModuleDescriptionInstanceRef
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import (
@@ -1052,7 +1052,7 @@ class ARXMLParser(AbstractARXMLParser):
         for child_element in self.findall(element, "REQUIRED-MODE-GROUPS/*"):
             tag_name = self.getTagName(child_element)
             if tag_name == "MODE-DECLARATION-GROUP-PROTOTYPE":
-                prototype = parent.createProvidedModeGroup(self.getShortName(child_element))
+                prototype = parent.createRequiredModeGroup(self.getShortName(child_element))
                 self.readModeDeclarationGroupPrototype(child_element, prototype)
             else:
                 self.notImplemented("Unsupported RequiredModeGroup <%s>" % tag_name)
@@ -2078,6 +2078,7 @@ class ARXMLParser(AbstractARXMLParser):
 
         self.readIdentifiable(element, desc)
         desc.setModuleId(self.getChildElementOptionalNumericalValue(element, "MODULE-ID"))
+        self.readBswModuleDescriptionExpectedEntryRefs(element, desc)
         self.readBswModuleDescriptionImplementedEntryRefs(element, desc)
         self.readBswModuleDescriptionProvidedModeGroups(element, desc)
         self.readBswModuleDescriptionRequiredModeGroups(element, desc)
@@ -2087,6 +2088,33 @@ class ARXMLParser(AbstractARXMLParser):
         self.readBswModuleDescriptionRequiredDatas(element, desc)
         self.readBswModuleDescriptionBswInternalBehaviors(element, desc)
         self.readBswModuleDescriptionRequiredTriggers(element, desc)
+        self.readBswModuleDescriptionBswModuleDependencies(element, desc)
+        self.readBswModuleDescriptionBswModuleDocumentation(element, desc)
+
+    def readBswModuleDescriptionExpectedEntryRefs(self, element: ET.Element, parent: BswModuleDescription):
+        for child_element in self.findall(element, "EXPECTED-ENTRYS/BSW-MODULE-ENTRY-REF-CONDITIONAL"):
+            ref = self.getChildElementOptionalRefType(child_element, "BSW-MODULE-ENTRY-REF")
+            if ref is not None:
+                parent.addExpectedEntryRef(ref)
+
+    def readBswModuleDescriptionBswModuleDependencies(self, element: ET.Element, parent: BswModuleDescription):
+        for child_element in self.findall(element, "BSW-MODULE-DEPENDENCYS/*"):
+            tag_name = self.getTagName(child_element)
+            if tag_name == "BSW-MODULE-DEPENDENCY":
+                dependency = parent.createBswModuleDependency(self.getShortName(child_element))
+                dependency.setTargetModuleId(self.getChildElementOptionalNumericalValue(child_element, "TARGET-MODULE-ID"))
+                dependency.setTargetModuleRef(self.getChildElementOptionalRefType(child_element, "TARGET-MODULE-REF"))
+            else:
+                self.notImplemented("Unsupported BswModuleDependency <%s>" % tag_name)
+
+    def readBswModuleDescriptionBswModuleDocumentation(self, element: ET.Element, parent: BswModuleDescription):
+        container = self.find(element, "BSW-MODULE-DOCUMENTATIONS")
+        if container is None:
+            return
+        child_element = self.find(container, "SW-COMPONENT-DOCUMENTATION")
+        if child_element is None:
+            return
+        parent.setBswModuleDocumentation(self.readSwComponentDocumentationElement(child_element))
 
     def readSwServiceArg(self, element: ET.Element, arg: SwServiceArg):
         self.readIdentifiable(element, arg)
@@ -2120,6 +2148,8 @@ class ARXMLParser(AbstractARXMLParser):
         entry.setExecutionContext(self.getChildElementOptionalLiteral(element, "EXECUTION-CONTEXT"))
         entry.setSwServiceImplPolicy(self.getChildElementOptionalLiteral(element, "SW-SERVICE-IMPL-POLICY"))
         entry.setBswEntryKind(self.getChildElementOptionalLiteral(element, "BSW-ENTRY-KIND"))
+        entry.setRole(self.getChildElementOptionalLiteral(element, "ROLE"))
+        entry.setFunctionPrototypeEmitter(self.getChildElementOptionalLiteral(element, "FUNCTION-PROTOTYPE-EMITTER"))
         self.readBswModuleEntryReturnType(element, entry)
 
     def readEngineeringObject(self, element: ET.Element, engineering_obj: EngineeringObject):
@@ -4240,10 +4270,7 @@ class ARXMLParser(AbstractARXMLParser):
         for child_element in self.findall(element, "CONSISTENCY-NEEDSS/CONSISTENCY-NEEDS"):
             self.readConsistencyNeeds(child_element, parent.createConsistencyNeeds(self.getShortName(child_element)))
 
-    def readSwComponentTypeSwComponentDocumentation(self, element: ET.Element, parent: SwComponentType):
-        child_element = self.find(element, "SW-COMPONENT-DOCUMENTATION")
-        if child_element is None:
-            return
+    def readSwComponentDocumentationElement(self, child_element: ET.Element) -> SwComponentDocumentation:
         documentation = SwComponentDocumentation()
         predefined_chapter_map = [
             ("SW-FEATURE-DEF", documentation.createSwFeatureDef),
@@ -4262,7 +4289,13 @@ class ARXMLParser(AbstractARXMLParser):
         for chapter_element in self.findall(child_element, "CHAPTER"):
             chapter = documentation.createChapter(self.getShortName(chapter_element))
             self.readChapterBody(chapter_element, chapter)
-        parent.setSwComponentDocumentation(documentation)
+        return documentation
+
+    def readSwComponentTypeSwComponentDocumentation(self, element: ET.Element, parent: SwComponentType):
+        child_element = self.find(element, "SW-COMPONENT-DOCUMENTATION")
+        if child_element is None:
+            return
+        parent.setSwComponentDocumentation(self.readSwComponentDocumentationElement(child_element))
 
     def readChapter(self, element: ET.Element, parent: ARObject) -> Chapter:
         chapter = Chapter(parent, self.getShortName(element))

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -35,7 +35,7 @@ from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswBehavior import (
     RoleBasedBswModuleEntryAssignment,
 )
 from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import BswImplementation
-from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleClientServerEntry, BswModuleEntry
+from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleClientServerEntry, BswModuleDependency, BswModuleEntry
 from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import BswModuleDescription
 from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview.InstanceRefs import ModeInBswModuleDescriptionInstanceRef
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import (
@@ -1459,11 +1459,7 @@ class ARXMLWriter(AbstractARXMLWriter):
             for ref in refs:
                 self.setChildElementOptionalRefType(child_element, "SWC-MAPPING-CONSTRAINT-REF", ref)
 
-    def writeSwComponentTypeSwComponentDocumentation(self, element: ET.Element, parent: SwComponentType):
-        documentation = parent.getSwComponentDocumentation()
-        if documentation is None:
-            return
-        child_element = ET.SubElement(element, "SW-COMPONENT-DOCUMENTATION")
+    def writeSwComponentDocumentationElement(self, child_element: ET.Element, documentation):
         predefined_chapters = [
             (documentation.getSwFeatureDef(), "SW-FEATURE-DEF"),
             (documentation.getSwFeatureDesc(), "SW-FEATURE-DESC"),
@@ -1478,6 +1474,13 @@ class ARXMLWriter(AbstractARXMLWriter):
                 self.writeChapter(child_element, chapter, tag_name)
         for chapter in documentation.getChapters():
             self.writeChapter(child_element, chapter, "CHAPTER")
+
+    def writeSwComponentTypeSwComponentDocumentation(self, element: ET.Element, parent: SwComponentType):
+        documentation = parent.getSwComponentDocumentation()
+        if documentation is None:
+            return
+        child_element = ET.SubElement(element, "SW-COMPONENT-DOCUMENTATION")
+        self.writeSwComponentDocumentationElement(child_element, documentation)
 
     def writeChapter(self, element: ET.Element, chapter: Chapter, tag_name: str):
         child_element = ET.SubElement(element, tag_name)
@@ -4763,6 +4766,38 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.writeBswModuleDescriptionRequiredDatas(child_element, desc)
         self.writeBswModuleDescriptionInternalBehaviors(child_element, desc)
         self.writeBswModuleDescriptionReleasedTriggers(child_element, desc)
+        self.writeBswModuleDescriptionExpectedEntryRefs(child_element, desc)
+        self.writeBswModuleDescriptionBswModuleDependencies(child_element, desc)
+        self.writeBswModuleDescriptionBswModuleDocumentation(child_element, desc)
+
+    def writeBswModuleDescriptionExpectedEntryRefs(self, element: ET.Element, desc: BswModuleDescription):
+        refs = desc.getExpectedEntryRefs()
+        if len(refs) > 0:
+            entries_tag = ET.SubElement(element, "EXPECTED-ENTRYS")
+            for ref in refs:
+                entry_tag = ET.SubElement(entries_tag, "BSW-MODULE-ENTRY-REF-CONDITIONAL")
+                self.setChildElementOptionalRefType(entry_tag, "BSW-MODULE-ENTRY-REF", ref)
+
+    def writeBswModuleDescriptionBswModuleDependencies(self, element: ET.Element, desc: BswModuleDescription):
+        dependencies = desc.getBswModuleDependencies()
+        if len(dependencies) > 0:
+            container = ET.SubElement(element, "BSW-MODULE-DEPENDENCYS")
+            for dependency in dependencies:
+                if isinstance(dependency, BswModuleDependency):
+                    child_element = ET.SubElement(container, "BSW-MODULE-DEPENDENCY")
+                    self.writeIdentifiable(child_element, dependency)
+                    self.setChildElementOptionalNumericalValue(child_element, "TARGET-MODULE-ID", dependency.getTargetModuleId())
+                    self.setChildElementOptionalRefType(child_element, "TARGET-MODULE-REF", dependency.getTargetModuleRef())
+                else:
+                    self.notImplemented("Unsupported BswModuleDependency <%s>" % type(dependency))
+
+    def writeBswModuleDescriptionBswModuleDocumentation(self, element: ET.Element, desc: BswModuleDescription):
+        documentation = desc.getBswModuleDocumentation()
+        if documentation is None:
+            return
+        container = ET.SubElement(element, "BSW-MODULE-DOCUMENTATIONS")
+        child_element = ET.SubElement(container, "SW-COMPONENT-DOCUMENTATION")
+        self.writeSwComponentDocumentationElement(child_element, documentation)
 
     def setSwServiceArg(self, element: ET.Element, key: str, arg: SwServiceArg):
         self.logger.debug("Set SwServiceArg <%s>" % arg.getShortName())
@@ -4794,6 +4829,8 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.setChildElementOptionalLiteral(child_element, "EXECUTION-CONTEXT", entry.getExecutionContext())
         self.setChildElementOptionalLiteral(child_element, "SW-SERVICE-IMPL-POLICY", entry.getSwServiceImplPolicy())
         self.setChildElementOptionalLiteral(child_element, "BSW-ENTRY-KIND", entry.getBswEntryKind())
+        self.setChildElementOptionalLiteral(child_element, "ROLE", entry.getRole())
+        self.setChildElementOptionalLiteral(child_element, "FUNCTION-PROTOTYPE-EMITTER", entry.getFunctionPrototypeEmitter())
         self.writeBswModuleEntryReturnType(child_element, entry)
         self.writeBswModuleEntryArguments(child_element, entry)
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswInterfaces.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswInterfaces.py
@@ -6,8 +6,6 @@ and BswModuleClientServerEntry. These classes represent BSW-specific interface e
 that define dependencies, module entries, and client-server relationships in the AUTOSAR architecture.
 """
 
-import pytest
-
 from armodel import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import (
     BswCallType,

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswInterfaces.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswInterfaces.py
@@ -18,47 +18,95 @@ from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import (
     BswModuleEntry,
     SwServiceImplPolicyEnum,
 )
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARNumerical, Identifier, NameToken, PositiveInteger, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Identifier, NameToken, PositiveInteger, RefType
 
 
 class TestBswEntryKindEnum:
     """Test cases for BswEntryKindEnum enumeration."""
 
     def test_bsw_entry_kind_enum_values(self):
-        """Test BswEntryKindEnum values."""
-        assert BswEntryKindEnum.FUNCTION == "FUNCTION"
+        """Test BswEntryKindEnum values and instantiability (AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Table 4.2)."""
+        BswEntryKindEnum()
+        assert hasattr(BswEntryKindEnum, "ABSTRACT")
+        assert hasattr(BswEntryKindEnum, "CONCRETE")
+        assert BswEntryKindEnum.ABSTRACT == "abstract"
+        assert BswEntryKindEnum.CONCRETE == "concrete"
+
+    def test_bsw_entry_kind_enum_set_value(self):
+        """Test setting an enum value via the AREnum pattern."""
+        enum = BswEntryKindEnum()
+        enum.setValue(BswEntryKindEnum.ABSTRACT)
+        assert enum.getValue() == "abstract"
 
 
 class TestBswCallType:
     """Test cases for BswCallType enumeration."""
 
     def test_bsw_call_type_enum_values(self):
-        """Test BswCallType enum values."""
-        assert BswCallType.SYNCHRONOUS == "SYNCHRONOUS"
-        assert BswCallType.ASYNCHRONOUS == "ASYNCHRONOUS"
+        """Test BswCallType enum values and instantiability (AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Table 4.4)."""
+        BswCallType()
+        assert hasattr(BswCallType, "CALLBACK")
+        assert hasattr(BswCallType, "CALLOUT")
+        assert hasattr(BswCallType, "INTERRUPT")
+        assert hasattr(BswCallType, "REGULAR")
+        assert hasattr(BswCallType, "SCHEDULED")
+        assert BswCallType.CALLBACK == "callback"
+        assert BswCallType.CALLOUT == "callout"
+        assert BswCallType.INTERRUPT == "interrupt"
+        assert BswCallType.REGULAR == "regular"
+        assert BswCallType.SCHEDULED == "scheduled"
+
+    def test_bsw_call_type_enum_set_value(self):
+        """Test setting an enum value via the AREnum pattern."""
+        enum = BswCallType()
+        enum.setValue(BswCallType.REGULAR)
+        assert enum.getValue() == "regular"
 
 
 class TestBswExecutionContext:
     """Test cases for BswExecutionContext enumeration."""
 
     def test_bsw_execution_context_enum_values(self):
-        """Test BswExecutionContext enum values."""
-        assert BswExecutionContext.HOOK == "HOOK"
-        assert BswExecutionContext.INTERRUPT_CAT_1 == "INTERRUPT-CAT-1"
-        assert BswExecutionContext.INTERRUPT_CAT_2 == "INTERRUPT-CAT-2"
-        assert BswExecutionContext.TASK == "TASK"
-        assert BswExecutionContext.UNSPECIFIED == "UNSPECIFIED"
+        """Test BswExecutionContext enum values and instantiability (AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Table 4.3)."""
+        BswExecutionContext()
+        assert hasattr(BswExecutionContext, "HOOK")
+        assert hasattr(BswExecutionContext, "INTERRUPT_CAT_1")
+        assert hasattr(BswExecutionContext, "INTERRUPT_CAT_2")
+        assert hasattr(BswExecutionContext, "TASK")
+        assert hasattr(BswExecutionContext, "UNSPECIFIED")
+        assert BswExecutionContext.HOOK == "hook"
+        assert BswExecutionContext.INTERRUPT_CAT_1 == "interruptCat1"
+        assert BswExecutionContext.INTERRUPT_CAT_2 == "interruptCat2"
+        assert BswExecutionContext.TASK == "task"
+        assert BswExecutionContext.UNSPECIFIED == "unspecified"
+
+    def test_bsw_execution_context_enum_set_value(self):
+        """Test setting an enum value via the AREnum pattern."""
+        enum = BswExecutionContext()
+        enum.setValue(BswExecutionContext.TASK)
+        assert enum.getValue() == "task"
 
 
 class TestSwServiceImplPolicyEnum:
     """Test cases for SwServiceImplPolicyEnum enumeration."""
 
     def test_sw_service_impl_policy_enum_values(self):
-        """Test SwServiceImplPolicyEnum enum values."""
-        assert SwServiceImplPolicyEnum.INLINE == "INLINE"
-        assert SwServiceImplPolicyEnum.INLINE_CONDITIONAL == "INLINE-CONDITIONAL"
-        assert SwServiceImplPolicyEnum.MACRO == "MACRO"
-        assert SwServiceImplPolicyEnum.STANDARD == "STANDARD"
+        """Test SwServiceImplPolicyEnum enum values and instantiability (AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Table 4.5)."""
+        SwServiceImplPolicyEnum()
+        assert hasattr(SwServiceImplPolicyEnum, "INLINE")
+        assert hasattr(SwServiceImplPolicyEnum, "INLINE_CONDITIONAL")
+        assert hasattr(SwServiceImplPolicyEnum, "MACRO")
+        assert hasattr(SwServiceImplPolicyEnum, "STANDARD")
+        assert SwServiceImplPolicyEnum.INLINE == "inline"
+        assert SwServiceImplPolicyEnum.INLINE_CONDITIONAL == "inlineConditional"
+        assert SwServiceImplPolicyEnum.MACRO == "macro"
+        assert SwServiceImplPolicyEnum.STANDARD == "standard"
+
+    def test_sw_service_impl_policy_enum_set_value(self):
+        """Test setting an enum value via the AREnum pattern."""
+        enum = SwServiceImplPolicyEnum()
+        enum.setValue(SwServiceImplPolicyEnum.STANDARD)
+        assert enum.getValue() == "standard"
 
 
 class TestBswModuleDependency:
@@ -159,15 +207,15 @@ class TestBswModuleEntry:
         ar_root = document.createARPackage("AUTOSAR")
         entry = BswModuleEntry(ar_root, "test_entry")
 
-        result = entry.setBswEntryKind(BswEntryKindEnum.FUNCTION)
+        result = entry.setBswEntryKind(BswEntryKindEnum.CONCRETE)
 
         assert result == entry
-        assert entry.getBswEntryKind() == BswEntryKindEnum.FUNCTION
+        assert entry.getBswEntryKind() == BswEntryKindEnum.CONCRETE
 
         # Test setting None (should not change value)
         result = entry.setBswEntryKind(None)
         assert result == entry
-        assert entry.getBswEntryKind() == BswEntryKindEnum.FUNCTION  # Should remain unchanged
+        assert entry.getBswEntryKind() == BswEntryKindEnum.CONCRETE  # Should remain unchanged
 
     def test_get_set_call_type(self):
         """Test getter and setter for call type."""
@@ -175,15 +223,15 @@ class TestBswModuleEntry:
         ar_root = document.createARPackage("AUTOSAR")
         entry = BswModuleEntry(ar_root, "test_entry")
 
-        result = entry.setCallType(BswCallType.SYNCHRONOUS)
+        result = entry.setCallType(BswCallType.REGULAR)
 
         assert result == entry
-        assert entry.getCallType() == BswCallType.SYNCHRONOUS
+        assert entry.getCallType() == BswCallType.REGULAR
 
         # Test setting None (should not change value)
         result = entry.setCallType(None)
         assert result == entry
-        assert entry.getCallType() == BswCallType.SYNCHRONOUS  # Should remain unchanged
+        assert entry.getCallType() == BswCallType.REGULAR  # Should remain unchanged
 
     def test_get_set_execution_context(self):
         """Test getter and setter for execution context."""
@@ -200,16 +248,6 @@ class TestBswModuleEntry:
         result = entry.setExecutionContext(None)
         assert result == entry
         assert entry.getExecutionContext() == "TASK"  # Should remain unchanged
-
-    def test_set_execution_context_invalid(self):
-        """Test setting invalid execution context raises ValueError."""
-        document = AUTOSAR.getInstance()
-        ar_root = document.createARPackage("AUTOSAR")
-        entry = BswModuleEntry(ar_root, "test_entry")
-
-        with pytest.raises(ValueError) as exc_info:
-            entry.setExecutionContext("INVALID_CONTEXT")
-        assert "Invalid execution context" in str(exc_info.value)
 
     def test_get_set_function_prototype_emitter(self):
         """Test getter and setter for function prototype emitter."""
@@ -304,7 +342,7 @@ class TestBswModuleEntry:
         ar_root = document.createARPackage("AUTOSAR")
         entry = BswModuleEntry(ar_root, "test_entry")
 
-        service_id = ARNumerical()
+        service_id = PositiveInteger()
         service_id.setValue(123)
         result = entry.setServiceId(service_id)
 
@@ -333,48 +371,13 @@ class TestBswModuleEntry:
         assert entry.getSwServiceImplPolicy() == SwServiceImplPolicyEnum.STANDARD  # Should remain unchanged
 
     def test_set_sw_service_impl_policy_invalid(self):
-        """Test setting invalid SW service implementation policy raises ValueError."""
+        """Setting a non-None SW service implementation policy stores it (no ValueError validation)."""
         document = AUTOSAR.getInstance()
         ar_root = document.createARPackage("AUTOSAR")
         entry = BswModuleEntry(ar_root, "test_entry")
 
-        with pytest.raises(ValueError) as exc_info:
-            entry.setSwServiceImplPolicy("INVALID_POLICY")
-        assert "Invalid SwServiceImplPolicy" in str(exc_info.value)
-
-    def test_str_method(self):
-        """Test string representation of BswModuleEntry."""
-        document = AUTOSAR.getInstance()
-        ar_root = document.createARPackage("AUTOSAR")
-        entry = BswModuleEntry(ar_root, "test_entry")
-
-        # Set some properties to test string representation including serviceId
-        service_id = ARNumerical()
-        service_id.setValue(123)
-        entry.setServiceId(service_id)
-        entry.setIsReentrant(True)
-        entry.setIsSynchronous(False)
-        entry.setCallType(BswCallType.SYNCHRONOUS)
-        entry.setExecutionContext("TASK")
-        entry.setSwServiceImplPolicy(SwServiceImplPolicyEnum.STANDARD)
-
-        # Call the __str__ method which should work with serviceId set
-        str_repr = str(entry)
-
-        assert "short_name" in str_repr
-        assert "test_entry" in str_repr
-        assert "service_id" in str_repr
-        assert "123" in str_repr
-        assert "is_reentrant" in str_repr
-        assert "True" in str_repr
-        assert "is_synchronous" in str_repr
-        assert "False" in str_repr
-        assert "call_type" in str_repr
-        assert "SYNCHRONOUS" in str_repr
-        assert "execution_context" in str_repr
-        assert "TASK" in str_repr
-        assert "sw_service_impl_policy" in str_repr
-        assert "STANDARD" in str_repr
+        entry.setSwServiceImplPolicy("INLINE")
+        assert entry.getSwServiceImplPolicy() == "INLINE"
 
 
 class TestBswModuleClientServerEntry:

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswOverview.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswOverview.py
@@ -39,24 +39,69 @@ class TestBswModuleDescription:
         assert desc.getRequiredModeGroups() == []
         assert desc.getRequiredTriggers() == []
 
-    def test_get_set_bsw_module_dependencies(self):
-        """Test getter and setter for BSW module dependencies."""
+    def test_create_bsw_module_dependency(self):
+        """Test creating a BSW module dependency via the create pattern (spec multiplicity *)."""
         document = AUTOSAR.getInstance()
         ar_root = document.createARPackage("AUTOSAR")
         desc = BswModuleDescription(ar_root, "test_bsw_module")
 
-        # Create a mock dependency
+        dependency = desc.createBswModuleDependency("test_dependency")
+
+        assert dependency.short_name == "test_dependency"
+        assert len(desc.getBswModuleDependencies()) == 1
+        assert desc.getBswModuleDependencies()[0] == dependency
+
+    def test_add_bsw_module_dependency(self):
+        """Test adding a BSW module dependency instance."""
+        document = AUTOSAR.getInstance()
+        ar_root = document.createARPackage("AUTOSAR")
+        desc = BswModuleDescription(ar_root, "test_bsw_module")
+
         dependency = BswModuleDependency(ar_root, "test_dependency")
-        dependencies = [dependency]
-        result = desc.setBswModuleDependencies(dependencies)
+        result = desc.addBswModuleDependency(dependency)
 
         assert result == desc
-        assert desc.getBswModuleDependencies() == dependencies
+        assert desc.getBswModuleDependencies() == [dependency]
+
+        # Test adding None (should not be added)
+        result = desc.addBswModuleDependency(None)
+        assert result == desc
+        assert len(desc.getBswModuleDependencies()) == 1  # Should remain unchanged
+
+    def test_get_set_bsw_module_documentation(self):
+        """Test getter and setter for BSW module documentation."""
+        document = AUTOSAR.getInstance()
+        ar_root = document.createARPackage("AUTOSAR")
+        desc = BswModuleDescription(ar_root, "test_bsw_module")
+
+        doc = SwComponentDocumentation()
+        result = desc.setBswModuleDocumentation(doc)
+
+        assert result == desc
+        assert desc.getBswModuleDocumentation() == doc
 
         # Test setting None (should not change value)
-        result = desc.setBswModuleDependencies(None)
+        result = desc.setBswModuleDocumentation(None)
         assert result == desc
-        assert desc.getBswModuleDependencies() == dependencies  # Should remain unchanged
+        assert desc.getBswModuleDocumentation() == doc  # Should remain unchanged
+
+    def test_add_expected_entry_ref(self):
+        """Test adding an expected entry reference."""
+        document = AUTOSAR.getInstance()
+        ar_root = document.createARPackage("AUTOSAR")
+        desc = BswModuleDescription(ar_root, "test_bsw_module")
+
+        ref = RefType()
+        ref.setValue("/path/to/expected/entry")
+        result = desc.addExpectedEntryRef(ref)
+
+        assert result == desc
+        assert desc.getExpectedEntryRefs() == [ref]
+
+        # Test adding None (should not be added)
+        result = desc.addExpectedEntryRef(None)
+        assert result == desc
+        assert len(desc.getExpectedEntryRefs()) == 1  # Should remain unchanged
 
     def test_get_set_bsw_module_documentation(self):
         """Test getter and setter for BSW module documentation."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswOverview.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswOverview.py
@@ -103,23 +103,6 @@ class TestBswModuleDescription:
         assert result == desc
         assert len(desc.getExpectedEntryRefs()) == 1  # Should remain unchanged
 
-    def test_get_set_bsw_module_documentation(self):
-        """Test getter and setter for BSW module documentation."""
-        document = AUTOSAR.getInstance()
-        ar_root = document.createARPackage("AUTOSAR")
-        desc = BswModuleDescription(ar_root, "test_bsw_module")
-
-        doc = SwComponentDocumentation()
-        result = desc.setBswModuleDocumentation(doc)
-
-        assert result == desc
-        assert desc.getBswModuleDocumentation() == doc
-
-        # Test setting None (should not change value)
-        result = desc.setBswModuleDocumentation(None)
-        assert result == desc
-        assert desc.getBswModuleDocumentation() == doc  # Should remain unchanged
-
     def test_get_set_expected_entry_refs(self):
         """Test getter and setter for expected entry references."""
         document = AUTOSAR.getInstance()

--- a/tests/test_armodel/parser/test_arxml_parser_bsw_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_bsw_handlers.py
@@ -126,7 +126,7 @@ class TestBswModuleDescriptionHandlers:
             root_tag="BSW-MODULE-DESCRIPTION",
         )
         parser.readBswModuleDescriptionRequiredModeGroups(element, desc)
-        assert len(desc.getProvidedModeGroups()) == 1
+        assert len(desc.getRequiredModeGroups()) == 1
 
     def test_readBswModuleDescriptionRequiredModeGroups_unsupported_warns(self, warning_parser, caplog):
         from armodel.models import BswModuleDescription

--- a/tests/test_armodel/parser/test_bsw_module_descriiption.py
+++ b/tests/test_armodel/parser/test_bsw_module_descriiption.py
@@ -216,3 +216,117 @@ class TestBswMD:
         writer.save("data/generated_BswM_Bswmd.arxml", document)
 
         assert filecmp.cmp(get_test_file_path("BswM_Bswmd.arxml"), "data/generated_BswM_Bswmd.arxml", shallow=False) is True
+
+
+class TestReadBswModuleEntry:
+    def test_read_entry_attributes(self):
+        from xml.etree import ElementTree as ET
+
+        document = AUTOSAR.getInstance()
+        document.clear()
+        pkg = document.createARPackage("Pkg")
+        parser = ARXMLParser()
+        xml = (
+            "<BSW-MODULE-ENTRY xmlns='http://autosar.org/schema/r4.0'>"
+            "<SHORT-NAME>Entry</SHORT-NAME>"
+            "<ROLE>theRole</ROLE>"
+            "<FUNCTION-PROTOTYPE-EMITTER>RTE</FUNCTION-PROTOTYPE-EMITTER>"
+            "<CALL-TYPE>scheduled</CALL-TYPE>"
+            "<BSW-ENTRY-KIND>concrete</BSW-ENTRY-KIND>"
+            "<SERVICE-ID>42</SERVICE-ID>"
+            "</BSW-MODULE-ENTRY>"
+        )
+        elem = ET.fromstring(xml)
+        entry = pkg.createBswModuleEntry("Entry")
+        parser.readBswModuleEntry(elem, entry)
+
+        assert entry.getRole().getText() == "theRole"
+        assert entry.getFunctionPrototypeEmitter().getText() == "RTE"
+        assert entry.getCallType().getText() == "scheduled"
+        assert entry.getBswEntryKind().getText() == "concrete"
+        assert entry.getServiceId().getValue() == 42
+
+
+class TestReadWriteBswModuleEntryRoundTrip:
+    def test_round_trip_entry_attributes(self, tmp_path):
+        from xml.etree import ElementTree as ET
+
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral
+
+        ET.register_namespace("", "http://autosar.org/schema/r4.0")
+        document = AUTOSAR.getInstance()
+        document.clear()
+        pkg = document.createARPackage("Pkg")
+        entry = pkg.createBswModuleEntry("Entry")
+        entry.setRole(ARLiteral().setValue("theRole"))
+        entry.setFunctionPrototypeEmitter(ARLiteral().setValue("RTE"))
+        entry.setCallType(ARLiteral().setValue("scheduled"))
+        entry.setBswEntryKind(ARLiteral().setValue("concrete"))
+
+        writer = ARXMLWriter()
+        root = ET.Element("{http://autosar.org/schema/r4.0}AR-PACKAGES")
+        writer.writeBswModuleEntry(root, entry)
+        reparsed = ET.fromstring(ET.tostring(root))
+        reparsed_entry = reparsed.find("{http://autosar.org/schema/r4.0}BSW-MODULE-ENTRY")
+        entry2 = pkg.createBswModuleEntry("Entry2")
+        parser = ARXMLParser()
+        parser.readBswModuleEntry(reparsed_entry, entry2)
+
+        assert entry2.getRole().getText() == "theRole"
+        assert entry2.getFunctionPrototypeEmitter().getText() == "RTE"
+        assert entry2.getCallType().getText() == "scheduled"
+        assert entry2.getBswEntryKind().getText() == "concrete"
+
+
+class TestReadWriteBswModuleDescriptionRoundTrip:
+    def test_round_trip_new_attributes(self, tmp_path):
+        from xml.etree import ElementTree as ET
+
+        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleDependency
+        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import BswModuleDescription
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import ModeDeclarationGroupPrototype
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger, RefType
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SoftwareComponentDocumentation import SwComponentDocumentation
+
+        ET.register_namespace("", "http://autosar.org/schema/r4.0")
+        document = AUTOSAR.getInstance()
+        document.clear()
+        pkg = document.createARPackage("Pkg")
+        desc = pkg.createBswModuleDescription("Desc")
+
+        dependency = desc.createBswModuleDependency("dep1")
+        dependency.setTargetModuleId(PositiveInteger().setValue("7"))
+        dependency.setTargetModuleRef(RefType().setValue("/Target/Module"))
+
+        doc = SwComponentDocumentation()
+        desc.setBswModuleDocumentation(doc)
+
+        desc.addExpectedEntryRef(RefType().setValue("/Expected/Entry"))
+
+        desc.createRequiredModeGroup("rmg1")
+
+        writer = ARXMLWriter()
+        root = ET.Element("{http://autosar.org/schema/r4.0}AR-PACKAGES")
+        writer.writeBswModuleDescription(root, desc)
+        reparsed = ET.fromstring(ET.tostring(root))
+
+        desc2 = pkg.createBswModuleDescription("Desc2")
+        parser = ARXMLParser()
+        reparsed_desc = reparsed.find("{http://autosar.org/schema/r4.0}BSW-MODULE-DESCRIPTION")
+        parser.readBswModuleDescription(reparsed_desc, desc2)
+
+        assert len(desc2.getBswModuleDependencies()) == 1
+        dep2 = desc2.getBswModuleDependencies()[0]
+        assert dep2.getShortName() == "dep1"
+        assert dep2.getTargetModuleId().getValue() == 7
+        assert dep2.getTargetModuleRef().getValue() == "/Target/Module"
+
+        assert desc2.getBswModuleDocumentation() is not None
+
+        assert len(desc2.getExpectedEntryRefs()) == 1
+        assert desc2.getExpectedEntryRefs()[0].getValue() == "/Expected/Entry"
+
+        # requiredModeGroup must be routed to the required list, not the provided list
+        assert len(desc2.getRequiredModeGroups()) == 1
+        assert desc2.getRequiredModeGroups()[0].getShortName() == "rmg1"
+        assert desc2.getProvidedModeGroups() == []

--- a/tests/test_armodel/parser/test_bsw_module_descriiption.py
+++ b/tests/test_armodel/parser/test_bsw_module_descriiption.py
@@ -282,9 +282,6 @@ class TestReadWriteBswModuleDescriptionRoundTrip:
     def test_round_trip_new_attributes(self, tmp_path):
         from xml.etree import ElementTree as ET
 
-        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleDependency
-        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import BswModuleDescription
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import ModeDeclarationGroupPrototype
         from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger, RefType
         from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SoftwareComponentDocumentation import SwComponentDocumentation
 

--- a/tests/test_armodel/writer/test_writer_bsw_module.py
+++ b/tests/test_armodel/writer/test_writer_bsw_module.py
@@ -1011,13 +1011,15 @@ class TestWriterBswModuleEntry:
 
     def test_writeBswModuleEntry_full(self, writer):
         entry = _make_entry()
-        entry.setServiceId(_numerical(42))
+        entry.setServiceId(_posint(42))
         entry.setIsReentrant(_bool(True))
         entry.setIsSynchronous(_bool(False))
         entry.setCallType(_literal("scheduled"))
         entry.setExecutionContext(_literal("task"))
         entry.setSwServiceImplPolicy(_literal("inline"))
-        entry.setBswEntryKind(_literal("function"))
+        entry.setBswEntryKind(_literal("concrete"))
+        entry.setRole(_literal("theRole"))
+        entry.setFunctionPrototypeEmitter(_literal("RTE"))
         entry.createReturnType("ret")
         entry.createArgument("arg")
         parent = _parent()
@@ -1031,6 +1033,8 @@ class TestWriterBswModuleEntry:
         assert e.find("EXECUTION-CONTEXT") is not None
         assert e.find("SW-SERVICE-IMPL-POLICY") is not None
         assert e.find("BSW-ENTRY-KIND") is not None
+        assert e.find("ROLE").text == "theRole"
+        assert e.find("FUNCTION-PROTOTYPE-EMITTER").text == "RTE"
         assert e.find("RETURN-TYPE") is not None
         assert e.find("ARGUMENTS") is not None
 


### PR DESCRIPTION
## Summary

Sync two BSW module description model classes to the AUTOSAR R23-11 spec (AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf).

- `BswModuleEntry` (Table 4.1): verbatim docstrings, reader/writer coverage. Stamped `# Spec verified: R23-11`.
- `BswModuleDescription` (Table 3.1): verbatim docstrings; `bswModuleDependencies` multiplicity corrected to `*` via `createBswModuleDependency` + `addBswModuleDependency`; added missing reader/writer coverage for `bswModuleDependency`, `bswModuleDocumentation`, and `expectedEntryRefs`. Stamped `# Spec verified: R23-11`.

## Changes

- Fix pre-existing reader bug: `readBswModuleDescriptionRequiredModeGroups` called `createProvidedModeGroup` instead of `createRequiredModeGroup`.
- `setChildElementOptionalNumericalValue` intentionally left unchanged; int-valued `PositiveInteger` is supplied as a string by callers so `_text` is populated.
- Updated `test_arxml_parser_bsw_handlers.py` to assert the corrected (required) mode-group routing; added `BswModuleDescription` round-trip test for the new attributes.

## Quality gates

- `npm run black-check`: clean
- `npm run flake8`: clean
- `python scripts/run_tests.py`: 6431 passed (6430 unit + 1 integration)

Closes #635