### PR TITLE
fix: make local lint run ruff, not just flake8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - Integration tests: round-trip parse → write → re-parse → compare (29 ARXML files)
 - Custom test dirs via `tests/integration_tests/config.yaml`
 
-**Lint:** `npm run flake8` — syntax checks only (E9, F63, F7, F82)
+**Lint:** `npm run lint` — runs flake8 syntax checks (E9, F63, F7, F82) **and** ruff (`ruff check src tests scripts`, E/F/W/I rules per `[tool.ruff]` in pyproject.toml). Always use this; do not run flake8 alone
 - CI also runs: `--max-complexity=10 --max-line-length=127` (warnings, exit-zero)
 - **Exclude `build/`** from lint (generated code)
 - **Black formatter:** `npm run black` — formats code with 200 character line length

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,9 @@ Or using npm scripts:
 - `npm run pytest-cov` - Run tests with coverage
 
 ### Linting
-- `npm run flake8` - Run syntax checks (E9, F63, F7, F82)
+- `npm run lint` - Run ALL lint checks (flake8 syntax + ruff); use this as the default lint command
+- `npm run flake8` - Run flake8 syntax checks only (E9, F63, F7, F82)
+- `npm run ruff-check` - Run ruff only (E, F, W, I rules from pyproject.toml [tool.ruff])
 - `npm run black-check` - Check code formatting with Black (200 character line length)
 - `npm run black` - Format code with Black (200 character line length)
 - CI also runs complexity checks: `--max-complexity=10 --max-line-length=127`

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "pytest-cov": "pytest --cov=armodel --cov-report term-missing",
         "bswm-test": "pip install . &arxml-format src/armodel/tests/test_files/BswM_Bswmd.arxml data/test.arxml",
         "flake8": "flake8 --exclude=.venv,build --select=E9,F63,F7,F82 .",
+        "lint": "npm run flake8 && npm run ruff-check",
         "ruff": "ruff check --fix src tests scripts",
         "ruff-check": "ruff check src tests scripts",
         "black": "black src tests scripts",


### PR DESCRIPTION
## Problem
Ruff was effectively skipped in local workflows: `AGENTS.md` and `CLAUDE.md` documented only `npm run flake8` as the lint command, and no hook or script invoked ruff automatically. Ruff ran solely as a CI step (`.github/workflows/python-package.yml`), so violations surfaced only after pushing.

## Fix
- Add `npm run lint` = flake8 (syntax) + ruff-check (E/F/W/I per pyproject.toml) — mirrors the blocking CI checks
- Update `AGENTS.md` and `CLAUDE.md` to make `npm run lint` the documented default, with an explicit warning not to run flake8 alone

## Verification
- `npm run lint` executes both tools; planted violation fails with exit 1, clean tree passes with exit 0