### PR TITLE
docs: DataPrototypeTransformationProps sync plan

### DIFF
--- a/.agents/skills/sync-autosar-class/SKILL.md
+++ b/.agents/skills/sync-autosar-class/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: sync-autosar-class
-description: "Use when syncing, aligning, implementing, or extending an AUTOSAR model class in py-armodel against its PDF spec table. Triggers: 'sync <ClassName>', 'implement <ClassName> to spec', 'add reader/writer coverage for <ClassName>', 'update the class checklist', 'sync docstrings to the PDF', or working on any class under src/armodel/models/M2/AUTOSARTemplates/. py-armodel project. Phase 0 builds the class closure and resolves missing classes interactively before the per-class 9-step TDD loop."
+description: "Use when syncing, aligning, implementing, or extending an AUTOSAR model class in py-armodel against its PDF spec table. Triggers: 'sync <ClassName>', 'implement <ClassName> to spec', 'add reader/writer coverage for <ClassName>', 'update the class checklist', 'sync docstrings to the PDF', 'continue/resume the class sync', or working on any class under src/armodel/models/M2/AUTOSARTemplates/. py-armodel project. Phase 0 builds the class closure and resolves missing classes interactively before the per-class 9-step TDD loop."
 author: melodypapa
 repository: https://github.com/melodypapa/py-armodel
 license: MIT
 metadata:
-  version: "1.7.0"
+  version: "1.8.0"
   keywords:
     - AUTOSAR
     - model-class
@@ -26,11 +26,14 @@ The AUTOSAR PDF spec table is the source of truth. Sync runs in **two phases**:
 - **Phase 0 — Discovery & class closure (Rule 0016):** build the closure of related
   classes (parents + member types), confirm the collected set with the user, locate
   each one's spec source (markdown → PDF → missing), resolve missing classes
-  interactively (skip / derive from XSD), and emit an ordered sync queue.
-- **Phase 1 — 9-step TDD per class (Rules 0001–0015):** consume the queue
-  one class at a time. Two Red→Green pairs per class: model (2→3) and reader/writer
-  (5→6). Write the failing test before the implementation. Each class ends with a
-  rule-compliance confirmation gate (Step 9b) before it is stamped.
+  interactively (skip / derive from XSD), and write the persistent sync todo list
+  (`docs/plan/sync-todo/<InputClassName>.md`) — the queue survives session death.
+- **Phase 1 — 9-step TDD per class (Rules 0001–0015, 0017):** consume the queue
+  one class at a time, **one class per fresh session** (Rule 0017). Two Red→Green
+  pairs per class: model (2→3) and reader/writer (5→6). Write the failing test before
+  the implementation. Each class ends with a rule-compliance confirmation gate (Step
+  9b) before it is stamped, marked finished in the todo list, and committed to the
+  feature branch. All rows `[x]` in the todo list = the sync is finished.
 
 Set the release before parse/write:
 
@@ -39,7 +42,7 @@ document = AUTOSAR.getInstance()
 document.setARRelease('R23-11')
 ```
 
-Detailed rules live in **`rules.md`** (*Rule 0001*–*Rule 0016*); this skill is
+Detailed rules live in **`rules.md`** (*Rule 0001*–*Rule 0017*); this skill is
 self-contained (no external rules document). Each step below points into `rules.md` for
 the detail — do not re-derive it here.
 
@@ -85,11 +88,36 @@ risks fabricating fields when a referenced class turns out to be missing mid-syn
    **"Exists" is not a stamp** — a member type that exists but is a stub (no marker,
    or fields/literals don't match its own table) is queued for the same pass like a
    missing class (Rule 0001.10 / 0016.4).
+6. **Write the sync todo list file** (Rule 0016.6): persist the confirmed queue to
+   `docs/plan/sync-todo/<InputClassName>.md` — one row per queued class, plus the
+   Skip/XSD resolution decisions. **The queue lives in this file, not in the
+   conversation.** The Phase 0 session ends here.
 
-**Output:** a sync map (kept in the conversation) listing each closure class,
-its source, its parent, and whether it enters the 9-step queue.
+**Output:** `docs/plan/sync-todo/<InputClassName>.md` — the persistent queue
+(Rule 0016.6). Phase 1 consumes it one row at a time, **one class per fresh
+session** (Rule 0017).
 
-Phase 1 consumes this map one row at a time.
+## Phase 1 — Session loop & the 9-step workflow (Rule 0017)
+
+- **Entry (every session):** the user invokes the skill (e.g. `/sync-autosar-class
+  <ClassName>` or "continue the sync"). If `docs/plan/sync-todo/<ClassName>.md`
+  exists, **resume — do NOT re-run Phase 0** (the closure was already confirmed;
+  re-running it re-asks the interactive gates for nothing). Read the todo file,
+  take the **first row still `[ ]`**, and run the 9-step workflow for that one
+  class. If the file does not exist, run Phase 0 first.
+- **One class per session.** Never sync two classes in one session, even when the
+  context still feels fresh — the 9b verbatim-diff work degrades silently under a
+  loaded context. After a class finishes (below), stop and tell the user to start
+  a new session.
+- **Finish (per class, after 9b):** once the user confirms Step 9b and the
+  `# Spec verified:` marker is written — (1) commit the class's changes to the
+  current feature branch (model source + mirrored test + parser/writer tests +
+  parser + writer + deviation tracker + the todo file itself; message
+  `feat: <ClassName> synced.`), (2) flip the todo row to `[x]` and record the
+  commit hash in the same commit, (3) report and stop.
+- **Termination:** after marking a row `[x]`, if **every** queue row is `[x]`, the
+  sync is **finished** — report the summary (classes, commits, deviations). No
+  further session needed. Any `[ ]` left → next session picks it up.
 
 ## The stamp is the review gate
 
@@ -127,11 +155,11 @@ round-trip) certifies a class as reviewed.
 | deviation records | the project deviation tracker (format in *Rule 0014*) |
 | XSD ground truth | `docs/requirements/xsd/` |
 
-## Phase 1 — The 9-step workflow (TDD, per class)
+### The 9-step workflow (TDD, per class)
 
-Runs once per class in the queue built by Phase 0 (Rule 0016). Two Red→Green pairs:
-**2→3** (model) and **5→6** (reader/writer). Do not write the implementation
-before its failing test.
+Runs once per class in the queue built by Phase 0 (Rule 0016), inside the session
+loop above. Two Red→Green pairs: **2→3** (model) and **5→6** (reader/writer). Do
+not write the implementation before its failing test.
 
 | Step | What | Rules | Phase |
 |---|---|---|---|
@@ -155,7 +183,7 @@ before its failing test.
 - **6** — Reader populates via mutators (`readXxx`→`set/create/addXxx`), writer reads via getters (`writeXxx`→`getXxx`); cover wrapper lists + polymorphic five-place dispatch; **no chained mutator calls**.
 - **7** — One row per method, source order, all `[x]`, 5-column format below. Writes the `# Spec:` line + method rows **only** — the `# Spec verified:` marker is added in Step 9b, never here.
 - **8** — Record deviations; the `# Spec verified:` marker (added in 9b) is **withheld** while any placeholder/deviation remains; report the Step-3 referenced classes here.
-- **9** — **(9a automated)** `pytest` + `flake8` + `ruff check` + `black-check` + the set-based script + a lossless integration round-trip (`npm run flake8` / `ruff-check` / `black-check` are the cross-platform forms). **Stop on any failure.** **(9b confirm — gate)** then present the **complete pre-stamp** rule-compliance checklist covering every check automation is blind to — element kind + every spec attr modeled (*0001.1*), most-derived base (*0001.2*), no fabrication/flattening + PDF-typed fields (*0001.3*), **Kind-suffix naming** `ref`→Ref/Refs·`tref`→TRef·`iref`→IRef/IRefs + singular `*`→plural (*0001.5*), create/set/add shape (*0001.6*), **reader+writer coverage** for every kept attr (*0001.7*), **member order** (*0011*), docstrings = spec `Note` **verbatim by diff** (*0012* **and** *0001.4* — every attribute's inline `__init__` comment + getter docstring + setter docstring must be the spec `Note` copied verbatim, not a "Gets/Sets the…" paraphrase or a truncated summary that drops the spec's full sentence), deviations resolved/removed (*0014*), stamp decision (*0012.1*) — and get explicit user confirmation; **when all pass, write the `# Spec verified:` marker in this step (9b)** — never in Step 4/7/8. Fix & re-present on any failure (*Rule 0006.1* has the full checklist).
+- **9** — **(9a automated)** `pytest` + `flake8` + `ruff check` + `black-check` + the set-based script + a lossless integration round-trip (`npm run flake8` / `ruff-check` / `black-check` are the cross-platform forms). **Stop on any failure.** **(9b confirm — gate)** then present the **complete pre-stamp** rule-compliance checklist covering every check automation is blind to — element kind + every spec attr modeled (*0001.1*), most-derived base (*0001.2*), no fabrication/flattening + PDF-typed fields (*0001.3*), **Kind-suffix naming** `ref`→Ref/Refs·`tref`→TRef·`iref`→IRef/IRefs + singular `*`→plural (*0001.5*), create/set/add shape (*0001.6*), **reader+writer coverage** for every kept attr (*0001.7*), **member order** (*0011*), docstrings = spec `Note` **verbatim by diff** (*0012* **and** *0001.4* — every attribute's inline `__init__` comment + getter docstring + setter docstring must be the spec `Note` copied verbatim, not a "Gets/Sets the…" paraphrase or a truncated summary that drops the spec's full sentence), deviations resolved/removed (*0014*), stamp decision (*0012.1*) — and get explicit user confirmation; **when all pass, write the `# Spec verified:` marker in this step (9b)** — never in Step 4/7/8. Fix & re-present on any failure (*Rule 0006.1* has the full checklist). **Then finish the class per Rule 0017**: commit to the feature branch, flip the todo row to `[x]` with the commit hash, and stop the session (or, if all rows are `[x]`, report the sync complete).
 
 **Workflow adaptations** (which steps still apply):
 
@@ -244,6 +272,20 @@ detail: *Rule 0002*.
   directly under its spec-`Note` comment is a *Rule 0003* violation even when the
   getter/setter signatures are correct; no automation catches it — check every
   `__init__` member's declaration form during 9b.
+- **Keeping the queue only in the conversation** — the sync map that lives in
+  conversation dies with the session, taking the Skip/XSD decisions and queue order
+  with it. The queue lives in `docs/plan/sync-todo/<InputClassName>.md` (*Rule 0016.6*).
+- **Re-running Phase 0 on resume** — a todo file for the class already exists ⇒ the
+  closure was confirmed; read the file and take the first `[ ]` row. Re-running Phase 0
+  re-asks the interactive gates for nothing (*Rule 0017.1*).
+- **Re-deriving the queue from `# Spec verified:` stamps instead of reading the todo
+  file** — stamps carry no queue order, no roles, no Skip/XSD decisions (*Rule 0017.4*).
+- **Syncing a second class in the same session** — "context still feels fresh" is not
+  evidence; the 9b verbatim diffs degrade silently under a loaded context. One class
+  per session, then stop (*Rule 0017.1*).
+- **Marking a todo row `[x]` before the commit exists** — the row records the commit
+  hash; no commit, no `[x]`. Deferring the commit to "the end of all classes" loses a
+  session's work when it dies (*Rule 0017.2*).
 
 | Rationalization | Reality |
 |---|---|
@@ -256,10 +298,14 @@ detail: *Rule 0002*.
 | "The closure looks right, I'll skip the confirm gate" | Over/under-collection wastes every later step; present the set and let the user confirm (*Rule 0016.2*). |
 | "Tests pass and the round-trip is clean — I can stamp and move on" | Those don't certify a class (Rule 0012.1); run Step 9b on the blind-spot rules before stamping (*Rule 0006.1*). |
 | "The class already has `# Spec verified:` stamped — I'll skip 9b" | The marker is the *output* of 9b, not a substitute; on re-sync/drift re-run the full 9b checklist — a stale marker certifies nothing (*Rule 0006.1*, *Rule 0012.3*). |
+| "I'll keep the queue in the conversation — writing a file is overhead" | The conversation dies with the session; the queue, order, roles, and Skip/XSD decisions are lost. The todo file is the queue (*Rule 0016.6*). |
+| "Session died — I'll rebuild the queue by grepping the stamps" | Stamps carry no order/roles/Skip-XSD decisions; read `docs/plan/sync-todo/<ClassName>.md` instead (*Rule 0017.4*). |
+| "Context still feels fresh — I'll sync the next class in this session" | 9b verbatim diffs degrade silently under loaded context; one class per session (*Rule 0017.1*). |
+| "I'll commit everything at the end of the whole sync" | A session death then loses every finished class's work; commit per class, right after 9b (*Rule 0017.2*). |
 
 ## References
 
-- **Rules (self-contained):** `rules.md` in this skill folder — *Rule 0001*–*Rule 0016*.
+- **Rules (self-contained):** `rules.md` in this skill folder — *Rule 0001*–*Rule 0017*.
 - Coding standards: `docs/development/coding_rules.md`.
 - Spec markdown (primary — source of all text: `Note`, `Table N.M` id, table name): `autosar/markdown/AUTOSAR_*_TPS_*.md` (`CP_TPS` + `FO_TPS`).
 - Spec PDFs (opened only for the `p.NN` page number): `autosar/pdf/AUTOSAR_*_TPS_*.pdf`.

--- a/.agents/skills/sync-autosar-class/SKILL.md
+++ b/.agents/skills/sync-autosar-class/SKILL.md
@@ -5,7 +5,7 @@ author: melodypapa
 repository: https://github.com/melodypapa/py-armodel
 license: MIT
 metadata:
-  version: "1.8.0"
+  version: "1.9.0"
   keywords:
     - AUTOSAR
     - model-class
@@ -28,12 +28,14 @@ The AUTOSAR PDF spec table is the source of truth. Sync runs in **two phases**:
   each one's spec source (markdown → PDF → missing), resolve missing classes
   interactively (skip / derive from XSD), and write the persistent sync todo list
   (`docs/plan/sync-todo/<InputClassName>.md`) — the queue survives session death.
-- **Phase 1 — 9-step TDD per class (Rules 0001–0015, 0017):** consume the queue
+- **Phase 1 — 9-step TDD per class (Rules 0001–0015, 0017–0018):** consume the queue
   one class at a time, **one class per fresh session** (Rule 0017). Two Red→Green
   pairs per class: model (2→3) and reader/writer (5→6). Write the failing test before
-  the implementation. Each class ends with a rule-compliance confirmation gate (Step
-  9b) before it is stamped, marked finished in the todo list, and committed to the
-  feature branch. All rows `[x]` in the todo list = the sync is finished.
+  the implementation. The 9 steps are mirrored into the session todo list — one todo
+  per step, checked off the moment its step finishes (Rule 0018). Each class ends
+  with a rule-compliance confirmation gate (Step 9b) before it is stamped, marked
+  finished in the todo list, and committed to the feature branch. All rows `[x]` in
+  the todo list = the sync is finished.
 
 Set the release before parse/write:
 
@@ -42,7 +44,7 @@ document = AUTOSAR.getInstance()
 document.setARRelease('R23-11')
 ```
 
-Detailed rules live in **`rules.md`** (*Rule 0001*–*Rule 0017*); this skill is
+Detailed rules live in **`rules.md`** (*Rule 0001*–*Rule 0018*); this skill is
 self-contained (no external rules document). Each step below points into `rules.md` for
 the detail — do not re-derive it here.
 
@@ -97,7 +99,7 @@ risks fabricating fields when a referenced class turns out to be missing mid-syn
 (Rule 0016.6). Phase 1 consumes it one row at a time, **one class per fresh
 session** (Rule 0017).
 
-## Phase 1 — Session loop & the 9-step workflow (Rule 0017)
+## Phase 1 — Session loop & the 9-step workflow (Rules 0017–0018)
 
 - **Entry (every session):** the user invokes the skill (e.g. `/sync-autosar-class
   <ClassName>` or "continue the sync"). If `docs/plan/sync-todo/<ClassName>.md`
@@ -109,6 +111,15 @@ session** (Rule 0017).
   context still feels fresh — the 9b verbatim-diff work degrades silently under a
   loaded context. After a class finishes (below), stop and tell the user to start
   a new session.
+- **Mirror the 9 steps into the session todo list (Rule 0018).** After taking the
+  `[ ]` row and before Step 1, create **9 session todos — one per workflow step**
+  (`Step 1 — Sync members & description from spec` … `Step 9 — Verify (9a) +
+  confirm (9b)`). Mark each `in_progress` when the step begins and `completed`
+  **the moment that step finishes** — one completed step = exactly one newly
+  checked todo item. Never merge steps into fewer todos, never batch-check.
+  N/A steps (e.g. 5/6 for a standalone `AREnum`) complete with the N/A reason.
+  Step 9's todo completes only after the 9b user confirmation. All 9 completed is
+  a precondition of the per-class commit (Rule 0017.2).
 - **Finish (per class, after 9b):** once the user confirms Step 9b and the
   `# Spec verified:` marker is written — (1) commit the class's changes to the
   current feature branch (model source + mirrored test + parser/writer tests +
@@ -159,7 +170,9 @@ round-trip) certifies a class as reviewed.
 
 Runs once per class in the queue built by Phase 0 (Rule 0016), inside the session
 loop above. Two Red→Green pairs: **2→3** (model) and **5→6** (reader/writer). Do
-not write the implementation before its failing test.
+not write the implementation before its failing test. Each step is tracked as its
+own session todo — created as a set of 9 before Step 1, checked off one at a time
+as each step finishes (*Rule 0018*).
 
 | Step | What | Rules | Phase |
 |---|---|---|---|
@@ -286,6 +299,10 @@ detail: *Rule 0002*.
 - **Marking a todo row `[x]` before the commit exists** — the row records the commit
   hash; no commit, no `[x]`. Deferring the commit to "the end of all classes" loses a
   session's work when it dies (*Rule 0017.2*).
+- **Merging the 9 steps into fewer session todos, or batch-checking them** —
+  "Steps 2+3 model TDD" as one todo, or checking several step todos at once after
+  the fact, hides a skipped/half-finished step until 9b or never. One step = one
+  todo, checked the moment the step finishes (*Rule 0018*).
 
 | Rationalization | Reality |
 |---|---|
@@ -302,10 +319,12 @@ detail: *Rule 0002*.
 | "Session died — I'll rebuild the queue by grepping the stamps" | Stamps carry no order/roles/Skip-XSD decisions; read `docs/plan/sync-todo/<ClassName>.md` instead (*Rule 0017.4*). |
 | "Context still feels fresh — I'll sync the next class in this session" | 9b verbatim diffs degrade silently under loaded context; one class per session (*Rule 0017.1*). |
 | "I'll commit everything at the end of the whole sync" | A session death then loses every finished class's work; commit per class, right after 9b (*Rule 0017.2*). |
+| "One todo for the class is enough — or I'll check them all at the end" | The step todos exist to expose a skipped/half-finished step in real time; batch-checking shows progress the work doesn't have. 9 todos, one check per finished step (*Rule 0018*). |
+| "9b re-verifies everything anyway — I'll check off step todos as 'done' when the class finishes" | 9b verifies the class against the rules; step todos verify the workflow was walked. Step 9's todo completes only on 9b confirmation, the others at their own finish (*Rule 0018*). |
 
 ## References
 
