### PR TITLE
feat: sync RootSwCompositionPrototype to R23-11 SystemTemplate spec

### DIFF
--- a/docs/plan/sync-todo/RootSwCompositionPrototype.md
+++ b/docs/plan/sync-todo/RootSwCompositionPrototype.md
@@ -1,0 +1,17 @@
+# Sync Queue: RootSwCompositionPrototype
+
+Input class: `RootSwCompositionPrototype`
+Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 4.1, p.186 (matches SWCT Table E.39)
+Created: 2026-08-22
+
+## Closure (confirmed)
+| Class | Role | Notes |
+|-------|------|-------|
+| RootSwCompositionPrototype | input | Full 9-step sync. No `# Spec:`/marker. Drift: `calibrationParameterValueSet` Mult `*` (list) vs current singular; rename existing field to conform. |
+| AtpPrototype | base | Exists, abstract, imported from GenericStructure/AbstractStructure.py. Out of scope (no stamping). |
+| CalibrationParameterValueSet | member ref | primitive `RefType`* — no model class |
+| FlatMap | member ref | primitive `RefType` |
+| CompositionSwComponentType | member tref | primitive `TRefType` |
+
+## Queue (dependency-first)
+- [x] RootSwCompositionPrototype (commit `cdde9780`)

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/__init__.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpPrototype, AtpStructureElement
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DataMapping import DataMapping
@@ -394,46 +394,76 @@ class SystemMapping(Identifiable):
 
 class RootSwCompositionPrototype(AtpPrototype):
     """
-    Represents the root software composition prototype in the system,
-    defining references to calibration parameter value sets, flat maps,
-    and software composition templates for the top-level composition.
+    The RootSwCompositionPrototype represents the top-level-composition of software components within a given System. According to the use case of the System, this may for example be a more or less complete VFB description, the software of a System Extract or the software of a flat ECU Extract with only atomic SWCs. Therefore the RootSwComposition will only occasionally contain all atomic software components that are used in a complete VFB System. The OEM is primarily interested in the required functionality and the interfaces defining the integration of the Software Component into the System. The internal structure of such a component contains often substantial intellectual property of a supplier. Therefore a top-level software composition will often contain empty compositions which represent subsystems. The contained SwComponentPrototypes are fully specified by their SwComponentTypes (including Port Prototypes, PortInterfaces, VariableDataPrototypes, SwcInternalBehavior etc.), and their ports are interconnected using SwConnectorPrototypes.
     """
 
     # RootSwCompositionPrototype method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getCalibrationParameterValueSetRef [x] impl  [ ] docstring  [ ] test
