### PR TITLE
feat: ProvidedServiceInstance synced (Table E.37, R23-11)

### DIFF
--- a/docs/plan/sync-todo/ProvidedServiceInstance.md
+++ b/docs/plan/sync-todo/ProvidedServiceInstance.md
@@ -1,0 +1,22 @@
+# Sync todo: ProvidedServiceInstance
+
+Input class: ProvidedServiceInstance
+Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.160, p.486
+Release target: R23-11
+Worktree: .worktrees/feature-sync-providedserviceinstance (branch feature/sync-providedserviceinstance-r23-11)
+
+## Closure (confirmed with user)
+- input: ProvidedServiceInstance (M2::AUTOSARTemplates::SystemTemplate::Fibex::Fibex4Ethernet::ServiceInstances)
+- base: AbstractServiceInstance (exists, conforms to Table 6.158) — NOT re-queued
+- member types:
+  - EventHandler (aggr, *) — exists
+  - ApplicationEndpoint (ref) — exists
+  - SdServerConfig (aggr) — exists
+  - PositiveInteger (attr/primitive) — exists
+  - SomeipSdServerServiceInstanceConfig (ref target for sdServerTimerConfig) — ref-only, stored as RefType, NOT modeled as a class
+
+## Resolution decisions
+- SomeipSdServerServiceInstanceConfig: ref-only dependency (RefType). No class modeled.
+
+## Queue (dependency-first)
+- [ ] ProvidedServiceInstance  — add missing attrs: loadBalancingPriority, loadBalancingWeight, localUnicastAddressRefs (0..2), minorVersion, remoteMulticastSubscriptionAddressRefs (*), remoteUnicastAddressRefs (*), sdServerTimerConfigRef (0..1). Verify base AbstractServiceInstance. Commit: <hash>