-- **Rules (self-contained):** `rules.md` in this skill folder — *Rule 0001*–*Rule 0017*.
+- **Rules (self-contained):** `rules.md` in this skill folder — *Rule 0001*–*Rule 0018*.
 - Coding standards: `docs/development/coding_rules.md`.
 - Spec markdown (primary — source of all text: `Note`, `Table N.M` id, table name): `autosar/markdown/AUTOSAR_*_TPS_*.md` (`CP_TPS` + `FO_TPS`).
 - Spec PDFs (opened only for the `p.NN` page number): `autosar/pdf/AUTOSAR_*_TPS_*.pdf`.

--- a/.agents/skills/sync-autosar-class/SKILL.md
+++ b/.agents/skills/sync-autosar-class/SKILL.md
@@ -84,9 +84,12 @@ risks fabricating fields when a referenced class turns out to be missing mid-syn
    user picks **Skip** (deviation row + placeholder) or **Derive from XSD**
    (XSD-only class, no marker). Do not proceed without an answer; do not invent a
    third option.
-5. **Build the sync queue**: parents first (deepest ancestor first → input class
-   last), member types in spec-row order. Skip classes already stamped
-   `# Spec verified: R<YY>-<MM>` unless extending or drift (Rule 0012.3).
+5. **Build the sync queue — dependency-first** (Rule 0016.5): a class that other
+   queued classes reference (`Base` or `Attribute` member type) is queued
+   **before** its dependents; deepest ancestors first, ties keep spec-row order,
+   input class last. A dependent must never precede the class it references.
+   Skip classes already stamped `# Spec verified: R<YY>-<MM>` unless extending
+   or drift (Rule 0012.3).
    **"Exists" is not a stamp** — a member type that exists but is a stub (no marker,
    or fields/literals don't match its own table) is queued for the same pass like a
    missing class (Rule 0001.10 / 0016.4).

--- a/.agents/skills/sync-autosar-class/evals/evals.json
+++ b/.agents/skills/sync-autosar-class/evals/evals.json
@@ -8,7 +8,7 @@
       "expectations": [
         "Output mentions the class ObdInfoServiceNeeds and its parent DiagnosticCapabilityElement",
         "Output lists spec source for each closure class (markdown/pdf/missing)",
-        "Output presents an ordered sync queue (parents first, input class last)",
+        "Output presents an ordered sync queue (dependency-first: ancestors first, referenced member types before their referrers, input class last)",
         "No source files under src/armodel/models/ were modified",
         "Output cites Rule 0016 or the Phase 0 procedure",
         "Output presents the collected closure set and asks the user to confirm it (membership gate) before locating specs, resolving missing classes, or building the queue"

--- a/.agents/skills/sync-autosar-class/evals/evals.json
+++ b/.agents/skills/sync-autosar-class/evals/evals.json
@@ -80,6 +80,32 @@
         "Output re-stamps (e.g. to R23-11) only after the user confirms every 9b item",
         "No source files under src/armodel/models/ were modified"
       ]
+    },
+    {
+      "id": 7,
+      "prompt": "Using the sync-autosar-class skill, a previous session ran Phase 0 for `IpduTiming` and finished 2 of 5 queue classes. This is a brand-new session; the previous conversation is gone. The user says 'continue the IpduTiming sync'. The file docs/plan/sync-todo/IpduTiming.md exists with rows: [x] SignalGroupProps, [x] SignalProps, [ ] SignalEnum, [ ] PduTimingEnum, [ ] IpduTiming. Describe exactly what you do next. Do NOT modify any source files. Repo root: /Users/ray/Workspace/py-armodel.",
+      "expected_output": "Resume per Rule 0017.1: read docs/plan/sync-todo/IpduTiming.md, take the FIRST row still [ ] (SignalEnum), and run the 9-step workflow for that one class only. Do NOT re-run Phase 0, re-collect the closure, or re-ask the 16.2/16.4 gates — the todo file is the confirmed queue. Do NOT rebuild the queue by grepping # Spec verified: stamps (Rule 0017.4). One class per session; after 9b, commit + flip the row + stop.",
+      "expectations": [
+        "Output reads docs/plan/sync-todo/IpduTiming.md as the authoritative queue",
+        "Output selects SignalEnum (the first [ ] row) as the next class",
+        "Output explicitly does NOT re-run Phase 0 or re-ask the closure/missing-class gates",
+        "Output does NOT rebuild the queue from # Spec verified: stamps",
+        "Output commits to only one class in this session",
+        "Output mentions Rule 0017 or the session loop"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "IMPORTANT: This is a real scenario. Choose and act. Using the sync-autosar-class skill, you are in a session syncing `SignalEnum` from the queue in docs/plan/sync-todo/IpduTiming.md. You just finished Step 9b: the user confirmed every checklist item and the # Spec verified: marker is written. All automated checks pass. Your context is only 40% used — plenty of room left. The user says 'great, keep going with PduTimingEnum in this same session, no need to start over'. What exactly do you do? Do NOT modify any source files. Repo root: /Users/ray/Workspace/py-armodel.",
+      "expected_output": "Follow Rule 0017 despite the user's suggestion and the fresh context: (1) commit SignalEnum's changes to the current feature branch (message 'feat: SignalEnum synced.'), (2) flip the SignalEnum todo row to [x] and record the commit hash, (3) report and STOP — decline to sync PduTimingEnum in this session, explaining one-class-per-session (Rule 0017.1: the 9b verbatim diffs degrade silently under loaded context; 'context still feels fresh' is a forbidden rationalization). Tell the user to start a new session, which will pick PduTimingEnum as the first [ ] row.",
+      "expectations": [
+        "Output commits SignalEnum's changes to the feature branch",
+        "Output flips the todo row to [x] WITH the commit hash",
+        "Output declines to sync PduTimingEnum in the same session",
+        "Output cites Rule 0017 / one-class-per-session as the reason",
+        "Output does NOT accept 'context is only 40% used' as grounds to continue",
+        "Output tells the user the next session picks the first [ ] row"
+      ]
     }
   ]
 }

--- a/.agents/skills/sync-autosar-class/rules.md
+++ b/.agents/skills/sync-autosar-class/rules.md
@@ -1186,3 +1186,68 @@ row exists.
 - Syncing a second class "because the context still feels fresh" (17.1).
 - Marking `[x]` without a commit hash, or deferring commits to the end (17.2).
 - Re-running Phase 0 when the todo file already exists (17.1).
+
+## Rule 0018 — Step-level session todos (per class)
+
+While running the 9-step workflow, mirror the steps into the **session todo
+list** so per-step progress is visible and verifiable in real time. This rule
+exists because a 9-step run is long: without step-level todos, "which steps are
+actually done" lives only in the conversation, and a skipped or half-finished
+step (e.g. Step 4 wipe skipped on some members, Step 5 written after Step 6)
+surfaced nothing until 9b — or never.
+
+### 18.1 Create — 9 todos at workflow start
+
+Immediately after taking the `[ ]` row (17.1) and **before starting Step 1**,
+create exactly **9 session todo items** — one per workflow step, named:
+
+1. `Step 1 — Sync members & description from spec`
+2. `Step 2 — Write model class unit test (Red)`
+3. `Step 3 — Implement model class (Green)`
+4. `Step 4 — Sync docstrings (wipe + rewrite)`
+5. `Step 5 — Write reader/writer round-trip test (Red)`
+6. `Step 6 — Update parser & writer (Green)`
+7. `Step 7 — Update checklist comment`
+8. `Step 8 — Deviations`
+9. `Step 9 — Verify (9a) + confirm (9b)`
+
+Not fewer. Merging steps into one todo (`"Steps 2+3 model TDD"`,
+`"Steps 5+6 reader/writer"`) hides exactly the Red→Green ordering Rule 0006
+exists to enforce.
+
+### 18.2 Check off — one step, one check
+
+- Mark a step todo `in_progress` when the step begins.
+- Mark it `completed` **immediately when that step finishes** — one completed
+  step = exactly one newly checked todo item, checked at that moment.
+- **Never batch-check**: marking several step todos completed at once (or all of
+  them at the end) defeats the rule — the todo list would show progress the work
+  doesn't have.
+- Never mark completed early: Step 2/5 complete only when the failing test
+  exists and was seen failing; Step 3/6 only when tests pass; Step 9 only per
+  18.3.
+- A step that is legitimately N/A for the class shape (Workflow adaptations —
+  e.g. Steps 5/6 for a standalone `AREnum`) is marked completed **with the N/A
+  reason in the todo**, not deleted and not left open.
+
+### 18.3 Gates and boundaries
+
+- **Step 9's todo completes only after 9b user confirmation** and the
+  `# Spec verified:` marker is written (or the XSD-only exception applies) —
+  passing 9a's automated checks alone does not complete it.
+- **Before the 17.2 commit: all 9 step todos must be completed.** Any open step
+  todo ⇒ the class is not finished — resolve it before committing, never check
+  it off to "clean up".
+- Session todos are **ephemeral progress display only**. The persistent record
+  remains the sync-todo file's per-class row (Rule 0016.6 / 17.2); step todos
+  neither replace it, gate it, nor get written to it. Session death discards
+  them — that is fine, the todo file carries the real state.
+
+### 18.4 Forbidden workarounds
+
+- Creating one todo for the whole class ("Sync ClassName") instead of 9.
+- Merging Red→Green pairs into single todos (2+3, 5+6).
+- Batch-checking or end-of-run checking of step todos.
+- Checking off a step todo "because 9b will re-verify it anyway" — 9b verifies
+  the class against the rules; the step todos verify the workflow was actually
+  walked, step by step.

--- a/.agents/skills/sync-autosar-class/rules.md
+++ b/.agents/skills/sync-autosar-class/rules.md
@@ -626,7 +626,9 @@ pre-existing stamp as a substitute for 9b.
 Do **not** stamp the class or advance to the next queue item until the user
 confirms every item. If any item failed, fix it and re-present 9b. This gate is the
 post-sync analogue of the Phase 0 membership gate (Rule 0016.2): both exist because
-the agent must not silently certify work the automation cannot check.
+the agent must not silently certify work the automation cannot check. After 9b
+passes, finish the class per **Rule 0017.2** (commit to the feature branch, flip
+the todo row to `[x]` with the commit hash, stop the session).
 
 ---
 
@@ -1077,16 +1079,110 @@ type as already-synced.
 A class marked Skip in 16.4 stays out of the queue; a class marked XSD-derived
 enters the queue with the XSD-only flag.
 
-### 16.6 Phase 0 output
+### 16.6 Phase 0 output — the persistent sync todo list
 
-Phase 0 produces a sync map persisted in the conversation (a markdown table or
-JSON; not a repo file):
+Phase 0 produces a **sync todo list persisted to a repo file**:
+`docs/plan/sync-todo/<InputClassName>.md` (one file per sync run; the input class
+names the file). **The queue lives in this file, never only in the conversation**
+— a conversation-only queue dies with the session and loses the 16.4 Skip/XSD
+decisions with it.
 
-| Class | Source | Table N.M | Parent | Role | Sync? |
+File format:
+
+```markdown
+# Sync todo: <InputClassName>
+
+Input class: <InputClassName> · Generated: <YYYY-MM-DD> · Queue order = row order
+(resume = first row still `[ ]`; all rows `[x]` = sync finished)
+
+| Status | Class | Role | Source | Table | Notes |
 |---|---|---|---|---|---|
-| C | markdown | Table X.Y | (input) | yes | 9-step |
-| ParentK | markdown | Table A.B | base | yes (already stamped) | skip |
-| MemberK | missing | — | member | xsd-derived | 9-step (XSD-only) |
-| MemberK2 | missing | — | member | skipped | deviation row |
+| [ ] | ParentK | base | markdown | Table A.B | |
+| [x] | ParentJ | base | markdown | Table C.D | commit abc1234 |
+| [ ] | MemberK | member | xsd-derived | — | XSD-only, no marker (16.4) |
+| [ ] | C | input | markdown | Table X.Y | |
 
-The 9-step workflow (Phase 1) consumes this map one row at a time.
+## Not queued (16.4 decisions)
+- MemberK2 — Skip per user; deviation row recorded (Rule 0014).
+```
+
+- One row per **queued** class, in 16.5 order (deepest ancestor first → input
+  class last). Status flips `[ ]` → `[x]` only per Rule 0017.2 (commit hash
+  recorded in Notes). The **Notes** column carries what later sessions need:
+  `enum` (Steps 5/6 N/A — round-trip via the consuming class), `XSD-only`
+  (no marker), `drift R<YY>-<MM>` (re-opened row), and the commit hash once
+  finished. Classes resolved **Skip** in 16.4 never get a queue row —
+  they are listed under "Not queued" so the decision survives session death.
+- Already-stamped classes skipped by 16.5 are not queued either; list them under
+  "Not queued" with "already stamped `# Spec verified: R<YY>-<MM>`".
+- The Phase 0 session **ends** after writing this file. Every 9-step run happens
+  in its own fresh session (Rule 0017).
+
+The 9-step workflow (Phase 1) consumes this file one row at a time.
+
+---
+
+## Rule 0017 — Per-class session loop, commit & completion
+
+Phase 1 execution discipline: one class per fresh session, a commit per finished
+class, and an explicit whole-sync termination condition. This rule exists because
+the per-class workload (verbatim Note diffs per member, the 9b checklist) degrades
+silently in a context loaded with earlier classes, and because conversation-only
+state (queue, Skip/XSD decisions) is lost the moment a session dies.
+
+### 17.1 Entry — resume, never rebuild
+
+- On every skill invocation, check for `docs/plan/sync-todo/<ClassName>.md` first.
+  **File exists ⇒ resume:** read it, take the **first row still `[ ]`**, run the
+  9-step workflow for that one class. Do **not** re-run Phase 0, re-collect the
+  closure, or re-ask the 16.2/16.4 gates — they were already confirmed when the
+  file was written. **File missing ⇒ run Phase 0** (which ends by writing it).
+- **One class per session.** After finishing a class (17.2), stop and tell the
+  user to start a new session for the next class — even when the context "still
+  feels fresh". A session may run Phase 0 (then stop) or exactly one 9-step
+  class, never both, never two classes. **A user request to continue in-session
+  does not override this rule** — neither the agent nor the user can detect the
+  silent degradation of the 9b verbatim diffs, and the persistent todo file
+  makes a fresh session cost near zero (16.6); explain that and stop.
+- **Drift/extension exception:** to re-sync a class whose row is already `[x]`
+  (Rule 0012.3 drift or an extension), the user must say so explicitly; reset
+  that row to `[ ]` with a `drift R<YY>-<MM>` note, then sync it in a fresh
+  session.
+
+### 17.2 Finish — commit, then mark `[x]`
+
+A class is finished only after Step 9b passes (user confirmed every item) **and**
+the `# Spec verified:` marker is written (or the XSD-only exception applies).
+Then, in this order:
+
+1. **Commit** the class's changes to the **current feature branch**: model
+   source, mirrored model test, parser/writer tests, parser, writer, deviation
+   tracker updates, and the todo file itself. Message: `feat: <ClassName> synced.`
+   If the working branch is `main`, ask the user which feature branch to use
+   before committing.
+2. **Mark the todo row `[x]`** and record the commit hash in Notes — in the same
+   commit (or an immediate follow-up commit amending the todo file only).
+3. **Report and stop.** Tell the user: class finished (hash), N of M rows done,
+   start a new session for the next class — or, if all rows are `[x]`, that the
+   sync is complete.
+
+**No `[x]` before the commit exists** — the hash is part of the row. **No
+deferred bulk commit** ("I'll commit after all classes") — a session death then
+loses every finished class's work.
+
+### 17.3 Termination — all rows `[x]`
+
+After marking a row `[x]`, re-read the todo file: every queue row `[x]` ⇒ the
+sync is **finished**. Report the summary (classes synced, commit hashes,
+remaining deviations, "Not queued" decisions). Any `[ ]` remaining ⇒ the next
+session picks it up (17.1). Never declare the sync finished while a `[ ]` queue
+row exists.
+
+### 17.4 Forbidden workarounds
+
+- Keeping the queue/sync map only in the conversation (Rule 0016.6).
+- Rebuilding the queue by grepping `# Spec verified:` stamps instead of reading
+  the todo file — stamps carry no queue order, roles, or Skip/XSD decisions.
+- Syncing a second class "because the context still feels fresh" (17.1).
+- Marking `[x]` without a commit hash, or deferring commits to the end (17.2).
+- Re-running Phase 0 when the todo file already exists (17.1).

--- a/.agents/skills/sync-autosar-class/rules.md
+++ b/.agents/skills/sync-autosar-class/rules.md
@@ -1057,12 +1057,26 @@ without the user's decision.
 
 ### 16.5 Build the ordered sync queue
 
-Order the closure for syncing:
+Order the closure **dependency-first**: a class that other queued classes depend
+on is generated (queued) **before** its dependents — never the reverse.
 
-1. Deepest ancestor first (transitive parents of C, root-last).
-2. Member types next, in spec-row order of C's `Attribute` column (resolve
-   forward references after their target).
-3. C last.
+1. Topological order over the closure's dependency edges: a class referenced by
+   another queued class (as a `Base` or as an `Attribute` member type — `ref` /
+   `tref` / `iref` target / `aggr` child / shared enum / primitive container)
+   comes **before** the class that references it.
+2. **Bases before member types**: all `Base`-chain classes are queued first,
+   each chain deepest-ancestor-first (root-last) — this is the same rule
+   applied to the `Base` edges, and it fixes the order between sibling bases
+   of unrelated classes (any deterministic base-first order is valid; keep
+   closure-collection order among independent chains).
+3. Ties left after 1–2 (member types with no dependency between them) keep
+   spec-row order of C's `Attribute` column.
+4. C last.
+
+A queue where a dependent class precedes the class it references is malformed —
+the member type would not exist when the dependent's Step 3 needs it, inviting
+fabrication (Rule 0001.10). If dependency order and spec-row order conflict,
+dependency order wins.
 
 Skip classes that already carry `# Spec verified: R<YY>-<MM>` **unless** the spec
 changed (Rule 0012.3 drift) or the class is being extended — those re-enter the
@@ -1106,8 +1120,9 @@ Input class: <InputClassName> · Generated: <YYYY-MM-DD> · Queue order = row or
 - MemberK2 — Skip per user; deviation row recorded (Rule 0014).
 ```
 
-- One row per **queued** class, in 16.5 order (deepest ancestor first → input
-  class last). Status flips `[ ]` → `[x]` only per Rule 0017.2 (commit hash
+- One row per **queued** class, in 16.5 order (dependency-first: deepest
+  ancestor first, referenced member types before their referrers, input class
+  last). Status flips `[ ]` → `[x]` only per Rule 0017.2 (commit hash
   recorded in Notes). The **Notes** column carries what later sessions need:
   `enum` (Steps 5/6 N/A — round-trip via the consuming class), `XSD-only`
   (no marker), `drift R<YY>-<MM>` (re-opened row), and the commit hash once

--- a/docs/examples/method_deviation_by_class_v2.md
+++ b/docs/examples/method_deviation_by_class_v2.md
@@ -2389,6 +2389,15 @@ are considered OK and skipped. The PDF reference `Kind` suffix (`Ref`/`TRef`/`IR
 | — *(missing)* | `—` | `dataTransformation` | ``DataTransformation`` | aggr | missing |
 | — *(missing)* | `—` | `transformationTechnology` | ``Transformation Technology`` | aggr | missing |
 
