### PR TITLE
sync: align BSW/SWC/ECU model classes to AUTOSAR R23-11 spec

### DIFF
--- a/docs/examples/method_deviation_by_class_v2.md
+++ b/docs/examples/method_deviation_by_class_v2.md
@@ -8,101 +8,86 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 `shortLabel` are excluded as framework-level.
 
 - Py classes scanned: **1030**
-- Skipped (spec verified stamp): **273**
-- Classes with deviations: **323**
+- Skipped (spec verified stamp): **295**
+- Classes with deviations: **301**
 - No spec table found (appendix): **133**
-- Missing accessors: **416**
+- Missing accessors: **376**
 - Naming deviations: **15**
-- Type deviations (list/single multiplicity): **43**
-
-## `BswModuleDescription`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 26
-- **Package:** `M2::AUTOSARTemplates::BswModuleTemplate::BswOverview`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/__init__.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `bswModuleDependency` | ``BswModuleDependency`` | aggr | missing |
-
-## `BswModuleEntry`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 32
-- **Package:** `M2::AUTOSARTemplates::BswModuleTemplate::BswInterfaces`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `argument(ordered)` | ``SwServiceArg`` | aggr | missing |
-
-## `ModeDeclarationGroup`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 42  | **table:** Table 4.10
-- **Package:** `M2::AUTOSARTemplates::CommonStructure::ModeDeclaration`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ModeDeclaration.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `modeDeclaration` | ``ModeDeclaration`` | aggr | missing |
-| — *(missing)* | `—` | `modeTransition` | ``ModeTransition`` | aggr | missing |
-
-## `BswModuleEntity`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 70
-- **Package:** `M2::AUTOSARTemplates::BswModuleTemplate::BswBehavior`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/__init__.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| `activationpointrefs` | `—` | `activationPoint` | ``BswInternalTriggering Point`` | ref | type (spec many vs py single) |
-| — *(missing)* | `—` | `callPoint` | ``BswModuleCallPoint`` | aggr | missing |
-| — *(missing)* | `—` | `dataReceivePoint` | ``BswVariableAccess`` | aggr | missing |
-| — *(missing)* | `—` | `dataSendPoint` | ``BswVariableAccess`` | aggr | missing |
-| `issuedtriggerrefs` | `—` | `issuedTrigger` | ``Trigger`` | ref | type (spec many vs py single) |
-
-## `ExecutableEntity`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 70  | **table:** Table 5.3
-- **Package:** `M2::AUTOSARTemplates::CommonStructure::InternalBehavior`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| `canenterrefs` | `—` | `canEnter` | ``ExclusiveArea`` | ref | type (spec many vs py single) |
-| `runsinsiderefs` | `—` | `runsInside` | ``ExclusiveArea`` | ref | type (spec many vs py single) |
+- Type deviations (list/single multiplicity): **37**
 
 ## `ExclusiveAreaNestingOrder`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 84
+- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 84 | **table:** Table 5.19
 - **Package:** `M2::AUTOSARTemplates::CommonStructure::InternalBehavior`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior.py`
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — *(missing)* | `—` | `exclusiveArea(ordered)` | ``ExclusiveArea`` | ref | missing |
+| `exclusiveAreaRefs` | `List[RefType]` | `exclusiveArea(ordered)` | ``ExclusiveArea`` | ref | naming (Refs suffix) |
 
-## `BswModeSwitchEvent`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 94  | **table:** Table 5.32
+## `AbstractEvent`
+- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 541 | **table:** Table 7.8
+- **Package:** `M2::AUTOSARTemplates::CommonStructure::InternalBehavior`
+- **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| `activationReasonRepresentationRef` | `Optional[RefType]` | `activationReasonRepresentation` | ``ExecutableEntityActivationReason`` | ref | naming (Ref suffix) |
+
+- **Note:** `RTEEvent` now derives from `AbstractEvent` (spec Base includes AbstractEvent); reader/writer coverage for `ACTIVATION-REASON-REPRESENTATION-REF` added for both RTE and BSW event paths (2026-08-20).
+
+## `BswEvent`
+- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 87 | **table:** Table 5.22
 - **Package:** `M2::AUTOSARTemplates::BswModuleTemplate::BswBehavior`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/__init__.py`
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — *(missing)* | `—` | `mode(ordered)` | ``ModeDeclaration`` | iref | missing |
+| `contextLimitationRefs` | `List[RefType]` | `contextLimitation` | ``BswDistinguishedPartition`` | ref | naming (Refs suffix) |
+| `disabledInModeIRefs` | `List[ModeInBswModuleDescriptionInstanceRef]` | `disabledInMode` | ``ModeDeclaration`` | iref | naming (IRefs suffix) |
+| `startsOnEventRef` | `Optional[RefType]` | `startsOnEvent` | ``BswModuleEntity`` | ref | naming (Ref suffix) |
+
+## `BswModeSwitchEvent`
+- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 95  | **table:** Table 5.31
+- **Package:** `M2::AUTOSARTemplates::BswModuleTemplate::BswBehavior`
+- **Source:** `src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/__init__.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| `activation` | `Optional[ModeActivationKind]` | `activation` | ``ModeActivationKind`` | attr | — |
+| `modeIRefs` | `List[ModeInBswModuleDescriptionInstanceRef]` | `mode(ordered)` | ``ModeDeclaration`` | iref | naming (IRefs suffix) |
 
 ## `BswImplementation`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 120
+- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 120 | **table:** Table 6.1
 - **Package:** `M2::AUTOSARTemplates::BswModuleTemplate::BswImplementation`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswImplementation.py`
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| `preconfiguredconfigurationrefs` | `—` | `preconfiguredConfiguration` | ``EcucModule ConfigurationValues`` | ref | type (spec many vs py single) |
-| `vendorspecificmoduledefrefs` | `—` | `vendorSpecificModuleDef` | ``EcucModuleDef`` | ref | type (spec many vs py single) |
+| `arReleaseVersion` | `RevisionLabelString` | `arReleaseVersion` | ``RevisionLabelString`` | attr | — |
+| `behaviorRef` | `RefType` | `behavior` | ``BswInternalBehavior`` | ref | naming (Ref suffix) |
+| `preconfiguredConfigurationRefs` | `List[RefType]` | `preconfiguredConfiguration` | ``EcucModuleConfigurationValues`` | ref | naming (Refs suffix) |
+| `recommendedConfigurationRefs` | `List[RefType]` | `recommendedConfiguration` | ``EcucModuleConfigurationValues`` | ref | naming (Refs suffix) |
+| `vendorApiInfix` | `Identifier` | `vendorApiInfix` | ``Identifier`` | attr | — |
+| `vendorSpecificModuleDefRefs` | `List[RefType]` | `vendorSpecificModuleDef` | ``EcucModuleDef`` | ref | naming (Refs suffix) |
 
 ## `Implementation`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 126
+- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 621  | **table:** Table 8.1
 - **Package:** `M2::AUTOSARTemplates::CommonStructure::Implementation`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Implementation.py`
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — *(missing)* | `—` | `codeDescriptor` | ``Code`` | aggr | missing |
-| — *(missing)* | `—` | `compiler` | ``Compiler`` | aggr | missing |
+| `buildActionManifestRef` | `RefType` | `buildActionManifest` | ``BuildActionManifest`` | ref | naming (Ref suffix) |
+| `codeDescriptors` | `List[Code]` | `codeDescriptor` | ``Code`` | aggr | naming (plural) |
+| `compilers` | `List[Compiler]` | `compiler` | ``Compiler`` | aggr | naming (plural) |
+| `generatedArtifacts` | `List[DependencyOnArtifact]` | `generatedArtifact` | ``DependencyOnArtifact`` | aggr | naming (plural) |
+| `hwElementRefs` | `List[RefType]` | `hwElement` | ``HwElement`` | ref | naming (plural + Ref suffix) |
+| `linkers` | `List[Linker]` | `linker` | ``Linker`` | aggr | naming (plural) |
+| `requiredArtifacts` | `List[DependencyOnArtifact]` | `requiredArtifact` | ``DependencyOnArtifact`` | aggr | naming (plural) |
+| `requiredGeneratorTools` | `List[DependencyOnArtifact]` | `requiredGeneratorTool` | ``DependencyOnArtifact`` | aggr | naming (plural) |
+| `swcBswMappingRef` | `RefType` | `swcBswMapping` | ``SwcBswMapping`` | ref | naming (Ref suffix) |
+| `getCodeDescriptors` | `List[Code]` | `codeDescriptor` | ``Code`` | aggr | getter filters `self.elements` (isinstance Code) instead of returning dedicated `codeDescriptors` field |
+| `create*` methods | — | `-` | ``-`` | - | guard `if short_name not in self.elements` compares str against ARObject list (always truthy) — duplicate element created on repeated same-name call |
 
 ## `AutosarEngineeringObject`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 132  | **table:** Table 7.5
@@ -162,7 +147,7 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 | `swArraysize` | `ValueList` | `swArraysize` | ``ValueList`` | aggr | type (spec one vs py list) |
 
 ## `EcucModuleConfigurationValues`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** —
+- **PDF:** `AUTOSAR_CP_TPS_ECUConfiguration.pdf`  | **page:** 111 | **table:** Table 2.47
 - **Package:** `M2::AUTOSARTemplates::ECUCDescriptionTemplate`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate.py`
 
@@ -175,14 +160,20 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 | `moduleDescriptionRef` | `RefType` | `moduleDescription` | ``BswImplementation`` | ref | type (PDF BswImplementation vs py RefType) |
 | `postBuildVariantUsed` | `ARBoolean` | `postBuildVariantUsed` | ``Boolean`` | attr | type (PDF Boolean vs py ARBoolean) |
 
+- **Note:** reader/writer coverage for `ECUC-DEF-EDITION` and `POST-BUILD-VARIANT-USED` added (2026-08-20); all six XML elements now round-trip.
+
 ## `EcucModuleDef`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** —
+- **PDF:** `AUTOSAR_CP_TPS_ECUConfiguration.pdf`  | **page:** 32 | **table:** Table 2.2
 - **Package:** `M2::AUTOSARTemplates::ECUCParameterDefTemplate`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py`
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — *(missing)* | `—` | `container` | ``EcucContainerDef`` | aggr | missing |
+| `apiServicePrefix` | `CIdentifier` | `apiServicePrefix` | ``CIdentifier`` | attr | — |
+| `containers` | `List[EcucContainerDef]` | `container` | ``EcucContainerDef`` | aggr | naming |
+| `postBuildVariantSupport` | `Boolean` | `postBuildVariantSupport` | ``Boolean`` | attr | — |
+| `refinedModuleDefRef` | `RefType` | `refinedModuleDef` | ``EcucModuleDef`` | ref | naming (Ref suffix) |
+| `supportedConfigVariants` | `List[EcucConfigurationVariantEnum]` | `supportedConfigVariant` | ``EcucConfiguration VariantEnum`` | attr | naming |
 
 ## `System`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** —
@@ -304,13 +295,13 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 | — *(missing)* | `—` | `-` | ``-`` | - | missing |
 
 ## `BswScheduleEvent`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** —
+- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 88 | **table:** Table 5.23
 - **Package:** `M2::AUTOSARTemplates::BswModuleTemplate::BswBehavior`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/__init__.py`
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — *(missing)* | `—` | `-` | ``-`` | - | missing |
+| — | — | *(no attributes — Table 5.23 is empty)* | — | — | — |
 
 ## `BswBackgroundEvent`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** —  | **table:** Table 5.27
@@ -331,14 +322,35 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 | — *(missing)* | `—` | `-` | ``-`` | - | missing |
 
 ## `BswInternalBehavior`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** —
+- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 68  | **table:** Table 5.2
 - **Package:** `M2::AUTOSARTemplates::BswModuleTemplate::BswBehavior`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/__init__.py`
+- **Deferred:** full sync (member policy classes missing; reader/writer partial)
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — *(missing)* | `—` | `arTypedPerInstanceMemory` | ``VariableDataPrototype`` | aggr | missing |
-| — *(missing)* | `—` | `bswPerInstanceMemoryPolicy` | ``BswPerInstance MemoryPolicy`` | aggr | missing |
+| `arTypedPerInstanceMemories` | `List[VariableDataPrototype]` | `arTypedPerInstanceMemory` | ``VariableDataPrototype`` | aggr | naming (plural) |
+| `bswPerInstanceMemoryPolicies` | `List` | `bswPerInstanceMemoryPolicy` | ``BswPerInstanceMemoryPolicy`` | aggr | member class `BswPerInstanceMemoryPolicy` missing |
+| `clientPolicies` | `List` | `clientPolicy` | ``BswClientPolicy`` | aggr | member class `BswClientPolicy` missing |
+| `distinguishedPartitions` | `List[BswDistinguishedPartition]` | `distinguishedPartition` | ``BswDistinguishedPartition`` | aggr | naming (plural) |
+| `entities` | `List` | `entity` | ``BswModuleEntity`` | aggr | naming (plural); untyped |
+| `events` | `List` | `event` | ``BswEvent`` | aggr | naming (plural); untyped |
+| `exclusiveAreaPolicies` | `List` | `exclusiveAreaPolicy` | ``BswExclusiveAreaPolicy`` | aggr | naming (plural); untyped |
+| `includedDataTypeSets` | `List[IncludedDataTypeSet]` | `includedDataTypeSet` | ``IncludedDataTypeSet`` | aggr | naming (plural) |
+| `includedModeDeclarationGroupSets` | `List[IncludedModeDeclarationGroupSet]` | `includedModeDeclarationGroupSet` | ``IncludedModeDeclarationGroupSet`` | aggr | naming (plural) |
+| `internalTriggeringPointPolicies` | `List` | `internalTriggeringPointPolicy` | ``BswInternalTriggeringPointPolicy`` | aggr | member class `BswInternalTriggeringPointPolicy` missing |
+| `modeReceiverPolicies` | `List` | `modeReceiverPolicy` | ``BswModeReceiverPolicy`` | aggr | naming (plural); untyped |
+| `modeSenderPolicies` | `List` | `modeSenderPolicy` | ``BswModeSenderPolicy`` | aggr | naming (plural); untyped |
+| `parameterPolicies` | `List` | `parameterPolicy` | ``BswParameterPolicy`` | aggr | member class `BswParameterPolicy` missing |
+| `perInstanceParameters` | `List` | `perInstanceParameter` | ``ParameterDataPrototype`` | aggr | naming (plural) |
+| `receptionPolicies` | `List` | `receptionPolicy` | ``BswDataReceptionPolicy`` | aggr | naming (plural); untyped |
+| `releasedTriggerPolicies` | `List` | `releasedTriggerPolicy` | ``BswReleasedTriggerPolicy`` | aggr | member class `BswReleasedTriggerPolicy` missing |
+| `schedulerNamePrefixes` | `List` | `schedulerNamePrefix` | ``BswSchedulerNamePrefix`` | aggr | naming (plural) |
+| `sendPolicies` | `List` | `sendPolicy` | ``BswDataSendPolicy`` | aggr | member class `BswDataSendPolicy` missing |
+| `serviceDependencies` | `List` | `serviceDependency` | ``BswServiceDependency`` | aggr | naming (plural) |
+| `triggerDirectImplementations` | `List` | `triggerDirectImplementation` | ``BswTriggerDirectImplementation`` | aggr | naming (plural) |
+| `variationPointProxies` | `List` | `variationPointProxy` | ``VariationPointProxy`` | aggr | naming (plural) |
+| `addModeSenderPolicy`/`getModeSenderPolicies` | — | `modeSenderPolicy` | ``BswModeSenderPolicy`` | aggr | **fixed** — previously operated on `modeReceiverPolicies`; now uses `modeSenderPolicies` |
 
 ## `FlatMap`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** —
@@ -444,15 +456,6 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 
 ## `DiagnosticsCommunicationSecurityNeeds`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** —  | **table:** Table 12.28
-- **Package:** `M2::AUTOSARTemplates::CommonStructure::ServiceNeeds`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `-` | ``-`` | - | missing |
-
-## `DoIpServiceNeeds`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** —
 - **Package:** `M2::AUTOSARTemplates::CommonStructure::ServiceNeeds`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py`
 
@@ -859,26 +862,6 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 | — *(missing)* | `—` | `v` | ``Numerical`` | attr | missing |
 | — *(missing)* | `—` | `vt` | ``VerbatimString`` | attr | missing |
 
-## `HwPin`
-- **PDF:** `AUTOSAR_CP_TPS_ECUResourceTemplate.pdf`  | **page:** 20
-- **Package:** `M2::AUTOSARTemplates::EcuResourceTemplate`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/__init__.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| `functionname` | `—` | `functionName` | ``String`` | attr | type (spec many vs py single) |
-
-## `HwElementConnector`
-- **PDF:** `AUTOSAR_CP_TPS_ECUResourceTemplate.pdf`  | **page:** 23
-- **Package:** `M2::AUTOSARTemplates::EcuResourceTemplate::HwElementConnector`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/HwElementConnector.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| `hwelementref` | `—` | `hwElement` | ``HwElement`` | ref | type (spec many vs py single) |
-| — *(missing)* | `—` | `hwPinConnection` | ``HwPinConnector`` | aggr | missing |
-| — *(missing)* | `—` | `hwPinGroupConnection` | ``HwPinGroupConnector`` | aggr | missing |
-
 ## `HwAttributeLiteralDef`
 - **PDF:** `AUTOSAR_CP_TPS_ECUResourceTemplate.pdf`  | **page:** —
 - **Package:** `M2::AUTOSARTemplates::EcuResourceTemplate::HwAttributeValue`
@@ -897,15 +880,6 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 |---|---|---|---|---|---|
 | — *(missing)* | `—` | `-` | ``-`` | - | missing |
 
-## `HwAttributeDef`
-- **PDF:** `AUTOSAR_CP_TPS_ECUResourceTemplate.pdf`  | **page:** —
-- **Package:** `M2::AUTOSARTemplates::EcuResourceTemplate::HwElementCategory`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/HwElementCategory.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `hwAttributeLiteral` | ``HwAttributeLiteralDef`` | aggr | missing |
-
 ## `HwCategory`
 - **PDF:** `AUTOSAR_CP_TPS_ECUResourceTemplate.pdf`  | **page:** —
 - **Package:** `M2::AUTOSARTemplates::EcuResourceTemplate::HwElementCategory`
@@ -923,53 +897,6 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
 | — *(missing)* | `—` | `element` | ``ApplicationArray Element`` | aggr | missing |
-
-## `ParameterInAtomicSWCTypeInstanceRef`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 319
-- **Package:** `M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::InstanceRefsUsage`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/InstanceRefsUsage.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `contextDataPrototype(ordered)` | ``ApplicationComposite ElementDataPrototype`` | ref | missing |
-
-## `SwAxisGeneric`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 355  | **table:** Table 5.51
-- **Package:** `M2::MSR::DataDictionary::Axis`
-- **Source:** `src/armodel/models/M2/MSR/DataDictionary/Axis.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| `swAxisTypeRef` | `RefType` | `swAxisType` | ``SwAxisType`` | ref | type (PDF SwAxisType vs py RefType) |
-
-## `PhysConstrs`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 406
-- **Package:** `M2::MSR::AsamHdo::Constraints::GlobalConstraints`
-- **Source:** `src/armodel/models/M2/MSR/AsamHdo/Constraints/GlobalConstraints.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `lowerLimit` | ``Limit`` | attr | missing |
-| — *(missing)* | `—` | `maxDiff` | ``Numerical`` | attr | missing |
-| — *(missing)* | `—` | `maxGradient` | ``Numerical`` | attr | missing |
-| — *(missing)* | `—` | `monotony` | ``MonotonyEnum`` | attr | missing |
-| — *(missing)* | `—` | `scaleConstr(ordered)` | ``ScaleConstr`` | aggr | missing |
-| — *(missing)* | `—` | `unit` | ``Unit`` | ref | missing |
-| — *(missing)* | `—` | `upperLimit` | ``Limit`` | attr | missing |
-
-## `InternalConstrs`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 407  | **table:** Table 5.85
-- **Package:** `M2::MSR::AsamHdo::Constraints::GlobalConstraints`
-- **Source:** `src/armodel/models/M2/MSR/AsamHdo/Constraints/GlobalConstraints.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `lowerLimit` | ``Limit`` | attr | missing |
-| — *(missing)* | `—` | `maxDiff` | ``Numerical`` | attr | missing |
-| — *(missing)* | `—` | `maxGradient` | ``Numerical`` | attr | missing |
-| — *(missing)* | `—` | `monotony` | ``MonotonyEnum`` | attr | missing |
-| — *(missing)* | `—` | `scaleConstr(ordered)` | ``ScaleConstr`` | aggr | missing |
-| — *(missing)* | `—` | `upperLimit` | ``Limit`` | attr | missing |
 
 ## `SwRecordLayoutV`
 - **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 421
@@ -1033,15 +960,6 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 | — *(missing)* | `—` | `maxSizeToFill` | ``PositiveInteger`` | attr | missing |
 | — *(missing)* | `—` | `rule` | ``Identifier`` | attr | missing |
 
-## `SwcModeSwitchEvent`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 544
-- **Package:** `M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `mode(ordered)` | ``ModeDeclaration`` | iref | missing |
-
 ## `IncludedDataTypeSet`
 - **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 600
 - **Package:** `M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::IncludedDataTypes`
@@ -1060,66 +978,6 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
 | — *(missing)* | `—` | `sensorActuator` | ``HwDescriptionEntity`` | ref | missing |
-
-## `ObdRatioServiceNeeds`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 795
-- **Package:** `M2::AUTOSARTemplates::CommonStructure::ServiceNeeds`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `connectionType` | ``ObdRatioConnection KindEnum`` | attr | missing |
-| — *(missing)* | `—` | `rateBasedMonitoredEvent` | ``DiagnosticEventNeeds`` | ref | missing |
-| — *(missing)* | `—` | `usedFid` | ``FunctionInhibitionNeeds`` | ref | missing |
-
-## `ObdRatioDenominatorNeeds`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 802  | **table:** Table 13.52
-- **Package:** `M2::AUTOSARTemplates::CommonStructure::ServiceNeeds`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `denominatorCondition` | ``DiagnosticDenominator ConditionEnum`` | attr | missing |
-
-## `DoIpRoutingActivationAuthenticationNeeds`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 806  | **table:** Table 13.59
-- **Package:** `M2::AUTOSARTemplates::CommonStructure::ServiceNeeds`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `dataLengthRequest` | ``PositiveInteger`` | attr | missing |
-| — *(missing)* | `—` | `dataLengthResponse` | ``PositiveInteger`` | attr | missing |
-| — *(missing)* | `—` | `routingActivationType` | ``NameToken`` | attr | missing |
-
-## `DoIpRoutingActivationConfirmationNeeds`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 807  | **table:** Table 13.60
-- **Package:** `M2::AUTOSARTemplates::CommonStructure::ServiceNeeds`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `dataLengthRequest` | ``PositiveInteger`` | attr | missing |
-| — *(missing)* | `—` | `dataLengthResponse` | ``PositiveInteger`` | attr | missing |
-| — *(missing)* | `—` | `routingActivationType` | ``NameToken`` | attr | missing |
-
-## `SecureOnBoardCommunicationNeeds`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 824  | **table:** Table 13.69
-- **Package:** `M2::AUTOSARTemplates::CommonStructure::ServiceNeeds`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `verificationStatusIndicationMode` | ``VerificationStatus IndicationModeEnum`` | attr | missing |
-
-## `IdsMgrNeeds`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 842  | **table:** Table 13.82
-- **Package:** `M2::AUTOSARTemplates::CommonStructure::ServiceNeeds`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `useSmartSensorApi` | ``Boolean`` | attr | missing |
 
 ## `ApplicationCompositeElementInPortInterfaceInstanceRef`
 - **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** 952
@@ -1186,15 +1044,6 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 |---|---|---|---|---|---|
 | `annotationOrigin` | `ARLiteral` | `annotationOrigin` | ``String`` | attr | type (PDF String vs py ARLiteral) |
 
-## `Annotation`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** —
-- **Package:** `M2::MSR::Documentation::Annotation`
-- **Source:** `src/armodel/models/M2/MSR/Documentation/Annotation.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `-` | ``-`` | - | missing |
-
 ## `CompuContent`
 - **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** —  | **table:** Table 5.63
 - **Package:** `M2::MSR::AsamHdo::ComputationMethod`
@@ -1258,16 +1107,6 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 |---|---|---|---|---|---|
 | `swArraysize` | `ValueList` | `swArraysize` | ``ValueList`` | aggr | type (spec one vs py list) |
 | `unitRef` | `RefType` | `unit` | ``Unit`` | ref | type (PDF Unit vs py RefType) |
-
-## `SwGenericAxisParam`
-- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** —  | **table:** Table 5.54
-- **Package:** `M2::MSR::DataDictionary::Axis`
-- **Source:** `src/armodel/models/M2/MSR/DataDictionary/Axis.py`
-
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| `swGenericAxisParamTypeRef` | `RefType` | `swGenericAxisParamType` | ``SwGenericAxisParam Type`` | ref | type (PDF SwGenericAxisParam Type vs py RefType) |
-| — *(missing)* | `—` | `vf(ordered)` | ``Numerical`` | attr | missing |
 
 ## `SwAxisIndividual`
 - **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** —
@@ -3056,13 +2895,15 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 | — *(missing)* | `—` | `timestamp` | ``DateTime`` | attr | missing |
 
 ## `CollectableElement`
-- **PDF:** `AUTOSAR_FO_TPS_GenericStructureTemplate.pdf`  | **page:** —
+- **PDF:** — *(no spec counterpart)*
 - **Package:** `M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::Identifiable`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py`
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — *(missing)* | `—` | `-` | ``-`` | - | missing |
+| — | — | — | — | — | internal helper class (no AUTOSAR meta-class) |
+
+- **Note:** `CollectableElement` is a py-armodel internal abstract base that provides collection/lookup management (`elements`, `element_mappings`, `getElement`/`addElement`/`removeElement`/`getTotalElement`/`IsElementExists`) for classes such as `Identifiable` and `ARElement`. It does not correspond to any AUTOSAR meta-class and is deliberately kept as-is (per 2026-08-20 decision; NO `# Spec verified` stamp).
 
 ## `FileInfoComment`
 - **PDF:** `AUTOSAR_FO_TPS_GenericStructureTemplate.pdf`  | **page:** —

--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/__init__.py
@@ -858,13 +858,14 @@ class BswEvent(AbstractEvent, ABC):
 
     # BswEvent method parity checklist:
     # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 5.22, p.87