--- a/docs/plan/sync-todo/ProvidedServiceInstance.md
+++ b/docs/plan/sync-todo/ProvidedServiceInstance.md
@@ -19,4 +19,4 @@ Worktree: .worktrees/feature-sync-providedserviceinstance (branch feature/sync-p
 - SomeipSdServerServiceInstanceConfig: ref-only dependency (RefType). No class modeled.
 
 ## Queue (dependency-first)
-- [ ] ProvidedServiceInstance  — add missing attrs: loadBalancingPriority, loadBalancingWeight, localUnicastAddressRefs (0..2), minorVersion, remoteMulticastSubscriptionAddressRefs (*), remoteUnicastAddressRefs (*), sdServerTimerConfigRef (0..1). Verify base AbstractServiceInstance. Commit: <hash>
+- [x] ProvidedServiceInstance  — all 14 spec attributes (Table E.37) modeled verbatim with reader+writer coverage; kept allowedServiceConsumerRefs (→NetworkEndpoint) and autoAvailable (→Boolean) per user direction (SoftwareComponentTemplate Table E.37 is the complete/correct source). Base AbstractServiceInstance verified. Commit: 033f8184

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances.py
@@ -2,7 +2,7 @@
 # It defines consumed and provided service instances, application endpoints, and SOAD configurations
 
 from abc import ABC
-from typing import List
+from typing import List, Optional
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, PositiveInteger, RefType, String, TimeValue
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
@@ -805,37 +805,138 @@ class EventHandler(Identifiable):
 
 class ProvidedServiceInstance(AbstractServiceInstance):
     """
-    Represents a provided service instance in the AUTOSAR service-oriented
-    architecture, defining how services are provided to clients including
-    service identifiers, instance identifiers, and server configuration.
+    Service instances that are provided by the ECU that is connected via the ApplicationEndpoint to a CommunicationConnector.
     """
 
     # ProvidedServiceInstance method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getEventHandlers             [x] impl  [ ] docstring  [ ] test
-    # [ ] createEventHandler           [x] impl  [ ] docstring  [ ] test
-    # [ ] getInstanceIdentifier        [x] impl  [ ] docstring  [ ] test
-    # [ ] setInstanceIdentifier        [x] impl  [ ] docstring  [ ] test
-    # [ ] getPriority                  [x] impl  [ ] docstring  [ ] test
-    # [ ] setPriority                  [x] impl  [ ] docstring  [ ] test
-    # [ ] getSdServerConfig            [x] impl  [ ] docstring  [ ] test
-    # [ ] setSdServerConfig            [x] impl  [ ] docstring  [ ] test
-    # [ ] getServiceIdentifier         [x] impl  [ ] docstring  [ ] test
-    # [ ] setServiceIdentifier         [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table E.37, p.1002
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                                   [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getAllowedServiceConsumerRefs              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addAllowedServiceConsumerRef               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] setAllowedServiceConsumerRefs              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getAutoAvailable                           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setAutoAvailable                           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getEventHandlers                            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createEventHandler                         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getInstanceIdentifier                       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setInstanceIdentifier                       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getLoadBalancingPriority                   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setLoadBalancingPriority                   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getLoadBalancingWeight                     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setLoadBalancingWeight                     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getLocalUnicastAddressRefs                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setLocalUnicastAddressRefs                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] addLocalUnicastAddressRef                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMinorVersion                            [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMinorVersion                            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPriority                                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setPriority                                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRemoteMulticastSubscriptionAddressRefs [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setRemoteMulticastSubscriptionAddressRefs [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] addRemoteMulticastSubscriptionAddressRef  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRemoteUnicastAddressRefs                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setRemoteUnicastAddressRefs                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] addRemoteUnicastAddressRef                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSdServerConfig                          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSdServerConfig                          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSdServerTimerConfigRef                  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSdServerTimerConfigRef                  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getServiceIdentifier                       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setServiceIdentifier                       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
+        # NetworkEndpoints on which the ConsumedService Instances that are communicating with this Provided ServiceInstance are allowed to be located so that the ACL check in the ServiceDiscovery is successful and the connection is allowed to be established. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=allowedServiceConsumer.networkEndpoint, allowedServiceConsumer.variationPoint.shortLabel atp.Status=draft vh.latestBindingTime=postBuild
+        self.allowedServiceConsumerRefs: List[RefType] = []
+
+        # Defines that this ProvidedServiceInstance shall be offered by the service discovery at ECU start.
+        self.autoAvailable: Optional[Boolean] = None
+
+        # Collection of event groups provided by the Provided ServiceInstance Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=eventHandler.shortName, event Handler.variationPoint.shortLabel vh.latestBindingTime=postBuild
         self.eventHandlers: List[EventHandler] = []
-        self.instanceIdentifier: PositiveInteger = None
-        self.priority: PositiveInteger = None
-        self.sdServerConfig = None
-        self.serviceIdentifier: PositiveInteger = None
+
+        # Instance identifier. Can be used for e.g. service discovery to identify the instance of the service.
+        self.instanceIdentifier: Optional[PositiveInteger] = None
+
+        # Defines the value to be used for load balancing priority in the service offer. Lower value means higher priority.
+        self.loadBalancingPriority: Optional[PositiveInteger] = None
+
+        # Defines the value to be used for load balancing weight in the service offer. Higher value means higher probability to be chosen.
+        self.loadBalancingWeight: Optional[PositiveInteger] = None
+
+        # The local address over which the PSI is provided (udp, tcp or both). Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=localUnicastAddress.applicationEndpoint, localUnicastAddress.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        self.localUnicastAddressRefs: List[RefType] = []
+
+        # Minor Version of the Service that is provided by this ProvidedServiceInstance.
+        self.minorVersion: Optional[PositiveInteger] = None
+
+        # Defines the frame priority where values from 0 (best effort) to 7 (highest) are allowed.
+        self.priority: Optional[PositiveInteger] = None
+
+        # This reference defines the remote multicast subscribed addresses of service consumers. This reference shall ONLY be used if the remote address of the clients is determined from the configuration and not at runtime. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=remoteMulticastSubscription Address.applicationEndpoint, remoteMulticast SubscriptionAddress.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        self.remoteMulticastSubscriptionAddressRefs: List[RefType] = []
+
+        # This reference defines the remote addresses of service consumers. This reference shall ONLY be used if the remote address of the clients is determined from the configuration and not at runtime. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=remoteUnicastAddress.applicationEndpoint, remoteUnicastAddress.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        self.remoteUnicastAddressRefs: List[RefType] = []
+
+        # Service Discovery Server configuration. Tags: atp.Status=obsolete
+        self.sdServerConfig: Optional[SdServerConfig] = None
+
+        # Server specific configuration settings relevant for the SOME/IP service discovery. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=sdServerTimerConfig.someipSdServer ServiceInstanceConfig, sdServerTimer Config.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        self.sdServerTimerConfigRef: Optional[RefType] = None
+
+        # This attribute represents the ability to describe the SOME/ IP service ID that is offered.
+        self.serviceIdentifier: Optional[PositiveInteger] = None
+
+    def getAllowedServiceConsumerRefs(self):
+        """
+        NetworkEndpoints on which the ConsumedService Instances that are communicating with this Provided ServiceInstance are allowed to be located so that the ACL check in the ServiceDiscovery is successful and the connection is allowed to be established. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=allowedServiceConsumer.networkEndpoint, allowedServiceConsumer.variationPoint.shortLabel atp.Status=draft vh.latestBindingTime=postBuild
+        """
+        return self.allowedServiceConsumerRefs
+
+    def addAllowedServiceConsumerRef(self, allowed_service_consumer_ref: RefType) -> "ProvidedServiceInstance":
+        """
+        NetworkEndpoints on which the ConsumedService Instances that are communicating with this Provided ServiceInstance are allowed to be located so that the ACL check in the ServiceDiscovery is successful and the connection is allowed to be established. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=allowedServiceConsumer.networkEndpoint, allowedServiceConsumer.variationPoint.shortLabel atp.Status=draft vh.latestBindingTime=postBuild
+        """
+        if allowed_service_consumer_ref is not None:
+            self.allowedServiceConsumerRefs.append(allowed_service_consumer_ref)
+        return self
+
+    def setAllowedServiceConsumerRefs(self, allowed_service_consumer_refs: List[RefType]) -> "ProvidedServiceInstance":
+        """
+        NetworkEndpoints on which the ConsumedService Instances that are communicating with this Provided ServiceInstance are allowed to be located so that the ACL check in the ServiceDiscovery is successful and the connection is allowed to be established. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=allowedServiceConsumer.networkEndpoint, allowedServiceConsumer.variationPoint.shortLabel atp.Status=draft vh.latestBindingTime=postBuild
+        """
+        if allowed_service_consumer_refs is not None:
+            self.allowedServiceConsumerRefs = allowed_service_consumer_refs
+        return self
+
+    def getAutoAvailable(self):
+        """
+        Defines that this ProvidedServiceInstance shall be offered by the service discovery at ECU start.
+        """
+        return self.autoAvailable
+
+    def setAutoAvailable(self, value):
+        """
+        Defines that this ProvidedServiceInstance shall be offered by the service discovery at ECU start.
+        """
+        if value is not None:
+            self.autoAvailable = value
+        return self
 
     def getEventHandlers(self):
+        """
+        Collection of event groups provided by the Provided ServiceInstance Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=eventHandler.shortName, event Handler.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
         return self.eventHandlers
 
     def createEventHandler(self, short_name: str) -> EventHandler:
+        """
+        Collection of event groups provided by the Provided ServiceInstance Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=eventHandler.shortName, event Handler.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
         if short_name not in self.elements:
             instance = EventHandler(self, short_name)
             self.addElement(instance)
@@ -843,33 +944,179 @@ class ProvidedServiceInstance(AbstractServiceInstance):
         return self.getElement(short_name)
 
     def getInstanceIdentifier(self):
+        """
+        Instance identifier. Can be used for e.g. service discovery to identify the instance of the service.
+        """
         return self.instanceIdentifier
 
     def setInstanceIdentifier(self, value):
+        """
+        Instance identifier. Can be used for e.g. service discovery to identify the instance of the service.
+        """
         if value is not None:
             self.instanceIdentifier = value
         return self
 
+    def getLoadBalancingPriority(self):
+        """
+        Defines the value to be used for load balancing priority in the service offer. Lower value means higher priority.
+        """
+        return self.loadBalancingPriority
+
+    def setLoadBalancingPriority(self, value):
+        """
+        Defines the value to be used for load balancing priority in the service offer. Lower value means higher priority.
+        """
+        if value is not None:
+            self.loadBalancingPriority = value
+        return self
+
+    def getLoadBalancingWeight(self):
+        """
+        Defines the value to be used for load balancing weight in the service offer. Higher value means higher probability to be chosen.
+        """
+        return self.loadBalancingWeight
+
+    def setLoadBalancingWeight(self, value):
+        """
+        Defines the value to be used for load balancing weight in the service offer. Higher value means higher probability to be chosen.
+        """
+        if value is not None:
+            self.loadBalancingWeight = value
+        return self
+
+    def getLocalUnicastAddressRefs(self):
+        """
+        The local address over which the PSI is provided (udp, tcp or both). Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=localUnicastAddress.applicationEndpoint, localUnicastAddress.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        return self.localUnicastAddressRefs
+
+    def setLocalUnicastAddressRefs(self, value):
+        """
+        The local address over which the PSI is provided (udp, tcp or both). Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=localUnicastAddress.applicationEndpoint, localUnicastAddress.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        if value is not None:
+            self.localUnicastAddressRefs = value
+        return self
+
+    def addLocalUnicastAddressRef(self, value):
+        """
+        The local address over which the PSI is provided (udp, tcp or both). Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=localUnicastAddress.applicationEndpoint, localUnicastAddress.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        if value is not None:
+            self.localUnicastAddressRefs.append(value)
+        return self
+
+    def getMinorVersion(self):
+        """
+        Minor Version of the Service that is provided by this ProvidedServiceInstance.
+        """
+        return self.minorVersion
+
+    def setMinorVersion(self, value):
+        """
+        Minor Version of the Service that is provided by this ProvidedServiceInstance.
+        """
+        if value is not None:
+            self.minorVersion = value
+        return self
+
     def getPriority(self):
+        """
+        Defines the frame priority where values from 0 (best effort) to 7 (highest) are allowed.
+        """
         return self.priority
 
     def setPriority(self, value):
+        """
+        Defines the frame priority where values from 0 (best effort) to 7 (highest) are allowed.
+        """
         if value is not None:
             self.priority = value
         return self
 
+    def getRemoteMulticastSubscriptionAddressRefs(self):
+        """
+        This reference defines the remote multicast subscribed addresses of service consumers. This reference shall ONLY be used if the remote address of the clients is determined from the configuration and not at runtime. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=remoteMulticastSubscription Address.applicationEndpoint, remoteMulticast SubscriptionAddress.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        return self.remoteMulticastSubscriptionAddressRefs
+
+    def setRemoteMulticastSubscriptionAddressRefs(self, value):
+        """
+        This reference defines the remote multicast subscribed addresses of service consumers. This reference shall ONLY be used if the remote address of the clients is determined from the configuration and not at runtime. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=remoteMulticastSubscription Address.applicationEndpoint, remoteMulticast SubscriptionAddress.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        if value is not None:
+            self.remoteMulticastSubscriptionAddressRefs = value
+        return self
+
+    def addRemoteMulticastSubscriptionAddressRef(self, value):
+        """
+        This reference defines the remote multicast subscribed addresses of service consumers. This reference shall ONLY be used if the remote address of the clients is determined from the configuration and not at runtime. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=remoteMulticastSubscription Address.applicationEndpoint, remoteMulticast SubscriptionAddress.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        if value is not None:
+            self.remoteMulticastSubscriptionAddressRefs.append(value)
+        return self
+
+    def getRemoteUnicastAddressRefs(self):
+        """
+        This reference defines the remote addresses of service consumers. This reference shall ONLY be used if the remote address of the clients is determined from the configuration and not at runtime. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=remoteUnicastAddress.applicationEndpoint, remoteUnicastAddress.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        return self.remoteUnicastAddressRefs
+
+    def setRemoteUnicastAddressRefs(self, value):
+        """
+        This reference defines the remote addresses of service consumers. This reference shall ONLY be used if the remote address of the clients is determined from the configuration and not at runtime. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=remoteUnicastAddress.applicationEndpoint, remoteUnicastAddress.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        if value is not None:
+            self.remoteUnicastAddressRefs = value
+        return self
+
+    def addRemoteUnicastAddressRef(self, value):
+        """
+        This reference defines the remote addresses of service consumers. This reference shall ONLY be used if the remote address of the clients is determined from the configuration and not at runtime. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=remoteUnicastAddress.applicationEndpoint, remoteUnicastAddress.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        if value is not None:
+            self.remoteUnicastAddressRefs.append(value)
+        return self
+
     def getSdServerConfig(self):
+        """
+        Service Discovery Server configuration. Tags: atp.Status=obsolete
+        """
         return self.sdServerConfig
 
     def setSdServerConfig(self, value):
+        """
+        Service Discovery Server configuration. Tags: atp.Status=obsolete
+        """
         if value is not None:
             self.sdServerConfig = value
         return self
 
+    def getSdServerTimerConfigRef(self):
+        """
+        Server specific configuration settings relevant for the SOME/IP service discovery. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=sdServerTimerConfig.someipSdServer ServiceInstanceConfig, sdServerTimer Config.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        return self.sdServerTimerConfigRef
+
+    def setSdServerTimerConfigRef(self, value):
+        """
+        Server specific configuration settings relevant for the SOME/IP service discovery. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=sdServerTimerConfig.someipSdServer ServiceInstanceConfig, sdServerTimer Config.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        if value is not None:
+            self.sdServerTimerConfigRef = value
+        return self
+
     def getServiceIdentifier(self):
+        """
+        This attribute represents the ability to describe the SOME/ IP service ID that is offered.
+        """
         return self.serviceIdentifier
 
     def setServiceIdentifier(self, value):
+        """
+        This attribute represents the ability to describe the SOME/ IP service ID that is offered.
+        """
         if value is not None:
             self.serviceIdentifier = value
         return self

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -6161,7 +6161,23 @@ class ARXMLParser(AbstractARXMLParser):
         self.readIdentifiable(element, instance)
         self.readProvidedServiceInstanceEventHandlers(element, instance)
         instance.setInstanceIdentifier(self.getChildElementOptionalPositiveInteger(element, "INSTANCE-IDENTIFIER"))
+        instance.setLoadBalancingPriority(self.getChildElementOptionalPositiveInteger(element, "LOAD-BALANCING-PRIORITY"))
+        instance.setLoadBalancingWeight(self.getChildElementOptionalPositiveInteger(element, "LOAD-BALANCING-WEIGHT"))
+        for ref in self.getChildElementRefTypeList(element, "LOCAL-UNICAST-ADDRESSS/APPLICATION-ENDPOINT-REF-CONDITIONAL/APPLICATION-ENDPOINT-REF"):
+            instance.addLocalUnicastAddressRef(ref)
+        instance.setMinorVersion(self.getChildElementOptionalPositiveInteger(element, "MINOR-VERSION"))
+        instance.setPriority(self.getChildElementOptionalPositiveInteger(element, "PRIORITY"))
+        for ref in self.getChildElementRefTypeList(element, "REMOTE-MULTICAST-SUBSCRIPTION-ADDRESSS/APPLICATION-ENDPOINT-REF-CONDITIONAL/APPLICATION-ENDPOINT-REF"):
+            instance.addRemoteMulticastSubscriptionAddressRef(ref)
+        for ref in self.getChildElementRefTypeList(element, "REMOTE-UNICAST-ADDRESSS/APPLICATION-ENDPOINT-REF-CONDITIONAL/APPLICATION-ENDPOINT-REF"):
+            instance.addRemoteUnicastAddressRef(ref)
         instance.setSdServerConfig(self.getSdServerConfig(element, "SD-SERVER-CONFIG"))
+        instance.setSdServerTimerConfigRef(
+            self.getChildElementOptionalRefType(element, "SD-SERVER-TIMER-CONFIGS/SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG-REF-CONDITIONAL/SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG-REF")
+        )
+        for ref in self.getChildElementRefTypeList(element, "ALLOWED-SERVICE-CONSUMERS/NETWORK-ENDPOINT-REF-CONDITIONAL/NETWORK-ENDPOINT-REF"):
+            instance.addAllowedServiceConsumerRef(ref)
+        instance.setAutoAvailable(self.getChildElementOptionalBooleanValue(element, "AUTO-AVAILABLE"))
         instance.setServiceIdentifier(self.getChildElementOptionalPositiveInteger(element, "SERVICE-IDENTIFIER"))
 
     def readSocketAddressApplicationEndpointProvidedServiceInstance(self, element: ET.Element, end_point: ApplicationEndpoint):

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -6673,7 +6673,41 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.writeIdentifiable(child_element, instance)
             self.writeProvidedServiceInstanceEventHandlers(child_element, instance)
             self.setChildElementOptionalPositiveInteger(child_element, "INSTANCE-IDENTIFIER", instance.getInstanceIdentifier())
+            self.setChildElementOptionalPositiveInteger(child_element, "LOAD-BALANCING-PRIORITY", instance.getLoadBalancingPriority())
+            self.setChildElementOptionalPositiveInteger(child_element, "LOAD-BALANCING-WEIGHT", instance.getLoadBalancingWeight())
+            refs = instance.getLocalUnicastAddressRefs()
+            if len(refs) > 0:
+                wrapper = ET.SubElement(child_element, "LOCAL-UNICAST-ADDRESSS")
+                for ref in refs:
+                    cond_tag = ET.SubElement(wrapper, "APPLICATION-ENDPOINT-REF-CONDITIONAL")
+                    self.setChildElementOptionalRefType(cond_tag, "APPLICATION-ENDPOINT-REF", ref)
+            self.setChildElementOptionalPositiveInteger(child_element, "MINOR-VERSION", instance.getMinorVersion())
+            self.setChildElementOptionalPositiveInteger(child_element, "PRIORITY", instance.getPriority())
+            refs = instance.getRemoteMulticastSubscriptionAddressRefs()
+            if len(refs) > 0:
+                wrapper = ET.SubElement(child_element, "REMOTE-MULTICAST-SUBSCRIPTION-ADDRESSS")
+                for ref in refs:
+                    cond_tag = ET.SubElement(wrapper, "APPLICATION-ENDPOINT-REF-CONDITIONAL")
+                    self.setChildElementOptionalRefType(cond_tag, "APPLICATION-ENDPOINT-REF", ref)
+            refs = instance.getRemoteUnicastAddressRefs()
+            if len(refs) > 0:
+                wrapper = ET.SubElement(child_element, "REMOTE-UNICAST-ADDRESSS")
+                for ref in refs:
+                    cond_tag = ET.SubElement(wrapper, "APPLICATION-ENDPOINT-REF-CONDITIONAL")
+                    self.setChildElementOptionalRefType(cond_tag, "APPLICATION-ENDPOINT-REF", ref)
             self.setSdServerConfig(child_element, "SD-SERVER-CONFIG", instance.getSdServerConfig())
+            ref = instance.getSdServerTimerConfigRef()
+            if ref is not None:
+                wrapper = ET.SubElement(child_element, "SD-SERVER-TIMER-CONFIGS")
+                cond_tag = ET.SubElement(wrapper, "SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG-REF-CONDITIONAL")
+                self.setChildElementOptionalRefType(cond_tag, "SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG-REF", ref)
+            refs = instance.getAllowedServiceConsumerRefs()
+            if len(refs) > 0:
+                wrapper = ET.SubElement(child_element, "ALLOWED-SERVICE-CONSUMERS")
+                for ref in refs:
+                    cond_tag = ET.SubElement(wrapper, "NETWORK-ENDPOINT-REF-CONDITIONAL")
+                    self.setChildElementOptionalRefType(cond_tag, "NETWORK-ENDPOINT-REF", ref)
+            self.setChildElementOptionalBooleanValue(child_element, "AUTO-AVAILABLE", instance.getAutoAvailable())
             self.setChildElementOptionalPositiveInteger(child_element, "SERVICE-IDENTIFIER", instance.getServiceIdentifier())
 
     def writeSocketAddressApplicationEndpointProvidedServiceInstance(self, element: ET.Element, end_point: ApplicationEndpoint):

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/test_ServiceInstances.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/test_ServiceInstances.py
@@ -587,19 +587,38 @@ class Test_Fibex4EthernetServiceInstances:
         # Test default values
         assert instance.getEventHandlers() == []
         assert instance.getInstanceIdentifier() is None
+        assert instance.getLoadBalancingPriority() is None
+        assert instance.getLoadBalancingWeight() is None
+        assert instance.getLocalUnicastAddressRefs() == []
+        assert instance.getMinorVersion() is None
         assert instance.getPriority() is None
+        assert instance.getRemoteMulticastSubscriptionAddressRefs() == []
+        assert instance.getRemoteUnicastAddressRefs() == []
         assert instance.getSdServerConfig() is None
+        assert instance.getSdServerTimerConfigRef() is None
         assert instance.getServiceIdentifier() is None
 
         # Test setter/getter methods with method chaining - with None
         assert instance == instance.setInstanceIdentifier(None)  # Test method chaining with None
         assert instance.getInstanceIdentifier() is None  # Should remain None
 
+        assert instance == instance.setLoadBalancingPriority(None)  # Test method chaining with None
+        assert instance.getLoadBalancingPriority() is None  # Should remain None
+
+        assert instance == instance.setLoadBalancingWeight(None)  # Test method chaining with None
+        assert instance.getLoadBalancingWeight() is None  # Should remain None
+
+        assert instance == instance.setMinorVersion(None)  # Test method chaining with None
+        assert instance.getMinorVersion() is None  # Should remain None
+
         assert instance == instance.setPriority(None)  # Test method chaining with None
         assert instance.getPriority() is None  # Should remain None
 
         assert instance == instance.setSdServerConfig(None)  # Test method chaining with None
         assert instance.getSdServerConfig() is None  # Should remain None
+
+        assert instance == instance.setSdServerTimerConfigRef(None)  # Test method chaining with None
+        assert instance.getSdServerTimerConfigRef() is None  # Should remain None
 
         assert instance == instance.setServiceIdentifier(None)  # Test method chaining with None
         assert instance.getServiceIdentifier() is None  # Should remain None
@@ -608,6 +627,18 @@ class Test_Fibex4EthernetServiceInstances:
         instance.setInstanceIdentifier(200)
         assert instance.getInstanceIdentifier() == 200
         assert instance == instance.setInstanceIdentifier(200)  # Test method chaining
+
+        instance.setLoadBalancingPriority(7)
+        assert instance.getLoadBalancingPriority() == 7
+        assert instance == instance.setLoadBalancingPriority(7)  # Test method chaining
+
+        instance.setLoadBalancingWeight(3)
+        assert instance.getLoadBalancingWeight() == 3
+        assert instance == instance.setLoadBalancingWeight(3)  # Test method chaining
+
+        instance.setMinorVersion(2)
+        assert instance.getMinorVersion() == 2
+        assert instance == instance.setMinorVersion(2)  # Test method chaining
 
         instance.setPriority(3)
         assert instance.getPriority() == 3
@@ -618,14 +649,49 @@ class Test_Fibex4EthernetServiceInstances:
         assert instance.getSdServerConfig() == config
         assert instance == instance.setSdServerConfig(config)  # Test method chaining
 
+        instance.setSdServerTimerConfigRef("sd_server_timer_config_ref")
+        assert instance.getSdServerTimerConfigRef() == "sd_server_timer_config_ref"
+        assert instance == instance.setSdServerTimerConfigRef("sd_server_timer_config_ref")  # Test method chaining
+
         instance.setServiceIdentifier(25)
         assert instance.getServiceIdentifier() == 25
         assert instance == instance.setServiceIdentifier(25)  # Test method chaining
+
+        # Test add methods for reference lists
+        instance.addLocalUnicastAddressRef("local_unicast_ref1")
+        assert "local_unicast_ref1" in instance.getLocalUnicastAddressRefs()
+        assert instance == instance.addLocalUnicastAddressRef("local_unicast_ref1")  # Test method chaining
+
+        instance.addAllowedServiceConsumerRef("network_endpoint_ref1")
+        assert "network_endpoint_ref1" in instance.getAllowedServiceConsumerRefs()
+        assert instance == instance.addAllowedServiceConsumerRef("network_endpoint_ref1")  # Test method chaining
+        assert instance == instance.setAllowedServiceConsumerRefs(["network_endpoint_ref2"])
+        assert instance.getAllowedServiceConsumerRefs() == ["network_endpoint_ref2"]
+        assert instance == instance.setAllowedServiceConsumerRefs(None)  # None no-op
+        assert instance.getAllowedServiceConsumerRefs() == ["network_endpoint_ref2"]
+
+        instance.setLocalUnicastAddressRefs(["local_unicast_ref2"])
+        assert "local_unicast_ref2" in instance.getLocalUnicastAddressRefs()
+
+        instance.addRemoteMulticastSubscriptionAddressRef("remote_multicast_ref1")
+        assert "remote_multicast_ref1" in instance.getRemoteMulticastSubscriptionAddressRefs()
+        assert instance == instance.addRemoteMulticastSubscriptionAddressRef("remote_multicast_ref1")  # Test method chaining
+
+        instance.addRemoteUnicastAddressRef("remote_unicast_ref1")
+        assert "remote_unicast_ref1" in instance.getRemoteUnicastAddressRefs()
+        assert instance == instance.addRemoteUnicastAddressRef("remote_unicast_ref1")  # Test method chaining
 
         # Test create method for event handlers
         event_handler = instance.createEventHandler("test_event_handler")
         assert isinstance(event_handler, EventHandler)
         assert len(instance.getEventHandlers()) == 1
+
+        # Test autoAvailable attribute (Boolean, 0..1)
+        assert instance == instance.setAutoAvailable(None)  # None no-op
+        assert instance.getAutoAvailable() is None
+        instance.setAutoAvailable(True)
+        assert instance.getAutoAvailable() is True
+        assert instance == instance.setAutoAvailable(True)  # Test method chaining
 
     def test_ApplicationEndpoint(self):
         """Test ApplicationEndpoint class functionality."""

--- a/tests/test_armodel/parser/test_arxml_parser_service_instances.py
+++ b/tests/test_armodel/parser/test_arxml_parser_service_instances.py
@@ -1,0 +1,107 @@
+"""Tests for ProvidedServiceInstance reader coverage (sync R23-11, Table E.37)."""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from armodel.models import AUTOSAR
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import (
+    ApplicationEndpoint,
+    ProvidedServiceInstance,
+    SoAdConfig,
+    SocketAddress,
+)
+
+NS = "http://autosar.org/schema/r4.0"
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def parser():
+    AUTOSAR.getInstance().new()
+    return ARXMLParser()
+
+
+def _snip(inner: str, root_tag: str = "PROVIDED-SERVICE-INSTANCE") -> ET.Element:
+    return ET.fromstring(f"<{root_tag} xmlns='{NS}'>{inner}</{root_tag}>")
+
+
+class TestReadProvidedServiceInstance:
+    def test_read_provided_service_instance_all_attrs(self, parser):
+        config = SoAdConfig()
+        address = SocketAddress(parent=config, short_name="sa")
+        endpoint = ApplicationEndpoint(parent=address, short_name="ae")
+        instance = ProvidedServiceInstance(parent=endpoint, short_name="psi")
+        element = _snip(
+            "<SHORT-NAME>psi</SHORT-NAME>"
+            "<INSTANCE-IDENTIFIER>200</INSTANCE-IDENTIFIER>"
+            "<LOAD-BALANCING-PRIORITY>7</LOAD-BALANCING-PRIORITY>"
+            "<LOAD-BALANCING-WEIGHT>3</LOAD-BALANCING-WEIGHT>"
+            "<LOCAL-UNICAST-ADDRESSS>"
+            "<APPLICATION-ENDPOINT-REF-CONDITIONAL>"
+            "<APPLICATION-ENDPOINT-REF DEST='APPLICATION-ENDPOINT'>/ep1</APPLICATION-ENDPOINT-REF>"
+            "</APPLICATION-ENDPOINT-REF-CONDITIONAL>"
+            "</LOCAL-UNICAST-ADDRESSS>"
+            "<MINOR-VERSION>2</MINOR-VERSION>"
+            "<PRIORITY>3</PRIORITY>"
+            "<REMOTE-MULTICAST-SUBSCRIPTION-ADDRESSS>"
+            "<APPLICATION-ENDPOINT-REF-CONDITIONAL>"
+            "<APPLICATION-ENDPOINT-REF DEST='APPLICATION-ENDPOINT'>/ep2</APPLICATION-ENDPOINT-REF>"
+            "</APPLICATION-ENDPOINT-REF-CONDITIONAL>"
+            "</REMOTE-MULTICAST-SUBSCRIPTION-ADDRESSS>"
+            "<REMOTE-UNICAST-ADDRESSS>"
+            "<APPLICATION-ENDPOINT-REF-CONDITIONAL>"
+            "<APPLICATION-ENDPOINT-REF DEST='APPLICATION-ENDPOINT'>/ep3</APPLICATION-ENDPOINT-REF>"
+            "</APPLICATION-ENDPOINT-REF-CONDITIONAL>"
+            "</REMOTE-UNICAST-ADDRESSS>"
+            "<SD-SERVER-TIMER-CONFIGS>"
+            "<SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG-REF-CONDITIONAL>"
+            "<SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG-REF DEST='SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG'>/sd1</SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG-REF>"
+            "</SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG-REF-CONDITIONAL>"
+            "</SD-SERVER-TIMER-CONFIGS>"
+            "<ALLOWED-SERVICE-CONSUMERS>"
+            "<NETWORK-ENDPOINT-REF-CONDITIONAL>"
+            "<NETWORK-ENDPOINT-REF DEST='NETWORK-ENDPOINT'>/nep1</NETWORK-ENDPOINT-REF>"
+            "</NETWORK-ENDPOINT-REF-CONDITIONAL>"
+            "</ALLOWED-SERVICE-CONSUMERS>"
+            "<AUTO-AVAILABLE>true</AUTO-AVAILABLE>"
+            "<SERVICE-IDENTIFIER>25</SERVICE-IDENTIFIER>"
+        )
+        parser.readProvidedServiceInstance(element, instance)
+        assert instance.getInstanceIdentifier().getValue() == 200
+        assert instance.getLoadBalancingPriority().getValue() == 7
+        assert instance.getLoadBalancingWeight().getValue() == 3
+        assert len(instance.getLocalUnicastAddressRefs()) == 1
+        assert instance.getLocalUnicastAddressRefs()[0].getValue() == "/ep1"
+        assert instance.getMinorVersion().getValue() == 2
+        assert instance.getPriority().getValue() == 3
+        assert len(instance.getRemoteMulticastSubscriptionAddressRefs()) == 1
+        assert instance.getRemoteMulticastSubscriptionAddressRefs()[0].getValue() == "/ep2"
+        assert len(instance.getRemoteUnicastAddressRefs()) == 1
+        assert instance.getRemoteUnicastAddressRefs()[0].getValue() == "/ep3"
+        assert instance.getSdServerTimerConfigRef().getValue() == "/sd1"
+        assert len(instance.getAllowedServiceConsumerRefs()) == 1
+        assert instance.getAllowedServiceConsumerRefs()[0].getValue() == "/nep1"
+        assert instance.getAutoAvailable().getValue() is True
+        assert instance.getServiceIdentifier().getValue() == 25
+
+    def test_read_provided_service_instance_empty_ref_lists(self, parser):
+        config = SoAdConfig()
+        address = SocketAddress(parent=config, short_name="sa")
+        endpoint = ApplicationEndpoint(parent=address, short_name="ae")
+        instance = ProvidedServiceInstance(parent=endpoint, short_name="psi")
+        element = _snip("<SHORT-NAME>psi</SHORT-NAME>")
+        parser.readProvidedServiceInstance(element, instance)
+        assert instance.getLocalUnicastAddressRefs() == []
+        assert instance.getRemoteMulticastSubscriptionAddressRefs() == []
+        assert instance.getRemoteUnicastAddressRefs() == []
+        assert instance.getAllowedServiceConsumerRefs() == []
+        assert instance.getAutoAvailable() is None
+        assert instance.getSdServerTimerConfigRef() is None

--- a/tests/test_armodel/parser/test_arxml_parser_service_instances.py
+++ b/tests/test_armodel/parser/test_arxml_parser_service_instances.py
@@ -5,13 +5,13 @@ import xml.etree.ElementTree as ET
 import pytest
 
 from armodel.models import AUTOSAR
-from armodel.parser.arxml_parser import ARXMLParser
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import (
     ApplicationEndpoint,
     ProvidedServiceInstance,
     SoAdConfig,
     SocketAddress,
 )
+from armodel.parser.arxml_parser import ARXMLParser
 
 NS = "http://autosar.org/schema/r4.0"
 

--- a/tests/test_armodel/writer/test_writer_service_instances.py
+++ b/tests/test_armodel/writer/test_writer_service_instances.py
@@ -1,0 +1,170 @@
+"""Writer tests for ProvidedServiceInstance (sync R23-11, Table E.37)."""
+
+import xml.etree.cElementTree as ET
+
+import pytest
+
+from armodel.models import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    Boolean,
+    PositiveInteger,
+    RefType,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import (
+    ApplicationEndpoint,
+    ProvidedServiceInstance,
+    SoAdConfig,
+    SocketAddress,
+)
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+
+NS = "http://autosar.org/schema/r4.0"
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+@pytest.fixture
+def parser():
+    AUTOSAR.getInstance().new()
+    return ARXMLParser()
+
+
+def _parent():
+    return ET.Element("PARENT")
+
+
+def _pos_int(text):
+    val = PositiveInteger()
+    val.setValue(text)
+    return val
+
+
+def _ref(dest, value):
+    ref = RefType()
+    ref.setDest(dest)
+    ref.setValue(value)
+    return ref
+
+
+def _bool(value):
+    b = Boolean()
+    b.setValue(value)
+    return b
+
+
+def _serialize_and_wrap(parent: ET.Element) -> ET.Element:
+    inner = ET.tostring(parent).decode("utf-8")
+    root = ET.fromstring(f"<AUTOSAR xmlns='{NS}'>{inner}</AUTOSAR>")
+    return root[0][0]
+
+
+class TestWriteProvidedServiceInstance:
+    def test_write_provided_service_instance_all_attrs(self, writer):
+        config = SoAdConfig()
+        address = SocketAddress(parent=config, short_name="sa")
+        endpoint = ApplicationEndpoint(parent=address, short_name="ae")
+        instance = ProvidedServiceInstance(parent=endpoint, short_name="psi")
+        instance.setInstanceIdentifier(_pos_int("200"))
+        instance.setLoadBalancingPriority(_pos_int("7"))
+        instance.setLoadBalancingWeight(_pos_int("3"))
+        instance.addLocalUnicastAddressRef(_ref("APPLICATION-ENDPOINT", "/ep1"))
+        instance.setMinorVersion(_pos_int("2"))
+        instance.setPriority(_pos_int("3"))
+        instance.addRemoteMulticastSubscriptionAddressRef(_ref("APPLICATION-ENDPOINT", "/ep2"))
+        instance.addRemoteUnicastAddressRef(_ref("APPLICATION-ENDPOINT", "/ep3"))
+        instance.setSdServerTimerConfigRef(_ref("SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG", "/sd1"))
+        instance.addAllowedServiceConsumerRef(_ref("NETWORK-ENDPOINT", "/nep1"))
+        instance.setAutoAvailable(_bool("true"))
+        instance.setServiceIdentifier(_pos_int("25"))
+
+        parent = _parent()
+        writer.writeProvidedServiceInstance(parent, instance)
+
+        psi = parent.find("PROVIDED-SERVICE-INSTANCE")
+        assert psi is not None
+        assert psi.find("INSTANCE-IDENTIFIER").text == "200"
+        assert psi.find("LOAD-BALANCING-PRIORITY").text == "7"
+        assert psi.find("LOAD-BALANCING-WEIGHT").text == "3"
+        assert psi.find("MINOR-VERSION").text == "2"
+        assert psi.find("PRIORITY").text == "3"
+        assert psi.find("SERVICE-IDENTIFIER").text == "25"
+        lus = psi.find("LOCAL-UNICAST-ADDRESSS")
+        assert lus is not None
+        assert lus.find("APPLICATION-ENDPOINT-REF-CONDITIONAL/APPLICATION-ENDPOINT-REF").text == "/ep1"
+        rms = psi.find("REMOTE-MULTICAST-SUBSCRIPTION-ADDRESSS")
+        assert rms is not None
+        assert rms.find("APPLICATION-ENDPOINT-REF-CONDITIONAL/APPLICATION-ENDPOINT-REF").text == "/ep2"
+        ru = psi.find("REMOTE-UNICAST-ADDRESSS")
+        assert ru is not None
+        assert ru.find("APPLICATION-ENDPOINT-REF-CONDITIONAL/APPLICATION-ENDPOINT-REF").text == "/ep3"
+        sstc = psi.find("SD-SERVER-TIMER-CONFIGS")
+        assert sstc is not None
+        assert sstc.find("SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG-REF-CONDITIONAL/SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG-REF").text == "/sd1"
+        asc = psi.find("ALLOWED-SERVICE-CONSUMERS")
+        assert asc is not None
+        assert asc.find("NETWORK-ENDPOINT-REF-CONDITIONAL/NETWORK-ENDPOINT-REF").text == "/nep1"
+        assert psi.find("AUTO-AVAILABLE").text == "true"
+
+    def test_write_provided_service_instance_empty_ref_lists(self, writer):
+        config = SoAdConfig()
+        address = SocketAddress(parent=config, short_name="sa")
+        endpoint = ApplicationEndpoint(parent=address, short_name="ae")
+        instance = ProvidedServiceInstance(parent=endpoint, short_name="psi")
+        parent = _parent()
+        writer.writeProvidedServiceInstance(parent, instance)
+        psi = parent.find("PROVIDED-SERVICE-INSTANCE")
+        assert psi.find("LOCAL-UNICAST-ADDRESSS") is None
+        assert psi.find("REMOTE-MULTICAST-SUBSCRIPTION-ADDRESSS") is None
+        assert psi.find("REMOTE-UNICAST-ADDRESSS") is None
+        assert psi.find("SD-SERVER-TIMER-CONFIGS") is None
+        assert psi.find("ALLOWED-SERVICE-CONSUMERS") is None
+        assert psi.find("AUTO-AVAILABLE") is None
+
+    def test_round_trip_provided_service_instance(self, writer, parser):
+        config = SoAdConfig()
+        address = SocketAddress(parent=config, short_name="sa")
+        endpoint = ApplicationEndpoint(parent=address, short_name="ae")
+        instance = ProvidedServiceInstance(parent=endpoint, short_name="psi")
+        instance.setInstanceIdentifier(_pos_int("200"))
+        instance.setLoadBalancingPriority(_pos_int("7"))
+        instance.setLoadBalancingWeight(_pos_int("3"))
+        instance.addLocalUnicastAddressRef(_ref("APPLICATION-ENDPOINT", "/ep1"))
+        instance.setMinorVersion(_pos_int("2"))
+        instance.setPriority(_pos_int("3"))
+        instance.addRemoteMulticastSubscriptionAddressRef(_ref("APPLICATION-ENDPOINT", "/ep2"))
+        instance.addRemoteUnicastAddressRef(_ref("APPLICATION-ENDPOINT", "/ep3"))
+        instance.setSdServerTimerConfigRef(_ref("SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG", "/sd1"))
+        instance.addAllowedServiceConsumerRef(_ref("NETWORK-ENDPOINT", "/nep1"))
+        instance.setAutoAvailable(_bool("true"))
+        instance.setServiceIdentifier(_pos_int("25"))
+
+        parent = _parent()
+        writer.writeProvidedServiceInstance(parent, instance)
+        element = _serialize_and_wrap(parent)
+
+        recovered = ProvidedServiceInstance(parent=endpoint, short_name="psi")
+        parser.readProvidedServiceInstance(element, recovered)
+        assert recovered.getInstanceIdentifier().getValue() == 200
+        assert recovered.getLoadBalancingPriority().getValue() == 7
+        assert recovered.getLoadBalancingWeight().getValue() == 3
+        assert [r.getValue() for r in recovered.getLocalUnicastAddressRefs()] == ["/ep1"]
+        assert recovered.getMinorVersion().getValue() == 2
+        assert recovered.getPriority().getValue() == 3
+        assert [r.getValue() for r in recovered.getRemoteMulticastSubscriptionAddressRefs()] == ["/ep2"]
+        assert [r.getValue() for r in recovered.getRemoteUnicastAddressRefs()] == ["/ep3"]
+        assert recovered.getSdServerTimerConfigRef().getValue() == "/sd1"
+        assert [r.getValue() for r in recovered.getAllowedServiceConsumerRefs()] == ["/nep1"]
+        assert recovered.getAutoAvailable().getValue() is True
+        assert recovered.getServiceIdentifier().getValue() == 25


### PR DESCRIPTION
## Summary
- Sync `ProvidedServiceInstance` to AUTOSAR R23-11 spec.
- Source of truth: `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`, Table E.37, p.1002 (the complete/correct table; SystemTemplate Table 6.160 is incomplete).
- All 14 spec attributes modeled with verbatim `Note` docstrings and reordered to spec display order: `allowedServiceConsumerRefs` (→NetworkEndpoint), `autoAvailable` (→Boolean), `eventHandler`, `instanceIdentifier`, `loadBalancingPriority`, `loadBalancingWeight`, `localUnicastAddressRefs` (0..2), `minorVersion`, `priority`, `remoteMulticastSubscriptionAddressRefs`, `remoteUnicastAddressRefs`, `sdServerConfig`, `sdServerTimerConfigRef`, `serviceIdentifier`.
- Parser/writer now read and write `ALLOWED-SERVICE-CONSUMERS` and `AUTO-AVAILABLE`.
- Added/extended model, parser, and writer round-trip tests.

## Verification
- 22 unit/round-trip tests pass; 3529 broader tests + integration round-trip pass.
- flake8, ruff, black clean.
- `# Spec verified: R23-11` marker added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)