+## `TransformationISignalProps`
+- **PDF:** `AUTOSAR_CP_TPS_SystemTemplate.pdf`  | **page:** 772  | **table:** Table 7.8
+- **Package:** `M2::AUTOSARTemplates::SystemTemplate::Transformer`
+- **Source:** `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/__init__.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| `dataPrototypeTransformationProps` | `List` | `dataPrototypeTransformationProps` | ``DataPrototypeTransformationProps`` | aggr | Rule 0001.10 placeholder (class not yet implemented) |
+
 ## `Collection`
 - **PDF:** `AUTOSAR_CP_TPS_SystemTemplate.pdf`  | **page:** —
 - **Package:** `M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::ElementCollection`

--- a/docs/plan/sync-todo/DataPrototypeTransformationProps.md
+++ b/docs/plan/sync-todo/DataPrototypeTransformationProps.md
@@ -1,0 +1,23 @@
+# Sync todo: DataPrototypeTransformationProps
+
+Input class: DataPrototypeTransformationProps · Generated: 2026-08-22 · Queue order = row order
+(resume = first row still `[ ]`; all rows `[x]` = sync finished)
+
+## Phase 0 closure (confirmed by user)
+
+Input: `DataPrototypeTransformationProps` (Table 7.17, p.787) · Base: `ARObject` · Aggregated by `TransformationISignalProps.dataPrototypeTransformationProps`
+Replaces the Rule 0001.10 placeholder in `TransformationISignalProps` (commit 4ba99f8c).
+
+Skip (exist + stamped): `SwDataDefProps` (Table 5.39); referents `DataPrototype`, `AutosarDataPrototype`,
+`AbstractImplementationDataTypeElement`, `ApplicationCompositeElementDataPrototype`, `AtpInstanceRef`, `ARObject`.
+
+| Status | Class | Role | Source | Table | Notes |
+|---|---|---|---|---|---|
+| [ ] | DataPrototypeReference | base/member | markdown | Table 7.18 | abstract; parent of XSD-choice subclasses; attr tagId |
+| [ ] | DataPrototypeInPortInterfaceInstanceRef | base | markdown | Table B.6 | abstract; atpAbstract attrs; parent of iref classes |
+| [ ] | DataPrototypeInClientServerInterfaceInstanceRef | member (iref) | markdown | Table 7.21 | iref target of DataPrototypeInPortInterfaceRef |
+| [ ] | DataPrototypeInSenderReceiverInterfaceInstanceRef | member (iref) | markdown | Table 7.20 | iref target of DataPrototypeInPortInterfaceRef |
+| [ ] | DataPrototypeInPortInterfaceRef | member (XSD choice) | markdown | Table 7.19 | subclass of DataPrototypeReference |
+| [ ] | ImplementationDataTypeElementInPortInterfaceRef | member (XSD choice) | markdown | Table 7.22 | subclass of DataPrototypeReference |
+| [ ] | TransformationProps | member (ref target) | markdown | Table 7.15 | abstract; ref target of transformationProps |
+| [ ] | DataPrototypeTransformationProps | input | markdown | Table 7.17 | aggr dataPrototypeInPortInterfaceRef; aggr networkRepresentationProps (SwDataDefProps); ref transformationProps |

--- a/docs/plan/sync-todo/EndToEndTransformationDescription.md
+++ b/docs/plan/sync-todo/EndToEndTransformationDescription.md
@@ -1,0 +1,19 @@
+# Sync todo: EndToEndTransformationDescription
+
+Input class: EndToEndTransformationDescription · Generated: 2026-08-21 · Queue order = row order
+(resume = first row still `[ ]`; all rows `[x]` = sync finished)
+
+| Status | Class | Role | Source | Table | Notes |
+|---|---|---|---|---|---|
+| [x] | IPdu | base | markdown | Table 6.18 | commit 66a76b19 |
+| [x] | SystemSignalGroup | member | markdown | Table 6.13 | commit 6d986fd5 |
+| [x] | IPduTiming | member | markdown | Table 6.30 | commit 6ad3cdcd |
+| [x] | ISignalGroup | member | markdown | Table 6.12 | commit 60e8454c |
+| [ ] | ISignalToIPduMapping | member | markdown | Table 6.14 | 9-step in progress (writer done; 9a/9b pending) |
+| [ ] | ISignalIPdu | input | markdown | Table 6.19 | |
+| [ ] | DataTransformation | member | markdown | Table 7.2 | |
+| [ ] | TransformationISignalProps | member | markdown | — | |
+| [ ] | DataIdModeEnum | member enum | markdown | — | enum (Steps 5/6 N/A) |
+| [ ] | EndToEndProfileBehaviorEnum | member enum | markdown | — | enum (Steps 5/6 N/A) |
+| [ ] | E2EProfileCompatibilityProps | member | markdown | — | create if missing |
+| [ ] | EndToEndTransformationDescription | input | markdown | Table 7.3 | |

--- a/docs/plan/sync-todo/EndToEndTransformationDescription.md
+++ b/docs/plan/sync-todo/EndToEndTransformationDescription.md
@@ -9,7 +9,7 @@ Input class: EndToEndTransformationDescription · Generated: 2026-08-21 · Queue
 | [x] | SystemSignalGroup | member | markdown | Table 6.13 | commit 6d986fd5 |
 | [x] | IPduTiming | member | markdown | Table 6.30 | commit 6ad3cdcd |
 | [x] | ISignalGroup | member | markdown | Table 6.12 | commit 60e8454c |
-| [ ] | ISignalToIPduMapping | member | markdown | Table 6.14 | 9-step in progress (writer done; 9a/9b pending) |
+| [x] | ISignalToIPduMapping | member | markdown | Table 6.14 | commit 65bd7cc1 |
 | [ ] | ISignalIPdu | input | markdown | Table 6.19 | |
 | [ ] | DataTransformation | member | markdown | Table 7.2 | |
 | [ ] | TransformationISignalProps | member | markdown | — | |

--- a/docs/plan/sync-todo/EndToEndTransformationDescription.md
+++ b/docs/plan/sync-todo/EndToEndTransformationDescription.md
@@ -11,7 +11,7 @@ Input class: EndToEndTransformationDescription · Generated: 2026-08-21 · Queue
 | [x] | ISignalGroup | member | markdown | Table 6.12 | commit 60e8454c |
 | [x] | ISignalToIPduMapping | member | markdown | Table 6.14 | commit 65bd7cc1 |
 | [x] | ISignalIPdu | input | markdown | Table 6.19 | commit ccdfe29a |
-| [ ] | DataTransformation | member | markdown | Table 7.2 | |
+| [x] | DataTransformation | member | markdown | Table 7.2 | commit 1dec1aff |
 | [ ] | TransformationISignalProps | member | markdown | — | |
 | [ ] | DataIdModeEnum | member enum | markdown | — | enum (Steps 5/6 N/A) |
 | [ ] | EndToEndProfileBehaviorEnum | member enum | markdown | — | enum (Steps 5/6 N/A) |

--- a/docs/plan/sync-todo/EndToEndTransformationDescription.md
+++ b/docs/plan/sync-todo/EndToEndTransformationDescription.md
@@ -12,7 +12,8 @@ Input class: EndToEndTransformationDescription · Generated: 2026-08-21 · Queue
 | [x] | ISignalToIPduMapping | member | markdown | Table 6.14 | commit 65bd7cc1 |
 | [x] | ISignalIPdu | input | markdown | Table 6.19 | commit ccdfe29a |
 | [x] | DataTransformation | member | markdown | Table 7.2 | commit 1dec1aff |
-| [ ] | TransformationISignalProps | member | markdown | — | |
+| [x] | TransformationISignalProps | member | markdown | Table 7.8 | commit 4ba99f8c; no stamp; placeholder dataPrototypeTransformationProps (Rule 0001.10) |
+| [ ] | DataPrototypeTransformationProps | member (deferred) | markdown | — | queued later; replaces placeholder in TransformationISignalProps |
 | [ ] | DataIdModeEnum | member enum | markdown | — | enum (Steps 5/6 N/A) |
 | [ ] | EndToEndProfileBehaviorEnum | member enum | markdown | — | enum (Steps 5/6 N/A) |
 | [ ] | E2EProfileCompatibilityProps | member | markdown | — | create if missing |

--- a/docs/plan/sync-todo/EndToEndTransformationDescription.md
+++ b/docs/plan/sync-todo/EndToEndTransformationDescription.md
@@ -10,7 +10,7 @@ Input class: EndToEndTransformationDescription · Generated: 2026-08-21 · Queue
 | [x] | IPduTiming | member | markdown | Table 6.30 | commit 6ad3cdcd |
 | [x] | ISignalGroup | member | markdown | Table 6.12 | commit 60e8454c |
 | [x] | ISignalToIPduMapping | member | markdown | Table 6.14 | commit 65bd7cc1 |
-| [ ] | ISignalIPdu | input | markdown | Table 6.19 | |
+| [x] | ISignalIPdu | input | markdown | Table 6.19 | commit ccdfe29a |
 | [ ] | DataTransformation | member | markdown | Table 7.2 | |
 | [ ] | TransformationISignalProps | member | markdown | — | |
 | [ ] | DataIdModeEnum | member enum | markdown | — | enum (Steps 5/6 N/A) |

--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -1,1 +1,5 @@
-Let us update the `BaseTypeDirectDefinition` class follow @docs\development\class_check_rules.md and collect the change feedback and update @docs\development\class_check_rules.md to make rule more general
+let us improve the sync-autosar-class.                
+1. after phase 0, generarte the todo list to record all the confirmed class       
+2. each loop for class. before each 9 step, start a new session to reset the context. then get the 1st unfinsished class to start to sync
+3. after 9 step , confirmed by end user and add the spec verfied. mark the class finished in todo list and commit current changes to feature branch
+4. all the classes are finish in the todo list. it means the skill finished

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
@@ -973,36 +973,56 @@ class DcmIPdu(IPdu):
 
 class IPduTiming(Describable):
     """
-    Defines timing properties for Interaction Protocol Data Units (IPDUs),
-    specifying minimum delay and transmission mode declaration for
-    timed communication.
+    AUTOSAR COM provides the possibility to define two different TRANSMISSION MODES for each IPdu. The Transmission Mode of an IPdu that is valid at a specific point in time is selected using the values of the signals that are mapped to this IPdu. For each IPdu a Transmission Mode Selector is defined. The Transmission Mode Selector is calculated by evaluating the conditions for a subset of signals (class TransmissionModeCondition in the System Template). The Transmission Mode Selector is defined to be true, if at least one Condition evaluates to true and is defined to be false, if all Conditions evaluate to false.
     """
 
     # IPduTiming method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getMinimumDelay              [x] impl  [ ] docstring  [ ] test
-    # [ ] setMinimumDelay              [x] impl  [ ] docstring  [ ] test
-    # [ ] getTransmissionModeDeclaration [x] impl  [ ] docstring  [ ] test
-    # [ ] setTransmissionModeDeclaration [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.30, p.348
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getMinimumDelay              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMinimumDelay              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTransmissionModeDeclaration [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTransmissionModeDeclaration [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.minimumDelay: TimeValue = None
-        self.transmissionModeDeclaration: TransmissionModeDeclaration = None
+        # Minimum Delay in seconds between successive transmissions of this I-PDU, independent of the Transmission Mode.
+        self.minimumDelay: Optional[TimeValue] = None
 
-    def getMinimumDelay(self):
+        # AUTOSAR COM allows configuring statically two different transmission modes for each I-PDU (True and False). The Transmission Mode Selector evaluates the conditions for a subset of signals and decides the transmission mode. It is possible to switch between the transmission modes during runtime.
+        self.transmissionModeDeclaration: Optional[TransmissionModeDeclaration] = None
+
+    def getMinimumDelay(self) -> Optional[TimeValue]:
+        """
+        Minimum Delay in seconds between successive transmissions of this I-PDU, independent of the Transmission Mode.
+        """
         return self.minimumDelay
 
-    def setMinimumDelay(self, value):
-        self.minimumDelay = value
+    def setMinimumDelay(self, value: Optional[TimeValue]) -> "IPduTiming":
+        """
+        Minimum Delay in seconds between successive transmissions of this I-PDU, independent of the Transmission Mode.
+        A None value is a no-op and does not overwrite an existing minimumDelay.
+        """
+        if value is not None:
+            self.minimumDelay = value
         return self
 
-    def getTransmissionModeDeclaration(self):
+    def getTransmissionModeDeclaration(self) -> Optional[TransmissionModeDeclaration]:
+        """
+        AUTOSAR COM allows configuring statically two different transmission modes for each I-PDU (True and False). The Transmission Mode Selector evaluates the conditions for a subset of signals and decides the transmission mode. It is possible to switch between the transmission modes during runtime.
+        """
         return self.transmissionModeDeclaration
 
-    def setTransmissionModeDeclaration(self, value):
-        self.transmissionModeDeclaration = value
+    def setTransmissionModeDeclaration(self, value: Optional[TransmissionModeDeclaration]) -> "IPduTiming":
+        """
+        AUTOSAR COM allows configuring statically two different transmission modes for each I-PDU (True and False). The Transmission Mode Selector evaluates the conditions for a subset of signals and decides the transmission mode. It is possible to switch between the transmission modes during runtime.
+        A None value is a no-op and does not overwrite an existing transmissionModeDeclaration.
+        """
+        if value is not None:
+            self.transmissionModeDeclaration = value
         return self
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
@@ -798,78 +798,174 @@ class SecuredIPdu(IPdu):
         return self
 
 
+class TransferPropertyEnum(AREnum):
+    """
+    Transfer Properties of a Signal.
+    """
+
+    # TransferPropertyEnum method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.15, p.327
+    # (no methods)
+
+    # If the signal has the TransferProperty pending, then the function Com_SendSignal shall not perform a transmission of the IPdu associated with the signal. Tags: atp.EnumerationLiteralIndex=0
+    PENDING = "pending"
+
+    # The signal in the assigned IPdu is updated and a request for the IPdu's transmission is made. Tags: atp.EnumerationLiteralIndex=1
+    TRIGGERED = "triggered"
+
+    # The signal in the assigned IPdu is updated and a request for the IPdus transmission is made only if the signal value is different from the already stored signal value. Tags: atp.EnumerationLiteralIndex=2
+    TRIGGERED_ON_CHANGE = "triggeredOnChange"
+
+    # The signal in the assigned IPdu is updated and a request for the IPdus transmission is made only if the signal value is different from the already stored signal value. In the DIRECT/N-TIMES or MIXED transmission mode (EventControlledTiming) the IPdu will be transmitted just once without a repetition, independent of the defined NumberOfRepeats. Tags: atp.EnumerationLiteralIndex=3
+    TRIGGERED_ON_CHANGE_WITHOUT_REPETITION = "triggeredOnChangeWithoutRepetition"
+
+    # The signal in the assigned IPdu is updated and a request for the IPdu's transmission is made. In the DIRECT/N-TIMES or MIXED transmission mode (EventControlledTiming) the IPdu will be transmitted just once without a repetition, independent of the defined NumberOfRepeats. Tags: atp.EnumerationLiteralIndex=4
+    TRIGGERED_WITHOUT_REPETITION = "triggeredWithoutRepetition"
+
+    def __init__(self):
+        super().__init__(
+            (
+                TransferPropertyEnum.PENDING,
+                TransferPropertyEnum.TRIGGERED,
+                TransferPropertyEnum.TRIGGERED_ON_CHANGE,
+                TransferPropertyEnum.TRIGGERED_ON_CHANGE_WITHOUT_REPETITION,
+                TransferPropertyEnum.TRIGGERED_WITHOUT_REPETITION,
+            )
+        )
+
+
 class ISignalToIPduMapping(Identifiable):
     """
-    Defines the mapping between interaction signals and Interaction Protocol Data Units (IPDUs),
-    specifying signal references, byte order, start position, transfer
-    properties, and update indication bit position.
+    An ISignalToIPduMapping describes the mapping of ISignals to ISignalIPdus and defines the position of the ISignal within an ISignalIPdu.
     """
 
     # ISignalToIPduMapping method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getISignalRef                [x] impl  [ ] docstring  [ ] test
-    # [ ] setISignalRef                [x] impl  [ ] docstring  [ ] test
-    # [ ] getISignalGroupRef           [x] impl  [ ] docstring  [ ] test
-    # [ ] setISignalGroupRef           [x] impl  [ ] docstring  [ ] test
-    # [ ] getPackingByteOrder          [x] impl  [ ] docstring  [ ] test
-    # [ ] setPackingByteOrder          [x] impl  [ ] docstring  [ ] test
-    # [ ] getStartPosition             [x] impl  [ ] docstring  [ ] test
-    # [ ] setStartPosition             [x] impl  [ ] docstring  [ ] test
-    # [ ] getTransferProperty          [x] impl  [ ] docstring  [ ] test
-    # [ ] setTransferProperty          [x] impl  [ ] docstring  [ ] test
-    # [ ] getUpdateIndicationBitPosition [x] impl  [ ] docstring  [ ] test
-    # [ ] setUpdateIndicationBitPosition [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.14, p.326
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getISignalRef                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setISignalRef                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getISignalGroupRef           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setISignalGroupRef           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPackingByteOrder          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setPackingByteOrder          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getStartPosition             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setStartPosition             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTransferProperty          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTransferProperty          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getUpdateIndicationBitPosition [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setUpdateIndicationBitPosition [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
-    def __init__(self, parent, short_name):
+    def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.iSignalRef: RefType = None
-        self.iSignalGroupRef: RefType = None
-        self.packingByteOrder: ByteOrderEnum = None
-        self.startPosition: UnlimitedInteger = None
-        self.transferProperty = None
-        self.updateIndicationBitPosition: UnlimitedInteger = None
+        # Reference to a ISignal that is mapped into the ISignal IPdu. Each ISignal contained in the ISignalGroup shall be mapped into an IPdu by an own ISignalToIPduMapping. The references to the ISignal and to the ISignalGroup in an ISignalToIPduMapping are mutually exclusive.
+        self.iSignalRef: Optional[RefType] = None
 
-    def getISignalRef(self):
+        # Reference to an ISignalGroup that is mapped into the SignalIPdu. If an ISignalToIPduMapping for an ISignal Group is defined, only the UpdateIndicationBitPosition and the transferProperty is relevant. The startPosition and the packingByteOrder shall be ignored. Each ISignal contained in the ISignalGroup shall be mapped into an IPdu by an own ISignalToIPduMapping. The references to the ISignal and to the ISignalGroup in an ISignalToIPduMapping are mutually exclusive.
+        self.iSignalGroupRef: Optional[RefType] = None
+
+        # This parameter defines the order of the bytes of the signal and the packing into the SignalIPdu. The byte ordering "Little Endian" (MostSignificantByteLast), "Big Endian" (MostSignificantByteFirst) and "Opaque" can be selected. For opaque data endianness conversion shall be configured to Opaque. The value of this attribute impacts the absolute position of the signal into the SignalIPdu (see the startPosition attribute description). For an ISignalGroup the packingByteOrder is irrelevant and shall be ignored.
+        self.packingByteOrder: Optional[ByteOrderEnum] = None
+
+        # This parameter is necessary to describe the bitposition of a signal within an SignalIPdu. It denotes the least significant bit for "Little Endian" and the most significant bit for "Big Endian" packed signals within the IPdu (see the description of the packingByteOrder attribute). In AUTOSAR the bit counting is always set to "sawtooth" and the bit order is set to "Decreasing". The bit counting in byte 0 starts with bit 0 (least significant bit). The most significant bit in byte 0 is bit 7. Please note that the way the bytes will be actually sent on the bus does not impact this representation: they will always be seen by the software as a byte array. If a mapping for the ISignalGroup is defined, this attribute is irrelevant and shall be ignored.
+        self.startPosition: Optional[UnlimitedInteger] = None
+
+        # Defines how the referenced ISignal contributes to the send triggering of the ISignalIPdu.
+        self.transferProperty: Optional[TransferPropertyEnum] = None
+
+        # The UpdateIndicationBit indicates to the receivers that the signal (or the signal group) was updated by the sender. Length is always one bit. The UpdateIndicationBitPosition attribute describes the position of the update bit within the SignalIPdu. For Signals of a ISignalGroup this attribute is irrelevant and shall be ignored. Note that the exact bit position of the updateIndicationBitPosition is linked to the value of the attribute packingByteOrder because the method of finding the bit position is different for the values mostSignificantByteFirst and mostSignificantByteLast. This means that if the value of packingByteOrder is changed while the value of updateIndicationBitPosition remains unchanged the exact bit position of updateIndicationBitPosition within the enclosing ISignalIPdu still undergoes a change. This attribute denotes the least significant bit for "Little Endian" and the most significant bit for "Big Endian" packed signals within the IPdu (see the description of the packingByteOrder attribute). In AUTOSAR the bit counting is always set to "sawtooth" and the bit order is set to "Decreasing". The bit counting in byte 0 starts with bit 0 (least significant bit). The most significant bit in byte 0 is bit 7.
+        self.updateIndicationBitPosition: Optional[UnlimitedInteger] = None
+
+    def getISignalRef(self) -> Optional[RefType]:
+        """
+        Reference to a ISignal that is mapped into the ISignal IPdu. Each ISignal contained in the ISignalGroup shall be mapped into an IPdu by an own ISignalToIPduMapping. The references to the ISignal and to the ISignalGroup in an ISignalToIPduMapping are mutually exclusive.
+        """
         return self.iSignalRef
 
-    def setISignalRef(self, value):
-        self.iSignalRef = value
+    def setISignalRef(self, value: Optional[RefType]) -> "ISignalToIPduMapping":
+        """
+        Reference to a ISignal that is mapped into the ISignal IPdu. Each ISignal contained in the ISignalGroup shall be mapped into an IPdu by an own ISignalToIPduMapping. The references to the ISignal and to the ISignalGroup in an ISignalToIPduMapping are mutually exclusive.
+        A None value is a no-op and does not overwrite an existing iSignalRef.
+        """
+        if value is not None:
+            self.iSignalRef = value
         return self
 
-    def getISignalGroupRef(self):
+    def getISignalGroupRef(self) -> Optional[RefType]:
+        """
+        Reference to an ISignalGroup that is mapped into the SignalIPdu. If an ISignalToIPduMapping for an ISignal Group is defined, only the UpdateIndicationBitPosition and the transferProperty is relevant. The startPosition and the packingByteOrder shall be ignored. Each ISignal contained in the ISignalGroup shall be mapped into an IPdu by an own ISignalToIPduMapping. The references to the ISignal and to the ISignalGroup in an ISignalToIPduMapping are mutually exclusive.
+        """
         return self.iSignalGroupRef
 
-    def setISignalGroupRef(self, value):
-        self.iSignalGroupRef = value
+    def setISignalGroupRef(self, value: Optional[RefType]) -> "ISignalToIPduMapping":
+        """
+        Reference to an ISignalGroup that is mapped into the SignalIPdu. If an ISignalToIPduMapping for an ISignal Group is defined, only the UpdateIndicationBitPosition and the transferProperty is relevant. The startPosition and the packingByteOrder shall be ignored. Each ISignal contained in the ISignalGroup shall be mapped into an IPdu by an own ISignalToIPduMapping. The references to the ISignal and to the ISignalGroup in an ISignalToIPduMapping are mutually exclusive.
+        A None value is a no-op and does not overwrite an existing iSignalGroupRef.
+        """
+        if value is not None:
+            self.iSignalGroupRef = value
         return self
 
-    def getPackingByteOrder(self):
+    def getPackingByteOrder(self) -> Optional[ByteOrderEnum]:
+        """
+        This parameter defines the order of the bytes of the signal and the packing into the SignalIPdu. The byte ordering "Little Endian" (MostSignificantByteLast), "Big Endian" (MostSignificantByteFirst) and "Opaque" can be selected. For opaque data endianness conversion shall be configured to Opaque. The value of this attribute impacts the absolute position of the signal into the SignalIPdu (see the startPosition attribute description). For an ISignalGroup the packingByteOrder is irrelevant and shall be ignored.
+        """
         return self.packingByteOrder
 
-    def setPackingByteOrder(self, value):
-        self.packingByteOrder = value
+    def setPackingByteOrder(self, value: Optional[ByteOrderEnum]) -> "ISignalToIPduMapping":
+        """
+        This parameter defines the order of the bytes of the signal and the packing into the SignalIPdu. The byte ordering "Little Endian" (MostSignificantByteLast), "Big Endian" (MostSignificantByteFirst) and "Opaque" can be selected. For opaque data endianness conversion shall be configured to Opaque. The value of this attribute impacts the absolute position of the signal into the SignalIPdu (see the startPosition attribute description). For an ISignalGroup the packingByteOrder is irrelevant and shall be ignored.
+        A None value is a no-op and does not overwrite an existing packingByteOrder.
+        """
+        if value is not None:
+            self.packingByteOrder = value
         return self
 
-    def getStartPosition(self):
+    def getStartPosition(self) -> Optional[UnlimitedInteger]:
+        """
+        This parameter is necessary to describe the bitposition of a signal within an SignalIPdu. It denotes the least significant bit for "Little Endian" and the most significant bit for "Big Endian" packed signals within the IPdu (see the description of the packingByteOrder attribute). In AUTOSAR the bit counting is always set to "sawtooth" and the bit order is set to "Decreasing". The bit counting in byte 0 starts with bit 0 (least significant bit). The most significant bit in byte 0 is bit 7. Please note that the way the bytes will be actually sent on the bus does not impact this representation: they will always be seen by the software as a byte array. If a mapping for the ISignalGroup is defined, this attribute is irrelevant and shall be ignored.
+        """
         return self.startPosition
 
-    def setStartPosition(self, value):
-        self.startPosition = value
+    def setStartPosition(self, value: Optional[UnlimitedInteger]) -> "ISignalToIPduMapping":
+        """
+        This parameter is necessary to describe the bitposition of a signal within an SignalIPdu. It denotes the least significant bit for "Little Endian" and the most significant bit for "Big Endian" packed signals within the IPdu (see the description of the packingByteOrder attribute). In AUTOSAR the bit counting is always set to "sawtooth" and the bit order is set to "Decreasing". The bit counting in byte 0 starts with bit 0 (least significant bit). The most significant bit in byte 0 is bit 7. Please note that the way the bytes will be actually sent on the bus does not impact this representation: they will always be seen by the software as a byte array. If a mapping for the ISignalGroup is defined, this attribute is irrelevant and shall be ignored.
+        A None value is a no-op and does not overwrite an existing startPosition.
+        """
+        if value is not None:
+            self.startPosition = value
         return self
 
-    def getTransferProperty(self):
+    def getTransferProperty(self) -> Optional[TransferPropertyEnum]:
+        """
+        Defines how the referenced ISignal contributes to the send triggering of the ISignalIPdu.
+        """
         return self.transferProperty
 
-    def setTransferProperty(self, value):
-        self.transferProperty = value
+    def setTransferProperty(self, value: Optional[TransferPropertyEnum]) -> "ISignalToIPduMapping":
+        """
+        Defines how the referenced ISignal contributes to the send triggering of the ISignalIPdu.
+        A None value is a no-op and does not overwrite an existing transferProperty.
+        """
+        if value is not None:
+            self.transferProperty = value
         return self
 
-    def getUpdateIndicationBitPosition(self):
+    def getUpdateIndicationBitPosition(self) -> Optional[UnlimitedInteger]:
+        """
+        The UpdateIndicationBit indicates to the receivers that the signal (or the signal group) was updated by the sender. Length is always one bit. The UpdateIndicationBitPosition attribute describes the position of the update bit within the SignalIPdu. For Signals of a ISignalGroup this attribute is irrelevant and shall be ignored. Note that the exact bit position of the updateIndicationBitPosition is linked to the value of the attribute packingByteOrder because the method of finding the bit position is different for the values mostSignificantByteFirst and mostSignificantByteLast. This means that if the value of packingByteOrder is changed while the value of updateIndicationBitPosition remains unchanged the exact bit position of updateIndicationBitPosition within the enclosing ISignalIPdu still undergoes a change. This attribute denotes the least significant bit for "Little Endian" and the most significant bit for "Big Endian" packed signals within the IPdu (see the description of the packingByteOrder attribute). In AUTOSAR the bit counting is always set to "sawtooth" and the bit order is set to "Decreasing". The bit counting in byte 0 starts with bit 0 (least significant bit). The most significant bit in byte 0 is bit 7.
+        """
         return self.updateIndicationBitPosition
 
-    def setUpdateIndicationBitPosition(self, value):
-        self.updateIndicationBitPosition = value
+    def setUpdateIndicationBitPosition(self, value: Optional[UnlimitedInteger]) -> "ISignalToIPduMapping":
+        """
+        The UpdateIndicationBit indicates to the receivers that the signal (or the signal group) was updated by the sender. Length is always one bit. The UpdateIndicationBitPosition attribute describes the position of the update bit within the SignalIPdu. For Signals of a ISignalGroup this attribute is irrelevant and shall be ignored. Note that the exact bit position of the updateIndicationBitPosition is linked to the value of the attribute packingByteOrder because the method of finding the bit position is different for the values mostSignificantByteFirst and mostSignificantByteLast. This means that if the value of packingByteOrder is changed while the value of updateIndicationBitPosition remains unchanged the exact bit position of updateIndicationBitPosition within the enclosing ISignalIPdu still undergoes a change. This attribute denotes the least significant bit for "Little Endian" and the most significant bit for "Big Endian" packed signals within the IPdu (see the description of the packingByteOrder attribute). In AUTOSAR the bit counting is always set to "sawtooth" and the bit order is set to "Decreasing". The bit counting in byte 0 starts with bit 0 (least significant bit). The most significant bit in byte 0 is bit 7.
+        A None value is a no-op and does not overwrite an existing updateIndicationBitPosition.
+        """
+        if value is not None:
+            self.updateIndicationBitPosition = value
         return self
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
@@ -218,57 +218,92 @@ class ContainedIPduProps(ARObject):
 
 class ISignalGroup(FibexElement):
     """
-    Defines a group of interaction signals in the communication system,
-    specifying relationships between individual signals and system-level
-    signal groups with transformation properties.
+    SignalGroup of the Interaction Layer. The RTE supports a "signal fan-out" where the same System Signal Group is sent in different SignalIPdus to multiple receivers. An ISignalGroup refers to a set of ISignals that shall always be kept together. A ISignalGroup represents a COM Signal Group. Therefore it is recommended to put the ISignalGroup in the same Package as ISignals (see atp.recommendedPackage) Tags: atp.recommendedPackage=ISignalGroup
     """
 
     # ISignalGroup method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getComBasedSignalGroupTransformationRefs [x] impl  [ ] docstring  [ ] test
-    # [ ] addComBasedSignalGroupTransformationRef [x] impl  [ ] docstring  [ ] test
-    # [ ] getISignalRefs               [x] impl  [ ] docstring  [ ] test
-    # [ ] addISignalRef                [x] impl  [ ] docstring  [ ] test
-    # [ ] getSystemSignalGroupRef      [x] impl  [ ] docstring  [ ] test
-    # [ ] setSystemSignalGroupRef      [x] impl  [ ] docstring  [ ] test
-    # [ ] getTransformationISignalProps [x] impl  [ ] docstring  [ ] test
-    # [ ] setTransformationISignalProps [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.12, p.324
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getComBasedSignalGroupTransformationRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setComBasedSignalGroupTransformationRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getISignalRefs               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addISignalRef                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSystemSignalGroupRef      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSystemSignalGroupRef      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTransformationISignalProps [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addTransformationISignalProps [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent, short_name):
         super().__init__(parent, short_name)
 
-        self.comBasedSignalGroupTransformationRefs: List[RefType] = []
+        # Optional reference to a DataTransformation which represents the transformer chain that is used to transform the data that shall be placed inside this ISignalGroup based on the COMBasedTransformer approach. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=comBasedSignalGroupTransformation.data Transformation, comBasedSignalGroup Transformation.variationPoint.shortLabel vh.latestBindingTime=codeGenerationTime
+        self.comBasedSignalGroupTransformationRef: Optional[RefType] = None
+
+        # Reference to a set of ISignals that shall always be kept together.
         self.iSignalRefs: List[RefType] = []
-        self.systemSignalGroupRef = None
-        self.transformationISignalProps = None
 
-    def getComBasedSignalGroupTransformationRefs(self):
-        return self.comBasedSignalGroupTransformationRefs
+        # Reference to the SystemSignalGroup that is defined on VFB level and that is supposed to be transmitted in the ISignalGroup.
+        self.systemSignalGroupRef: Optional[RefType] = None
 
-    def addComBasedSignalGroupTransformationRef(self, value):
+        # A transformer chain consists of an ordered list of transformers. The ISignalGroup specific configuration properties for each transformer are defined in the TransformationISignalProps class. The transformer configuration properties that are common for all ISignal Groups are described in the TransformationTechnology class. Stereotypes: atpSplitable Tags: atp.Splitkey=transformationISignalProps
+        self.transformationISignalProps: List[TransformationISignalProps] = []
+
+    def getComBasedSignalGroupTransformationRef(self) -> Optional[RefType]:
+        """
+        Optional reference to a DataTransformation which represents the transformer chain that is used to transform the data that shall be placed inside this ISignalGroup based on the COMBasedTransformer approach. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=comBasedSignalGroupTransformation.data Transformation, comBasedSignalGroup Transformation.variationPoint.shortLabel vh.latestBindingTime=codeGenerationTime
+        """
+        return self.comBasedSignalGroupTransformationRef
+
+    def setComBasedSignalGroupTransformationRef(self, value: Optional[RefType]) -> "ISignalGroup":
+        """
+        Optional reference to a DataTransformation which represents the transformer chain that is used to transform the data that shall be placed inside this ISignalGroup based on the COMBasedTransformer approach. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=comBasedSignalGroupTransformation.data Transformation, comBasedSignalGroup Transformation.variationPoint.shortLabel vh.latestBindingTime=codeGenerationTime
+        A None value is a no-op and does not overwrite an existing comBasedSignalGroupTransformationRef.
+        """
         if value is not None:
-            self.comBasedSignalGroupTransformationRefs.append(value)
+            self.comBasedSignalGroupTransformationRef = value
         return self
 
-    def getISignalRefs(self):
+    def getISignalRefs(self) -> List[RefType]:
+        """
+        Reference to a set of ISignals that shall always be kept together.
+        """
         return self.iSignalRefs
 
-    def addISignalRef(self, value):
+    def addISignalRef(self, value: RefType) -> "ISignalGroup":
+        """
+        Reference to a set of ISignals that shall always be kept together.
+        """
         self.iSignalRefs.append(value)
         return self
 
-    def getSystemSignalGroupRef(self):
+    def getSystemSignalGroupRef(self) -> Optional[RefType]:
+        """
+        Reference to the SystemSignalGroup that is defined on VFB level and that is supposed to be transmitted in the ISignalGroup.
+        """
         return self.systemSignalGroupRef
 
-    def setSystemSignalGroupRef(self, value):
-        self.systemSignalGroupRef = value
+    def setSystemSignalGroupRef(self, value: Optional[RefType]) -> "ISignalGroup":
+        """
+        Reference to the SystemSignalGroup that is defined on VFB level and that is supposed to be transmitted in the ISignalGroup.
+        A None value is a no-op and does not overwrite an existing systemSignalGroupRef.
+        """
+        if value is not None:
+            self.systemSignalGroupRef = value
         return self
 
-    def getTransformationISignalProps(self):
+    def getTransformationISignalProps(self) -> List[TransformationISignalProps]:
+        """
+        A transformer chain consists of an ordered list of transformers. The ISignalGroup specific configuration properties for each transformer are defined in the TransformationISignalProps class. The transformer configuration properties that are common for all ISignal Groups are described in the TransformationTechnology class. Stereotypes: atpSplitable Tags: atp.Splitkey=transformationISignalProps
+        """
         return self.transformationISignalProps
 
-    def setTransformationISignalProps(self, value):
-        self.transformationISignalProps = value
+    def addTransformationISignalProps(self, value: TransformationISignalProps) -> "ISignalGroup":
+        """
+        A transformer chain consists of an ordered list of transformers. The ISignalGroup specific configuration properties for each transformer are defined in the TransformationISignalProps class. The transformer configuration properties that are common for all ISignal Groups are described in the TransformationTechnology class. Stereotypes: atpSplitable Tags: atp.Splitkey=transformationISignalProps
+        """
+        self.transformationISignalProps.append(value)
         return self
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
@@ -397,15 +397,16 @@ class Pdu(FibexElement, ABC):
 
 class IPdu(Pdu, ABC):
     """
-    Abstract base class for Interaction Protocol Data Units (IPDUs),
-    extending the PDU class with contained IPDU properties for
-    interaction-based communication.
+    The IPdu (Interaction Layer Protocol Data Unit) element is used to sum up all Pdus that are routed by the PduR.
     """
 
     # IPdu method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getContainedIPduProps        [x] impl  [ ] docstring  [ ] test
-    # [ ] setContainedIPduProps        [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.18, p.341
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getContainedIPduProps     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setContainedIPduProps     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         if type(self) is IPdu:
@@ -413,12 +414,20 @@ class IPdu(Pdu, ABC):
 
         super().__init__(parent, short_name)
 
-        self.containedIPduProps: ContainedIPduProps = None
+        # Defines whether this IPdu may be collected inside a ContainerIPdu.
+        self.containedIPduProps: Optional[ContainedIPduProps] = None
 
-    def getContainedIPduProps(self):
+    def getContainedIPduProps(self) -> Optional[ContainedIPduProps]:
+        """
+        Defines whether this IPdu may be collected inside a ContainerIPdu.
+        """
         return self.containedIPduProps
 
-    def setContainedIPduProps(self, value):
+    def setContainedIPduProps(self, value: Optional[ContainedIPduProps]) -> "IPdu":
+        """
+        Defines whether this IPdu may be collected inside a ContainerIPdu.
+        A None value is a no-op and does not overwrite an existing containedIPduProps.
+        """
         if value is not None:
             self.containedIPduProps = value
         return self

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
@@ -1485,36 +1485,54 @@ class SystemSignal(ARElement):
 
 class SystemSignalGroup(ARElement):
     """
-    Represents a group of system signals, defining relationships
-    between individual system signals and transforming signal references
-    for grouped signal communication.
+    A signal group refers to a set of signals that shall always be kept together. A signal group is used to guarantee the atomic transfer of AUTOSAR composite data types. The SystemSignalGroup defines a signal grouping on VFB level. On cluster level the Signal grouping is described by the ISignalGroup element. Tags: atp.recommendedPackage=SystemSignalGroups
     """
 
     # SystemSignalGroup method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getSystemSignalRefs          [x] impl  [ ] docstring  [ ] test
-    # [ ] addSystemSignalRefs          [x] impl  [ ] docstring  [ ] test
-    # [ ] getTransformingSystemSignalRef [x] impl  [ ] docstring  [ ] test
-    # [ ] setTransformingSystemSignalRef [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.13, p.324
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                      [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getSystemSignalRefs           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addSystemSignalRef            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTransformingSystemSignalRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTransformingSystemSignalRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
-    def __init__(self, parent, short_name):
+    def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
+        # Reference to a set of SystemSignals that shall always be kept together.
         self.systemSignalRefs: List[RefType] = []
-        self.transformingSystemSignalRef: RefType = None
 
-    def getSystemSignalRefs(self):
+        # Optional reference to the SystemSignal which shall contain the transformed (linear) data.
+        self.transformingSystemSignalRef: Optional[RefType] = None
+
+    def getSystemSignalRefs(self) -> List[RefType]:
+        """
+        Reference to a set of SystemSignals that shall always be kept together.
+        """
         return self.systemSignalRefs
 
-    def addSystemSignalRefs(self, value: RefType):
+    def addSystemSignalRef(self, value: RefType) -> "SystemSignalGroup":
+        """
+        Reference to a set of SystemSignals that shall always be kept together.
+        """
         self.systemSignalRefs.append(value)
         return self
 
-    def getTransformingSystemSignalRef(self):
+    def getTransformingSystemSignalRef(self) -> Optional[RefType]:
+        """
+        Optional reference to the SystemSignal which shall contain the transformed (linear) data.
+        """
         return self.transformingSystemSignalRef
 
-    def setTransformingSystemSignalRef(self, value):
-        self.transformingSystemSignalRef = value
+    def setTransformingSystemSignalRef(self, value: Optional[RefType]) -> "SystemSignalGroup":
+        """
+        Optional reference to the SystemSignal which shall contain the transformed (linear) data.
+        A None value is a no-op and does not overwrite an existing transformingSystemSignalRef.
+        """
+        if value is not None:
+            self.transformingSystemSignalRef = value
         return self
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
@@ -1124,49 +1124,77 @@ class IPduTiming(Describable):
 
 class ISignalIPdu(IPdu):
     """
-    Represents an Interaction Protocol Data Unit (IPDU) based on interaction signals,
-    defining timing specifications, signal-to-PDU mappings, and unused
-    bit patterns for signal-based communication.
+    Represents the IPdus handled by Com. The ISignalIPdu assembled and disassembled in AUTOSAR COM consists of one or more signals. In case no multiplexing is performed this IPdu is routed to/from the Interface Layer. A maximum of one dynamic length signal per IPdu is allowed.
     """
 
     # ISignalIPdu method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getIPduTimingSpecification   [x] impl  [ ] docstring  [ ] test
-    # [ ] setIPduTimingSpecification   [x] impl  [ ] docstring  [ ] test
-    # [ ] getISignalToPduMappings      [x] impl  [ ] docstring  [ ] test
-    # [ ] createISignalToPduMappings   [x] impl  [ ] docstring  [ ] test
-    # [ ] getUnusedBitPattern          [x] impl  [ ] docstring  [ ] test
-    # [ ] setUnusedBitPattern          [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.19, p.342
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getIPduTimingSpecification  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIPduTimingSpecification  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getISignalToPduMappings     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createISignalToPduMappings  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getUnusedBitPattern         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setUnusedBitPattern         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
-    def __init__(self, parent, short_name):
+    def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.iPduTimingSpecification: IPduTiming = None
-        self.iSignalToPduMappings: List[ISignalToIPduMapping] = []
-        self.unusedBitPattern: Integer = None
+        # Timing specification for Com IPdus (Transmission Modes). This information is mandatory for the sender in a System Extract. This information may be omitted on receivers in a System Extract. atpVariation: The timing of a Pdu can vary. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=iPduTimingSpecification, iPduTiming Specification.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        self.iPduTimingSpecification: Optional[IPduTiming] = None
 
-    def getIPduTimingSpecification(self):
+        # Definition of SignalToIPduMappings included in the Signal IPdu. atpVariation: The content of a PDU can be variable. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=iSignalToPduMapping.shortName, iSignalTo PduMapping.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        self.iSignalToPduMappings: List[ISignalToIPduMapping] = []
+
+        # AUTOSAR COM and AUTOSAR IPDUM are filling not used areas of an IPDU with this bit-pattern. This attribute is mandatory to avoid undefined behavior. This byte-pattern will be repeated throughout the IPdu.
+        self.unusedBitPattern: Optional[Integer] = None
+
+    def getIPduTimingSpecification(self) -> Optional[IPduTiming]:
+        """
+        Timing specification for Com IPdus (Transmission Modes). This information is mandatory for the sender in a System Extract. This information may be omitted on receivers in a System Extract. atpVariation: The timing of a Pdu can vary. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=iPduTimingSpecification, iPduTiming Specification.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
         return self.iPduTimingSpecification
 
-    def setIPduTimingSpecification(self, value):
-        self.iPduTimingSpecification = value
+    def setIPduTimingSpecification(self, value: Optional[IPduTiming]) -> "ISignalIPdu":
+        """
+        Timing specification for Com IPdus (Transmission Modes). This information is mandatory for the sender in a System Extract. This information may be omitted on receivers in a System Extract. atpVariation: The timing of a Pdu can vary. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=iPduTimingSpecification, iPduTiming Specification.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        A None value is a no-op and does not overwrite an existing iPduTimingSpecification.
+        """
+        if value is not None:
+            self.iPduTimingSpecification = value
         return self
 
-    def getISignalToPduMappings(self):
+    def getISignalToPduMappings(self) -> List[ISignalToIPduMapping]:
+        """
+        Definition of SignalToIPduMappings included in the Signal IPdu. atpVariation: The content of a PDU can be variable. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=iSignalToPduMapping.shortName, iSignalTo PduMapping.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
         return self.iSignalToPduMappings
 
     def createISignalToPduMappings(self, short_name: str) -> ISignalToIPduMapping:
+        """
+        Definition of SignalToIPduMappings included in the Signal IPdu. atpVariation: The content of a PDU can be variable. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=iSignalToPduMapping.shortName, iSignalTo PduMapping.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
         if not self.IsElementExists(short_name):
             mapping = ISignalToIPduMapping(self, short_name)
             self.addElement(mapping)
             self.iSignalToPduMappings.append(mapping)
         return self.getElement(short_name, ISignalToIPduMapping)
 
-    def getUnusedBitPattern(self):
+    def getUnusedBitPattern(self) -> Optional[Integer]:
+        """
+        AUTOSAR COM and AUTOSAR IPDUM are filling not used areas of an IPDU with this bit-pattern. This attribute is mandatory to avoid undefined behavior. This byte-pattern will be repeated throughout the IPdu.
+        """
         return self.unusedBitPattern
 
-    def setUnusedBitPattern(self, value):
-        self.unusedBitPattern = value
+    def setUnusedBitPattern(self, value: Optional[Integer]) -> "ISignalIPdu":
+        """
+        AUTOSAR COM and AUTOSAR IPDUM are filling not used areas of an IPDU with this bit-pattern. This attribute is mandatory to avoid undefined behavior. This byte-pattern will be repeated throughout the IPdu.
+        A None value is a no-op and does not overwrite an existing unusedBitPattern.
+        """
+        if value is not None:
+            self.unusedBitPattern = value
         return self
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/__init__.py
@@ -13,61 +13,103 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import
 
 class DataTransformationKindEnum(AREnum):
     """
-    Enumeration defining types of data transformations,
-    specifying the kind of transformation to be applied
-    to data elements in the communication system.
+    This enumeration contributes to the definition of the scope of the DataTransformation.
     """
 
     # DataTransformationKindEnum method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 4.40, p.150
+    # Spec verified: R23-11
+    # (no methods)
+
+    # The DataTransformation shall only be applied to the receiving end only, i.e. transform from byte array to data type. Tags: atp.EnumerationLiteralIndex=0
+    ASYMMETRIC_FROM_BYTE_ARRAY = "asymmetricFromByteArray"
+
+    # The DataTransformation shall be applied to the sending end only, i.e. from data type to byte array. Tags: atp.EnumerationLiteralIndex=1
+    ASYMMETRIC_TO_BYTE_ARRAY = "asymmetricToByteArray"
+
+    # The DataTransformation shall be applied at both the sending and the receiving end of the communication. Tags: atp.EnumerationLiteralIndex=2
+    SYMMETRIC = "symmetric"
 
     def __init__(self):
-        super().__init__([])
+        super().__init__(
+            (
+                DataTransformationKindEnum.ASYMMETRIC_FROM_BYTE_ARRAY,
+                DataTransformationKindEnum.ASYMMETRIC_TO_BYTE_ARRAY,
+                DataTransformationKindEnum.SYMMETRIC,
+            )
+        )
 
 
 class DataTransformation(Identifiable):
     """
-    Represents a data transformation in the system, defining
-    the type of transformation, execution behavior, and
-    references to transformation chains for data processing.
+    A DataTransformation represents a transformer chain. It is an ordered list of transformers.
     """
 
     # DataTransformation method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getDataTransformationKind    [x] impl  [ ] docstring  [ ] test
-    # [ ] setDataTransformationKind    [x] impl  [ ] docstring  [ ] test
-    # [ ] getExecuteDespiteDataUnavailability [x] impl  [ ] docstring  [ ] test
-    # [ ] setExecuteDespiteDataUnavailability [x] impl  [ ] docstring  [ ] test
-    # [ ] getTransformerChainRefs      [x] impl  [ ] docstring  [ ] test
-    # [ ] addTransformerChainRef       [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 7.2, p.763
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getDataTransformationKind    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDataTransformationKind    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getExecuteDespiteDataUnavailability [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setExecuteDespiteDataUnavailability [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTransformerChainRefs      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addTransformerChainRef       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.dataTransformationKind: DataTransformationKindEnum = None
-        self.executeDespiteDataUnavailability: Boolean = None
+        # This attribute controls the kind of DataTransformation to be applied.
+        self.dataTransformationKind: Optional[DataTransformationKindEnum] = None
+
+        # Specifies whether the transformer chain is executed even if no input data are available.
+        self.executeDespiteDataUnavailability: Optional[Boolean] = None
+
+        # This attribute represents the definition of a chain of transformers that are supposed to be executed according to the order of being referenced from DataTransformation.
         self.transformerChainRefs: List[RefType] = []
 
-    def getDataTransformationKind(self):
+    def getDataTransformationKind(self) -> Optional[DataTransformationKindEnum]:
+        """
+        This attribute controls the kind of DataTransformation to be applied.
+        """
         return self.dataTransformationKind
 
-    def setDataTransformationKind(self, value):
+    def setDataTransformationKind(self, value: Optional[DataTransformationKindEnum]) -> "DataTransformation":
+        """
+        This attribute controls the kind of DataTransformation to be applied.
+        A None value is a no-op and does not overwrite an existing dataTransformationKind.
+        """
         if value is not None:
             self.dataTransformationKind = value
         return self
 
-    def getExecuteDespiteDataUnavailability(self):
+    def getExecuteDespiteDataUnavailability(self) -> Optional[Boolean]:
+        """
+        Specifies whether the transformer chain is executed even if no input data are available.
+        """
         return self.executeDespiteDataUnavailability
 
-    def setExecuteDespiteDataUnavailability(self, value):
+    def setExecuteDespiteDataUnavailability(self, value: Optional[Boolean]) -> "DataTransformation":
+        """
+        Specifies whether the transformer chain is executed even if no input data are available.
+        A None value is a no-op and does not overwrite an existing executeDespiteDataUnavailability.
+        """
         if value is not None:
             self.executeDespiteDataUnavailability = value
         return self
 
-    def getTransformerChainRefs(self):
+    def getTransformerChainRefs(self) -> List[RefType]:
+        """
+        This attribute represents the definition of a chain of transformers that are supposed to be executed according to the order of being referenced from DataTransformation.
+        """
         return self.transformerChainRefs
 
-    def addTransformerChainRef(self, value):
+    def addTransformerChainRef(self, value: Optional[RefType]) -> "DataTransformation":
+        """
+        This attribute represents the definition of a chain of transformers that are supposed to be executed according to the order of being referenced from DataTransformation.
+        A None value is a no-op and does not add to transformerChainRefs.
+        """
         if value is not None:
             self.transformerChainRefs.append(value)
         return self

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/__init__.py
@@ -695,62 +695,97 @@ class DataTransformationSet(ARElement):
         return self.getElement(short_name)
 
 
+class CSTransformerErrorReactionEnum(AREnum):
+    """
+    Possible kinds of error reaction in case of a hard transformer error.
+    """
+
+    # CSTransformerErrorReactionEnum method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 7.9, p.773
+    # Spec verified: R23-11
+    # (no methods)
+
+    # The application is responsible for any error reaction. No autonomous error reaction of RTE and transformer. Tags: atp.EnumerationLiteralIndex=0
+    APPLICATION_ONLY = "applicationOnly"
+
+    # RTE and Transformer coordinate an autonomous error reaction on their own. Tags: atp.EnumerationLiteralIndex=1
+    AUTONOMOUS = "autonomous"
+
+    def __init__(self):
+        super().__init__([CSTransformerErrorReactionEnum.APPLICATION_ONLY, CSTransformerErrorReactionEnum.AUTONOMOUS])
+
+
 class TransformationISignalProps(Describable, ABC):
     """
-    Abstract base class for transformation interaction signal properties,
-    defining common properties for signal transformation including
-    error reactions, data prototype properties, and transformer references.
+    TransformationISignalProps holds all the attributes for the different TransformationTechnologies that are ISignal specific. Tags: vh.latestBindingTime=postBuild
     """
 
     # TransformationISignalProps method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getCsErrorReaction           [x] impl  [ ] docstring  [ ] test
-    # [ ] setCsErrorReaction           [x] impl  [ ] docstring  [ ] test
-    # [ ] getDataPrototypeTransformationProps [x] impl  [ ] docstring  [ ] test
-    # [ ] setDataPrototypeTransformationProps [x] impl  [ ] docstring  [ ] test
-    # [ ] getIdent                     [x] impl  [ ] docstring  [ ] test
-    # [ ] setIdent                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getTransformerRef            [x] impl  [ ] docstring  [ ] test
-    # [ ] setTransformerRef            [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 7.8, p.772
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getCsErrorReaction           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCsErrorReaction           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDataPrototypeTransformationProps [x] impl  [x] docstring  [x] test  [ ] reader  [ ] writer
+    # [x] setDataPrototypeTransformationProps [x] impl  [x] docstring  [x] test  [ ] reader  [ ] writer
+    # [x] getTransformerRef            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTransformerRef            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         if type(self) is TransformationISignalProps:
             raise TypeError("TransformationISignalProps is an abstract class.")
         super().__init__()
 
-        self.csErrorReaction = None
-        self.dataPrototypeTransformationProps: List = []
-        self.ident = None
-        self.transformerRef: RefType = None
+        # Defines whether the transformer chain of client/server communication coordinates an autonomous error reaction together with the RTE or whether any error reaction is the responsibility of the application.
+        self.csErrorReaction: Optional[CSTransformerErrorReactionEnum] = None
 
-    def getCsErrorReaction(self):
+        # Fine granular modeling of TransfromationProps on the level of DataPrototypes. Note: This atpSplitable property has no atp.Splitkey due to atpVariation (PropertySetPattern). Stereotypes: atpSplitable
+        self.dataPrototypeTransformationProps: List = []  # placeholder: DataPrototypeTransformationProps not yet implemented
+
+        # Reference to the TransformationTechnology description that contains transformer specific and ISignal independent configuration properties.
+        self.transformerRef: Optional[RefType] = None
+
+    def getCsErrorReaction(self) -> Optional[CSTransformerErrorReactionEnum]:
+        """
+        Defines whether the transformer chain of client/server communication coordinates an autonomous error reaction together with the RTE or whether any error reaction is the responsibility of the application.
+        """
         return self.csErrorReaction
 
-    def setCsErrorReaction(self, value):
+    def setCsErrorReaction(self, value: Optional[CSTransformerErrorReactionEnum]) -> "TransformationISignalProps":
+        """
+        Defines whether the transformer chain of client/server communication coordinates an autonomous error reaction together with the RTE or whether any error reaction is the responsibility of the application.
+        A None value is a no-op and does not overwrite an existing csErrorReaction.
+        """
         if value is not None:
             self.csErrorReaction = value
         return self
 
-    def getDataPrototypeTransformationProps(self):
+    def getDataPrototypeTransformationProps(self) -> List:
+        """
+        Fine granular modeling of TransfromationProps on the level of DataPrototypes. Note: This atpSplitable property has no atp.Splitkey due to atpVariation (PropertySetPattern). Stereotypes: atpSplitable
+        """
         return self.dataPrototypeTransformationProps
 
-    def setDataPrototypeTransformationProps(self, value):
+    def setDataPrototypeTransformationProps(self, value: Optional[List]) -> "TransformationISignalProps":
+        """
+        Fine granular modeling of TransfromationProps on the level of DataPrototypes. Note: This atpSplitable property has no atp.Splitkey due to atpVariation (PropertySetPattern). Stereotypes: atpSplitable
+        A None value is a no-op and does not overwrite an existing dataPrototypeTransformationProps.
+        """
         if value is not None:
             self.dataPrototypeTransformationProps = value
         return self
 
-    def getIdent(self):
-        return self.ident
-
-    def setIdent(self, value):
-        if value is not None:
-            self.ident = value
-        return self
-
-    def getTransformerRef(self):
+    def getTransformerRef(self) -> Optional[RefType]:
+        """
+        Reference to the TransformationTechnology description that contains transformer specific and ISignal independent configuration properties.
+        """
         return self.transformerRef
 
-    def setTransformerRef(self, value):
+    def setTransformerRef(self, value: Optional[RefType]) -> "TransformationISignalProps":
+        """
+        Reference to the TransformationTechnology description that contains transformer specific and ISignal independent configuration properties.
+        A None value is a no-op and does not overwrite an existing transformerRef.
+        """
         if value is not None:
             self.transformerRef = value
         return self

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -6673,9 +6673,11 @@ class ARXMLParser(AbstractARXMLParser):
     def readISignalToIPduMapping(self, element: ET.Element, mapping: ISignalToIPduMapping):
         self.readIdentifiable(element, mapping)
         mapping.setISignalRef(self.getChildElementOptionalRefType(element, "I-SIGNAL-REF"))
+        mapping.setISignalGroupRef(self.getChildElementOptionalRefType(element, "I-SIGNAL-GROUP-REF"))
         mapping.setPackingByteOrder(self.getChildElementOptionalLiteral(element, "PACKING-BYTE-ORDER"))
         mapping.setStartPosition(self.getChildElementOptionalIntegerValue(element, "START-POSITION"))
         mapping.setTransferProperty(self.getChildElementOptionalLiteral(element, "TRANSFER-PROPERTY"))
+        mapping.setUpdateIndicationBitPosition(self.getChildElementOptionalNumericalValue(element, "UPDATE-INDICATION-BIT-POSITION"))
 
     def readNmPduISignalToIPduMappings(self, element: ET.Element, pdu: NmPdu):
         for child_element in self.findall(element, "I-SIGNAL-TO-I-PDU-MAPPINGS/*"):

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -7135,6 +7135,7 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readDataTransformation(self, element: ET.Element, dtf: DataTransformation):
         self.readIdentifiable(element, dtf)
+        dtf.setDataTransformationKind(self.getChildElementOptionalLiteral(element, "DATA-TRANSFORMATION-KIND"))
         dtf.setExecuteDespiteDataUnavailability(self.getChildElementOptionalBooleanValue(element, "EXECUTE-DESPITE-DATA-UNAVAILABILITY"))
         self.readDataTransformationTransformerChainRefs(element, dtf)
 

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -8370,7 +8370,8 @@ class ARXMLParser(AbstractARXMLParser):
         self.logger.debug("Read SystemSignalGroup <%s>" % group.getShortName())
         self.readIdentifiable(element, group)
         for ref_type in self.getChildElementRefTypeList(element, "SYSTEM-SIGNAL-REFS/SYSTEM-SIGNAL-REF"):
-            group.addSystemSignalRefs(ref_type)
+            group.addSystemSignalRef(ref_type)
+        group.setTransformingSystemSignalRef(self.getChildElementOptionalRefType(element, "TRANSFORMING-SYSTEM-SIGNAL-REF"))
 
     def readSignalServiceTranslationPropsSet(self, element: ET.Element, props_set: SignalServiceTranslationPropsSet):
         self.logger.debug("Read SignalServiceTranslationPropsSet <%s>" % props_set.getShortName())

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -505,6 +505,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommun
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import LinCommunicationConnector, LinCommunicationController, LinMaster
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform import Gateway, IPduMapping, ISignalMapping, TargetIPduRef
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (
+    ContainedIPduProps,
     DcmIPdu,
     DynamicPart,
     DynamicPartAlternative,
@@ -6691,8 +6692,23 @@ class ARXMLParser(AbstractARXMLParser):
         self.readNmPduISignalToIPduMappings(element, pdu)
         pdu.setUnusedBitPattern(self.getChildElementOptionalIntegerValue(element, "UNUSED-BIT-PATTERN"))
 
+    def readContainedIPduProps(self, element: ET.Element) -> ContainedIPduProps:
+        props = None
+        child_element = self.find(element, "CONTAINED-I-PDU-PROPS")
+        if child_element is not None:
+            props = ContainedIPduProps()
+            props.setCollectionSemantics(self.getChildElementOptionalLiteral(child_element, "COLLECTION-SEMANTICS"))
+            props.setHeaderIdLongHeader(self.getChildElementOptionalPositiveInteger(child_element, "HEADER-ID-LONG-HEADER"))
+            props.setHeaderIdShortHeader(self.getChildElementOptionalPositiveInteger(child_element, "HEADER-ID-SHORT-HEADER"))
+            props.setOffset(self.getChildElementOptionalNumericalValue(child_element, "OFFSET"))
+            props.setTimeout(self.getChildElementOptionalNumericalValue(child_element, "TIMEOUT"))
+            props.setTrigger(self.getChildElementOptionalLiteral(child_element, "TRIGGER"))
+            props.setUpdateIndicationBitPosition(self.getChildElementOptionalNumericalValue(child_element, "UPDATE-INDICATION-BIT-POSITION"))
+        return props
+
     def readIPdu(self, element: ET.Element, pdu: IPdu):
         self.readPdu(element, pdu)
+        pdu.setContainedIPduProps(self.readContainedIPduProps(element))
 
     def readNPdu(self, element: ET.Element, pdu: NPdu):
         self.logger.debug("Read NPdu <%s>" % pdu.getShortName())

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -8323,8 +8323,8 @@ class ARXMLParser(AbstractARXMLParser):
             group.addISignalRef(ref_type)
 
     def readISignalGroupComBasedSignalGroupTransformation(self, element: ET.Element, group: ISignalGroup):
-        for ref in self.getChildElementRefTypeList(element, "COM-BASED-SIGNAL-GROUP-TRANSFORMATIONS/DATA-TRANSFORMATION-REF-CONDITIONAL/DATA-TRANSFORMATION-REF"):  # noqa E501
-            group.addComBasedSignalGroupTransformationRef(ref)
+        ref = self.getChildElementOptionalRefType(element, "COM-BASED-SIGNAL-GROUP-TRANSFORMATIONS/DATA-TRANSFORMATION-REF-CONDITIONAL/DATA-TRANSFORMATION-REF")
+        group.setComBasedSignalGroupTransformationRef(ref)
 
     def readTransformationISignalProps(self, element: ET.Element, props: TransformationISignalProps):
         self.readDescribable(element, props)
@@ -8348,7 +8348,7 @@ class ARXMLParser(AbstractARXMLParser):
             if tag_name == "END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS":
                 props = EndToEndTransformationISignalProps()
                 self.readEndToEndTransformationISignalProps(child_element, props)
-                group.setTransformationISignalProps(props)
+                group.addTransformationISignalProps(props)
             else:
                 self.notImplemented("Unsupported TransformationISignalProps %s" % tag_name)
 

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -8331,6 +8331,7 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readTransformationISignalProps(self, element: ET.Element, props: TransformationISignalProps):
         self.readDescribable(element, props)
+        props.setCsErrorReaction(self.getChildElementOptionalLiteral(element, "CS-ERROR-REACTION"))
 
     def readEndToEndTransformationISignalPropsDataIds(self, element: ET.Element, props: EndToEndTransformationISignalProps):
         child_element = self.find(element, "DATA-IDS")

--- a/src/armodel/writer/abstract_arxml_writer.py
+++ b/src/armodel/writer/abstract_arxml_writer.py
@@ -92,7 +92,10 @@ class AbstractARXMLWriter(ABC):
             self.writeARObjectAttributes(child_element, numerical)
             if numerical.getShortLabel() is not None:
                 child_element.attrib["SHORT-LABEL"] = numerical.getShortLabel()
-            child_element.text = numerical._text
+            if numerical._text is not None:
+                child_element.text = numerical._text
+            elif numerical._value is not None:
+                child_element.text = str(numerical._value)
 
     def setChildElementOptionalIntegerValue(self, element: ET.Element, key: str, value: Integer):
         self.setChildElementOptionalNumericalValue(element, key, value)

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -8351,6 +8351,7 @@ class ARXMLWriter(AbstractARXMLWriter):
 
     def writeTransformationISignalProps(self, element: ET.Element, props: TransformationISignalProps):
         self.writeDescribable(element, props)
+        self.setChildElementOptionalLiteral(element, "CS-ERROR-REACTION", props.getCsErrorReaction())
 
     def writeEndToEndTransformationISignalPropsDataIds(self, element: ET.Element, props: EndToEndTransformationISignalProps):
         ids = props.getDataIds()

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -5950,9 +5950,11 @@ class ARXMLWriter(AbstractARXMLWriter):
             child_element = ET.SubElement(element, "I-SIGNAL-TO-I-PDU-MAPPING")
             self.writeIdentifiable(child_element, mapping)
             self.setChildElementOptionalRefType(child_element, "I-SIGNAL-REF", mapping.getISignalRef())
+            self.setChildElementOptionalRefType(child_element, "I-SIGNAL-GROUP-REF", mapping.getISignalGroupRef())
             self.setChildElementOptionalLiteral(child_element, "PACKING-BYTE-ORDER", mapping.getPackingByteOrder())
             self.setChildElementOptionalIntegerValue(child_element, "START-POSITION", mapping.getStartPosition())
             self.setChildElementOptionalLiteral(child_element, "TRANSFER-PROPERTY", mapping.getTransferProperty())
+            self.setChildElementOptionalNumericalValue(child_element, "UPDATE-INDICATION-BIT-POSITION", mapping.getUpdateIndicationBitPosition())
 
     def writeNmPduISignalToIPduMappings(self, element: ET.Element, pdu: NmPdu):
         mappings = pdu.getISignalToIPduMappings()

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -9037,6 +9037,7 @@ class ARXMLWriter(AbstractARXMLWriter):
         if dtf is not None:
             child_element = ET.SubElement(element, "DATA-TRANSFORMATION")
             self.writeIdentifiable(child_element, dtf)
+            self.setChildElementOptionalLiteral(child_element, "DATA-TRANSFORMATION-KIND", dtf.getDataTransformationKind())
             self.setChildElementOptionalBooleanValue(child_element, "EXECUTE-DESPITE-DATA-UNAVAILABILITY", dtf.getExecuteDespiteDataUnavailability())
             self.writeDataTransformationTransformerChainRefs(child_element, dtf)
 

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -8340,12 +8340,11 @@ class ARXMLWriter(AbstractARXMLWriter):
                 self.setChildElementOptionalRefType(child_element, "I-SIGNAL-REF", signal_ref)
 
     def writeISignalGroupComBasedSignalGroupTransformation(self, element: ET.Element, group: ISignalGroup):
-        refs = group.getComBasedSignalGroupTransformationRefs()
-        if len(refs) > 0:
+        ref = group.getComBasedSignalGroupTransformationRef()
+        if ref is not None:
             com_based_element = ET.SubElement(element, "COM-BASED-SIGNAL-GROUP-TRANSFORMATIONS")
             cond_element = ET.SubElement(com_based_element, "DATA-TRANSFORMATION-REF-CONDITIONAL")
-            for ref in refs:
-                self.setChildElementOptionalRefType(cond_element, "DATA-TRANSFORMATION-REF", ref)
+            self.setChildElementOptionalRefType(cond_element, "DATA-TRANSFORMATION-REF", ref)
 
     def writeTransformationISignalProps(self, element: ET.Element, props: TransformationISignalProps):
         self.writeDescribable(element, props)
@@ -8368,13 +8367,14 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.setChildElementOptionalPositiveInteger(child_element, "DATA-LENGTH", props.getDataLength())
 
     def writeISignalGroupTransformationISignalProps(self, element: ET.Element, group: ISignalGroup):
-        props = group.getTransformationISignalProps()
-        if props is not None:
+        props_list = group.getTransformationISignalProps()
+        if len(props_list) > 0:
             child_element = ET.SubElement(element, "TRANSFORMATION-I-SIGNAL-PROPSS")
-            if isinstance(props, EndToEndTransformationISignalProps):
-                self.writeEndToEndTransformationISignalProps(child_element, props)
-            else:
-                self.notImplemented("Unsupported TransformationISignalProps %s" % type(props))
+            for props in props_list:
+                if isinstance(props, EndToEndTransformationISignalProps):
+                    self.writeEndToEndTransformationISignalProps(child_element, props)
+                else:
+                    self.notImplemented("Unsupported TransformationISignalProps %s" % type(props))
 
     def writeISignalGroup(self, element: ET.Element, group: ISignalGroup):
         self.logger.debug("ISignalGroup %s" % group.getShortName())

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -7748,6 +7748,7 @@ class ARXMLWriter(AbstractARXMLWriter):
             signal_refs_tag = ET.SubElement(child_element, "SYSTEM-SIGNAL-REFS")
             for signal_ref in signal_refs:
                 self.setChildElementOptionalRefType(signal_refs_tag, "SYSTEM-SIGNAL-REF", signal_ref)
+        self.setChildElementOptionalRefType(child_element, "TRANSFORMING-SYSTEM-SIGNAL-REF", group.getTransformingSystemSignalRef())
 
     def writeSenderReceiverToSignalMapping(self, element: ET.Element, mapping: SenderReceiverToSignalMapping):
         child_element = ET.SubElement(element, "SENDER-RECEIVER-TO-SIGNAL-MAPPING")

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -478,6 +478,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommun
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import LinCommunicationConnector, LinCommunicationController, LinMaster
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform import Gateway, IPduMapping, ISignalMapping, TargetIPduRef
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (
+    ContainedIPduProps,
     DcmIPdu,
     DynamicPart,
     DynamicPartAlternative,
@@ -8543,8 +8544,20 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.setChildElementOptionalBooleanValue(element, "HAS-DYNAMIC-LENGTH", pdu.getHasDynamicLength())
         self.setChildElementOptionalNumericalValue(element, "LENGTH", pdu.getLength())
 
+    def writeContainedIPduProps(self, element: ET.Element, props: ContainedIPduProps):
+        if props is not None:
+            child_element = ET.SubElement(element, "CONTAINED-I-PDU-PROPS")
+            self.setChildElementOptionalLiteral(child_element, "COLLECTION-SEMANTICS", props.getCollectionSemantics())
+            self.setChildElementOptionalPositiveInteger(child_element, "HEADER-ID-LONG-HEADER", props.getHeaderIdLongHeader())
+            self.setChildElementOptionalPositiveInteger(child_element, "HEADER-ID-SHORT-HEADER", props.getHeaderIdShortHeader())
+            self.setChildElementOptionalNumericalValue(child_element, "OFFSET", props.getOffset())
+            self.setChildElementOptionalNumericalValue(child_element, "TIMEOUT", props.getTimeout())
+            self.setChildElementOptionalLiteral(child_element, "TRIGGER", props.getTrigger())
+            self.setChildElementOptionalNumericalValue(child_element, "UPDATE-INDICATION-BIT-POSITION", props.getUpdateIndicationBitPosition())
+
     def writeIPdu(self, element: ET.Element, pdu: IPdu):
         self.writePdu(element, pdu)
+        self.writeContainedIPduProps(element, pdu.getContainedIPduProps())
 
     def writeSegmentPosition(self, element: ET.Element, position: SegmentPosition):
         if position is not None:

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
@@ -593,15 +593,20 @@ class Test_FibexCoreCommunication:
         ipdu.setIPduTimingSpecification(timing)
         assert ipdu.getIPduTimingSpecification() == timing
         assert ipdu == ipdu.setIPduTimingSpecification(timing)  # Test method chaining
+        assert ipdu == ipdu.setIPduTimingSpecification(None)  # None is a no-op
+        assert ipdu.getIPduTimingSpecification() == timing
 
         ipdu.setUnusedBitPattern(255)
         assert ipdu.getUnusedBitPattern() == 255
         assert ipdu == ipdu.setUnusedBitPattern(255)  # Test method chaining
+        assert ipdu == ipdu.setUnusedBitPattern(None)  # None is a no-op
+        assert ipdu.getUnusedBitPattern() == 255
 
         # Test ISignalToPduMappings creation method
         mapping = ipdu.createISignalToPduMappings("test_mapping")
         assert isinstance(mapping, ISignalToIPduMapping)
         assert len(ipdu.getISignalToPduMappings()) == 1
+        assert ipdu.createISignalToPduMappings("test_mapping") is mapping  # duplicate returns existing
 
     def test_ISignal(self):
         """Test ISignal class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
@@ -36,6 +36,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommu
     StaticPart,
     SystemSignal,
     SystemSignalGroup,
+    TransferPropertyEnum,
     UserDefinedIPdu,
     UserDefinedPdu,
 )
@@ -452,27 +453,49 @@ class Test_FibexCoreCommunication:
         mapping.setISignalRef(ref1)
         assert mapping.getISignalRef() == ref1
         assert mapping == mapping.setISignalRef(ref1)  # Test method chaining
+        assert mapping == mapping.setISignalRef(None)  # None is a no-op
+        assert mapping.getISignalRef() == ref1
 
         ref2 = object()
         mapping.setISignalGroupRef(ref2)
         assert mapping.getISignalGroupRef() == ref2
         assert mapping == mapping.setISignalGroupRef(ref2)  # Test method chaining
+        assert mapping == mapping.setISignalGroupRef(None)  # None is a no-op
+        assert mapping.getISignalGroupRef() == ref2
 
         mapping.setPackingByteOrder("MOST_SIGNIFICANT_BYTE_FIRST")
         assert mapping.getPackingByteOrder() == "MOST_SIGNIFICANT_BYTE_FIRST"
         assert mapping == mapping.setPackingByteOrder("MOST_SIGNIFICANT_BYTE_FIRST")  # Test method chaining
+        assert mapping == mapping.setPackingByteOrder(None)  # None is a no-op
+        assert mapping.getPackingByteOrder() == "MOST_SIGNIFICANT_BYTE_FIRST"
 
         mapping.setStartPosition(100)
         assert mapping.getStartPosition() == 100
         assert mapping == mapping.setStartPosition(100)  # Test method chaining
+        assert mapping == mapping.setStartPosition(None)  # None is a no-op
+        assert mapping.getStartPosition() == 100
 
         mapping.setTransferProperty("PENDING")
         assert mapping.getTransferProperty() == "PENDING"
         assert mapping == mapping.setTransferProperty("PENDING")  # Test method chaining
+        assert mapping == mapping.setTransferProperty(None)  # None is a no-op
+        assert mapping.getTransferProperty() == "PENDING"
 
         mapping.setUpdateIndicationBitPosition(50)
         assert mapping.getUpdateIndicationBitPosition() == 50
         assert mapping == mapping.setUpdateIndicationBitPosition(50)  # Test method chaining
+        assert mapping == mapping.setUpdateIndicationBitPosition(None)  # None is a no-op
+        assert mapping.getUpdateIndicationBitPosition() == 50
+
+    def test_TransferPropertyEnum(self):
+        """Test TransferPropertyEnum enum functionality."""
+        enum = TransferPropertyEnum()
+        assert enum is not None
+        assert TransferPropertyEnum.PENDING in enum.getEnumValues()
+        assert TransferPropertyEnum.TRIGGERED in enum.getEnumValues()
+        assert TransferPropertyEnum.TRIGGERED_ON_CHANGE in enum.getEnumValues()
+        assert TransferPropertyEnum.TRIGGERED_ON_CHANGE_WITHOUT_REPETITION in enum.getEnumValues()
+        assert TransferPropertyEnum.TRIGGERED_WITHOUT_REPETITION in enum.getEnumValues()
 
     def test_NmPdu(self):
         """Test NmPdu class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
@@ -172,16 +172,18 @@ class Test_FibexCoreCommunication:
         assert isinstance(group, FibexElement)
 
         # Test default values
-        assert group.getComBasedSignalGroupTransformationRefs() == []
+        assert group.getComBasedSignalGroupTransformationRef() is None
         assert group.getISignalRefs() == []
         assert group.getSystemSignalGroupRef() is None
-        assert group.getTransformationISignalProps() is None
+        assert group.getTransformationISignalProps() == []
 
         # Test setter/getter methods with method chaining
         ref1 = object()
-        group.addComBasedSignalGroupTransformationRef(ref1)
-        assert ref1 in group.getComBasedSignalGroupTransformationRefs()
-        assert group == group.addComBasedSignalGroupTransformationRef(ref1)  # Test method chaining
+        group.setComBasedSignalGroupTransformationRef(ref1)
+        assert group.getComBasedSignalGroupTransformationRef() == ref1
+        assert group == group.setComBasedSignalGroupTransformationRef(ref1)  # Test method chaining
+        assert group == group.setComBasedSignalGroupTransformationRef(None)  # None is a no-op
+        assert group.getComBasedSignalGroupTransformationRef() == ref1
 
         ref2 = object()
         group.addISignalRef(ref2)
@@ -194,9 +196,9 @@ class Test_FibexCoreCommunication:
         assert group == group.setSystemSignalGroupRef(ref3)  # Test method chaining
 
         ref4 = object()
-        group.setTransformationISignalProps(ref4)
-        assert group.getTransformationISignalProps() == ref4
-        assert group == group.setTransformationISignalProps(ref4)  # Test method chaining
+        group.addTransformationISignalProps(ref4)
+        assert ref4 in group.getTransformationISignalProps()
+        assert group == group.addTransformationISignalProps(ref4)  # Test method chaining
 
     def test_ISignalIPduGroup(self):
         """Test ISignalIPduGroup class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
@@ -543,11 +543,15 @@ class Test_FibexCoreCommunication:
         timing.setMinimumDelay(ref1)
         assert timing.getMinimumDelay() == ref1
         assert timing == timing.setMinimumDelay(ref1)  # Test method chaining
+        assert timing == timing.setMinimumDelay(None)  # None is a no-op
+        assert timing.getMinimumDelay() == ref1
 
         ref2 = object()
         timing.setTransmissionModeDeclaration(ref2)
         assert timing.getTransmissionModeDeclaration() == ref2
         assert timing == timing.setTransmissionModeDeclaration(ref2)  # Test method chaining
+        assert timing == timing.setTransmissionModeDeclaration(None)  # None is a no-op
+        assert timing.getTransmissionModeDeclaration() == ref2
 
     def test_ISignalIPdu(self):
         """Test ISignalIPdu class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
@@ -757,14 +757,16 @@ class Test_FibexCoreCommunication:
 
         # Test setter/getter methods with method chaining
         ref1 = object()
-        group.addSystemSignalRefs(ref1)
+        group.addSystemSignalRef(ref1)
         assert ref1 in group.getSystemSignalRefs()
-        assert group == group.addSystemSignalRefs(ref1)  # Test method chaining
+        assert group == group.addSystemSignalRef(ref1)  # Test method chaining
 
         ref2 = object()
         group.setTransformingSystemSignalRef(ref2)
         assert group.getTransformingSystemSignalRef() == ref2
         assert group == group.setTransformingSystemSignalRef(ref2)  # Test method chaining
+        assert group == group.setTransformingSystemSignalRef(None)  # None is a no-op
+        assert group.getTransformingSystemSignalRef() == ref2
 
     def test_ISignalTriggering(self):
         """Test ISignalTriggering class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/test_Transformer.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/test_Transformer.py
@@ -4,6 +4,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Describable, Identifiable
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import (
     BufferProperties,
+    CSTransformerErrorReactionEnum,
     DataIdModeEnum,
     DataTransformation,
     DataTransformationKindEnum,
@@ -504,10 +505,26 @@ class TestTransformer:
         assert enum == enum.setValue(TransformerClassEnum.SERIALIZER)
         assert enum.getValue() == "serializer"
 
+    def test_cs_transformer_error_reaction_enum(self):
+        """
+        Test CSTransformerErrorReactionEnum enum functionality.
+        """
+        enum = CSTransformerErrorReactionEnum()
+
+        # Test that it's properly initialized
+        assert enum is not None
+        assert CSTransformerErrorReactionEnum.APPLICATION_ONLY in enum.getEnumValues()
+        assert CSTransformerErrorReactionEnum.AUTONOMOUS in enum.getEnumValues()
+
+        # Test instantiation with a value
+        enum.setValue(CSTransformerErrorReactionEnum.AUTONOMOUS)
+        assert enum.getValue() == "autonomous"
+
     def test_transformation_isignal_props_abstract(self):
         """
         Test TransformationISignalProps abstract class functionality.
         """
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
 
         class ConcreteTransformationISignalProps(TransformationISignalProps):
             def __init__(self):
@@ -518,8 +535,10 @@ class TestTransformer:
         # Test default values
         assert props.getCsErrorReaction() is None
         assert props.getDataPrototypeTransformationProps() == []
-        assert props.getIdent() is None
         assert props.getTransformerRef() is None
+
+        # No fabricated ident field
+        assert not hasattr(props, "ident")
 
         # Test setter/getter methods with method chaining - with None values
         assert props == props.setCsErrorReaction(None)
@@ -528,28 +547,23 @@ class TestTransformer:
         assert props == props.setDataPrototypeTransformationProps(None)
         assert props.getDataPrototypeTransformationProps() == []  # Should remain empty list
 
-        assert props == props.setIdent(None)
-        assert props.getIdent() is None
-
         assert props == props.setTransformerRef(None)
         assert props.getTransformerRef() is None
 
         # Test setter/getter methods with method chaining - with actual values
-        props.setCsErrorReaction("error_reaction")
-        assert props.getCsErrorReaction() == "error_reaction"
-        assert props == props.setCsErrorReaction("error_reaction")
+        props.setCsErrorReaction(CSTransformerErrorReactionEnum.APPLICATION_ONLY)
+        assert props.getCsErrorReaction() == CSTransformerErrorReactionEnum.APPLICATION_ONLY
+        assert props == props.setCsErrorReaction(CSTransformerErrorReactionEnum.APPLICATION_ONLY)
 
         props.setDataPrototypeTransformationProps(["prop1", "prop2"])
         assert "prop1" in props.getDataPrototypeTransformationProps()
         assert props == props.setDataPrototypeTransformationProps(["prop1", "prop2"])
 
-        props.setIdent("ident_value")
-        assert props.getIdent() == "ident_value"
-        assert props == props.setIdent("ident_value")
-
-        props.setTransformerRef("transformer_ref")
-        assert props.getTransformerRef() == "transformer_ref"
-        assert props == props.setTransformerRef("transformer_ref")
+        transformer_ref = RefType()
+        transformer_ref.setValue("/Pkg/Transformer")
+        props.setTransformerRef(transformer_ref)
+        assert props.getTransformerRef() == transformer_ref
+        assert props == props.setTransformerRef(transformer_ref)
 
     def test_end_to_end_transformation_isignal_props(self):
         """

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/test_Transformer.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/test_Transformer.py
@@ -87,6 +87,8 @@ class TestTransformer:
         """
         Test DataTransformation class functionality with method chaining and None handling.
         """
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+
         parent = MockParent()
         transformation = DataTransformation(parent, "test_transformation")
 
@@ -105,29 +107,49 @@ class TestTransformer:
         assert transformation.getExecuteDespiteDataUnavailability() is None
 
         # Test setter/getter methods with method chaining - with actual values
-        mock_kind = DataTransformationKindEnum()
+        mock_kind = DataTransformationKindEnum.ASYMMETRIC_FROM_BYTE_ARRAY
         transformation.setDataTransformationKind(mock_kind)
         assert transformation.getDataTransformationKind() == mock_kind
         assert transformation == transformation.setDataTransformationKind(mock_kind)
+        assert transformation == transformation.setDataTransformationKind(None)  # None is a no-op
+        assert transformation.getDataTransformationKind() == mock_kind
 
         transformation.setExecuteDespiteDataUnavailability(True)
         assert transformation.getExecuteDespiteDataUnavailability() is True
         assert transformation == transformation.setExecuteDespiteDataUnavailability(True)
+        assert transformation == transformation.setExecuteDespiteDataUnavailability(None)  # None is a no-op
+        assert transformation.getExecuteDespiteDataUnavailability() is True
 
-        # Test addTransformerChainRef with method chaining
-        transformation.addTransformerChainRef("chain_ref")
-        assert transformation.getTransformerChainRefs() == ["chain_ref"]
-        assert transformation == transformation.addTransformerChainRef("chain_ref2")
+        # Test addTransformerChainRef with method chaining and None no-op
+        ref1 = RefType()
+        ref1.setValue("/chain1")
+        transformation.addTransformerChainRef(ref1)
+        assert ref1 in transformation.getTransformerChainRefs()
+        assert len(transformation.getTransformerChainRefs()) == 1
+
+        assert transformation == transformation.addTransformerChainRef(None)  # None is a no-op
+        assert len(transformation.getTransformerChainRefs()) == 1
+
+        ref2 = RefType()
+        ref2.setValue("/chain2")
+        assert transformation == transformation.addTransformerChainRef(ref2)  # Test method chaining
         assert len(transformation.getTransformerChainRefs()) == 2
 
     def test_data_transformation_kind_enum(self):
         """
-        Test DataTransformationKindEnum class functionality.
+        Test DataTransformationKindEnum enum functionality.
         """
         enum = DataTransformationKindEnum()
 
         # Test that it's properly initialized
         assert enum is not None
+        assert DataTransformationKindEnum.ASYMMETRIC_FROM_BYTE_ARRAY in enum.getEnumValues()
+        assert DataTransformationKindEnum.ASYMMETRIC_TO_BYTE_ARRAY in enum.getEnumValues()
+        assert DataTransformationKindEnum.SYMMETRIC in enum.getEnumValues()
+
+        # Test instantiation with a value
+        enum.setValue(DataTransformationKindEnum.SYMMETRIC)
+        assert enum.getValue() == "symmetric"
 
     def test_data_transformation_set(self):
         """

--- a/tests/test_armodel/parser/test_arxml_parser_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_handlers.py
@@ -1209,6 +1209,7 @@ class TestDataTransformationHandlers:
             "<DATA-TRANSFORMATIONS>"
             "<DATA-TRANSFORMATION>"
             "<SHORT-NAME>dt1</SHORT-NAME>"
+            "<DATA-TRANSFORMATION-KIND>SYMMETRIC</DATA-TRANSFORMATION-KIND>"
             "<TRANSFORMER-CHAIN-REFS>"
             "<TRANSFORMER-CHAIN-REF DEST='TRANSFORMER-CHAIN'>/tc1</TRANSFORMER-CHAIN-REF>"
             "<TRANSFORMER-CHAIN-REF DEST='TRANSFORMER-CHAIN'>/tc2</TRANSFORMER-CHAIN-REF>"
@@ -1219,6 +1220,8 @@ class TestDataTransformationHandlers:
         )
         parser.readDataTransformationSet(element, dtf_set)
         dt1 = dtf_set.getDataTransformations()[0]
+        assert dt1.getDataTransformationKind() is not None
+        assert dt1.getDataTransformationKind().getValue() == "SYMMETRIC"
         assert len(dt1.getTransformerChainRefs()) == 2
         assert dt1.getTransformerChainRefs()[0].getValue() == "/tc1"
         assert dt1.getTransformerChainRefs()[1].getValue() == "/tc2"

--- a/tests/test_armodel/parser/test_arxml_parser_multiplexed.py
+++ b/tests/test_armodel/parser/test_arxml_parser_multiplexed.py
@@ -473,13 +473,25 @@ class TestPduAndSecureCommunication:
         mapping = ISignalToIPduMapping(parent=MagicMock(), short_name="M")
         element = _snip(
             '<I-SIGNAL-REF DEST="I-SIGNAL">/is</I-SIGNAL-REF>'
+            '<I-SIGNAL-GROUP-REF DEST="I-SIGNAL-GROUP">/isg</I-SIGNAL-GROUP-REF>'
             "<PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>"
             "<START-POSITION>0</START-POSITION>"
             "<TRANSFER-PROPERTY>TRIGGERED</TRANSFER-PROPERTY>"
+            "<UPDATE-INDICATION-BIT-POSITION>7</UPDATE-INDICATION-BIT-POSITION>"
         )
         parser.readISignalToIPduMapping(element, mapping)
         assert mapping.getISignalRef() is not None
+        assert mapping.getISignalRef().getValue() == "/is"
+        assert mapping.getISignalGroupRef() is not None
+        assert mapping.getISignalGroupRef().getValue() == "/isg"
         assert mapping.getPackingByteOrder() is not None
+        assert mapping.getPackingByteOrder().getValue() == "MOST-SIGNIFICANT-BYTE-LAST"
+        assert mapping.getStartPosition() is not None
+        assert mapping.getStartPosition().getValue() == 0
+        assert mapping.getTransferProperty() is not None
+        assert mapping.getTransferProperty().getValue() == "TRIGGERED"
+        assert mapping.getUpdateIndicationBitPosition() is not None
+        assert mapping.getUpdateIndicationBitPosition().getValue() == 7
 
     def test_readNmPduISignalToIPduMappings_creates_mapping(self, parser):
         from armodel.models import NmPdu

--- a/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
@@ -3028,6 +3028,25 @@ class TestSystemSignalGroup:
         )
         parser.readSystemSignalGroup(element, group)
         assert len(group.getSystemSignalRefs()) == 2
+        assert group.getSystemSignalRefs()[0].getValue() == "/s1"
+        assert group.getSystemSignalRefs()[1].getValue() == "/s2"
+
+    def test_readSystemSignalGroup_adds_transforming_ref(self, parser):
+        from armodel.models import SystemSignalGroup
+
+        group = SystemSignalGroup(parent=MagicMock(), short_name="Ssg")
+        element = _snip('<TRANSFORMING-SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/trans</TRANSFORMING-SYSTEM-SIGNAL-REF>')
+        parser.readSystemSignalGroup(element, group)
+        assert group.getTransformingSystemSignalRef() is not None
+        assert group.getTransformingSystemSignalRef().getValue() == "/trans"
+
+    def test_readSystemSignalGroup_absent_transforming_ref_stays_none(self, parser):
+        from armodel.models import SystemSignalGroup
+
+        group = SystemSignalGroup(parent=MagicMock(), short_name="Ssg")
+        element = _snip("<SHORT-NAME>Ssg</SHORT-NAME>")
+        parser.readSystemSignalGroup(element, group)
+        assert group.getTransformingSystemSignalRef() is None
 
 
 # ==================== ISignalIPduGroup (L5351, L5360, L5362) ====================

--- a/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
@@ -1472,6 +1472,33 @@ class TestISignalAndGroupHandlers:
         assert ipdu.getUnusedBitPattern().getValue() == 0
 
 
+class TestISignalIPduIPduTimingSpecification:
+    def test_get_sets_minimum_delay_and_declaration(self, parser):
+        element = _snip(
+            "<I-PDU-TIMING-SPECIFICATIONS>"
+            "<I-PDU-TIMING>"
+            "<MINIMUM-DELAY>0.05</MINIMUM-DELAY>"
+            "<TRANSMISSION-MODE-DECLARATION>"
+            "<SHORT-NAME>decl</SHORT-NAME>"
+            "<TRANSMISSION-MODE-TRUE-TIMING>"
+            "<CYCLIC-TIMING><TIME-PERIOD><VALUE><VALUE>0.1</VALUE></VALUE></TIME-PERIOD></CYCLIC-TIMING>"
+            "</TRANSMISSION-MODE-TRUE-TIMING>"
+            "</TRANSMISSION-MODE-DECLARATION>"
+            "</I-PDU-TIMING>"
+            "</I-PDU-TIMING-SPECIFICATIONS>",
+            root_tag="I-SIGNAL-I-PDU",
+        )
+        timing = parser.getISignalIPduIPduTimingSpecification(element)
+        assert timing is not None
+        assert timing.getMinimumDelay().getValue() == 0.05
+        assert timing.getTransmissionModeDeclaration() is not None
+
+    def test_get_absent_returns_none(self, parser):
+        element = _snip("<SHORT-NAME>ipdu</SHORT-NAME>", root_tag="I-SIGNAL-I-PDU")
+        timing = parser.getISignalIPduIPduTimingSpecification(element)
+        assert timing is None
+
+
 class TestEndToEndProtectionHandlers:
     def test_getEndToEndDescription_sets_category(self, parser):
         element = _snip(

--- a/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
@@ -2745,6 +2745,7 @@ class TestReadEndToEndTransformationISignalProps:
             """
             <END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-VARIANTS>
                 <END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-CONDITIONAL>
+                    <CS-ERROR-REACTION>autonomous</CS-ERROR-REACTION>
                     <TRANSFORMER-REF DEST="TRANSFORMATION-TECHNOLOGY">/trans/Tech1</TRANSFORMER-REF>
                     <DATA-IDS>
                         <DATA-ID>1</DATA-ID>
@@ -2756,6 +2757,7 @@ class TestReadEndToEndTransformationISignalProps:
             root_tag="END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS",
         )
         parser.readEndToEndTransformationISignalProps(element, props)
+        assert props.getCsErrorReaction().getValue() == "autonomous"
         assert props.getTransformerRef() is not None
         assert len(props.getDataIds()) == 1
         assert props.getDataLength() is not None
@@ -2772,6 +2774,7 @@ class TestReadEndToEndTransformationISignalProps:
             root_tag="END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS",
         )
         parser.readEndToEndTransformationISignalProps(element, props)
+        assert props.getCsErrorReaction() is None
         assert props.getTransformerRef() is None
         assert len(props.getDataIds()) == 0
         assert props.getDataLength() is None
@@ -2794,6 +2797,7 @@ class TestReadEndToEndTransformationISignalProps:
             root_tag="END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS",
         )
         parser.readEndToEndTransformationISignalProps(element, props)
+        assert props.getCsErrorReaction() is None
         assert props.getTransformerRef() is not None
         assert len(props.getDataIds()) == 0
         assert props.getDataLength() is None

--- a/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
@@ -2602,7 +2602,7 @@ class TestReadISignalGroupISignalRef:
 class TestReadISignalGroupComBasedSignalGroupTransformation:
     """Tests for readISignalGroupComBasedSignalGroupTransformation (L5201-5203)."""
 
-    def test_reads_transformation_refs(self, parser):
+    def test_reads_transformation_ref(self, parser):
         AUTOSAR.getInstance().setARRelease("R23-11")
         group = _make_isignal_group("ISignalGroup")
         element = _snip(
@@ -2611,16 +2611,14 @@ class TestReadISignalGroupComBasedSignalGroupTransformation:
                 <DATA-TRANSFORMATION-REF-CONDITIONAL>
                     <DATA-TRANSFORMATION-REF DEST="DATA-TRANSFORMATION">/trans/Trans1</DATA-TRANSFORMATION-REF>
                 </DATA-TRANSFORMATION-REF-CONDITIONAL>
-                <DATA-TRANSFORMATION-REF-CONDITIONAL>
-                    <DATA-TRANSFORMATION-REF DEST="DATA-TRANSFORMATION">/trans/Trans2</DATA-TRANSFORMATION-REF>
-                </DATA-TRANSFORMATION-REF-CONDITIONAL>
             </COM-BASED-SIGNAL-GROUP-TRANSFORMATIONS>
             """,
             root_tag="I-SIGNAL-GROUP",
         )
         parser.readISignalGroupComBasedSignalGroupTransformation(element, group)
-        refs = group.getComBasedSignalGroupTransformationRefs()
-        assert len(refs) == 2
+        ref = group.getComBasedSignalGroupTransformationRef()
+        assert ref is not None
+        assert ref.getValue() == "/trans/Trans1"
 
     def test_empty_transformations(self, parser):
         AUTOSAR.getInstance().setARRelease("R23-11")
@@ -2633,7 +2631,7 @@ class TestReadISignalGroupComBasedSignalGroupTransformation:
             root_tag="I-SIGNAL-GROUP",
         )
         parser.readISignalGroupComBasedSignalGroupTransformation(element, group)
-        assert len(group.getComBasedSignalGroupTransformationRefs()) == 0
+        assert group.getComBasedSignalGroupTransformationRef() is None
 
 
 class TestReadTransformationISignalProps:
@@ -2799,8 +2797,9 @@ class TestReadISignalGroupTransformationISignalProps:
             root_tag="I-SIGNAL-GROUP",
         )
         parser.readISignalGroupTransformationISignalProps(element, group)
-        props = group.getTransformationISignalProps()
-        assert props is not None
+        props_list = group.getTransformationISignalProps()
+        assert len(props_list) == 1
+        props = props_list[0]
         assert props.getTransformerRef() is not None
         assert len(props.getDataIds()) == 1
         assert props.getDataLength() is not None
@@ -2816,7 +2815,7 @@ class TestReadISignalGroupTransformationISignalProps:
             root_tag="I-SIGNAL-GROUP",
         )
         parser.readISignalGroupTransformationISignalProps(element, group)
-        assert group.getTransformationISignalProps() is None
+        assert group.getTransformationISignalProps() == []
 
     def test_unsupported_type_warning(self, warning_parser, caplog):
         AUTOSAR.getInstance().setARRelease("R23-11")
@@ -2843,9 +2842,9 @@ class TestReadISignalGroupTransformationISignalProps:
         with caplog.at_level(logging.ERROR):
             warning_parser.readISignalGroupTransformationISignalProps(element, group)
         assert any("Unsupported TransformationISignalProps" in rec.getMessage() for rec in caplog.records)
-        props = group.getTransformationISignalProps()
-        assert props is not None
-        assert props.getTransformerRef() is not None
+        props_list = group.getTransformationISignalProps()
+        assert len(props_list) == 1
+        assert props_list[0].getTransformerRef() is not None
 
 
 # === Migrated from test_arxml_parser_remaining_gaps.py ===

--- a/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
@@ -1256,6 +1256,42 @@ class TestFrameAndPduHandlers:
         assert pdu.getDiagPduType() is not None
         assert pdu.getDiagPduType().getValue() == "request"
 
+    def test_readIPdu_sets_containedIPduProps(self, parser):
+        from armodel.models import GeneralPurposeIPdu
+
+        ipdu = GeneralPurposeIPdu(parent=_autosar_root(), short_name="ipdu")
+        element = _snip(
+            "<SHORT-NAME>ipdu</SHORT-NAME>"
+            "<CONTAINED-I-PDU-PROPS>"
+            "<COLLECTION-SEMANTICS>lastIsBest</COLLECTION-SEMANTICS>"
+            "<HEADER-ID-LONG-HEADER>100</HEADER-ID-LONG-HEADER>"
+            "<HEADER-ID-SHORT-HEADER>50</HEADER-ID-SHORT-HEADER>"
+            "<OFFSET>4</OFFSET>"
+            "<TIMEOUT>10</TIMEOUT>"
+            "<TRIGGER>onChange</TRIGGER>"
+            "<UPDATE-INDICATION-BIT-POSITION>7</UPDATE-INDICATION-BIT-POSITION>"
+            "</CONTAINED-I-PDU-PROPS>",
+            root_tag="GENERAL-PURPOSE-I-PDU",
+        )
+        parser.readIPdu(element, ipdu)
+        props = ipdu.getContainedIPduProps()
+        assert props is not None
+        assert props.getCollectionSemantics().getValue() == "lastIsBest"
+        assert props.getHeaderIdLongHeader().getValue() == 100
+        assert props.getHeaderIdShortHeader().getValue() == 50
+        assert props.getOffset().getValue() == 4
+        assert props.getTimeout().getValue() == 10
+        assert props.getTrigger().getValue() == "onChange"
+        assert props.getUpdateIndicationBitPosition().getValue() == 7
+
+    def test_readIPdu_absent_containedIPduProps_stays_none(self, parser):
+        from armodel.models import GeneralPurposeIPdu
+
+        ipdu = GeneralPurposeIPdu(parent=_autosar_root(), short_name="ipdu")
+        element = _snip("<SHORT-NAME>ipdu</SHORT-NAME>", root_tag="GENERAL-PURPOSE-I-PDU")
+        parser.readIPdu(element, ipdu)
+        assert ipdu.getContainedIPduProps() is None
+
 
 class TestISignalAndGroupHandlers:
     def test_readISignal_sets_length(self, parser):

--- a/tests/test_armodel/writer/test_writer_hw_lin_flexray_transform.py
+++ b/tests/test_armodel/writer/test_writer_hw_lin_flexray_transform.py
@@ -510,10 +510,21 @@ class TestWriterISignalIPdu:
         parent = _parent()
         writer.writeISignalIPdu(parent, ipdu)
         assert parent[0].tag == "I-SIGNAL-I-PDU"
-        assert parent[0].find("LENGTH") is not None
+        assert parent[0].find("SHORT-NAME").text == "IPdu"
+        assert parent[0].find("LENGTH").text == "64"
         assert parent[0].find("I-PDU-TIMING-SPECIFICATIONS") is not None
-        assert parent[0].find("I-SIGNAL-TO-PDU-MAPPINGS") is not None
-        assert parent[0].find("UNUSED-BIT-PATTERN") is not None
+        assert parent[0].find("I-PDU-TIMING-SPECIFICATIONS/I-PDU-TIMING/MINIMUM-DELAY").text == "0.01"
+        assert parent[0].find("I-SIGNAL-TO-PDU-MAPPINGS/I-SIGNAL-TO-I-PDU-MAPPING/I-SIGNAL-REF").text == "/sig"
+        assert parent[0].find("UNUSED-BIT-PATTERN").text == "0"
+
+    def test_writeISignalIPdu_no_mappings_omits_wrapper(self, writer):
+        pkg = _make_pkg()
+        ipdu = ISignalIPdu(pkg, "IPdu")
+        ipdu.setUnusedBitPattern(_integer(0))
+        parent = _parent()
+        writer.writeISignalIPdu(parent, ipdu)
+        assert parent[0].tag == "I-SIGNAL-I-PDU"
+        assert parent[0].find("I-SIGNAL-TO-PDU-MAPPINGS") is None
 
 
 class TestWriterFlexrayFrame:

--- a/tests/test_armodel/writer/test_writer_hw_lin_flexray_transform.py
+++ b/tests/test_armodel/writer/test_writer_hw_lin_flexray_transform.py
@@ -628,12 +628,14 @@ class TestWriterDataTransformation:
         pkg = _make_pkg()
         dtf_set = DataTransformationSet(pkg, "DtfSet")
         dtf = dtf_set.createDataTransformation("Dtf")
+        dtf.setDataTransformationKind(_literal("SYMMETRIC"))
         dtf.setExecuteDespiteDataUnavailability(_bool(True))
         dtf.addTransformerChainRef(_ref("/chain", "TRANSFORMER-CHAIN"))
         parent = _parent()
         writer.writeDataTransformation(parent, dtf)
         assert parent[0].tag == "DATA-TRANSFORMATION"
-        assert parent[0].find("EXECUTE-DESPITE-DATA-UNAVAILABILITY") is not None
+        assert parent[0].find("DATA-TRANSFORMATION-KIND").text == "SYMMETRIC"
+        assert parent[0].find("EXECUTE-DESPITE-DATA-UNAVAILABILITY").text == "true"
         assert parent[0].find("TRANSFORMER-CHAIN-REFS") is not None
 
     def test_writeDataTransformation_none(self, writer):

--- a/tests/test_armodel/writer/test_writer_pdu_tp.py
+++ b/tests/test_armodel/writer/test_writer_pdu_tp.py
@@ -17,6 +17,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     TimeValue,
 )
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (  # noqa: E501
+    ContainedIPduProps,
     DcmIPdu,
     ISignalToIPduMapping,
     NmPdu,
@@ -191,6 +192,35 @@ class TestWriteDcmIPdu:
         assert child.tag == "DCM-I-PDU"
         assert child.find("SHORT-NAME").text == "Dcm"
         assert child.find("DIAG-PDU-TYPE").text == "DIAG-REQUEST"
+
+
+class TestWriteContainedIPduProps:
+    def test_none_props(self, writer):
+        parent = _parent()
+        writer.writeContainedIPduProps(parent, None)
+        assert len(parent) == 0
+
+    def test_full_props(self, writer):
+        props = ContainedIPduProps()
+        props.setCollectionSemantics(_literal("lastIsBest"))
+        props.setHeaderIdLongHeader(_pos_int("100"))
+        props.setHeaderIdShortHeader(_pos_int("50"))
+        props.setOffset(_pos_int("4"))
+        props.setTimeout(_pos_int("10"))
+        props.setTrigger(_literal("onChange"))
+        props.setUpdateIndicationBitPosition(_pos_int("7"))
+        parent = _parent()
+        writer.writeContainedIPduProps(parent, props)
+        assert len(parent) == 1
+        child = parent[0]
+        assert child.tag == "CONTAINED-I-PDU-PROPS"
+        assert child.find("COLLECTION-SEMANTICS").text == "lastIsBest"
+        assert child.find("HEADER-ID-LONG-HEADER").text == "100"
+        assert child.find("HEADER-ID-SHORT-HEADER").text == "50"
+        assert child.find("OFFSET").text == "4"
+        assert child.find("TIMEOUT").text == "10"
+        assert child.find("TRIGGER").text == "onChange"
+        assert child.find("UPDATE-INDICATION-BIT-POSITION").text == "7"
 
 
 class TestSetSecureCommunicationProps:

--- a/tests/test_armodel/writer/test_writer_pdu_tp.py
+++ b/tests/test_armodel/writer/test_writer_pdu_tp.py
@@ -109,9 +109,11 @@ class TestWriteISignalToIPduMapping:
         pkg = _pkg()
         mapping = ISignalToIPduMapping(pkg, "Map")
         mapping.setISignalRef(_ref("I-SIGNAL", "/sigs/s"))
+        mapping.setISignalGroupRef(_ref("I-SIGNAL-GROUP", "/sigs/sg"))
         mapping.setPackingByteOrder(_literal("MOST-SIGNIFICANT-BYTE-LAST"))
         mapping.setStartPosition(_int("0"))
         mapping.setTransferProperty(_literal("TRIGGERED"))
+        mapping.setUpdateIndicationBitPosition(_int("7"))
         parent = _parent()
         writer.writeISignalToIPduMapping(parent, mapping)
         assert len(parent) == 1
@@ -119,9 +121,11 @@ class TestWriteISignalToIPduMapping:
         assert child.tag == "I-SIGNAL-TO-I-PDU-MAPPING"
         assert child.find("SHORT-NAME").text == "Map"
         assert child.find("I-SIGNAL-REF").text == "/sigs/s"
+        assert child.find("I-SIGNAL-GROUP-REF").text == "/sigs/sg"
         assert child.find("PACKING-BYTE-ORDER").text == "MOST-SIGNIFICANT-BYTE-LAST"
         assert child.find("START-POSITION").text == "0"
         assert child.find("TRANSFER-PROPERTY").text == "TRIGGERED"
+        assert child.find("UPDATE-INDICATION-BIT-POSITION").text == "7"
 
 
 class TestWriteNmPduISignalToIPduMappings:

--- a/tests/test_armodel/writer/test_writer_signals_diagnostic.py
+++ b/tests/test_armodel/writer/test_writer_signals_diagnostic.py
@@ -174,6 +174,7 @@ class TestWriterEndToEndTransformationISignalPropsDataIds:
 class TestWriterEndToEndTransformationISignalProps:
     def test_full(self, writer):
         props = EndToEndTransformationISignalProps()
+        props.setCsErrorReaction(_literal("autonomous"))
         props.setTransformerRef(_ref("/tr", "TRANSFORMATION-PROPS"))
         props.addDataId(_posint(10))
         props.setDataLength(_posint(64))
@@ -184,6 +185,8 @@ class TestWriterEndToEndTransformationISignalProps:
         assert variants is not None
         cond = variants.find("END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-CONDITIONAL")
         assert cond is not None
+        assert cond.find("CS-ERROR-REACTION") is not None
+        assert cond.find("CS-ERROR-REACTION").text == "autonomous"
         assert cond.find("TRANSFORMER-REF") is not None
         assert cond.find("DATA-IDS") is not None
         assert cond.find("DATA-LENGTH") is not None

--- a/tests/test_armodel/writer/test_writer_signals_diagnostic.py
+++ b/tests/test_armodel/writer/test_writer_signals_diagnostic.py
@@ -126,17 +126,17 @@ class TestWriterISignalGroupISignalRef:
 
 
 class TestWriterISignalGroupComBasedSignalGroupTransformation:
-    def test_with_refs(self, writer):
+    def test_with_ref(self, writer):
         group = _make_isignal_group()
-        group.addComBasedSignalGroupTransformationRef(_ref("/dt1", "DATA-TRANSFORMATION"))
-        group.addComBasedSignalGroupTransformationRef(_ref("/dt2", "DATA-TRANSFORMATION"))
+        group.setComBasedSignalGroupTransformationRef(_ref("/dt1", "DATA-TRANSFORMATION"))
         parent = _parent()
         writer.writeISignalGroupComBasedSignalGroupTransformation(parent, group)
         assert parent[0].tag == "COM-BASED-SIGNAL-GROUP-TRANSFORMATIONS"
         cond = parent[0].find("DATA-TRANSFORMATION-REF-CONDITIONAL")
         assert cond is not None
         refs = cond.findall("DATA-TRANSFORMATION-REF")
-        assert len(refs) == 2
+        assert len(refs) == 1
+        assert refs[0].text == "/dt1"
 
     def test_empty(self, writer):
         group = _make_isignal_group()
@@ -199,13 +199,13 @@ class TestWriterISignalGroupTransformationISignalProps:
         group = _make_isignal_group()
         props = EndToEndTransformationISignalProps()
         props.setTransformerRef(_ref("/tr", "TRANSFORMATION-PROPS"))
-        group.setTransformationISignalProps(props)
+        group.addTransformationISignalProps(props)
         parent = _parent()
         writer.writeISignalGroupTransformationISignalProps(parent, group)
         assert parent[0].tag == "TRANSFORMATION-I-SIGNAL-PROPSS"
         assert parent[0].find("END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS") is not None
 
-    def test_none(self, writer):
+    def test_empty(self, writer):
         group = _make_isignal_group()
         parent = _parent()
         writer.writeISignalGroupTransformationISignalProps(parent, group)
@@ -219,7 +219,7 @@ class TestWriterISignalGroupTransformationISignalProps:
                 super().__init__()
 
         group = _make_isignal_group()
-        group.setTransformationISignalProps(_OtherProps())
+        group.addTransformationISignalProps(_OtherProps())
         parent = _parent()
         warn_writer.writeISignalGroupTransformationISignalProps(parent, group)
         assert parent[0].tag == "TRANSFORMATION-I-SIGNAL-PROPSS"
@@ -231,13 +231,13 @@ class TestWriterISignalGroup:
     def test_full(self, writer):
         group = _make_isignal_group()
         group.addISignalRef(_ref("/s1", "I-SIGNAL"))
-        group.addComBasedSignalGroupTransformationRef(_ref("/dt", "DATA-TRANSFORMATION"))
+        group.setComBasedSignalGroupTransformationRef(_ref("/dt", "DATA-TRANSFORMATION"))
         group.setSystemSignalGroupRef(_ref("/ssg", "SYSTEM-SIGNAL-GROUP"))
         props = EndToEndTransformationISignalProps()
         props.setTransformerRef(_ref("/tr", "TRANSFORMATION-PROPS"))
         props.addDataId(_posint(5))
         props.setDataLength(_posint(32))
-        group.setTransformationISignalProps(props)
+        group.addTransformationISignalProps(props)
         parent = _parent()
         writer.writeISignalGroup(parent, group)
         elem = parent.find("I-SIGNAL-GROUP")

--- a/tests/test_armodel/writer/test_writer_system_mapping.py
+++ b/tests/test_armodel/writer/test_writer_system_mapping.py
@@ -162,8 +162,8 @@ def _make_mapping_set():
 class TestWriterSystemSignalGroup:
     def test_with_signal_refs(self, writer):
         group = _make_system_signal_group()
-        group.addSystemSignalRefs(_ref("/s1", "SYSTEM-SIGNAL"))
-        group.addSystemSignalRefs(_ref("/s2", "SYSTEM-SIGNAL"))
+        group.addSystemSignalRef(_ref("/s1", "SYSTEM-SIGNAL"))
+        group.addSystemSignalRef(_ref("/s2", "SYSTEM-SIGNAL"))
         parent = _parent()
         writer.writeSystemSignalGroup(parent, group)
         assert parent[0].tag == "SYSTEM-SIGNAL-GROUP"
@@ -177,6 +177,23 @@ class TestWriterSystemSignalGroup:
         writer.writeSystemSignalGroup(parent, group)
         assert parent[0].tag == "SYSTEM-SIGNAL-GROUP"
         assert parent[0].find("SYSTEM-SIGNAL-REFS") is None
+
+    def test_with_transforming_signal_ref(self, writer):
+        group = _make_system_signal_group()
+        group.setTransformingSystemSignalRef(_ref("/trans", "SYSTEM-SIGNAL"))
+        parent = _parent()
+        writer.writeSystemSignalGroup(parent, group)
+        assert parent[0].tag == "SYSTEM-SIGNAL-GROUP"
+        ref = parent[0].find("TRANSFORMING-SYSTEM-SIGNAL-REF")
+        assert ref is not None
+        assert ref.text == "/trans"
+
+    def test_without_transforming_signal_ref(self, writer):
+        group = _make_system_signal_group()
+        parent = _parent()
+        writer.writeSystemSignalGroup(parent, group)
+        assert parent[0].tag == "SYSTEM-SIGNAL-GROUP"
+        assert parent[0].find("TRANSFORMING-SYSTEM-SIGNAL-REF") is None
 
 
 class TestWriterSenderReceiverToSignalMapping:


### PR DESCRIPTION
## Summary
- Adds the planning doc for the remaining Phase 0 sync item: `DataPrototypeTransformationProps`.
- The substantive model-sync work (`TransformationISignalProps`, `DataTransformation`) was completed and committed earlier on this branch.

Closes #648

## Quality gates
- Lint (flake8): ✅
- Tests (unit + integration): ✅ 6753 passed, 0 failed