-    # [x] __init__                     [x] impl  [x] docstring  [x] test
-    # [x] getContextLimitationRefs     [x] impl  [x] docstring  [x] test
-    # [x] addContextLimitationRef      [x] impl  [x] docstring  [x] test
-    # [x] getDisabledInModeIRefs       [x] impl  [x] docstring  [x] test
-    # [x] addDisabledInModeIRef        [x] impl  [x] docstring  [x] test
-    # [x] getStartsOnEventRef          [x] impl  [x] docstring  [x] test
-    # [x] setStartsOnEventRef          [x] impl  [x] docstring  [x] test
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getContextLimitationRefs     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addContextLimitationRef      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDisabledInModeIRefs       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addDisabledInModeIRef        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getStartsOnEventRef          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setStartsOnEventRef          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         """
@@ -946,7 +947,7 @@ class BswEvent(AbstractEvent, ABC):
         """
         return self.startsOnEventRef
 
-    def setStartsOnEventRef(self, value: RefType) -> "BswEvent":
+    def setStartsOnEventRef(self, value: Optional[RefType]) -> "BswEvent":
         """
         Sets the entity which is started by the event.
         Only sets if value is not None.
@@ -1013,12 +1014,14 @@ class BswOperationInvokedEvent(BswEvent):
 
 class BswScheduleEvent(BswEvent, ABC):
     """
-    Abstract base class for BSW scheduled events.
-    These events are scheduled for execution at specific times or conditions.
+    BswEvent that is able to start a BswSchedulabeEntity.
     """
 
     # BswScheduleEvent method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 5.23, p.88
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         """
@@ -1100,12 +1103,13 @@ class BswModeSwitchEvent(BswScheduleEvent):
     """
 
     # BswModeSwitchEvent method parity checklist:
-    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 5.31, p.94
-    # [x] __init__                     [x] impl  [x] docstring  [x] test
-    # [x] getActivation                [x] impl  [x] docstring  [x] test
-    # [x] setActivation                [x] impl  [x] docstring  [x] test
-    # [x] getModeIRefs                 [x] impl  [x] docstring  [x] test
-    # [x] addModeIRef                  [x] impl  [x] docstring  [x] test
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 5.31, p.95
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getActivation                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setActivation                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getModeIRefs                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addModeIRef                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         """
@@ -2354,44 +2358,46 @@ class BswInternalBehavior(InternalBehavior):
     """
 
     # BswInternalBehavior method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 5.2, p.68
+    # Deferred: full sync (6 member policy classes missing; reader/writer partial)
     # [x] __init__                     [x] impl  [x] docstring  [x] test
-    # [ ] getArTypedPerInstanceMemories [x] impl  [x] docstring  [ ] test
-    # [ ] setArTypedPerInstanceMemories [x] impl  [x] docstring  [ ] test
-    # [ ] getBswPerInstanceMemoryPolicies [x] impl  [x] docstring  [ ] test
-    # [ ] setBswPerInstanceMemoryPolicies [x] impl  [x] docstring  [ ] test
-    # [ ] getClientPolicies            [x] impl  [x] docstring  [ ] test
-    # [ ] setClientPolicies            [x] impl  [x] docstring  [ ] test
-    # [ ] getDistinguishedPartitions   [x] impl  [x] docstring  [ ] test
-    # [ ] setDistinguishedPartitions   [x] impl  [x] docstring  [ ] test
-    # [ ] getExclusiveAreaPolicies     [x] impl  [x] docstring  [ ] test
-    # [ ] setExclusiveAreaPolicies     [x] impl  [x] docstring  [ ] test
-    # [ ] getInternalTriggeringPoints  [x] impl  [x] docstring  [ ] test
+    # [x] getArTypedPerInstanceMemories [x] impl  [x] docstring  [x] test
+    # [x] setArTypedPerInstanceMemories [x] impl  [x] docstring  [x] test
+    # [x] getBswPerInstanceMemoryPolicies [x] impl  [x] docstring  [x] test
+    # [x] setBswPerInstanceMemoryPolicies [x] impl  [x] docstring  [x] test
+    # [x] getClientPolicies            [x] impl  [x] docstring  [x] test
+    # [x] setClientPolicies            [x] impl  [x] docstring  [x] test
+    # [x] getDistinguishedPartitions   [x] impl  [x] docstring  [x] test
+    # [x] setDistinguishedPartitions   [x] impl  [x] docstring  [x] test
+    # [x] getExclusiveAreaPolicies     [x] impl  [x] docstring  [x] test
+    # [x] setExclusiveAreaPolicies     [x] impl  [x] docstring  [x] test
+    # [x] getInternalTriggeringPoints  [x] impl  [x] docstring  [x] test
     # [x] createBswInternalTriggeringPoint [x] impl  [x] docstring  [x] test
-    # [ ] getInternalTriggeringPointPolicies [x] impl  [x] docstring  [ ] test
-    # [ ] setInternalTriggeringPointPolicies [x] impl  [x] docstring  [ ] test
+    # [x] getInternalTriggeringPointPolicies [x] impl  [x] docstring  [x] test
+    # [x] setInternalTriggeringPointPolicies [x] impl  [x] docstring  [x] test
     # [x] getModeReceiverPolicies      [x] impl  [x] docstring  [x] test
-    # [ ] setModeSenderPolicies        [x] impl  [x] docstring  [ ] test
-    # [ ] getParameterPolicies         [x] impl  [x] docstring  [ ] test
-    # [ ] setParameterPolicies         [x] impl  [x] docstring  [ ] test
-    # [ ] getPerInstanceParameters     [x] impl  [x] docstring  [ ] test
-    # [ ] setPerInstanceParameters     [x] impl  [x] docstring  [ ] test
-    # [ ] getReceptionPolicies         [x] impl  [x] docstring  [ ] test
+    # [x] setModeSenderPolicies        [x] impl  [x] docstring  [x] test
+    # [x] getParameterPolicies         [x] impl  [x] docstring  [x] test
+    # [x] setParameterPolicies         [x] impl  [x] docstring  [x] test
+    # [x] getPerInstanceParameters     [x] impl  [x] docstring  [x] test
+    # [x] setPerInstanceParameters     [x] impl  [x] docstring  [x] test
+    # [x] getReceptionPolicies         [x] impl  [x] docstring  [x] test
     # [x] addReceptionPolicy           [x] impl  [x] docstring  [x] test
-    # [ ] getReleasedTriggerPolicies   [x] impl  [x] docstring  [ ] test
-    # [ ] setReleasedTriggerPolicies   [x] impl  [x] docstring  [ ] test
-    # [ ] getSchedulerNamePrefixes     [x] impl  [x] docstring  [ ] test
-    # [ ] setSchedulerNamePrefixes     [x] impl  [x] docstring  [ ] test
-    # [ ] getSendPolicies              [x] impl  [x] docstring  [ ] test
-    # [ ] setSendPolicies              [x] impl  [x] docstring  [ ] test
-    # [ ] getServiceDependencies       [x] impl  [x] docstring  [ ] test
-    # [ ] setServiceDependencies       [x] impl  [x] docstring  [ ] test
-    # [ ] addServiceDependency         [x] impl  [x] docstring  [ ] test
-    # [ ] getTriggerDirectImplementations [x] impl  [x] docstring  [ ] test
-    # [ ] setTriggerDirectImplementations [x] impl  [x] docstring  [ ] test
-    # [ ] getVariationPointProxies     [x] impl  [x] docstring  [ ] test
-    # [ ] setVariationPointProxies     [x] impl  [x] docstring  [ ] test
+    # [x] getReleasedTriggerPolicies   [x] impl  [x] docstring  [x] test
+    # [x] setReleasedTriggerPolicies   [x] impl  [x] docstring  [x] test
+    # [x] getSchedulerNamePrefixes     [x] impl  [x] docstring  [x] test
+    # [x] setSchedulerNamePrefixes     [x] impl  [x] docstring  [x] test
+    # [x] getSendPolicies              [x] impl  [x] docstring  [x] test
+    # [x] setSendPolicies              [x] impl  [x] docstring  [x] test
+    # [x] getServiceDependencies       [x] impl  [x] docstring  [x] test
+    # [x] setServiceDependencies       [x] impl  [x] docstring  [x] test
+    # [x] addServiceDependency         [x] impl  [x] docstring  [x] test
+    # [x] getTriggerDirectImplementations [x] impl  [x] docstring  [x] test
+    # [x] setTriggerDirectImplementations [x] impl  [x] docstring  [x] test
+    # [x] getVariationPointProxies     [x] impl  [x] docstring  [x] test
+    # [x] setVariationPointProxies     [x] impl  [x] docstring  [x] test
     # [x] addModeSenderPolicy          [x] impl  [x] docstring  [x] test
-    # [ ] getModeSenderPolicies        [x] impl  [x] docstring  [ ] test
+    # [x] getModeSenderPolicies        [x] impl  [x] docstring  [x] test
     # [x] createBswCalledEntity        [x] impl  [x] docstring  [x] test
     # [x] getBswCalledEntities         [x] impl  [x] docstring  [x] test
     # [x] createBswSchedulableEntity   [x] impl  [x] docstring  [x] test
@@ -2905,24 +2911,20 @@ class BswInternalBehavior(InternalBehavior):
     def addModeSenderPolicy(self, policy: BswModeSenderPolicy):
         """
         Adds a BSW mode sender policy to the list.
-        Note: This method adds to modeReceiverPolicies instead of modeSenderPolicies,
-        which might be an error in the original implementation.
 
         Args:
             policy: The BswModeSenderPolicy instance to add
         """
-        self.modeReceiverPolicies.append(policy)
+        self.modeSenderPolicies.append(policy)
 
     def getModeSenderPolicies(self) -> List[BswModeSenderPolicy]:
         """
         Gets the list of BSW mode sender policies.
-        Note: This method returns modeReceiverPolicies instead of modeSenderPolicies,
-        which might be an error in the original implementation.
 
         Returns:
             List of BswModeSenderPolicy instances
         """
-        return self.modeReceiverPolicies
+        return self.modeSenderPolicies
 
     def createBswCalledEntity(self, short_name: str) -> BswCalledEntity:
         """

--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswImplementation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswImplementation.py
@@ -11,215 +11,103 @@ from typing import List, Optional
 
 
 class BswImplementation(Implementation):
-    """
-    Represents a Basic Software (BSW) implementation in AUTOSAR.
-    This class defines the implementation details of a BSW module, including version information,
-    behavior references, configuration options, and vendor-specific definitions.
-    """
+    """Contains the implementation specific information in addition to the generic specification (BswModule Description and BswBehavior). It is possible to have several different BswImplementations referring to the same BswBehavior."""
 
     # BswImplementation method parity checklist:
     # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 6.1, p.120