-    # [ ] setCalibrationParameterValueSetRef [x] impl  [ ] docstring  [ ] test
-    # [ ] getFlatMapRef                [x] impl  [ ] docstring  [ ] test
-    # [ ] setFlatMapRef                [x] impl  [ ] docstring  [ ] test
-    # [ ] getSoftwareCompositionTRef   [x] impl  [ ] docstring  [ ] test
-    # [ ] setSoftwareCompositionTRef   [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 4.1, p.186
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getCalibrationParameterValueSetRefs [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addCalibrationParameterValueSetRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFlatMapRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFlatMapRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getSoftwareCompositionTRef [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setSoftwareCompositionTRef [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.calibrationParameterValueSetRef: RefType = None
-        self.flatMapRef: RefType = None
-        self.softwareCompositionTRef: TRefType = None
+        # Used CalibrationParameterValueSet for instance specific initialization of calibration parameters.
+        self.calibrationParameterValueSetRefs: List[RefType] = []
 
-    def getCalibrationParameterValueSetRef(self):
-        return self.calibrationParameterValueSetRef
+        # The FlatMap used in the scope of this RootSw CompositionPrototype.
+        self.flatMapRef: Optional[RefType] = None
 
-    def setCalibrationParameterValueSetRef(self, value):
-        self.calibrationParameterValueSetRef = value
+        # We assume that there is exactly one top-level composition that includes all Component instances of the system.
+        self.softwareCompositionTRef: Optional[TRefType] = None
+
+    def getCalibrationParameterValueSetRefs(self) -> List[RefType]:
+        """
+        Used CalibrationParameterValueSet for instance specific initialization of calibration parameters.
+        """
+        return self.calibrationParameterValueSetRefs
+
+    def addCalibrationParameterValueSetRef(self, value: Optional[RefType]) -> "RootSwCompositionPrototype":
+        """
+        Used CalibrationParameterValueSet for instance specific initialization of calibration parameters.
+        A None value is a no-op and does not add to calibrationParameterValueSetRefs.
+        """
+        if value is not None:
+            self.calibrationParameterValueSetRefs.append(value)
         return self
 
-    def getFlatMapRef(self):
+    def getFlatMapRef(self) -> Optional[RefType]:
+        """
+        The FlatMap used in the scope of this RootSw CompositionPrototype.
+        """
         return self.flatMapRef
 
-    def setFlatMapRef(self, value):
-        self.flatMapRef = value
+    def setFlatMapRef(self, value: Optional[RefType]) -> "RootSwCompositionPrototype":
+        """
+        The FlatMap used in the scope of this RootSw CompositionPrototype.
+        A None value is a no-op and does not overwrite an existing flatMapRef.
+        """
+        if value is not None:
+            self.flatMapRef = value
         return self
 
-    def getSoftwareCompositionTRef(self):
+    def getSoftwareCompositionTRef(self) -> Optional[TRefType]:
+        """
+        We assume that there is exactly one top-level composition that includes all Component instances of the system.
+        """
         return self.softwareCompositionTRef
 
-    def setSoftwareCompositionTRef(self, value):
-        self.softwareCompositionTRef = value
+    def setSoftwareCompositionTRef(self, value: Optional[TRefType]) -> "RootSwCompositionPrototype":
+        """
+        We assume that there is exactly one top-level composition that includes all Component instances of the system.
+        A None value is a no-op and does not overwrite an existing softwareCompositionTRef.
+        """
+        if value is not None:
+            self.softwareCompositionTRef = value
         return self
 
 

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -8713,6 +8713,8 @@ class ARXMLParser(AbstractARXMLParser):
             self.logger.debug("Read RootSwCompositionPrototype %s" % short_name)
             prototype = system.createRootSoftwareComposition(short_name)
             self.readIdentifiable(child_element, prototype)
+            for ref in self.getChildElementRefTypeList(child_element, "CALIBRATION-PARAMETER-VALUE-SET-REFS/CALIBRATION-PARAMETER-VALUE-SET-REF"):
+                prototype.addCalibrationParameterValueSetRef(ref)
             prototype.setFlatMapRef(self.getChildElementOptionalRefType(child_element, "FLAT-MAP-REF"))
             prototype.setSoftwareCompositionTRef(self.getChildElementOptionalRefType(child_element, "SOFTWARE-COMPOSITION-TREF"))
             try:

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -7902,6 +7902,11 @@ class ARXMLWriter(AbstractARXMLWriter):
             child_element = ET.SubElement(element, "ROOT-SOFTWARE-COMPOSITIONS")
             child_element = ET.SubElement(child_element, "ROOT-SW-COMPOSITION-PROTOTYPE")
             self.writeIdentifiable(child_element, prototype)
+            calibration_refs = prototype.getCalibrationParameterValueSetRefs()
+            if len(calibration_refs) > 0:
+                calibration_wrapper = ET.SubElement(child_element, "CALIBRATION-PARAMETER-VALUE-SET-REFS")
+                for ref in calibration_refs:
+                    self.setChildElementOptionalRefType(calibration_wrapper, "CALIBRATION-PARAMETER-VALUE-SET-REF", ref)
             self.setChildElementOptionalRefType(child_element, "FLAT-MAP-REF", prototype.getFlatMapRef())
             self.setChildElementOptionalRefType(child_element, "SOFTWARE-COMPOSITION-TREF", prototype.getSoftwareCompositionTRef())
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test___init__.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test___init__.py
@@ -1,3 +1,4 @@
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpPrototype
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate import ComManagementMapping, J1939SharedAddressCluster, RootSwCompositionPrototype, SwcToEcuMapping, System, SystemMapping
 
@@ -224,31 +225,41 @@ class TestSystemTemplate:
 
     def test_root_sw_composition_prototype(self):
         """
-        Test RootSwCompositionPrototype class functionality with method chaining.
+        Test RootSwCompositionPrototype class functionality with method chaining and None handling.
         """
         parent = MockParent()
         prototype = RootSwCompositionPrototype(parent, "test_root_sw_composition_prototype")
 
-        # Test constructor
-        assert prototype is not None
+        # Test inherited from AtpPrototype
+        assert isinstance(prototype, AtpPrototype)
 
         # Test default values
-        assert prototype.getCalibrationParameterValueSetRef() is None
+        assert prototype.getCalibrationParameterValueSetRefs() == []
         assert prototype.getFlatMapRef() is None
         assert prototype.getSoftwareCompositionTRef() is None
 
+        # Test add/get calibrationParameterValueSetRefs
+        prototype.addCalibrationParameterValueSetRef("/t/f/CalibrationParameterValueSet")
+        prototype.addCalibrationParameterValueSetRef("/t/f/CalibrationParameterValueSet2")
+        assert prototype.getCalibrationParameterValueSetRefs() == [
+            "/t/f/CalibrationParameterValueSet",
+            "/t/f/CalibrationParameterValueSet2",
+        ]
+        prototype.addCalibrationParameterValueSetRef(None)
+        assert len(prototype.getCalibrationParameterValueSetRefs()) == 2
+
         # Test setter/getter methods with method chaining
-        prototype.setCalibrationParameterValueSetRef("calibration_ref")
-        assert prototype.getCalibrationParameterValueSetRef() == "calibration_ref"
-        assert prototype == prototype.setCalibrationParameterValueSetRef("calibration_ref")
+        prototype.setFlatMapRef("/t/f/FlatMap")
+        assert prototype.getFlatMapRef() == "/t/f/FlatMap"
+        assert prototype == prototype.setFlatMapRef("/t/f/FlatMap")
+        prototype.setFlatMapRef(None)
+        assert prototype.getFlatMapRef() == "/t/f/FlatMap"
 
-        prototype.setFlatMapRef("flat_map_ref")
-        assert prototype.getFlatMapRef() == "flat_map_ref"
-        assert prototype == prototype.setFlatMapRef("flat_map_ref")
-
-        prototype.setSoftwareCompositionTRef("sw_composition_ref")
-        assert prototype.getSoftwareCompositionTRef() == "sw_composition_ref"
-        assert prototype == prototype.setSoftwareCompositionTRef("sw_composition_ref")
+        prototype.setSoftwareCompositionTRef("/t/f/CompositionSwComponentType")
+        assert prototype.getSoftwareCompositionTRef() == "/t/f/CompositionSwComponentType"
+        assert prototype == prototype.setSoftwareCompositionTRef("/t/f/CompositionSwComponentType")
+        prototype.setSoftwareCompositionTRef(None)
+        assert prototype.getSoftwareCompositionTRef() == "/t/f/CompositionSwComponentType"
 
     def test_j1939_shared_address_cluster(self):
         """

--- a/tests/test_armodel/parser/test_arxml_parser_orchestrators.py
+++ b/tests/test_armodel/parser/test_arxml_parser_orchestrators.py
@@ -2675,13 +2675,11 @@ class TestReadSenderRecRecordElementMapping:
         )
 
         mapping = SenderRecRecordElementMapping()
-        element = _snip(
-            """
+        element = _snip("""
             <APPLICATION-RECORD-ELEMENT-REF DEST="RECORD-ELEMENT">/App/Rec1</APPLICATION-RECORD-ELEMENT-REF>
             <IMPLEMENTATION-RECORD-ELEMENT-REF DEST="RECORD-ELEMENT">/Impl/Rec1</IMPLEMENTATION-RECORD-ELEMENT-REF>
             <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/Sig/S1</SYSTEM-SIGNAL-REF>
-        """
-        )
+        """)
         parser.readSenderRecRecordElementMapping(element, mapping)
         assert mapping.getApplicationRecordElementRef() is not None
         assert mapping.getApplicationRecordElementRef().getValue() == "/App/Rec1"
@@ -2716,8 +2714,7 @@ class TestReadSenderRecArrayTypeMappingRecordElementMapping:
         )
 
         mapping = SenderRecRecordTypeMapping()
-        element = _snip(
-            """
+        element = _snip("""
             <RECORD-ELEMENT-MAPPINGS>
                 <SENDER-REC-RECORD-ELEMENT-MAPPING>
                     <APPLICATION-RECORD-ELEMENT-REF DEST="RECORD-ELEMENT">/App/Rec1</APPLICATION-RECORD-ELEMENT-REF>
@@ -2725,8 +2722,7 @@ class TestReadSenderRecArrayTypeMappingRecordElementMapping:
                     <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/Sig/S1</SYSTEM-SIGNAL-REF>
                 </SENDER-REC-RECORD-ELEMENT-MAPPING>
             </RECORD-ELEMENT-MAPPINGS>
-        """
-        )
+        """)
         parser.readSenderRecArrayTypeMappingRecordElementMapping(element, mapping)
         mappings = mapping.getRecordElementMappings()
         assert len(mappings) == 1
@@ -2739,15 +2735,13 @@ class TestReadSenderRecArrayTypeMappingRecordElementMapping:
         )
 
         mapping = SenderRecRecordTypeMapping()
-        element = _snip(
-            """
+        element = _snip("""
             <RECORD-ELEMENT-MAPPINGS>
                 <UNKNOWN-MAPPING>
                     <SHORT-NAME>X</SHORT-NAME>
                 </UNKNOWN-MAPPING>
             </RECORD-ELEMENT-MAPPINGS>
-        """
-        )
+        """)
         with pytest.raises(NotImplementedError):
             parser.readSenderRecArrayTypeMappingRecordElementMapping(element, mapping)
 
@@ -2757,15 +2751,13 @@ class TestReadSenderRecArrayTypeMappingRecordElementMapping:
         )
 
         mapping = SenderRecRecordTypeMapping()
-        element = _snip(
-            """
+        element = _snip("""
             <RECORD-ELEMENT-MAPPINGS>
                 <UNKNOWN-MAPPING>
                     <SHORT-NAME>X</SHORT-NAME>
                 </UNKNOWN-MAPPING>
             </RECORD-ELEMENT-MAPPINGS>
-        """
-        )
+        """)
         with caplog.at_level(logging.ERROR):
             warning_parser.readSenderRecArrayTypeMappingRecordElementMapping(element, mapping)
         assert any("Unsupported RecordElementMapping" in rec.getMessage() for rec in caplog.records)
@@ -2794,8 +2786,7 @@ class TestReadSenderRecRecordTypeMapping:
         )
 
         mapping = SenderRecRecordTypeMapping()
-        element = _snip(
-            """
+        element = _snip("""
             <RECORD-ELEMENT-MAPPINGS>
                 <SENDER-REC-RECORD-ELEMENT-MAPPING>
                     <APPLICATION-RECORD-ELEMENT-REF DEST="RECORD-ELEMENT">/App/Rec1</APPLICATION-RECORD-ELEMENT-REF>
@@ -2808,8 +2799,7 @@ class TestReadSenderRecRecordTypeMapping:
                     <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/Sig/S2</SYSTEM-SIGNAL-REF>
                 </SENDER-REC-RECORD-ELEMENT-MAPPING>
             </RECORD-ELEMENT-MAPPINGS>
-        """
-        )
+        """)
         parser.readSenderRecRecordTypeMapping(element, mapping)
         mappings = mapping.getRecordElementMappings()
         assert len(mappings) == 2
@@ -2830,8 +2820,7 @@ class TestReadSenderReceiverToSignalGroupMappingTypeMapping:
         )
 
         mapping = SenderReceiverToSignalGroupMapping()
-        element = _snip(
-            """
+        element = _snip("""
             <TYPE-MAPPING>
                 <SENDER-REC-RECORD-TYPE-MAPPING>
                     <RECORD-ELEMENT-MAPPINGS>
@@ -2843,8 +2832,7 @@ class TestReadSenderReceiverToSignalGroupMappingTypeMapping:
                     </RECORD-ELEMENT-MAPPINGS>
                 </SENDER-REC-RECORD-TYPE-MAPPING>
             </TYPE-MAPPING>
-        """
-        )
+        """)
         parser.readSenderReceiverToSignalGroupMappingTypeMapping(element, mapping)
         type_mapping = mapping.getTypeMapping()
         assert type_mapping is not None
@@ -2858,15 +2846,13 @@ class TestReadSenderReceiverToSignalGroupMappingTypeMapping:
         )
 
         mapping = SenderReceiverToSignalGroupMapping()
-        element = _snip(
-            """
+        element = _snip("""
             <TYPE-MAPPING>
                 <UNKNOWN-TYPE-MAPPING>
                     <SHORT-NAME>X</SHORT-NAME>
                 </UNKNOWN-TYPE-MAPPING>
             </TYPE-MAPPING>
-        """
-        )
+        """)
         with pytest.raises(NotImplementedError):
             parser.readSenderReceiverToSignalGroupMappingTypeMapping(element, mapping)
 
@@ -2876,15 +2862,13 @@ class TestReadSenderReceiverToSignalGroupMappingTypeMapping:
         )
 
         mapping = SenderReceiverToSignalGroupMapping()
-        element = _snip(
-            """
+        element = _snip("""
             <TYPE-MAPPING>
                 <UNKNOWN-TYPE-MAPPING>
                     <SHORT-NAME>X</SHORT-NAME>
                 </UNKNOWN-TYPE-MAPPING>
             </TYPE-MAPPING>
-        """
-        )
+        """)
         with caplog.at_level(logging.ERROR):
             warning_parser.readSenderReceiverToSignalGroupMappingTypeMapping(element, mapping)
         assert any("Unsupported Type Mapping" in rec.getMessage() for rec in caplog.records)
@@ -2909,8 +2893,7 @@ class TestReadSystemMappingDataMappings:
 
     def test_reads_sender_receiver_to_signal_mapping(self, parser):
         mapping = _make_system_mapping()
-        element = _snip(
-            """
+        element = _snip("""
             <DATA-MAPPINGS>
                 <SENDER-RECEIVER-TO-SIGNAL-MAPPING>
                     <COMMUNICATION-DIRECTION>IN</COMMUNICATION-DIRECTION>
@@ -2923,8 +2906,7 @@ class TestReadSystemMappingDataMappings:
                     <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/Sig/S1</SYSTEM-SIGNAL-REF>
                 </SENDER-RECEIVER-TO-SIGNAL-MAPPING>
             </DATA-MAPPINGS>
-        """
-        )
+        """)
         parser.readSystemMappingDataMappings(element, mapping)
         data_mappings = mapping.getDataMappings()
         assert len(data_mappings) == 1
@@ -2939,8 +2921,7 @@ class TestReadSystemMappingDataMappings:
 
     def test_reads_sender_receiver_to_signal_group_mapping(self, parser):
         mapping = _make_system_mapping()
-        element = _snip(
-            """
+        element = _snip("""
             <DATA-MAPPINGS>
                 <SENDER-RECEIVER-TO-SIGNAL-GROUP-MAPPING>
                     <DATA-ELEMENT-IREF>
@@ -2963,8 +2944,7 @@ class TestReadSystemMappingDataMappings:
                     </TYPE-MAPPING>
                 </SENDER-RECEIVER-TO-SIGNAL-GROUP-MAPPING>
             </DATA-MAPPINGS>
-        """
-        )
+        """)
         parser.readSystemMappingDataMappings(element, mapping)
         data_mappings = mapping.getDataMappings()
         assert len(data_mappings) == 1
@@ -2983,8 +2963,7 @@ class TestReadSystemMappingDataMappings:
 
     def test_reads_both_signal_and_signal_group_mappings(self, parser):
         mapping = _make_system_mapping()
-        element = _snip(
-            """
+        element = _snip("""
             <DATA-MAPPINGS>
                 <SENDER-RECEIVER-TO-SIGNAL-MAPPING>
                     <DATA-ELEMENT-IREF>
@@ -2999,37 +2978,32 @@ class TestReadSystemMappingDataMappings:
                     <SIGNAL-GROUP-REF DEST="SIGNAL-GROUP">/Sig/Group1</SIGNAL-GROUP-REF>
                 </SENDER-RECEIVER-TO-SIGNAL-GROUP-MAPPING>
             </DATA-MAPPINGS>
-        """
-        )
+        """)
         parser.readSystemMappingDataMappings(element, mapping)
         data_mappings = mapping.getDataMappings()
         assert len(data_mappings) == 2
 
     def test_unsupported_data_mapping_raises(self, parser):
         mapping = _make_system_mapping()
-        element = _snip(
-            """
+        element = _snip("""
             <DATA-MAPPINGS>
                 <UNKNOWN-MAPPING>
                     <SHORT-NAME>X</SHORT-NAME>
                 </UNKNOWN-MAPPING>
             </DATA-MAPPINGS>
-        """
-        )
+        """)
         with pytest.raises(NotImplementedError):
             parser.readSystemMappingDataMappings(element, mapping)
 
     def test_unsupported_data_mapping_logs_warning(self, warning_parser, caplog):
         mapping = _make_system_mapping()
-        element = _snip(
-            """
+        element = _snip("""
             <DATA-MAPPINGS>
                 <UNKNOWN-MAPPING>
                     <SHORT-NAME>X</SHORT-NAME>
                 </UNKNOWN-MAPPING>
             </DATA-MAPPINGS>
-        """
-        )
+        """)
         with caplog.at_level(logging.ERROR):
             warning_parser.readSystemMappingDataMappings(element, mapping)
         assert any("Unsupported Data Mapping" in rec.getMessage() for rec in caplog.records)
@@ -3324,6 +3298,45 @@ class TestSystemMappingGaps:
 
 
 class TestRootSwCompositionPrototype:
+    def test_readRootSwCompositionPrototype_full(self, parser):
+        from armodel.models import System
+
+        system = System(parent=_autosar_root(), short_name="sys")
+        element = _snip(
+            "<ROOT-SOFTWARE-COMPOSITIONS>"
+            "<ROOT-SW-COMPOSITION-PROTOTYPE>"
+            "<SHORT-NAME>root</SHORT-NAME>"
+            "<CALIBRATION-PARAMETER-VALUE-SET-REFS>"
+            "<CALIBRATION-PARAMETER-VALUE-SET-REF DEST='CALIBRATION-PARAMETER-VALUE-SET'>/a</CALIBRATION-PARAMETER-VALUE-SET-REF>"
+            "<CALIBRATION-PARAMETER-VALUE-SET-REF DEST='CALIBRATION-PARAMETER-VALUE-SET'>/b</CALIBRATION-PARAMETER-VALUE-SET-REF>"
+            "</CALIBRATION-PARAMETER-VALUE-SET-REFS>"
+            "<FLAT-MAP-REF DEST='FLAT-MAP'>/fm</FLAT-MAP-REF>"
+            "<SOFTWARE-COMPOSITION-TREF DEST='COMPOSITION-SW-COMPONENT-TYPE'>/sc</SOFTWARE-COMPOSITION-TREF>"
+            "</ROOT-SW-COMPOSITION-PROTOTYPE>"
+            "</ROOT-SOFTWARE-COMPOSITIONS>",
+            root_tag="SYSTEM",
+        )
+        parser.readRootSwCompositionPrototype(element, system)
+        prototype = system.getRootSoftwareComposition()
+        assert prototype is not None
+        assert prototype.getShortName() == "root"
+        assert [r.getValue() for r in prototype.getCalibrationParameterValueSetRefs()] == ["/a", "/b"]
+        assert prototype.getFlatMapRef().getValue() == "/fm"
+        assert prototype.getSoftwareCompositionTRef().getValue() == "/sc"
+
+    def test_readRootSwCompositionPrototype_empty_list(self, parser):
+        from armodel.models import System
+
+        system = System(parent=_autosar_root(), short_name="sys")
+        element = _snip(
+            "<ROOT-SOFTWARE-COMPOSITIONS>" "<ROOT-SW-COMPOSITION-PROTOTYPE>" "<SHORT-NAME>root</SHORT-NAME>" "</ROOT-SW-COMPOSITION-PROTOTYPE>" "</ROOT-SOFTWARE-COMPOSITIONS>",
+            root_tag="SYSTEM",
+        )
+        parser.readRootSwCompositionPrototype(element, system)
+        prototype = system.getRootSoftwareComposition()
+        assert prototype is not None
+        assert prototype.getCalibrationParameterValueSetRefs() == []
+
     def test_readRootSwCompositionPrototype_duplicate_warns(self, warning_parser, caplog):
         system_pkg = _autosar_root().createARPackage("SysPkg")
         system = system_pkg.createSystem("Sys")

--- a/tests/test_armodel/writer/test_writer_system_mapping.py
+++ b/tests/test_armodel/writer/test_writer_system_mapping.py
@@ -504,6 +504,8 @@ class TestWriterRootSwCompositionPrototype:
     def test_full(self, writer):
         system = _make_system()
         root = system.createRootSoftwareComposition("Root")
+        root.addCalibrationParameterValueSetRef(_ref("/a", "CALIBRATION-PARAMETER-VALUE-SET"))
+        root.addCalibrationParameterValueSetRef(_ref("/b", "CALIBRATION-PARAMETER-VALUE-SET"))
         root.setFlatMapRef(_ref("/fm", "FLAT-MAP"))
         root.setSoftwareCompositionTRef(_ref("/sc", "SW-COMPONENT-TYPE"))
         parent = _parent()
@@ -512,8 +514,21 @@ class TestWriterRootSwCompositionPrototype:
         assert outer.tag == "ROOT-SOFTWARE-COMPOSITIONS"
         proto = outer.find("ROOT-SW-COMPOSITION-PROTOTYPE")
         assert proto is not None
+        calibration_refs = proto.find("CALIBRATION-PARAMETER-VALUE-SET-REFS")
+        assert calibration_refs is not None
+        assert len(calibration_refs.findall("CALIBRATION-PARAMETER-VALUE-SET-REF")) == 2
         assert proto.find("FLAT-MAP-REF") is not None
         assert proto.find("SOFTWARE-COMPOSITION-TREF") is not None
+
+    def test_empty_calibration_refs_writes_no_wrapper(self, writer):
+        system = _make_system()
+        system.createRootSoftwareComposition("Root")
+        parent = _parent()
+        writer.writeRootSwCompositionPrototype(parent, system)
+        outer = parent[0]
+        proto = outer.find("ROOT-SW-COMPOSITION-PROTOTYPE")
+        assert proto is not None
+        assert proto.find("CALIBRATION-PARAMETER-VALUE-SET-REFS") is None
 
 
 class TestWriterSystemFibexElementRefs:


### PR DESCRIPTION
## Summary
Sync `RootSwCompositionPrototype` to the AUTOSAR CP R23-11 SystemTemplate spec (Table 4.1, p.186).

## Changes (commits `cdde9780`)
- **Model** (`SystemTemplate/__init__.py`): `calibrationParameterValueSet` corrected from a singular ref to a `*` ref list (`calibrationParameterValueSetRefs` + `getCalibrationParameterValueSetRefs`/`addCalibrationParameterValueSetRef`); `flatMapRef`/`softwareCompositionTRef` conform to Kind-suffix naming; docstrings synced verbatim from the spec `Note`; guarded None-no-op setters; `# Spec verified: R23-11`.
- **Parser**: read `CALIBRATION-PARAMETER-VALUE-SET-REFS` list (previously omitted).
- **Writer**: emit the calibration refs wrapper (empty list → no wrapper).
- **Tests**: model, parser round-trip (full + empty list), writer round-trip updated/extended via the 9-step TDD workflow.

## Verification
9a passed: 6790 unit tests · flake8 · ruff · black-check · set-based checklist-vs-methods · lossless integration round-trip. 9b rule-compliance confirmed.

## NOTES
Repo-wide `black-check` flags 6 pre-existing unrelated test files (not touched here).