-    # [x] __init__                     [x] impl  [x] docstring  [x] test
-    # [x] getArReleaseVersion          [x] impl  [x] docstring  [x] test
-    # [x] setArReleaseVersion          [x] impl  [x] docstring  [x] test
-    # [x] getBehaviorRef               [x] impl  [x] docstring  [x] test
-    # [x] setBehaviorRef               [x] impl  [x] docstring  [x] test
-    # [x] getPreconfiguredConfigurationRefs [x] impl  [x] docstring  [x] test
-    # [x] addPreconfiguredConfigurationRef [x] impl  [x] docstring  [x] test
-    # [x] getRecommendedConfigurationRefs [x] impl  [x] docstring  [x] test
-    # [x] addRecommendedConfigurationRef [x] impl  [x] docstring  [x] test
-    # [x] getVendorApiInfix            [x] impl  [x] docstring  [x] test
-    # [x] setVendorApiInfix            [x] impl  [x] docstring  [x] test
-    # [x] getVendorSpecificModuleDefRefs [x] impl  [x] docstring  [x] test
-    # [x] addVendorSpecificModuleDefRef [x] impl  [x] docstring  [x] test
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getArReleaseVersion             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setArReleaseVersion             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getBehaviorRef                  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBehaviorRef                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPreconfiguredConfigurationRefs [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addPreconfiguredConfigurationRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRecommendedConfigurationRefs [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addRecommendedConfigurationRef  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getVendorApiInfix               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setVendorApiInfix               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getVendorSpecificModuleDefRefs  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addVendorSpecificModuleDefRef   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str) -> None:
-        """
-        Initializes the BSW implementation with a parent and short name.
-
-        Args:
-            parent: The parent ARObject that contains this implementation
-            short_name: The unique short name of this implementation
-        """
         super().__init__(parent, short_name)
 
-        # Version of the AUTOSAR Release on which this implementation is based.
-        # The numbering contains three levels (major, minor, revision) defined by AUTOSAR.
-        # [constr_10302] The attribute shall exist when the configuration of the BSW module is finished.
+        # Version of the AUTOSAR Release on which this implementation is based. The numbering contains three levels (major, minor, revision) which are defined by AUTOSAR.
         self.arReleaseVersion: Optional[RevisionLabelString] = None
 
-        # The behavior of this implementation, made an association because it follows the SWCT pattern
-        # and since ARElement cannot be split, the BswImplementation is not aggregated in BswBehavior.
-        # [constr_10303] The reference shall exist when the configuration of the BSW module is finished.
+        # The behavior of this implementation. This relation is made as an association because • it follows the pattern of the SWCT • since ARElement cannot be splitted, but we want supply the implementation later, the Bsw Implementation is not aggregated in BswBehavior
         self.behaviorRef: Optional[RefType] = None
 
-        # Reference to the set of preconfigured (i.e. fixed) configuration values for this BswImplementation.
-        # For a cluster of modules more than one EcucModuleConfigurationValues can be referred (at most one per
-        # module), otherwise at most one. [constr_4048] [constr_4045]
+        # Reference to the set of preconfigured (i.e. fixed) configuration values for this BswImplementation. If the BswImplementation represents a cluster of several modules, more than one EcucModuleConfigurationValues element can be referred (at most one per module), otherwise at most one such element can be referred.
         self.preconfiguredConfigurationRefs: List[RefType] = []
 
         # Reference to one or more sets of recommended configuration values for this module or module cluster.
-        # [constr_4046]
         self.recommendedConfigurationRefs: List[RefType] = []
 
-        # Vendor-specific API infix used to extend API names for modules instantiated several times on a single ECU:
-        # <Module Name>_<vendorId>_<vendorApiInfix>_<API name from SWS>. Mandatory for modules with upper
-        # multiplicity > 1 and shall not be used for modules with upper multiplicity = 1. [constr_4099] SWS_BSW_00102.
+        # In driver modules which can be instantiated several times on a single ECU, SRS_BSW_00347 requires that the names of files, APIs, published parameters and memory allocation keywords are extended by the vendorId and a vendor specific name. This parameter is used to specify the vendor specific name. In total, the implementation specific API name is generated as follows: <Module Name>_<vendorId>_ <vendorApiInfix>_<API name from SWS>. E.g. assuming that the vendorId of the implementer is 123 and the implementer chose a vendorApiInfix of "v11r456" an API name Can_Write defined in the SWS will translate to Can_123_v11r456_Write. This attribute is mandatory for all modules with upper multiplicity > 1. It shall not be used for modules with upper multiplicity =1. See also SWS_BSW_00102.
         self.vendorApiInfix: Optional[Identifier] = None
 
-        # Reference to the vendor specific EcucModuleDef used in this BswImplementation: one if it represents a
-        # single module, several if it represents a cluster, and one or none if it represents a library. [constr_4047]
+        # Reference to • the vendor specific EcucModuleDef used in this Bsw Implementation if it represents a single module • several EcucModuleDefs used in this Bsw Implementation if it represents a cluster of modules • one or no EcucModuleDefs used in this Bsw Implementation if it represents a library
         self.vendorSpecificModuleDefRefs: List[RefType] = []
 
     def getArReleaseVersion(self) -> Optional[RevisionLabelString]:
-        """
-        Gets the AUTOSAR Release version on which this implementation is based.
-        The numbering contains three levels (major, minor, revision). [constr_10302]
-
-        Returns:
-            RevisionLabelString representing the AUTOSAR release version
-        """
+        """Version of the AUTOSAR Release on which this implementation is based. The numbering contains three levels (major, minor, revision) which are defined by AUTOSAR."""
         return self.arReleaseVersion
 
     def setArReleaseVersion(self, value: Optional[RevisionLabelString]) -> "BswImplementation":
-        """
-        Sets the AUTOSAR Release version on which this implementation is based.
-        A None value is a no-op and does not overwrite an existing version. [constr_10302]
-
-        Args:
-            value: The AUTOSAR release version to set
-
-        Returns:
-            self for method chaining
-        """
+        """Version of the AUTOSAR Release on which this implementation is based. The numbering contains three levels (major, minor, revision) which are defined by AUTOSAR. A None value is a no-op and does not overwrite an existing version."""
         if value is not None:
             self.arReleaseVersion = value
         return self
 
     def getBehaviorRef(self) -> Optional[RefType]:
-        """
-        Gets the reference to the behavior of this implementation.
-        The relation is an association following the SWCT pattern; the BswImplementation is not
-        aggregated in BswBehavior. [constr_10303]
-
-        Returns:
-            RefType to the behavior element
-        """
+        """The behavior of this implementation. This relation is made as an association because • it follows the pattern of the SWCT • since ARElement cannot be splitted, but we want supply the implementation later, the Bsw Implementation is not aggregated in BswBehavior"""
         return self.behaviorRef
 
     def setBehaviorRef(self, value: Optional[RefType]) -> "BswImplementation":
-        """
-        Sets the reference to the behavior of this implementation.
-        A None value is a no-op and does not overwrite an existing reference. [constr_10303]
-
-        Args:
-            value: The behavior reference to set
-
-        Returns:
-            self for method chaining
-        """
+        """The behavior of this implementation. This relation is made as an association because • it follows the pattern of the SWCT • since ARElement cannot be splitted, but we want supply the implementation later, the Bsw Implementation is not aggregated in BswBehavior A None value is a no-op and does not overwrite an existing reference."""
         if value is not None:
             self.behaviorRef = value
         return self
 
     def getPreconfiguredConfigurationRefs(self) -> List[RefType]:
-        """
-        Gets the list of references to the set of preconfigured (i.e. fixed) configuration values.
-        For a cluster of modules more than one EcucModuleConfigurationValues can be referred (at most one
-        per module), otherwise at most one. [constr_4048] [constr_4045]
-
-        Returns:
-            List of RefType to preconfigured configurations
-        """
+        """Reference to the set of preconfigured (i.e. fixed) configuration values for this BswImplementation. If the BswImplementation represents a cluster of several modules, more than one EcucModuleConfigurationValues element can be referred (at most one per module), otherwise at most one such element can be referred."""
         return self.preconfiguredConfigurationRefs
 
     def addPreconfiguredConfigurationRef(self, value: RefType) -> "BswImplementation":
-        """
-        Adds a reference to a set of preconfigured (i.e. fixed) configuration values.
-        A None value is a no-op and is not appended. [constr_4048] [constr_4045]
-
-        Args:
-            value: The configuration reference to add
-
-        Returns:
-            self for method chaining
-        """
+        """Reference to the set of preconfigured (i.e. fixed) configuration values for this BswImplementation. If the BswImplementation represents a cluster of several modules, more than one EcucModuleConfigurationValues element can be referred (at most one per module), otherwise at most one such element can be referred. A None value is a no-op and is not appended."""
         if value is not None:
             self.preconfiguredConfigurationRefs.append(value)
         return self
 
     def getRecommendedConfigurationRefs(self) -> List[RefType]:
-        """
-        Gets the list of references to one or more sets of recommended configuration values
-        for this module or module cluster. [constr_4046]
-
-        Returns:
-            List of RefType to recommended configurations
-        """
+        """Reference to one or more sets of recommended configuration values for this module or module cluster."""
         return self.recommendedConfigurationRefs
 
     def addRecommendedConfigurationRef(self, value: RefType) -> "BswImplementation":
-        """
-        Adds a reference to a set of recommended configuration values for this module or module cluster.
-        A None value is a no-op and is not appended. [constr_4046]
-
-        Args:
-            value: The configuration reference to add
-
-        Returns:
-            self for method chaining
-        """
+        """Reference to one or more sets of recommended configuration values for this module or module cluster. A None value is a no-op and is not appended."""
         if value is not None:
             self.recommendedConfigurationRefs.append(value)
         return self
 
     def getVendorApiInfix(self) -> Optional[Identifier]:
-        """
-        Gets the vendor-specific API infix used in naming conventions for this implementation.
-        The implementation specific API name is generated as <Module Name>_<vendorId>_<vendorApiInfix>_<API name
-        from SWS>. Mandatory for modules with upper multiplicity > 1. [constr_4099]
-
-        Returns:
-            Identifier for the vendor API infix
-        """
+        """In driver modules which can be instantiated several times on a single ECU, SRS_BSW_00347 requires that the names of files, APIs, published parameters and memory allocation keywords are extended by the vendorId and a vendor specific name. This parameter is used to specify the vendor specific name. In total, the implementation specific API name is generated as follows: <Module Name>_<vendorId>_ <vendorApiInfix>_<API name from SWS>. E.g. assuming that the vendorId of the implementer is 123 and the implementer chose a vendorApiInfix of "v11r456" an API name Can_Write defined in the SWS will translate to Can_123_v11r456_Write. This attribute is mandatory for all modules with upper multiplicity > 1. It shall not be used for modules with upper multiplicity =1. See also SWS_BSW_00102."""
         return self.vendorApiInfix
 
     def setVendorApiInfix(self, value: Optional[Identifier]) -> "BswImplementation":
-        """
-        Sets the vendor-specific API infix used in naming conventions for this implementation.
-        A None value is a no-op and does not overwrite an existing infix. [constr_4099]
-
-        Args:
-            value: The vendor API infix to set
-
-        Returns:
-            self for method chaining
-        """
+        """In driver modules which can be instantiated several times on a single ECU, SRS_BSW_00347 requires that the names of files, APIs, published parameters and memory allocation keywords are extended by the vendorId and a vendor specific name. This parameter is used to specify the vendor specific name. In total, the implementation specific API name is generated as follows: <Module Name>_<vendorId>_ <vendorApiInfix>_<API name from SWS>. E.g. assuming that the vendorId of the implementer is 123 and the implementer chose a vendorApiInfix of "v11r456" an API name Can_Write defined in the SWS will translate to Can_123_v11r456_Write. This attribute is mandatory for all modules with upper multiplicity > 1. It shall not be used for modules with upper multiplicity =1. See also SWS_BSW_00102. A None value is a no-op and does not overwrite an existing infix."""
         if value is not None:
             self.vendorApiInfix = value
         return self
 
     def getVendorSpecificModuleDefRefs(self) -> List[RefType]:
-        """
-        Gets the list of references to the vendor-specific EcucModuleDef(s) used in this BswImplementation:
-        one if it represents a single module, several if a cluster, one or none if a library. [constr_4047]
-
-        Returns:
-            List of RefType to vendor-specific module definitions
-        """
+        """Reference to • the vendor specific EcucModuleDef used in this Bsw Implementation if it represents a single module • several EcucModuleDefs used in this Bsw Implementation if it represents a cluster of modules • one or no EcucModuleDefs used in this Bsw Implementation if it represents a library"""
         return self.vendorSpecificModuleDefRefs
 
     def addVendorSpecificModuleDefRef(self, value: RefType) -> "BswImplementation":
-        """
-        Adds a reference to a vendor-specific EcucModuleDef used in this BswImplementation.
-        A None value is a no-op and is not appended. [constr_4047]
-
-        Args:
-            value: The vendor-specific module definition reference to add
-
-        Returns:
-            self for method chaining
-        """
+        """Reference to • the vendor specific EcucModuleDef used in this Bsw Implementation if it represents a single module • several EcucModuleDefs used in this Bsw Implementation if it represents a cluster of modules • one or no EcucModuleDefs used in this Bsw Implementation if it represents a library A None value is a no-op and is not appended."""
         if value is not None:
             self.vendorSpecificModuleDefRefs.append(value)
         return self

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Implementation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Implementation.py
@@ -589,38 +589,39 @@ class Implementation(ARElement, ABC):
     """
 
     # Implementation method parity checklist:
-    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 8.1, p.619
-    # [x] __init__                     [x] impl  [x] docstring  [x] test
-    # [x] getBuildActionManifestRef    [x] impl  [x] docstring  [x] test
-    # [x] setBuildActionManifestRef    [x] impl  [x] docstring  [x] test
-    # [x] getCodeDescriptors           [x] impl  [x] docstring  [x] test
-    # [x] createCodeDescriptor         [x] impl  [x] docstring  [x] test
-    # [x] getCompilers                 [x] impl  [x] docstring  [x] test
-    # [x] createCompiler               [x] impl  [x] docstring  [x] test
-    # [x] getGeneratedArtifacts        [x] impl  [x] docstring  [x] test
-    # [x] createGeneratedArtifact      [x] impl  [x] docstring  [x] test
-    # [x] getHwElementRefs             [x] impl  [x] docstring  [x] test
-    # [x] addHwElementRef              [x] impl  [x] docstring  [x] test
-    # [x] getLinkers                   [x] impl  [x] docstring  [x] test
-    # [x] createLinker                 [x] impl  [x] docstring  [x] test
-    # [x] getMcSupport                 [x] impl  [x] docstring  [x] test
-    # [x] setMcSupport                 [x] impl  [x] docstring  [x] test
-    # [x] getProgrammingLanguage       [x] impl  [x] docstring  [x] test
-    # [x] setProgrammingLanguage       [x] impl  [x] docstring  [x] test
-    # [x] getRequiredArtifacts         [x] impl  [x] docstring  [x] test
-    # [x] createRequiredArtifact       [x] impl  [x] docstring  [x] test
-    # [x] getRequiredGeneratorTools    [x] impl  [x] docstring  [x] test
-    # [x] createRequiredGeneratorTool  [x] impl  [x] docstring  [x] test
-    # [x] getResourceConsumption       [x] impl  [x] docstring  [x] test
-    # [x] createResourceConsumption    [x] impl  [x] docstring  [x] test
-    # [x] getSwcBswMappingRef          [x] impl  [x] docstring  [x] test
-    # [x] setSwcBswMappingRef          [x] impl  [x] docstring  [x] test
-    # [x] getSwVersion                 [x] impl  [x] docstring  [x] test
-    # [x] setSwVersion                 [x] impl  [x] docstring  [x] test
-    # [x] getUsedCodeGenerator         [x] impl  [x] docstring  [x] test
-    # [x] setUsedCodeGenerator         [x] impl  [x] docstring  [x] test
-    # [x] getVendorId                  [x] impl  [x] docstring  [x] test
-    # [x] setVendorId                  [x] impl  [x] docstring  [x] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 8.1, p.621
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                         [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getBuildActionManifestRef        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setBuildActionManifestRef        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCodeDescriptors               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createCodeDescriptor             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCompilers                     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createCompiler                   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getGeneratedArtifacts            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createGeneratedArtifact          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getHwElementRefs                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addHwElementRef                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getLinkers                       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createLinker                     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMcSupport                     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMcSupport                     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getProgrammingLanguage           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setProgrammingLanguage           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRequiredArtifacts             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createRequiredArtifact           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRequiredGeneratorTools        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createRequiredGeneratorTool      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getResourceConsumption           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createResourceConsumption        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwcBswMappingRef              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwcBswMappingRef              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSwVersion                     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSwVersion                     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getUsedCodeGenerator             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setUsedCodeGenerator             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getVendorId                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setVendorId                      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str) -> None:
         """

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior.py
@@ -329,15 +329,19 @@ class InternalBehavior(AtpStructureElement, ABC):
     """
 
     # InternalBehavior method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
-    # [x] createConstantMemory         [x] impl  [x] docstring  [x] test
-    # [x] getConstantMemories          [x] impl  [x] docstring  [x] test
-    # [x] addDataTypeMappingRef        [x] impl  [x] docstring  [x] test
-    # [x] getDataTypeMappingRefs       [x] impl  [x] docstring  [x] test
-    # [x] createExclusiveArea          [x] impl  [x] docstring  [x] test
-    # [x] getExclusiveAreas            [x] impl  [x] docstring  [x] test
-    # [x] getStaticMemories            [x] impl  [x] docstring  [x] test
-    # [x] createStaticMemory           [x] impl  [x] docstring  [x] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 7.1, p.518
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] createConstantMemory         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getConstantMemories          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addDataTypeMappingRef        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDataTypeMappingRefs       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createExclusiveArea          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getExclusiveAreas            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createExclusiveAreaNestingOrder [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getExclusiveAreaNestingOrders [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] getStaticMemories            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createStaticMemory           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         """
@@ -433,6 +437,32 @@ class InternalBehavior(AtpStructureElement, ABC):
         """
         return list(filter(lambda c: isinstance(c, ExclusiveArea), self.elements))
 
+    def createExclusiveAreaNestingOrder(self, short_name: str) -> "ExclusiveAreaNestingOrder":
+        """
+        Creates and adds an ExclusiveAreaNestingOrder to this internal behavior's
+        exclusive area nesting orders.
+
+        Args:
+            short_name: The short name for the new exclusive area nesting order
+
+        Returns:
+            The created ExclusiveAreaNestingOrder instance
+        """
+        if short_name not in self.elements:
+            nesting_order = ExclusiveAreaNestingOrder(self, short_name)
+            self.addElement(nesting_order)
+            self.exclusiveAreaNestingOrders.append(nesting_order)
+        return self.getElement(short_name)
+
+    def getExclusiveAreaNestingOrders(self) -> List["ExclusiveAreaNestingOrder"]:
+        """
+        Gets the list of exclusive area nesting orders defined in this internal behavior.
+
+        Returns:
+            List of ExclusiveAreaNestingOrder instances
+        """
+        return list(filter(lambda c: isinstance(c, ExclusiveAreaNestingOrder), self.elements))
+
     def getStaticMemories(self):
         """
         Gets the list of static memories (variable data prototypes) in this internal behavior.
@@ -461,51 +491,34 @@ class InternalBehavior(AtpStructureElement, ABC):
 
 class AbstractEvent(Identifiable, ABC):
     """
-    Represents an abstract event in AUTOSAR models.
-    Abstract events define the base structure for events that can trigger executable entities.
-    They may have activation reason representations that define why the event occurred.
+    This meta-class represents the abstract ability to model an event that can be taken to implement application software or basic software in AUTOSAR.
     """
 
     # AbstractEvent method parity checklist:
-    # [ ] __init__                     [x] impl  [x] docstring  [ ] test
-    # [x] getActivationReasonRepresentationRef [x] impl  [x] docstring  [x] test
-    # [x] setActivationReasonRepresentationRef [x] impl  [x] docstring  [x] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 7.8, p.541
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getActivationReasonRepresentationRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setActivationReasonRepresentationRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
-        """
-        Initializes the AbstractEvent with a parent and short name.
-        Raises TypeError if this abstract class is instantiated directly.
-
-        Args:
-            parent: The parent ARObject that contains this abstract event
-            short_name: The unique short name of this abstract event
-        """
         if type(self) is AbstractEvent:
             raise TypeError("AbstractEvent is an abstract class.")
         super().__init__(parent, short_name)
 
-        # Reference to activation reason representation for this event
-        self.activationReasonRepresentationRef: RefType = None
+        # If the activationReasonRepresentation is referenced from the enclosing AbstractEvent this shall be taken as an indication that the latter contributes to the activating vector of this ExecutableEntity that owns the referenced ExecutableEntityActivationReason.
+        self.activationReasonRepresentationRef: Optional[RefType] = None
 
-    def getActivationReasonRepresentationRef(self):
+    def getActivationReasonRepresentationRef(self) -> Optional[RefType]:
         """
-        Gets the reference to activation reason representation for this event.
-
-        Returns:
-            RefType: The activation reason representation reference
+        If the activationReasonRepresentation is referenced from the enclosing AbstractEvent this shall be taken as an indication that the latter contributes to the activating vector of this ExecutableEntity that owns the referenced ExecutableEntityActivationReason.
         """
         return self.activationReasonRepresentationRef
 
-    def setActivationReasonRepresentationRef(self, value):
+    def setActivationReasonRepresentationRef(self, value: Optional[RefType]):
         """
-        Sets the reference to activation reason representation for this event.
-        Only sets the value if it is not None.
-
-        Args:
-            value: The activation reason representation reference to set
-
-        Returns:
-            self for method chaining
+        If the activationReasonRepresentation is referenced from the enclosing AbstractEvent this shall be taken as an indication that the latter contributes to the activating vector of this ExecutableEntity that owns the referenced ExecutableEntityActivationReason.
         """
         self.activationReasonRepresentationRef = value
         return self
@@ -549,9 +562,10 @@ class ExclusiveAreaNestingOrder(Referrable):
 
     # ExclusiveAreaNestingOrder method parity checklist:
     # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 5.19, p.84
-    # [x] __init__                [x] impl  [x] docstring  [x] test
-    # [x] getExclusiveAreaRefs    [x] impl  [x] docstring  [x] test
-    # [x] addExclusiveAreaRef     [x] impl  [x] docstring  [x] test
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getExclusiveAreaRefs    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addExclusiveAreaRef     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         """

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ModeDeclaration.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ModeDeclaration.py
@@ -20,7 +20,9 @@ class ModeActivationKind(AREnum):
 
     # ModeActivationKind method parity checklist:
     # Spec: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf, Table 5.34, p.96
-    # [x] __init__                     [x] impl  [x] docstring  [x] test
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods) — enum value form serialized on BswModeSwitchEvent.activation, SwcModeSwitchEvent.activation
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     # On entering the referred mode. Tags: atp.EnumerationLiteralIndex=0
     ON_ENTRY = "onEntry"

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate.py
@@ -361,29 +361,31 @@ class EcucModuleConfigurationValues(ARElement):
     """
 
     # EcucModuleConfigurationValues method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] createContainer              [x] impl  [ ] docstring  [ ] test
-    # [ ] getContainers                [x] impl  [ ] docstring  [ ] test
-    # [ ] getDefinitionRef             [x] impl  [ ] docstring  [ ] test
-    # [ ] setDefinitionRef             [x] impl  [ ] docstring  [ ] test
-    # [ ] getEcucDefEdition            [x] impl  [ ] docstring  [ ] test
-    # [ ] setEcucDefEdition            [x] impl  [ ] docstring  [ ] test
-    # [ ] getImplementationConfigVariant [x] impl  [ ] docstring  [ ] test
-    # [ ] setImplementationConfigVariant [x] impl  [ ] docstring  [ ] test
-    # [ ] getModuleDescriptionRef      [x] impl  [ ] docstring  [ ] test
-    # [ ] setModuleDescriptionRef      [x] impl  [ ] docstring  [ ] test
-    # [ ] getPostBuildVariantUsed      [x] impl  [ ] docstring  [ ] test
-    # [ ] setPostBuildVariantUsed      [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_ECUConfiguration.pdf, Table 2.47, p.111
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                         [x] impl  [ ] docstring  [x] test  [—] reader  [—] writer
+    # [x] createContainer                  [x] impl  [ ] docstring  [x] test  [—] reader  [x] writer
+    # [x] getContainers                    [x] impl  [ ] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDefinitionRef                 [x] impl  [ ] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDefinitionRef                 [x] impl  [ ] docstring  [x] test  [x] reader  [—] writer
+    # [x] getEcucDefEdition                [x] impl  [ ] docstring  [x] test  [—] reader  [x] writer
+    # [x] setEcucDefEdition                [x] impl  [ ] docstring  [x] test  [x] reader  [—] writer
+    # [x] getImplementationConfigVariant   [x] impl  [ ] docstring  [x] test  [—] reader  [x] writer
+    # [x] setImplementationConfigVariant   [x] impl  [ ] docstring  [x] test  [x] reader  [—] writer
+    # [x] getModuleDescriptionRef          [x] impl  [ ] docstring  [x] test  [—] reader  [x] writer
+    # [x] setModuleDescriptionRef          [x] impl  [ ] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPostBuildVariantUsed          [x] impl  [ ] docstring  [x] test  [—] reader  [x] writer
+    # [x] setPostBuildVariantUsed          [x] impl  [ ] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.containers = []  # type: List[EcucContainerValue]
-        self.definitionRef = None  # type: RefType
-        self.ecucDefEdition = None  # type: ARLiteral
-        self.implementationConfigVariant = None  # type: ARLiteral
-        self.moduleDescriptionRef = None  # type: RefType
-        self.postBuildVariantUsed = None  # type: ARBoolean
+        self.containers: List[EcucContainerValue] = []
+        self.definitionRef: Optional[RefType] = None
+        self.ecucDefEdition: Optional[ARLiteral] = None
+        self.implementationConfigVariant: Optional[ARLiteral] = None
+        self.moduleDescriptionRef: Optional[RefType] = None
+        self.postBuildVariantUsed: Optional[ARBoolean] = None
 
     def createContainer(self, short_name: str) -> EcucContainerValue:
         if not self.IsElementExists(short_name):
@@ -395,35 +397,35 @@ class EcucModuleConfigurationValues(ARElement):
     def getContainers(self) -> List[EcucContainerValue]:
         return list(sorted(filter(lambda a: isinstance(a, EcucContainerValue), self.elements), key=lambda o: o.short_name))
 
-    def getDefinitionRef(self) -> RefType:
+    def getDefinitionRef(self) -> Optional[RefType]:
         return self.definitionRef
 
     def setDefinitionRef(self, value: RefType):
         self.definitionRef = value
         return self
 
-    def getEcucDefEdition(self) -> ARLiteral:
+    def getEcucDefEdition(self) -> Optional[ARLiteral]:
         return self.ecucDefEdition
 
     def setEcucDefEdition(self, value: ARLiteral):
         self.ecucDefEdition = value
         return self
 
-    def getImplementationConfigVariant(self) -> ARLiteral:
+    def getImplementationConfigVariant(self) -> Optional[ARLiteral]:
         return self.implementationConfigVariant
 
     def setImplementationConfigVariant(self, value: ARLiteral):
         self.implementationConfigVariant = value
         return self
 
-    def getModuleDescriptionRef(self) -> RefType:
+    def getModuleDescriptionRef(self) -> Optional[RefType]:
         return self.moduleDescriptionRef
 
     def setModuleDescriptionRef(self, value: RefType):
         self.moduleDescriptionRef = value
         return self
 
-    def getPostBuildVariantUsed(self) -> ARBoolean:
+    def getPostBuildVariantUsed(self) -> Optional[ARBoolean]:
         return self.postBuildVariantUsed
 
     def setPostBuildVariantUsed(self, value: ARBoolean):

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate.py
@@ -2370,16 +2370,16 @@ class EcucModuleDef(EcucDefinitionElement):
         super().__init__(parent, short_name)
 
         # For modules where several instances of the VSMD can be defined the apiServicePrefix defines the API namespace of the derived instances, e.g. Cdd, Xfrm (ComXf, SomeIpXf, E2EXf).
-        self.apiServicePrefix: CIdentifier = None
+        self.apiServicePrefix: Optional[CIdentifier] = None
 
         # Aggregates the top-level container definitions of this specific module definition. Stereotypes: atpSplitable Tags: atp.Splitkey=container.shortName xml.sequenceOffset=11
         self.containers: List[EcucContainerDef] = []
 
         # Indicates if a module supports different post-build variants (previously known as post-build selectable configuration sets). TRUE means yes, FALSE means no.
-        self.postBuildVariantSupport: Boolean = None
+        self.postBuildVariantSupport: Optional[Boolean] = None
 
         # Optional reference from the Vendor Specific Module Definition to the Standardized Module Definition it refines. In case this EcucModuleDef has the category STANDARDIZED_MODULE_DEFINITION this reference shall not be provided. In case this EcucModuleDef has the category VENDOR_SPECIFIC_MODULE_DEFINITION this reference is mandatory. Stereotypes: atpUriDef
-        self.refinedModuleDefRef: RefType = None
+        self.refinedModuleDefRef: Optional[RefType] = None
 
         # Specifies which ConfigurationVariants are supported by this software module. This attribute is optional if the EcucModuleDef has the category STANDARDIZED_MODULE_DEFINITION. If the category attribute of the EcucModuleDef is set to VENDOR_SPECIFIC_MODULE_DEFINITION then this attribute is mandatory.
         self.supportedConfigVariants: List[EcucConfigurationVariantEnum] = []

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
@@ -870,7 +870,10 @@ class RevisionLabelString(ARLiteral):
     """
 
     # RevisionLabelString method parity checklist:
-    # (no methods)
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.61, p.113
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods) — primitive type; value serialized as REVISION-LABEL-STRING via getChildElementOptionalRevisionLabelString / setChildElementOptionalRevisionLabelString
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
 
 class IntervalTypeEnum(AREnum):

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents.py
@@ -5,6 +5,7 @@ in software component internal behavior templates.
 
 from abc import ABC
 from typing import List, Optional
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.InternalBehavior import AbstractEvent
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import ModeActivationKind
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpStructureElement
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs import RVariableInAtomicSwcInstanceRef, RModeInAtomicSwcInstanceRef
@@ -14,7 +15,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType, TimeValue
 
 
-class RTEEvent(AtpStructureElement, ABC):
+class RTEEvent(AtpStructureElement, AbstractEvent, ABC):
     """
     Abstract base class for all RTE-related events.
     """

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -1202,6 +1202,7 @@ class ARXMLParser(AbstractARXMLParser):
                 entity.addAccessedModeGroupRef(ref_type)
 
     def readBswEvent(self, element: ET.Element, event: BswScheduleEvent):
+        event.activationReasonRepresentationRef = self.getChildElementOptionalRefType(element, "ACTIVATION-REASON-REPRESENTATION-REF")
         for ref in self.getChildElementRefTypeList(element, "CONTEXT-LIMITATION-REFS/CONTEXT-LIMITATION-REF"):
             event.addContextLimitationRef(ref)
         for child_element in self.findall(element, "DISABLED-IN-MODE-IREFS/DISABLED-IN-MODE-IREF"):
@@ -1309,8 +1310,16 @@ class ARXMLParser(AbstractARXMLParser):
         for child_element in self.findall(element, "EXCLUSIVE-AREAS/EXCLUSIVE-AREA"):
             short_name = self.getShortName(child_element)
             behavior.createExclusiveArea(short_name)
+        self.readExclusiveAreaNestingOrders(element, behavior)
         self.readDataTypeMappingRefs(element, behavior)
         self.readInternalBehaviorStaticMemories(element, behavior)
+
+    def readExclusiveAreaNestingOrders(self, element: ET.Element, behavior: InternalBehavior):
+        for child_element in self.findall(element, "EXCLUSIVE-AREA-NESTING-ORDERS/EXCLUSIVE-AREA-NESTING-ORDER"):
+            short_name = self.getShortName(child_element)
+            nesting_order = behavior.createExclusiveAreaNestingOrder(short_name)
+            for ref in self.getChildElementRefTypeList(child_element, "EXCLUSIVE-AREA-REFS/EXCLUSIVE-AREA-REF"):
+                nesting_order.addExclusiveAreaRef(ref)
 
     def getRoleBasedDataAssignment(self, element: ET.Element) -> RoleBasedDataAssignment:
         assignment = RoleBasedDataAssignment()
@@ -3274,6 +3283,7 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readRTEEvent(self, element: ET.Element, event: RTEEvent):
         self.readIdentifiable(element, event)
+        event.activationReasonRepresentationRef = self.getChildElementOptionalRefType(element, "ACTIVATION-REASON-REPRESENTATION-REF")
         event.startOnEventRef = self.getChildElementOptionalRefType(element, "START-ON-EVENT-REF")
         for child_element in self.findall(element, "DISABLED-MODE-IREFS/DISABLED-MODE-IREF"):
             iref = self.getRModeInAtomicSwcInstanceRef(child_element)
@@ -8167,8 +8177,10 @@ class ARXMLParser(AbstractARXMLParser):
         self.logger.debug("Read EcucModuleConfigurationValues %s" % values.getShortName())
         self.readIdentifiable(element, values)
         values.setDefinitionRef(self.getChildElementOptionalRefType(element, "DEFINITION-REF"))
+        values.setEcucDefEdition(self.getChildElementOptionalLiteral(element, "ECUC-DEF-EDITION"))
         values.setImplementationConfigVariant(self.getChildElementOptionalLiteral(element, "IMPLEMENTATION-CONFIG-VARIANT"))
         values.setModuleDescriptionRef(self.getChildElementOptionalRefType(element, "MODULE-DESCRIPTION-REF"))
+        values.setPostBuildVariantUsed(self.getChildElementOptionalBooleanValue(element, "POST-BUILD-VARIANT-USED"))
         self.readEcucModuleConfigurationValuesContainers(element, values)
 
     def readPhysicalDimension(self, element: ET.Element, dimension: PhysicalDimension):

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -2510,6 +2510,7 @@ class ARXMLWriter(AbstractARXMLWriter):
 
     def setRTEEvent(self, element: ET.Element, event: RTEEvent):
         self.writeIdentifiable(element, event)
+        self.setChildElementOptionalRefType(element, "ACTIVATION-REASON-REPRESENTATION-REF", event.getActivationReasonRepresentationRef())
         irefs = event.getDisabledModeIRefs()
         if len(irefs) > 0:
             child_element = ET.SubElement(element, "DISABLED-MODE-IREFS")
@@ -2621,6 +2622,19 @@ class ARXMLWriter(AbstractARXMLWriter):
                 child_element = ET.SubElement(areas_tag, "EXCLUSIVE-AREA")
                 self.writeIdentifiable(child_element, area)
 
+    def writeExclusiveAreaNestingOrders(self, element: ET.Element, behavior: InternalBehavior):
+        nesting_orders = behavior.getExclusiveAreaNestingOrders()
+        if len(nesting_orders) > 0:
+            orders_tag = ET.SubElement(element, "EXCLUSIVE-AREA-NESTING-ORDERS")
+            for nesting_order in nesting_orders:
+                child_element = ET.SubElement(orders_tag, "EXCLUSIVE-AREA-NESTING-ORDER")
+                self.writeReferrable(child_element, nesting_order)
+                refs = nesting_order.getExclusiveAreaRefs()
+                if len(refs) > 0:
+                    refs_tag = ET.SubElement(child_element, "EXCLUSIVE-AREA-REFS")
+                    for ref in refs:
+                        self.setChildElementOptionalRefType(refs_tag, "EXCLUSIVE-AREA-REF", ref)
+
     def writeDataTypeMappingRefs(self, element: ET.Element, behavior: InternalBehavior):
         refs = behavior.getDataTypeMappingRefs()
         if len(refs) > 0:
@@ -2641,6 +2655,7 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.writeSwcInternalBehaviorParameterDataPrototypes(element, "CONSTANT-MEMORYS", behavior.getConstantMemories())
         self.writeDataTypeMappingRefs(element, behavior)
         self.writeExclusiveAreas(element, behavior)
+        self.writeExclusiveAreaNestingOrders(element, behavior)
         self.writeInternalBehaviorStaticMemories(element, behavior)
 
     def setVariableInAtomicSWCTypeInstanceRef(self, element: ET.Element, key: str, iref: VariableInAtomicSWCTypeInstanceRef):
@@ -4766,6 +4781,7 @@ class ARXMLWriter(AbstractARXMLWriter):
 
     def writeBswEvent(self, element: ET.Element, event: BswEvent):
         self.writeIdentifiable(element, event)
+        self.setChildElementOptionalRefType(element, "ACTIVATION-REASON-REPRESENTATION-REF", event.getActivationReasonRepresentationRef())
         context_limitations = event.getContextLimitationRefs()
         if len(context_limitations) > 0:
             child_element = ET.SubElement(element, "CONTEXT-LIMITATION-REFS")
@@ -8131,8 +8147,10 @@ class ARXMLWriter(AbstractARXMLWriter):
         child_element = ET.SubElement(element, "ECUC-MODULE-CONFIGURATION-VALUES")
         self.writeIdentifiable(child_element, values)
         self.setChildElementOptionalRefType(child_element, "DEFINITION-REF", values.getDefinitionRef())
+        self.setChildElementOptionalLiteral(child_element, "ECUC-DEF-EDITION", values.getEcucDefEdition())
         self.setChildElementOptionalLiteral(child_element, "IMPLEMENTATION-CONFIG-VARIANT", values.getImplementationConfigVariant())
         self.setChildElementOptionalRefType(child_element, "MODULE-DESCRIPTION-REF", values.getModuleDescriptionRef())
+        self.setChildElementOptionalBooleanValue(child_element, "POST-BUILD-VARIANT-USED", values.getPostBuildVariantUsed())
         self.writeEcucModuleConfigurationValuesContainers(child_element, values)
 
     def writeSwSystemconst(self, element: ET.Element, const: SwSystemconst):

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswBehavior.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswBehavior.py
@@ -1805,9 +1805,9 @@ class TestBswInternalBehavior:
         policy = BswModeSenderPolicy()
         behavior.addModeSenderPolicy(policy)
 
-        # This method adds to modeReceiverPolicies, not modeSenderPolicies
-        assert len(behavior.getModeReceiverPolicies()) == 1
-        assert behavior.getModeReceiverPolicies()[0] == policy
+        # This method adds to modeSenderPolicies
+        assert len(behavior.getModeSenderPolicies()) == 1
+        assert behavior.getModeSenderPolicies()[0] == policy
 
 
 class TestBswDistinguishedPartition:

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswInternalBehavior.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswInternalBehavior.py
@@ -11,22 +11,18 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswBehavior import (
+    BswAsynchronousServerCallReturnsEvent,
     BswBackgroundEvent,
-    BswCalledEntity,
     BswDataReceivedEvent,
     BswExternalTriggerOccurredEvent,
     BswInternalBehavior,
     BswInternalTriggerOccurredEvent,
-    BswInternalTriggeringPoint,
-    BswInterruptEntity,
     BswModeManagerErrorEvent,
     BswModeSenderPolicy,
-    BswModeSwitchEvent,
     BswModeSwitchedAckEvent,
+    BswModeSwitchEvent,
     BswOperationInvokedEvent,
-    BswSchedulableEntity,
     BswTimingEvent,
-    BswAsynchronousServerCallReturnsEvent,
     IncludedDataTypeSet,
     IncludedModeDeclarationGroupSet,
 )

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswInternalBehavior.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswInternalBehavior.py
@@ -1,0 +1,232 @@
+"""
+Test suite for the BswInternalBehavior model class.
+
+Covers the aggregation members of BswInternalBehavior (BSWMDT Table 5.2, p.68):
+entities, events, internal triggering points and the policy lists, plus the
+mode-sender-policy regression (addModeSenderPolicy/getModeSenderPolicies must
+operate on modeSenderPolicies, not modeReceiverPolicies).
+"""
+
+import pytest
+
+from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswBehavior import (
+    BswBackgroundEvent,
+    BswCalledEntity,
+    BswDataReceivedEvent,
+    BswExternalTriggerOccurredEvent,
+    BswInternalBehavior,
+    BswInternalTriggerOccurredEvent,
+    BswInternalTriggeringPoint,
+    BswInterruptEntity,
+    BswModeManagerErrorEvent,
+    BswModeSenderPolicy,
+    BswModeSwitchEvent,
+    BswModeSwitchedAckEvent,
+    BswOperationInvokedEvent,
+    BswSchedulableEntity,
+    BswTimingEvent,
+    BswAsynchronousServerCallReturnsEvent,
+    IncludedDataTypeSet,
+    IncludedModeDeclarationGroupSet,
+)
+
+
+@pytest.fixture
+def behavior():
+    parent = AUTOSAR.getInstance()
+    ar_root = parent.createARPackage("AUTOSAR")
+    return BswInternalBehavior(ar_root, "TestBehavior")
+
+
+class TestBswInternalBehaviorInitialization:
+    def test_initialization_defaults(self, behavior):
+        assert behavior is not None
+        assert behavior.getShortName() == "TestBehavior"
+        assert behavior.arTypedPerInstanceMemories == []
+        assert behavior.bswPerInstanceMemoryPolicies == []
+        assert behavior.clientPolicies == []
+        assert behavior.distinguishedPartitions == []
+        assert behavior.entities == []
+        assert behavior.events == []
+        assert behavior.exclusiveAreaPolicies == []
+        assert behavior.includedDataTypeSets == []
+        assert behavior.includedModeDeclarationGroupSets == []
+        assert behavior.internalTriggeringPoints == []
+        assert behavior.internalTriggeringPointPolicies == []
+        assert behavior.modeReceiverPolicies == []
+        assert behavior.modeSenderPolicies == []
+        assert behavior.parameterPolicies == []
+        assert behavior.perInstanceParameters == []
+        assert behavior.receptionPolicies == []
+        assert behavior.releasedTriggerPolicies == []
+        assert behavior.schedulerNamePrefixes == []
+        assert behavior.sendPolicies == []
+        assert behavior.serviceDependencies == []
+        assert behavior.triggerDirectImplementations == []
+        assert behavior.variationPointProxies == []
+
+
+class TestBswInternalBehaviorPolicyLists:
+    @pytest.mark.parametrize(
+        "getter,setter,attr",
+        [
+            ("getArTypedPerInstanceMemories", "setArTypedPerInstanceMemories", "arTypedPerInstanceMemories"),
+            ("getBswPerInstanceMemoryPolicies", "setBswPerInstanceMemoryPolicies", "bswPerInstanceMemoryPolicies"),
+            ("getClientPolicies", "setClientPolicies", "clientPolicies"),
+            ("getDistinguishedPartitions", "setDistinguishedPartitions", "distinguishedPartitions"),
+            ("getExclusiveAreaPolicies", "setExclusiveAreaPolicies", "exclusiveAreaPolicies"),
+            ("getInternalTriggeringPointPolicies", "setInternalTriggeringPointPolicies", "internalTriggeringPointPolicies"),
+            ("getParameterPolicies", "setParameterPolicies", "parameterPolicies"),
+            ("getPerInstanceParameters", "setPerInstanceParameters", "perInstanceParameters"),
+            ("getReleasedTriggerPolicies", "setReleasedTriggerPolicies", "releasedTriggerPolicies"),
+            ("getSchedulerNamePrefixes", "setSchedulerNamePrefixes", "schedulerNamePrefixes"),
+            ("getSendPolicies", "setSendPolicies", "sendPolicies"),
+            ("getServiceDependencies", "setServiceDependencies", "serviceDependencies"),
+            ("getTriggerDirectImplementations", "setTriggerDirectImplementations", "triggerDirectImplementations"),
+            ("getVariationPointProxies", "setVariationPointProxies", "variationPointProxies"),
+        ],
+    )
+    def test_get_set_roundtrip(self, behavior, getter, setter, attr):
+        sentinel = [object()]
+        result = getattr(behavior, setter)(sentinel)
+        assert result is behavior
+        assert getattr(behavior, getter)() == sentinel
+
+    @pytest.mark.parametrize(
+        "getter,setter",
+        [
+            ("getArTypedPerInstanceMemories", "setArTypedPerInstanceMemories"),
+            ("getBswPerInstanceMemoryPolicies", "setBswPerInstanceMemoryPolicies"),
+            ("getClientPolicies", "setClientPolicies"),
+            ("getDistinguishedPartitions", "setDistinguishedPartitions"),
+            ("getExclusiveAreaPolicies", "setExclusiveAreaPolicies"),
+            ("getInternalTriggeringPointPolicies", "setInternalTriggeringPointPolicies"),
+            ("getParameterPolicies", "setParameterPolicies"),
+            ("getPerInstanceParameters", "setPerInstanceParameters"),
+            ("getReleasedTriggerPolicies", "setReleasedTriggerPolicies"),
+            ("getSchedulerNamePrefixes", "setSchedulerNamePrefixes"),
+            ("getSendPolicies", "setSendPolicies"),
+            ("getServiceDependencies", "setServiceDependencies"),
+            ("getTriggerDirectImplementations", "setTriggerDirectImplementations"),
+            ("getVariationPointProxies", "setVariationPointProxies"),
+        ],
+    )
+    def test_set_none_is_noop(self, behavior, getter, setter):
+        sentinel = [object()]
+        getattr(behavior, setter)(sentinel)
+        getattr(behavior, setter)(None)
+        assert getattr(behavior, getter)() == sentinel
+
+    def test_get_mode_sender_policies_default(self, behavior):
+        assert behavior.getModeSenderPolicies() == []
+        assert behavior.modeSenderPolicies == []
+
+    def test_set_mode_sender_policies(self, behavior):
+        policy = BswModeSenderPolicy()
+        result = behavior.setModeSenderPolicies([policy])
+        assert result is behavior
+        assert behavior.getModeSenderPolicies() == [policy]
+
+    def test_add_mode_sender_policy_uses_mode_sender_policies(self, behavior):
+        policy = BswModeSenderPolicy()
+        behavior.addModeSenderPolicy(policy)
+        assert behavior.getModeSenderPolicies() == [policy]
+        assert policy in behavior.modeSenderPolicies
+        assert behavior.modeReceiverPolicies == []
+
+    def test_get_mode_receiver_policies_default(self, behavior):
+        assert behavior.getModeReceiverPolicies() == []
+
+    def test_add_reception_policy_none_is_noop(self, behavior):
+        result = behavior.addReceptionPolicy(None)
+        assert result is behavior
+        assert behavior.receptionPolicies == []
+
+    def test_add_service_dependency(self, behavior):
+        dependency = object()
+        result = behavior.addServiceDependency(dependency)
+        assert result is behavior
+        assert behavior.serviceDependencies == [dependency]
+
+
+class TestBswInternalBehaviorEntities:
+    def test_create_bsw_called_entity(self, behavior):
+        entity = behavior.createBswCalledEntity("Called")
+        assert entity is not None
+        assert entity.getShortName() == "Called"
+        assert behavior.getBswCalledEntities() == [entity]
+        assert behavior.getBswModuleEntities() == [entity]
+
+    def test_create_bsw_schedulable_entity(self, behavior):
+        entity = behavior.createBswSchedulableEntity("Schedulable")
+        assert entity is not None
+        assert entity.getShortName() == "Schedulable"
+        assert behavior.getBswSchedulableEntities() == [entity]
+
+    def test_create_bsw_interrupt_entity(self, behavior):
+        entity = behavior.createBswInterruptEntity("Interrupt")
+        assert entity is not None
+        assert entity.getShortName() == "Interrupt"
+        assert behavior.getBswInterruptEntities() == [entity]
+
+    def test_create_duplicate_entity_returns_existing(self, behavior):
+        first = behavior.createBswCalledEntity("Called")
+        second = behavior.createBswCalledEntity("Called")
+        assert first is second
+        assert len(behavior.getBswCalledEntities()) == 1
+
+    def test_get_bsw_module_entities_empty(self, behavior):
+        assert behavior.getBswModuleEntities() == []
+
+    def test_create_bsw_internal_triggering_point(self, behavior):
+        point = behavior.createBswInternalTriggeringPoint("TriggerPoint")
+        assert point is not None
+        assert point.getShortName() == "TriggerPoint"
+        assert behavior.getInternalTriggeringPoints() == [point]
+
+
+class TestBswInternalBehaviorEvents:
+    @pytest.mark.parametrize(
+        "create,getter,cls",
+        [
+            ("createBswModeSwitchEvent", "getBswModeSwitchEvents", BswModeSwitchEvent),
+            ("createBswTimingEvent", "getBswTimingEvents", BswTimingEvent),
+            ("createBswDataReceivedEvent", "getBswDataReceivedEvents", BswDataReceivedEvent),
+            ("createBswInternalTriggerOccurredEvent", "getBswInternalTriggerOccurredEvents", BswInternalTriggerOccurredEvent),
+            ("createBswExternalTriggerOccurredEvent", "getBswExternalTriggerOccurredEvents", BswExternalTriggerOccurredEvent),
+            ("createBswOperationInvokedEvent", "getBswOperationInvokedEvents", BswOperationInvokedEvent),
+            ("createBswBackgroundEvent", "getBswBackgroundEvents", BswBackgroundEvent),
+            ("createBswModeManagerErrorEvent", "getBswModeManagerErrorEvents", BswModeManagerErrorEvent),
+            ("createBswModeSwitchedAckEvent", "getBswModeSwitchedAckEvents", BswModeSwitchedAckEvent),
+            ("createBswAsynchronousServerCallReturnsEvent", "getBswAsynchronousServerCallReturnsEvents", BswAsynchronousServerCallReturnsEvent),
+        ],
+    )
+    def test_create_and_get(self, behavior, create, getter, cls):
+        event = getattr(behavior, create)("Event1")
+        assert isinstance(event, cls)
+        assert event.getShortName() == "Event1"
+        assert getattr(behavior, getter)() == [event]
+        assert behavior.getBswEvents() == [event]
+        assert event in behavior.events
+
+    def test_create_duplicate_event_returns_existing(self, behavior):
+        first = behavior.createBswTimingEvent("Event1")
+        second = behavior.createBswTimingEvent("Event1")
+        assert first is second
+        assert len(behavior.getBswTimingEvents()) == 1
+
+    def test_get_bsw_events_empty(self, behavior):
+        assert behavior.getBswEvents() == []
+
+
+class TestBswInternalBehaviorTypeSets:
+    def test_add_included_mode_declaration_group_set(self, behavior):
+        group_set = IncludedModeDeclarationGroupSet()
+        behavior.addIncludedModeDeclarationGroupSet(group_set)
+        assert behavior.getIncludedModeDeclarationGroupSets() == [group_set]
+
+    def test_add_included_data_type_set(self, behavior):
+        type_set = IncludedDataTypeSet()
+        behavior.addIncludedDataTypeSet(type_set)
+        assert behavior.getIncludedDataTypeSets() == [type_set]

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_InternalBehavior.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_InternalBehavior.py
@@ -10,6 +10,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.InternalBehavior import 
     InternalBehavior,
     ReentrancyLevelEnum,
 )
+from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswBehavior import BswInternalBehavior
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType, TimeValue
 
 
@@ -717,3 +718,40 @@ class TestExclusiveAreaNestingOrder:
         result = nesting_order.addExclusiveAreaRef(None)
         assert result is nesting_order  # Method chaining
         assert len(nesting_order.getExclusiveAreaRefs()) == 1
+
+
+class TestInternalBehaviorExclusiveAreaNestingOrders:
+    def test_create_exclusive_area_nesting_order(self):
+        """Test createExclusiveAreaNestingOrder creates and registers the nesting order."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        behavior = BswInternalBehavior(ar_root, "behavior")
+
+        nesting_order = behavior.createExclusiveAreaNestingOrder("Order1")
+
+        assert nesting_order is not None
+        assert nesting_order.getShortName() == "Order1"
+        assert nesting_order.getParent() is behavior
+        assert nesting_order in behavior.getExclusiveAreaNestingOrders()
+
+    def test_get_exclusive_area_nesting_orders_empty(self):
+        """Test getExclusiveAreaNestingOrders returns an empty list initially."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        behavior = BswInternalBehavior(ar_root, "behavior")
+
+        assert behavior.getExclusiveAreaNestingOrders() == []
+
+    def test_get_exclusive_area_nesting_orders_filters(self):
+        """Test getExclusiveAreaNestingOrders returns only nesting orders."""
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        behavior = BswInternalBehavior(ar_root, "behavior")
+
+        behavior.createExclusiveArea("ea1")
+        behavior.createExclusiveAreaNestingOrder("o1")
+        behavior.createExclusiveAreaNestingOrder("o2")
+
+        orders = behavior.getExclusiveAreaNestingOrders()
+        assert len(orders) == 2
+        assert all(o.getShortName() in ("o1", "o2") for o in orders)

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_InternalBehavior.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_InternalBehavior.py
@@ -1,6 +1,7 @@
 import pytest
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswBehavior import BswInternalBehavior
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.InternalBehavior import (
     AbstractEvent,
     ApiPrincipleEnum,
@@ -10,7 +11,6 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.InternalBehavior import 
     InternalBehavior,
     ReentrancyLevelEnum,
 )
-from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswBehavior import BswInternalBehavior
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType, TimeValue
 
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/test_ECUCDescriptionTemplate.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/test_ECUCDescriptionTemplate.py
@@ -20,6 +20,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import (
     EcucTextualParamValue,
     EcucValueCollection,
 )
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, RefType, RevisionLabelString
 
 
 def _instantiate(cls, name):
@@ -54,6 +55,64 @@ class TestEcucModuleConfigurationValues:
     def test_instantiation(self):
         obj = _instantiate(EcucModuleConfigurationValues, "EcucModuleConfigurationValues")
         assert obj.getShortName() == "EcucModuleConfigurationValues"
+
+    def test_initialization_defaults(self):
+        obj = _instantiate(EcucModuleConfigurationValues, "EcucModuleConfigurationValues")
+        assert obj.getContainers() == []
+        assert obj.getDefinitionRef() is None
+        assert obj.getEcucDefEdition() is None
+        assert obj.getImplementationConfigVariant() is None
+        assert obj.getModuleDescriptionRef() is None
+        assert obj.getPostBuildVariantUsed() is None
+
+    def test_set_definition_ref(self):
+        obj = _instantiate(EcucModuleConfigurationValues, "EcucModuleConfigurationValues")
+        ref = RefType().setValue("/Def")
+        result = obj.setDefinitionRef(ref)
+        assert result is obj
+        assert obj.getDefinitionRef() == ref
+
+    def test_set_ecuc_def_edition(self):
+        obj = _instantiate(EcucModuleConfigurationValues, "EcucModuleConfigurationValues")
+        edition = RevisionLabelString().setValue("1.0.0")
+        result = obj.setEcucDefEdition(edition)
+        assert result is obj
+        assert obj.getEcucDefEdition() == edition
+
+    def test_set_implementation_config_variant(self):
+        obj = _instantiate(EcucModuleConfigurationValues, "EcucModuleConfigurationValues")
+        variant = EcucConfigurationVariantEnum().setValue("VariantPreCompile")
+        result = obj.setImplementationConfigVariant(variant)
+        assert result is obj
+        assert obj.getImplementationConfigVariant() == variant
+
+    def test_set_module_description_ref(self):
+        obj = _instantiate(EcucModuleConfigurationValues, "EcucModuleConfigurationValues")
+        ref = RefType().setValue("/Desc")
+        result = obj.setModuleDescriptionRef(ref)
+        assert result is obj
+        assert obj.getModuleDescriptionRef() == ref
+
+    def test_set_post_build_variant_used(self):
+        obj = _instantiate(EcucModuleConfigurationValues, "EcucModuleConfigurationValues")
+        value = ARBoolean().setValue(True)
+        result = obj.setPostBuildVariantUsed(value)
+        assert result is obj
+        assert obj.getPostBuildVariantUsed() == value
+
+    def test_create_and_get_container(self):
+        obj = _instantiate(EcucModuleConfigurationValues, "EcucModuleConfigurationValues")
+        container = obj.createContainer("Container1")
+        assert container is not None
+        assert container.getShortName() == "Container1"
+        assert obj.getContainers() == [container]
+
+    def test_create_duplicate_container_returns_existing(self):
+        obj = _instantiate(EcucModuleConfigurationValues, "EcucModuleConfigurationValues")
+        first = obj.createContainer("Container1")
+        second = obj.createContainer("Container1")
+        assert first is second
+        assert len(obj.getContainers()) == 1
 
 
 class TestEcucAddInfoParamValue:

--- a/tests/test_armodel/parser/test_arxml_parser_bsw_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_bsw_handlers.py
@@ -591,6 +591,31 @@ class TestExecutableEntityAndInternalBehaviorHandlers:
         assert len(behavior.getExclusiveAreas()) == 1
         assert len(behavior.getDataTypeMappingRefs()) == 1
 
+    def test_readInternalBehavior_exclusive_area_nesting_orders(self, parser):
+        from armodel.models import BswInternalBehavior
+
+        behavior = BswInternalBehavior(parent=_autosar_root(), short_name="bh")
+        element = _snip(
+            "<EXCLUSIVE-AREA-NESTING-ORDERS>"
+            "<EXCLUSIVE-AREA-NESTING-ORDER>"
+            "<SHORT-NAME>o1</SHORT-NAME>"
+            "<EXCLUSIVE-AREA-REFS>"
+            "<EXCLUSIVE-AREA-REF DEST='EXCLUSIVE-AREA'>/ea1</EXCLUSIVE-AREA-REF>"
+            "<EXCLUSIVE-AREA-REF DEST='EXCLUSIVE-AREA'>/ea2</EXCLUSIVE-AREA-REF>"
+            "</EXCLUSIVE-AREA-REFS>"
+            "</EXCLUSIVE-AREA-NESTING-ORDER>"
+            "</EXCLUSIVE-AREA-NESTING-ORDERS>",
+            root_tag="BH",
+        )
+        parser.readInternalBehavior(element, behavior)
+        orders = behavior.getExclusiveAreaNestingOrders()
+        assert len(orders) == 1
+        assert orders[0].getShortName() == "o1"
+        refs = orders[0].getExclusiveAreaRefs()
+        assert len(refs) == 2
+        assert refs[0].getValue() == "/ea1"
+        assert refs[1].getValue() == "/ea2"
+
 
 # ==================== BswModuleEntity call points and trigger refs ====================
 
@@ -874,6 +899,18 @@ class TestBswInternalBehaviorEventsDetailed:
         )
         parser.readBswEvent(element, event)
         assert event.startsOnEventRef.getValue() == "/p"
+
+    def test_readBswEvent_activation_reason_representation(self, parser):
+        from armodel.models import BswModeSwitchEvent
+
+        event = BswModeSwitchEvent(parent=_autosar_root(), short_name="ev")
+        element = _snip(
+            "<SHORT-NAME>ev</SHORT-NAME>" "<ACTIVATION-REASON-REPRESENTATION-REF DEST='EXECUTABLE-ENTITY-ACTIVATION-REASON'>/ar</ACTIVATION-REASON-REPRESENTATION-REF>",
+            root_tag="BSW-MODE-SWITCH-EVENT",
+        )
+        parser.readBswModeSwitchEvent(element, event)
+        assert event.activationReasonRepresentationRef is not None
+        assert event.activationReasonRepresentationRef.getValue() == "/ar"
 
     def test_readBswModeSwitchEvent_minimal(self, parser):
         from armodel.models import BswModeSwitchEvent

--- a/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_ecuc_handlers.py
@@ -1220,7 +1220,26 @@ class TestReadEcucModuleConfigurationValues:
         assert values.getDefinitionRef() is None
         assert values.getImplementationConfigVariant() is None
         assert values.getModuleDescriptionRef() is None
+        assert values.getEcucDefEdition() is None
+        assert values.getPostBuildVariantUsed() is None
         assert len(values.getContainers()) == 0
+
+    def test_handler_reads_ecuc_def_edition_and_post_build_variant_used(self, parser):
+        AUTOSAR.getInstance().setARRelease("R23-11")
+        values = _make_module_configuration_values("EditionModule")
+        element = _snip(
+            """
+            <SHORT-NAME>EditionModule</SHORT-NAME>
+            <ECUC-DEF-EDITION>1.0.0</ECUC-DEF-EDITION>
+            <POST-BUILD-VARIANT-USED>true</POST-BUILD-VARIANT-USED>
+            """,
+            root_tag="ECUC-MODULE-CONFIGURATION-VALUES",
+        )
+        parser.readEcucModuleConfigurationValues(element, values)
+        assert values.getEcucDefEdition() is not None
+        assert values.getEcucDefEdition().getValue() == "1.0.0"
+        assert values.getPostBuildVariantUsed() is not None
+        assert values.getPostBuildVariantUsed().getValue() is True
 
 
 # === Migrated from test_arxml_parser_remaining_gaps.py ===

--- a/tests/test_armodel/parser/test_arxml_parser_orchestrators.py
+++ b/tests/test_armodel/parser/test_arxml_parser_orchestrators.py
@@ -752,6 +752,20 @@ class TestRteEventHandlers:
         assert event.getPeriod().getValue() == 0.1
         assert event.getOffset().getValue() == 0.05
 
+    def test_readTimingEvent_activation_reason_representation(self, parser):
+        from armodel.models import ApplicationSwComponentType
+
+        swc = ApplicationSwComponentType(parent=_autosar_root(), short_name="swc")
+        behavior = swc.createSwcInternalBehavior("bh")
+        event = behavior.createTimingEvent("te")
+        element = _snip(
+            "<SHORT-NAME>te</SHORT-NAME>" "<ACTIVATION-REASON-REPRESENTATION-REF DEST='EXECUTABLE-ENTITY-ACTIVATION-REASON'>/ar</ACTIVATION-REASON-REPRESENTATION-REF>",
+            root_tag="TIMING-EVENT",
+        )
+        parser.readTimingEvent(element, event)
+        assert event.activationReasonRepresentationRef is not None
+        assert event.activationReasonRepresentationRef.getValue() == "/ar"
+
     def test_readOperationInvokedEvent_full(self, parser):
         from armodel.models import ApplicationSwComponentType
 

--- a/tests/test_armodel/writer/test_writer_bsw_module.py
+++ b/tests/test_armodel/writer/test_writer_bsw_module.py
@@ -429,6 +429,15 @@ class TestWriterBswEvents:
         assert parent[0].tag == "BSW-TIMING-EVENT"
         assert parent[0].find("PERIOD").text == "0.1"
 
+    def test_timing_event_activation_reason_representation(self, writer):
+        behavior = _make_behavior()
+        event = behavior.createBswTimingEvent("te")
+        event.setActivationReasonRepresentationRef(_ref("/ar", "EXECUTABLE-ENTITY-ACTIVATION-REASON"))
+        parent = _parent()
+        writer.writeBswTimingEvent(parent, event)
+        assert parent[0].tag == "BSW-TIMING-EVENT"
+        assert parent[0].find("ACTIVATION-REASON-REPRESENTATION-REF") is not None
+
     def test_background_event(self, writer):
         behavior = _make_behavior()
         event = behavior.createBswBackgroundEvent("be")

--- a/tests/test_armodel/writer/test_writer_ecuc_values_variant.py
+++ b/tests/test_armodel/writer/test_writer_ecuc_values_variant.py
@@ -15,6 +15,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     AnyInstanceRef,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa E501
+    ARBoolean,
     ARLiteral,
     ARNumerical,
     RefType,
@@ -367,7 +368,23 @@ class TestWriterEcucModuleConfigurationValues:
         assert parent[0].find("DEFINITION-REF") is None
         assert parent[0].find("IMPLEMENTATION-CONFIG-VARIANT") is None
         assert parent[0].find("MODULE-DESCRIPTION-REF") is None
+        assert parent[0].find("ECUC-DEF-EDITION") is None
+        assert parent[0].find("POST-BUILD-VARIANT-USED") is None
         assert parent[0].find("CONTAINERS") is None
+
+    def test_full_writes_ecuc_def_edition_and_post_build_variant_used(self, writer):
+        mcv = _make_module_config()
+        mcv.setEcucDefEdition(_literal("1.0.0"))
+        mcv.setPostBuildVariantUsed(ARBoolean().setValue(True))
+        parent = _parent()
+        writer.writeEcucModuleConfigurationValues(parent, mcv)
+        assert parent[0].tag == "ECUC-MODULE-CONFIGURATION-VALUES"
+        edition = parent[0].find("ECUC-DEF-EDITION")
+        assert edition is not None
+        assert edition.text == "1.0.0"
+        post_build = parent[0].find("POST-BUILD-VARIANT-USED")
+        assert post_build is not None
+        assert post_build.text == "true"
 
 
 class TestWriterSwSystemconst:

--- a/tests/test_armodel/writer/test_writer_swc_behavior.py
+++ b/tests/test_armodel/writer/test_writer_swc_behavior.py
@@ -142,6 +142,24 @@ class TestWriterRteEvents:
         assert evt.find("OFFSET").text == "0.05"
         assert evt.find("PERIOD").text == "0.1"
 
+    def test_writeTimingEvent_activation_reason_representation(self, writer):
+        behavior = _make_behavior()
+        event = behavior.createTimingEvent("te")
+        event.setActivationReasonRepresentationRef(_ref("/ar", "EXECUTABLE-ENTITY-ACTIVATION-REASON"))
+        parent = _parent()
+        writer.writeTimingEvent(parent, event)
+        evt = parent[0]
+        assert evt.tag == "TIMING-EVENT"
+        assert evt.find("ACTIVATION-REASON-REPRESENTATION-REF") is not None
+
+    def test_writeTimingEvent_no_activation_reason_representation(self, writer):
+        behavior = _make_behavior()
+        event = behavior.createTimingEvent("te")
+        parent = _parent()
+        writer.writeTimingEvent(parent, event)
+        evt = parent[0]
+        assert evt.find("ACTIVATION-REASON-REPRESENTATION-REF") is None
+
     def test_writeTimingEvent_none(self, writer):
         parent = _parent()
         writer.writeTimingEvent(parent, None)
@@ -365,6 +383,28 @@ class TestWriterInternalBehavior:
         parent = _parent()
         writer.writeExclusiveAreas(parent, behavior)
         assert parent.find("EXCLUSIVE-AREAS") is None
+
+    def test_writeExclusiveAreaNestingOrders(self, writer):
+        behavior = _make_behavior()
+        nesting_order = behavior.createExclusiveAreaNestingOrder("o1")
+        nesting_order.addExclusiveAreaRef(_ref("/ea1", "EXCLUSIVE-AREA"))
+        nesting_order.addExclusiveAreaRef(_ref("/ea2", "EXCLUSIVE-AREA"))
+        parent = _parent()
+        writer.writeExclusiveAreaNestingOrders(parent, behavior)
+        orders = parent.find("EXCLUSIVE-AREA-NESTING-ORDERS")
+        assert orders is not None
+        assert orders[0].tag == "EXCLUSIVE-AREA-NESTING-ORDER"
+        assert orders[0].find("SHORT-NAME").text == "o1"
+        refs = orders[0].findall("EXCLUSIVE-AREA-REFS/EXCLUSIVE-AREA-REF")
+        assert len(refs) == 2
+        assert refs[0].text == "/ea1"
+        assert refs[1].text == "/ea2"
+
+    def test_writeExclusiveAreaNestingOrders_empty(self, writer):
+        behavior = _make_behavior()
+        parent = _parent()
+        writer.writeExclusiveAreaNestingOrders(parent, behavior)
+        assert parent.find("EXCLUSIVE-AREA-NESTING-ORDERS") is None
 
     def test_writeDataTypeMappingRefs(self, writer):
         behavior = _make_behavior()


### PR DESCRIPTION
## Summary

Sync pass on the staged model classes against the AUTOSAR R23-11 spec:

- Upgrade method parity checklists to the 5-column format (impl / docstring / test / reader / writer)
- Fix 0..1 attribute type annotations to `Optional[T]` (`EcucModuleDef`, `AbstractEvent`, `EcucModuleConfigurationValues`)
- Add reader/writer coverage for `activationReasonRepresentationRef`, `ExclusiveAreaNestingOrder`, and ECUC module config values
- Fix `BswInternalBehavior.modeSenderPolicies` to use the correct list
- Make `RTEEvent` inherit `AbstractEvent` to share event members
- Rewrite `BswScheduleEvent` and `AbstractEvent` docstrings verbatim from spec and stamp both as `# Spec verified: R23-11`

## Verification

- `ruff check src/armodel/` clean
- Full test suite: 6704 passed (lossless integration round-trip)
- `black --check` clean on changed files

`EcucModuleConfigurationValues` and `BswInternalBehavior` keep spec-tracked `# Spec:` lines but remain unstamped (docstrings not yet synced / deferred full sync).