### PR TITLE
Feature/sync systemtemplate can

### DIFF
--- a/docs/examples/method_deviation_by_class_v2.md
+++ b/docs/examples/method_deviation_by_class_v2.md
@@ -1794,13 +1794,13 @@ No deviations — Table 2.53 attributes modeled verbatim: `annotation` (* aggr, 
 | — *(missing)* | `—` | `-` | ``-`` | - | missing |
 
 ## `BusspecificNmEcu`
-- **PDF:** `AUTOSAR_CP_TPS_SystemTemplate.pdf`  | **page:** —  | **table:** Table 6.301
+- **PDF:** `AUTOSAR_CP_TPS_SystemTemplate.pdf`  | **page:** 675  | **table:** Table 6.301
 - **Package:** `M2::AUTOSARTemplates::SystemTemplate::NetworkManagement`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py`
 
-| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
-|---|---|---|---|---|---|
-| — *(missing)* | `—` | `-` | ``-`` | - | missing |
+No deviations — abstract base (`Base: ARObject`) with an empty attribute table; the
+class docstring is the verbatim spec Note, serialization covered polymorphically via
+the concrete subclasses in `read/writeBusDependentNmEcus`.
 
 ## `J1939NmEcu`
 - **PDF:** `AUTOSAR_CP_TPS_SystemTemplate.pdf`  | **page:** —

--- a/docs/plan/sync-todo/AUTOSAR_CP_TPS_SystemTemplate_CAN.md
+++ b/docs/plan/sync-todo/AUTOSAR_CP_TPS_SystemTemplate_CAN.md
@@ -15,7 +15,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
 
 ### Bases (deepest ancestors first)
 
-- [ ] BusspecificNmEcu (base · markdown · Table 6.301)
+- [x] BusspecificNmEcu (base · markdown · Table 6.301 · commit 72de0edb)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -23,8 +23,8 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 5 — Write reader/writer round-trip test (Red)
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] PhysicalChannel (base · markdown · Table 3.7)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AUTOSAR_CP_TPS_SystemTemplate_CAN.md
+++ b/docs/plan/sync-todo/AUTOSAR_CP_TPS_SystemTemplate_CAN.md
@@ -1,0 +1,269 @@
+# Sync todo: AUTOSAR_CP_TPS_SystemTemplate (CAN subset)
+
+Input scope: CAN-related classes of `AUTOSAR_CP_TPS_SystemTemplate` (R23-11), collected
+from the v2 deviation tracker (`docs/examples/method_deviation_by_class_v2.md`) ·
+Generated: 2026-08-23 · Queue order = row order (dependency-first, Rule 0016.5)
+(resume = first class row still `[ ]`; all class rows `[x]` = sync finished)
+
+Closure confirmed by user 2026-08-23 (24 classes = 7 inputs + 6 bases + 11 members).
+No spec-missing classes -> no 16.4 Skip/XSD decisions required.
+
+Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
+(page numbers via `.claude/skills/sync-autosar-class/pdf_page.py <ClassName>`).
+
+## Queue (dependency-first)
+
+### Bases (deepest ancestors first)
+
+- [ ] BusspecificNmEcu (base · markdown · Table 6.301)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] PhysicalChannel (base · markdown · Table 3.7)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] Frame (base · markdown · Table 6.78)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] FrameTriggering (base · markdown · Table 6.79)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CommunicationConnector (base · markdown · Table 3.4)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] TpConfig (base · markdown · Table 6.237)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+
+### Member types
+
+- [ ] TtcanAbsolutelyScheduledTiming (member of CanFrameTriggering.absolutelyScheduledTiming · markdown · Table 6.115 · NEW class — create Fibex4Ttcan/TtcanCommunication.py package per spec pkg Fibex4Ttcan::TtcanCommunication; its member TtcanTriggerType enum is NOT queued here — handle per Rule 0001.10 in its own session)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanAddressingModeType (member of CanFrameTriggering.canAddressingMode · enum · markdown · Table 6.111 · NEW class in CanCommunication.py; Steps 5/6 N/A: standalone enum, round-trip via consuming class)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (N/A: standalone enum)
+  - [ ] Step 6 — Update parser & writer (N/A: standalone enum)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanFrameRxBehaviorEnum (member of CanFrameTriggering.canFrameRxBehavior · enum · markdown · Table 6.113 · NEW class in CanCommunication.py; Steps 5/6 N/A: standalone enum)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (N/A: standalone enum)
+  - [ ] Step 6 — Update parser & writer (N/A: standalone enum)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanFrameTxBehaviorEnum (member of CanFrameTriggering.canFrameTxBehavior · enum · markdown · Table 6.114 · NEW class in CanCommunication.py; Steps 5/6 N/A: standalone enum)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (N/A: standalone enum)
+  - [ ] Step 6 — Update parser & writer (N/A: standalone enum)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanXlFrameTriggeringProps (member of CanFrameTriggering.canXlFrameTriggeringProps · markdown · Table F.27 appendix · NEW class in CanCommunication.py)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] RxIdentifierRange (member of CanFrameTriggering.rxIdentifierRange · markdown · Table 6.112)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanTpAddress (member of CanTpConfig.tpAddress · markdown · Table 6.255)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanTpChannel (member of CanTpConfig.tpChannel · markdown · Table 6.252)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanTpConnection (member of CanTpConfig.tpConnection · markdown · Table 6.253)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanTpEcu (member of CanTpConfig.tpEcu · markdown · Table 6.256)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanTpNode (member of CanTpConfig.tpNode · markdown · Table 6.257)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+
+### Inputs
+
+- [ ] AbstractCanPhysicalChannel (input · markdown · Table 3.20 · also base of CanPhysicalChannel — queued before it)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanPhysicalChannel (input · markdown · Table 3.21)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanNmEcu (input · markdown · Table 6.312)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanTpConfig (input · markdown · Table 6.251)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanFrame (input · markdown · Table 6.109)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanFrameTriggering (input · markdown · Table 6.110)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] AbstractCanCommunicationConnector (input · markdown · Table 3.22)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+
+## Not queued
+
+- FibexElement — already stamped `# Spec verified: R23-11` (CoreCommunication.py).
+- NmEcu — excluded per user decision 2026-08-23 (aggregating container of bus-dependent NM Ecus, not a Base/member of the inputs).
+- ARObject / Referrable / MultilanguageReferrable / Identifiable / CollectableElement / PackageableElement — framework infrastructure shared by all syncs; CollectableElement keep-as-is per 2026-08-20 project decision (no stamp).

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -45,16 +45,16 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] FrameTriggering (base · markdown · Table 6.79)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [x] FrameTriggering (base · markdown · Table 6.79 · commit 6b6f90cb)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CommunicationConnector (base · markdown · Table 3.4)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -78,6 +78,27 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
 
 ### Member types
 
+- [ ] CanTpAddressingFormatType (member of CanTpConnection.addressingFormat · enum · markdown · Table 6.254 · p.610 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5 — missing member type; NEW class in TransportProtocols.py; Steps 5/6 N/A: standalone enum, round-trip via consuming class; synced, stamp deferred)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (N/A: standalone enum)
+  - [x] Step 6 — Update parser & writer (N/A: standalone enum)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] NetworkTargetAddressType (member of CanTpConnection.taType · enum · markdown · Table 6.258 · p.611 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5 — missing member type; NEW class in TransportProtocols.py; Steps 5/6 N/A: standalone enum; functionalCanFd/physicalCanFd literals EXCLUDED (atp.Status="removed" since 4.3.0, absent from R23-11 PDF); synced, stamp deferred)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (N/A: standalone enum)
+  - [x] Step 6 — Update parser & writer (N/A: standalone enum)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+
 - [ ] TpConnectionIdent (base of TpConnection.ident · markdown · Table 6.273 · p.633 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5 — unstamped stub discovered as CanTpConnection dependency; MOVED from TransportProtocols.py to DiagnosticConnection.py per spec Package; synced, stamp deferred)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -55,16 +55,16 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CommunicationConnector (base · markdown · Table 3.4)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [x] CommunicationConnector (base · markdown · Table 3.4 · commit a2211fdc)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] TpConfig (base · markdown · Table 6.237)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -78,7 +78,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
 
 ### Member types
 
-- [ ] CanTpAddressingFormatType (member of CanTpConnection.addressingFormat · enum · markdown · Table 6.254 · p.610 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5 — missing member type; NEW class in TransportProtocols.py; Steps 5/6 N/A: standalone enum, round-trip via consuming class; synced, stamp deferred)
+- [x] CanTpAddressingFormatType (member of CanTpConnection.addressingFormat · enum · markdown · Table 6.254 · p.610 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5 — missing member type; NEW class in TransportProtocols.py; Steps 5/6 N/A: standalone enum, round-trip via consuming class · commit d53cab5d · stamped R23-11 2026-08-24)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -87,7 +87,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (N/A: standalone enum)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] NetworkTargetAddressType (member of CanTpConnection.taType · enum · markdown · Table 6.258 · p.611 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5 — missing member type; NEW class in TransportProtocols.py; Steps 5/6 N/A: standalone enum; functionalCanFd/physicalCanFd literals EXCLUDED (atp.Status="removed" since 4.3.0, absent from R23-11 PDF); synced, stamp deferred)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
@@ -99,7 +99,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 
-- [ ] TpConnectionIdent (base of TpConnection.ident · markdown · Table 6.273 · p.633 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5 — unstamped stub discovered as CanTpConnection dependency; MOVED from TransportProtocols.py to DiagnosticConnection.py per spec Package; synced, stamp deferred)
+- [x] TpConnectionIdent (base of TpConnection.ident · markdown · Table 6.273 · p.633 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5; MOVED from TransportProtocols.py to DiagnosticConnection.py per spec Package · commit 99f16acc · stamped R23-11 2026-08-24)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -108,8 +108,8 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] TpConnection (base of CanTpConnection · markdown · Table 6.272 · p.633 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5 — same reason; MOVED to DiagnosticConnection.py; synced, stamp deferred)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
+- [x] TpConnection (base of CanTpConnection · markdown · Table 6.272 · p.633 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5; MOVED to DiagnosticConnection.py · commit 99f16acc · stamped R23-11 2026-08-24)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -118,7 +118,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 
 - [x] TtcanAbsolutelyScheduledTiming (member of CanFrameTriggering.absolutelyScheduledTiming · markdown · Table 6.115 · commit eaff8d16 · NEW class created in Fibex4Ttcan/TtcanCommunication.py; TtcanTriggerType enum (Table 6.116) also synced + stamped in the same session per user decision 2026-08-23)
   - [x] Step 1 — Sync members & description from spec
@@ -180,7 +180,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanTpAddress (member of CanTpConfig.tpAddress · markdown · Table 6.255 · p.610 · synced 2026-08-24, stamp deferred to batch confirmation)
+- [x] CanTpAddress (member of CanTpConfig.tpAddress · markdown · Table 6.255 · p.610 · commit 23a670d8 · stamped R23-11 2026-08-24)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -189,8 +189,8 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanTpChannel (member of CanTpConfig.tpChannel · markdown · Table 6.252 · p.608 · synced 2026-08-24, stamp deferred to batch confirmation; `channelMode` REMOVED — atp.Status="removed" since 4.4.0, absent from R23-11 PDF table per Rule 0015)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
+- [x] CanTpChannel (member of CanTpConfig.tpChannel · markdown · Table 6.252 · p.608 · commit 029d2081 · stamped R23-11 2026-08-24; `channelMode` REMOVED — atp.Status="removed" since 4.4.0, absent from R23-11 PDF table per Rule 0015)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -199,7 +199,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanTpConnection (member of CanTpConfig.tpConnection · markdown · Table 6.253 + 6.252 block (spec splits the table across two page-blocks) · p.608-609 · synced 2026-08-24, stamp deferred to batch confirmation)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -26,25 +26,25 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
 - [x] PhysicalChannel (base · markdown · Table 3.7 · commit b8e87cce)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] Frame (base · markdown · Table 6.78)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
+- [x] Frame (base · markdown · Table 6.78 · commit 66b0cb82)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] FrameTriggering (base · markdown · Table 6.79)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -273,25 +273,25 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanFrame (input · markdown · Table 6.109)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [ ] CanFrame (input · markdown · Table 6.109 · p.442 · synced 2026-08-24, stamp deferred to batch confirmation; marker class — frameLength/pduToFrameMappings already owned by stamped Frame base, no flattening)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanFrameTriggering (input · markdown · Table 6.110)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [ ] CanFrameTriggering (input · markdown · Table 6.110 · p.443 · synced 2026-08-24, stamp deferred to batch confirmation; `canFdFrameSupport` REMOVED (atp.Status="removed", absent from R23-11 PDF per Rule 0015); ADDED missing reader/writer coverage for absolutelyScheduledTimings, canXlFrameTriggeringProps, j1939requestable, rxMask, txMask; bulk setAbsolutelyScheduledTimings replaced by spec-shaped addAbsolutelyScheduledTiming)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 - [ ] AbstractCanCommunicationConnector (input · markdown · Table 3.22)
   - [ ] Step 1 — Sync members & description from spec

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -118,16 +118,16 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanXlFrameTriggeringProps (member of CanFrameTriggering.canXlFrameTriggeringProps · markdown · Table F.27 appendix · NEW class in CanCommunication.py)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [x] CanXlFrameTriggeringProps (member of CanFrameTriggering.canXlFrameTriggeringProps · markdown · Table F.27 appendix · NEW class in CanCommunication.py)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] RxIdentifierRange (member of CanFrameTriggering.rxIdentifierRange · markdown · Table 6.112)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -35,7 +35,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [x] Frame (base · markdown · Table 6.78 · commit 66b0cb82)
+- [x] Frame (base · markdown · Table 6.78 · commit 7e15bf7c)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -88,16 +88,16 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanAddressingModeType (member of CanFrameTriggering.canAddressingMode · enum · markdown · Table 6.111 · NEW class in CanCommunication.py; Steps 5/6 N/A: standalone enum, round-trip via consuming class)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (N/A: standalone enum)
-  - [ ] Step 6 — Update parser & writer (N/A: standalone enum)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [x] CanAddressingModeType (member of CanFrameTriggering.canAddressingMode · enum · markdown · Table 6.111 · NEW class in CanCommunication.py; Steps 5/6 N/A: standalone enum, round-trip via consuming class)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (N/A: standalone enum)
+  - [x] Step 6 — Update parser & writer (N/A: standalone enum)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanFrameRxBehaviorEnum (member of CanFrameTriggering.canFrameRxBehavior · enum · markdown · Table 6.113 · NEW class in CanCommunication.py; Steps 5/6 N/A: standalone enum)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -137,7 +137,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanTpAddress (member of CanTpConfig.tpAddress · markdown · Table 6.255)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -263,15 +263,15 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanTpConfig (input · markdown · Table 6.251)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [ ] CanTpConfig (input · markdown · Table 6.251 · p.607 · synced 2026-08-24, stamp deferred to batch confirmation)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanFrame (input · markdown · Table 6.109)
   - [ ] Step 1 — Sync members & description from spec

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -138,15 +138,15 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanTpAddress (member of CanTpConfig.tpAddress · markdown · Table 6.255)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [ ] CanTpAddress (member of CanTpConfig.tpAddress · markdown · Table 6.255 · p.610 · synced 2026-08-24, stamp deferred to batch confirmation)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanTpChannel (member of CanTpConfig.tpChannel · markdown · Table 6.252)
   - [ ] Step 1 — Sync members & description from spec

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -98,16 +98,16 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanFrameRxBehaviorEnum (member of CanFrameTriggering.canFrameRxBehavior · enum · markdown · Table 6.113 · NEW class in CanCommunication.py; Steps 5/6 N/A: standalone enum)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (N/A: standalone enum)
-  - [ ] Step 6 — Update parser & writer (N/A: standalone enum)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [x] CanFrameRxBehaviorEnum (member of CanFrameTriggering.canFrameRxBehavior · enum · markdown · Table 6.113 · NEW class in CanCommunication.py; Steps 5/6 N/A: standalone enum)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (N/A: standalone enum)
+  - [x] Step 6 — Update parser & writer (N/A: standalone enum)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanFrameTxBehaviorEnum (member of CanFrameTriggering.canFrameTxBehavior · enum · markdown · Table 6.114 · NEW class in CanCommunication.py; Steps 5/6 N/A: standalone enum)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -200,7 +200,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanTpConnection (member of CanTpConfig.tpConnection · markdown · Table 6.253 + 6.252 block (spec splits the table across two page-blocks) · p.608-609 · synced 2026-08-24, stamp deferred to batch confirmation)
+- [x] CanTpConnection (member of CanTpConfig.tpConnection · markdown · Table 6.253 + 6.252 block (spec splits the table across two page-blocks) · p.608-609 · commits 7b17e1d2+afb1eb32 · stamped R23-11 2026-08-24; addressingFormat retyped to CanTpAddressingFormatType per user review, parser/writer updated)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -209,8 +209,8 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanTpEcu (member of CanTpConfig.tpEcu · markdown · Table 6.256 · p.610 · synced 2026-08-24, stamp deferred to batch confirmation)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
+- [x] CanTpEcu (member of CanTpConfig.tpEcu · markdown · Table 6.256 · p.610 · commit 9ead7c58 · stamped R23-11 2026-08-24)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -219,8 +219,8 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanTpNode (member of CanTpConfig.tpNode · markdown · Table 6.257 · p.611 · synced 2026-08-24, stamp deferred to batch confirmation)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
+- [x] CanTpNode (member of CanTpConfig.tpNode · markdown · Table 6.257 · p.611 · commit 4edb4666 · stamped R23-11 2026-08-24)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -229,11 +229,11 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 
 ### Inputs
 
-- [ ] AbstractCanPhysicalChannel (input · markdown · Table 3.20 · p.73 · synced 2026-08-24, stamp deferred to batch confirmation; DEVIATION: source stays in FibexCore/CoreTopology.py (spec package Fibex4Can/CanTopology) — moving would need circular-import workarounds inside stamped CommunicationCluster factory/getter)
+- [ ] AbstractCanPhysicalChannel (input · markdown · Table 3.20 · p.73 · MOVED 2026-08-24 from FibexCore/CoreTopology.py to Fibex4Can/CanTopology.py per spec Package and user direction; awaiting stamp confirmation)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -243,7 +243,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanPhysicalChannel (input · markdown · Table 3.21 · p.73 · synced 2026-08-24, stamp deferred to batch confirmation; same placement deviation as AbstractCanPhysicalChannel)
+- [ ] CanPhysicalChannel (input · markdown · Table 3.21 · p.73 · MOVED 2026-08-24 together with its abstract base (same spec package; split placement impossible due to import cycle); awaiting stamp confirmation)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -253,7 +253,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanNmEcu (input · markdown · Table 6.312 · p.683 · synced 2026-08-24, stamp deferred to batch confirmation; ADDED missing CAN-NM-ECU dispatch in readBusDependentNmEcus/writeBusDependentNmEcus — only UDP was handled before)
+- [x] CanNmEcu (input · markdown · Table 6.312 · p.683 · commit ffa3009b · stamped R23-11 2026-08-24; ADDED missing CAN-NM-ECU dispatch in readBusDependentNmEcus/writeBusDependentNmEcus — only UDP was handled before)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -262,7 +262,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanTpConfig (input · markdown · Table 6.251 · p.607 · synced 2026-08-24, stamp deferred to batch confirmation)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -220,15 +220,15 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanTpNode (member of CanTpConfig.tpNode · markdown · Table 6.257)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [ ] CanTpNode (member of CanTpConfig.tpNode · markdown · Table 6.257 · p.611 · synced 2026-08-24, stamp deferred to batch confirmation)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 
 ### Inputs

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -78,16 +78,16 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
 
 ### Member types
 
-- [ ] TtcanAbsolutelyScheduledTiming (member of CanFrameTriggering.absolutelyScheduledTiming · markdown · Table 6.115 · NEW class — create Fibex4Ttcan/TtcanCommunication.py package per spec pkg Fibex4Ttcan::TtcanCommunication; its member TtcanTriggerType enum is NOT queued here — handle per Rule 0001.10 in its own session)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [x] TtcanAbsolutelyScheduledTiming (member of CanFrameTriggering.absolutelyScheduledTiming · markdown · Table 6.115 · commit eaff8d16 · NEW class created in Fibex4Ttcan/TtcanCommunication.py; TtcanTriggerType enum (Table 6.116) also synced + stamped in the same session per user decision 2026-08-23)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanAddressingModeType (member of CanFrameTriggering.canAddressingMode · enum · markdown · Table 6.111 · NEW class in CanCommunication.py; Steps 5/6 N/A: standalone enum, round-trip via consuming class)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -148,15 +148,15 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanTpChannel (member of CanTpConfig.tpChannel · markdown · Table 6.252)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [ ] CanTpChannel (member of CanTpConfig.tpChannel · markdown · Table 6.252 · p.608 · synced 2026-08-24, stamp deferred to batch confirmation; `channelMode` REMOVED — atp.Status="removed" since 4.4.0, absent from R23-11 PDF table per Rule 0015)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanTpConnection (member of CanTpConfig.tpConnection · markdown · Table 6.253)
   - [ ] Step 1 — Sync members & description from spec

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -128,7 +128,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [x] RxIdentifierRange (member of CanFrameTriggering.rxIdentifierRange · markdown · Table 6.112)
+- [x] RxIdentifierRange (member of CanFrameTriggering.rxIdentifierRange · markdown · Table 6.112 · commit a46fc48d)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -78,6 +78,27 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
 
 ### Member types
 
+- [ ] TpConnectionIdent (base of TpConnection.ident · markdown · Table 6.273 · p.633 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5 — unstamped stub discovered as CanTpConnection dependency; MOVED from TransportProtocols.py to DiagnosticConnection.py per spec Package; synced, stamp deferred)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] TpConnection (base of CanTpConnection · markdown · Table 6.272 · p.633 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5 — same reason; MOVED to DiagnosticConnection.py; synced, stamp deferred)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+
 - [x] TtcanAbsolutelyScheduledTiming (member of CanFrameTriggering.absolutelyScheduledTiming · markdown · Table 6.115 · commit eaff8d16 · NEW class created in Fibex4Ttcan/TtcanCommunication.py; TtcanTriggerType enum (Table 6.116) also synced + stamped in the same session per user decision 2026-08-23)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -243,7 +243,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanPhysicalChannel (input · markdown · Table 3.21 · p.73 · MOVED 2026-08-24 together with its abstract base (same spec package; split placement impossible due to import cycle); awaiting stamp confirmation)
+- [x] CanPhysicalChannel (input · markdown · Table 3.21 · p.73 · MOVED to Fibex4Can/CanTopology.py 2026-08-24 · commit this round · stamped R23-11 2026-08-24)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -252,7 +252,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [x] CanNmEcu (input · markdown · Table 6.312 · p.683 · commit ffa3009b · stamped R23-11 2026-08-24; ADDED missing CAN-NM-ECU dispatch in readBusDependentNmEcus/writeBusDependentNmEcus — only UDP was handled before)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
@@ -263,7 +263,27 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanTpConfig (input · markdown · Table 6.251 · p.607 · synced 2026-08-24, stamp deferred to batch confirmation)
+- [x] CanTpConfig (input · markdown · Table 6.251 · p.607 · commit a517c413 · stamped R23-11 2026-08-24)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
+- [x] CanFrame (input · markdown · Table 6.109 · p.442 · commit 5c6ec83e · stamped R23-11 2026-08-24; marker class — frameLength/pduToFrameMappings owned by stamped Frame base, no flattening)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
+- [ ] CanFrameTriggering (input · markdown · Table 6.110 · p.443 · commits 5c6ec83e + enum retyping fix 2026-08-24; `canFdFrameSupport` REMOVED (atp.Status="removed", absent from R23-11 PDF per Rule 0015); ADDED reader/writer coverage for absolutelyScheduledTimings, canXlFrameTriggeringProps, j1939requestable, rxMask, txMask; canAddressingMode/canFrameRxBehavior/canFrameTxBehavior retyped to their spec enums per user review; awaiting stamp confirmation)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -273,7 +293,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanFrame (input · markdown · Table 6.109 · p.442 · synced 2026-08-24, stamp deferred to batch confirmation; marker class — frameLength/pduToFrameMappings already owned by stamped Frame base, no flattening)
+- [x] AbstractCanCommunicationConnector (input · markdown · Table 3.22 · p.73 · commit 63393d16 · stamped R23-11 2026-08-24; marker class, reader/writer via CAN-COMMUNICATION-CONNECTOR dispatch)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -282,27 +302,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanFrameTriggering (input · markdown · Table 6.110 · p.443 · synced 2026-08-24, stamp deferred to batch confirmation; `canFdFrameSupport` REMOVED (atp.Status="removed", absent from R23-11 PDF per Rule 0015); ADDED missing reader/writer coverage for absolutelyScheduledTimings, canXlFrameTriggeringProps, j1939requestable, rxMask, txMask; bulk setAbsolutelyScheduledTimings replaced by spec-shaped addAbsolutelyScheduledTiming)
-  - [x] Step 1 — Sync members & description from spec
-  - [x] Step 2 — Write model class unit test (Red)
-  - [x] Step 3 — Implement model class (Green)
-  - [x] Step 4 — Sync docstrings (wipe + rewrite)
-  - [x] Step 5 — Write reader/writer round-trip test (Red)
-  - [x] Step 6 — Update parser & writer (Green)
-  - [x] Step 7 — Update checklist comment
-  - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] AbstractCanCommunicationConnector (input · markdown · Table 3.22 · p.73 · synced 2026-08-24, stamp deferred to batch confirmation; marker class, reader/writer via CAN-COMMUNICATION-CONNECTOR dispatch)
-  - [x] Step 1 — Sync members & description from spec
-  - [x] Step 2 — Write model class unit test (Red)
-  - [x] Step 3 — Implement model class (Green)
-  - [x] Step 4 — Sync docstrings (wipe + rewrite)
-  - [x] Step 5 — Write reader/writer round-trip test (Red)
-  - [x] Step 6 — Update parser & writer (Green)
-  - [x] Step 7 — Update checklist comment
-  - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 
 ## Not queued
 

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -65,16 +65,16 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] TpConfig (base · markdown · Table 6.237)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [x] TpConfig (base · markdown · Table 6.237 · commit 5678ae81)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 
 ### Member types
 

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -233,25 +233,25 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
 
 ### Inputs
 
-- [ ] AbstractCanPhysicalChannel (input · markdown · Table 3.20 · also base of CanPhysicalChannel — queued before it)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [ ] AbstractCanPhysicalChannel (input · markdown · Table 3.20 · p.73 · synced 2026-08-24, stamp deferred to batch confirmation; DEVIATION: source stays in FibexCore/CoreTopology.py (spec package Fibex4Can/CanTopology) — moving would need circular-import workarounds inside stamped CommunicationCluster factory/getter)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanPhysicalChannel (input · markdown · Table 3.21)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [ ] CanPhysicalChannel (input · markdown · Table 3.21 · p.73 · synced 2026-08-24, stamp deferred to batch confirmation; same placement deviation as AbstractCanPhysicalChannel)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanNmEcu (input · markdown · Table 6.312)
   - [ ] Step 1 — Sync members & description from spec

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -210,15 +210,15 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanTpEcu (member of CanTpConfig.tpEcu · markdown · Table 6.256)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [ ] CanTpEcu (member of CanTpConfig.tpEcu · markdown · Table 6.256 · p.610 · synced 2026-08-24, stamp deferred to batch confirmation)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanTpNode (member of CanTpConfig.tpNode · markdown · Table 6.257)
   - [ ] Step 1 — Sync members & description from spec

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -128,15 +128,15 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] RxIdentifierRange (member of CanFrameTriggering.rxIdentifierRange · markdown · Table 6.112)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [x] RxIdentifierRange (member of CanFrameTriggering.rxIdentifierRange · markdown · Table 6.112)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanTpAddress (member of CanTpConfig.tpAddress · markdown · Table 6.255)
   - [ ] Step 1 — Sync members & description from spec

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -293,15 +293,15 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] AbstractCanCommunicationConnector (input · markdown · Table 3.22)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [ ] AbstractCanCommunicationConnector (input · markdown · Table 3.22 · p.73 · synced 2026-08-24, stamp deferred to batch confirmation; marker class, reader/writer via CAN-COMMUNICATION-CONNECTOR dispatch)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 
 ## Not queued

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -108,16 +108,16 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanFrameTxBehaviorEnum (member of CanFrameTriggering.canFrameTxBehavior · enum · markdown · Table 6.114 · NEW class in CanCommunication.py; Steps 5/6 N/A: standalone enum)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (N/A: standalone enum)
-  - [ ] Step 6 — Update parser & writer (N/A: standalone enum)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [x] CanFrameTxBehaviorEnum (member of CanFrameTriggering.canFrameTxBehavior · enum · markdown · Table 6.114 · NEW class in CanCommunication.py; Steps 5/6 N/A: standalone enum)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (N/A: standalone enum)
+  - [x] Step 6 — Update parser & writer (N/A: standalone enum)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanXlFrameTriggeringProps (member of CanFrameTriggering.canXlFrameTriggeringProps · markdown · Table F.27 appendix · NEW class in CanCommunication.py)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -88,7 +88,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] NetworkTargetAddressType (member of CanTpConnection.taType · enum · markdown · Table 6.258 · p.611 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5 — missing member type; NEW class in TransportProtocols.py; Steps 5/6 N/A: standalone enum; functionalCanFd/physicalCanFd literals EXCLUDED (atp.Status="removed" since 4.3.0, absent from R23-11 PDF); synced, stamp deferred)
+- [x] NetworkTargetAddressType (member of CanTpConnection.taType · enum · markdown · Table 6.258 · p.611 verified against PDF text 2026-08-24 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5; NEW class in TransportProtocols.py; Steps 5/6 N/A: standalone enum; functionalCanFd/physicalCanFd literals EXCLUDED (atp.Status="removed" since 4.3.0) · commit d53cab5d · stamped R23-11 2026-08-24)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -97,7 +97,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (N/A: standalone enum)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 
 - [x] TpConnectionIdent (base of TpConnection.ident · markdown · Table 6.273 · p.633 · ADDED to queue 2026-08-24 per Rule 0016.4/0016.5; MOVED from TransportProtocols.py to DiagnosticConnection.py per spec Package · commit 99f16acc · stamped R23-11 2026-08-24)
   - [x] Step 1 — Sync members & description from spec
@@ -233,7 +233,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
 
 ### Inputs
 
-- [ ] AbstractCanPhysicalChannel (input · markdown · Table 3.20 · p.73 · MOVED 2026-08-24 from FibexCore/CoreTopology.py to Fibex4Can/CanTopology.py per spec Package and user direction; awaiting stamp confirmation)
+- [x] AbstractCanPhysicalChannel (input · markdown · Table 3.20 · p.73 · MOVED to Fibex4Can/CanTopology.py 2026-08-24 per spec Package and user direction · stamped R23-11 2026-08-24)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -242,7 +242,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [x] CanPhysicalChannel (input · markdown · Table 3.21 · p.73 · MOVED to Fibex4Can/CanTopology.py 2026-08-24 · commit this round · stamped R23-11 2026-08-24)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
@@ -283,7 +283,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanFrameTriggering (input · markdown · Table 6.110 · p.443 · commits 5c6ec83e + enum retyping fix 2026-08-24; `canFdFrameSupport` REMOVED (atp.Status="removed", absent from R23-11 PDF per Rule 0015); ADDED reader/writer coverage for absolutelyScheduledTimings, canXlFrameTriggeringProps, j1939requestable, rxMask, txMask; canAddressingMode/canFrameRxBehavior/canFrameTxBehavior retyped to their spec enums per user review; awaiting stamp confirmation)
+- [x] CanFrameTriggering (input · markdown · Table 6.110 · p.443 · commits 5c6ec83e + enum retyping fix d7f5d055; `canFdFrameSupport` REMOVED (atp.Status="removed", absent from R23-11 PDF per Rule 0015); ADDED reader/writer coverage for absolutelyScheduledTimings, canXlFrameTriggeringProps, j1939requestable, rxMask, txMask; canAddressingMode/canFrameRxBehavior/canFrameTxBehavior retyped to their spec enums per user review; stamped R23-11 2026-08-24)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
@@ -292,7 +292,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 6 — Update parser & writer (Green)
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [x] AbstractCanCommunicationConnector (input · markdown · Table 3.22 · p.73 · commit 63393d16 · stamped R23-11 2026-08-24; marker class, reader/writer via CAN-COMMUNICATION-CONNECTOR dispatch)
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -200,15 +200,15 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanTpConnection (member of CanTpConfig.tpConnection · markdown · Table 6.253)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [ ] CanTpConnection (member of CanTpConfig.tpConnection · markdown · Table 6.253 + 6.252 block (spec splits the table across two page-blocks) · p.608-609 · synced 2026-08-24, stamp deferred to batch confirmation)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanTpEcu (member of CanTpConfig.tpEcu · markdown · Table 6.256)
   - [ ] Step 1 — Sync members & description from spec

--- a/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
+++ b/docs/plan/sync-todo/AbstractCanCommunicationConnector.md
@@ -253,15 +253,15 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] CanNmEcu (input · markdown · Table 6.312)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
+- [ ] CanNmEcu (input · markdown · Table 6.312 · p.683 · synced 2026-08-24, stamp deferred to batch confirmation; ADDED missing CAN-NM-ECU dispatch in readBusDependentNmEcus/writeBusDependentNmEcus — only UDP was handled before)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 - [ ] CanTpConfig (input · markdown · Table 6.251)
   - [ ] Step 1 — Sync members & description from spec

--- a/docs/plan/sync-todo/BusspecificNmEcu.md
+++ b/docs/plan/sync-todo/BusspecificNmEcu.md
@@ -25,7 +25,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] PhysicalChannel (base · markdown · Table 3.7)
+- [x] PhysicalChannel (base · markdown · Table 3.7 · commit PENDING)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)
   - [ ] Step 3 — Implement model class (Green)

--- a/docs/plan/sync-todo/BusspecificNmEcu.md
+++ b/docs/plan/sync-todo/BusspecificNmEcu.md
@@ -25,7 +25,7 @@ Spec markdown: `autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md`
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [x] PhysicalChannel (base · markdown · Table 3.7 · commit PENDING)
+- [x] PhysicalChannel (base · markdown · Table 3.7 · commit b8e87cce)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)
   - [ ] Step 3 — Implement model class (Green)

--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -1,5 +1,1 @@
-let us improve the sync-autosar-class.                
-1. after phase 0, generarte the todo list to record all the confirmed class       
-2. each loop for class. before each 9 step, start a new session to reset the context. then get the 1st unfinsished class to start to sync
-3. after 9 step , confirmed by end user and add the spec verfied. mark the class finished in todo list and commit current changes to feature branch
-4. all the classes are finish in the todo list. it means the skill finished
+sync autosar class the unchecked classes one by one and commit the modfication first without spec verified, then list the modified class list and ask for confirmation the spec verified stamp together.

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DiagnosticConnection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DiagnosticConnection.py
@@ -16,6 +16,7 @@ class TpConnectionIdent(Referrable):
 
     # TpConnectionIdent method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.273, p.633
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # (no own attributes; Base = ARObject, Referrable)
@@ -31,6 +32,7 @@ class TpConnection(ARObject, ABC):
 
     # TpConnection method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.272, p.633
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getIdent                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DiagnosticConnection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DiagnosticConnection.py
@@ -1,9 +1,61 @@
 # This module contains AUTOSAR System Template classes for diagnostic connections
 # It defines connections for diagnostic services and communication between diagnostic entities
 
-from typing import List
+from abc import ABC
+from typing import List, Optional
+
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Referrable
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+
+
+class TpConnectionIdent(Referrable):
+    """
+    This meta-class is created to add the ability to become the target of a reference to the non-Referrable Tp Connection.
+    """
+
+    # TpConnectionIdent method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.273, p.633
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # (no own attributes; Base = ARObject, Referrable)
+
+    def __init__(self, parent: ARObject, short_name: str):
+        super().__init__(parent, short_name)
+
+
+class TpConnection(ARObject, ABC):
+    """
+    TpConnection Base Class.
+    """
+
+    # TpConnection method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.272, p.633
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getIdent                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] createTpConnectionIdent   [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+
+    def __init__(self):
+        if type(self) is TpConnection:
+            raise TypeError("TpConnection is an abstract class.")
+
+        super().__init__()
+
+        # This adds the ability to become referrable to Tp Connection.
+        self.ident: Optional[TpConnectionIdent] = None
+
+    def getIdent(self) -> Optional[TpConnectionIdent]:
+        """This adds the ability to become referrable to Tp Connection."""
+        return self.ident
+
+    def createTpConnectionIdent(self, short_name: str) -> TpConnectionIdent:
+        """This adds the ability to become referrable to Tp Connection."""
+        if self.getIdent() is not None:
+            return self.getIdent()
+        ident = TpConnectionIdent(self, short_name)
+        self.ident = ident
+        return ident
 
 
 class DiagnosticConnection(ARElement):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import Frame, FrameTriggering
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARLiteral, Boolean, Integer, PositiveInteger
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Boolean, Integer, PositiveInteger
 
 if TYPE_CHECKING:
     from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ttcan.TtcanCommunication import TtcanAbsolutelyScheduledTiming
@@ -228,6 +228,7 @@ class CanFrame(Frame):
 
     # CanFrame method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.109, p.442
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__    [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
     # (no own attributes; Base = ARObject, CollectableElement, FibexElement, Frame, Identifiable, MultilanguageReferrable, PackageableElement, Referrable)
@@ -270,16 +271,16 @@ class CanFrameTriggering(FrameTriggering):
         super().__init__(parent, short_name)
 
         # Each frame in TTCAN is identified by its slot id and communication cycle. A description is provided by the usage of AbsolutelyScheduledTiming.
-        self.absolutelyScheduledTimings: "List[TtcanAbsolutelyScheduledTiming]" = []
+        self.absolutelyScheduledTimings: List[TtcanAbsolutelyScheduledTiming] = []
 
         # The CAN protocol supports two types of frame formats. The standard frame format uses 11-bit identifiers and is defined in the CAN specification 2.0 A. Additionally the extended frame format allows 29-bit identifiers and is defined in the CAN specification 2.0 B.
-        self.canAddressingMode: Optional[ARLiteral] = None
+        self.canAddressingMode: Optional[CanAddressingModeType] = None
 
         # Defines which CAN protocol shall be expected for frame reception.
-        self.canFrameRxBehavior: Optional[ARLiteral] = None
+        self.canFrameRxBehavior: Optional[CanFrameRxBehaviorEnum] = None
 
         # Defines which CAN protocol shall be used for frame transmission.
-        self.canFrameTxBehavior: Optional[ARLiteral] = None
+        self.canFrameTxBehavior: Optional[CanFrameTxBehaviorEnum] = None
 
         # Definition of CAN XL specific attributes in case the frame is a CAN XL frame.
         self.canXlFrameTriggeringProps: Optional[CanXlFrameTriggeringProps] = None
@@ -312,11 +313,11 @@ class CanFrameTriggering(FrameTriggering):
             self.absolutelyScheduledTimings.append(value)
         return self
 
-    def getCanAddressingMode(self) -> Optional[ARLiteral]:
+    def getCanAddressingMode(self) -> Optional[CanAddressingModeType]:
         """The CAN protocol supports two types of frame formats. The standard frame format uses 11-bit identifiers and is defined in the CAN specification 2.0 A. Additionally the extended frame format allows 29-bit identifiers and is defined in the CAN specification 2.0 B."""
         return self.canAddressingMode
 
-    def setCanAddressingMode(self, value: Optional[ARLiteral]) -> "CanFrameTriggering":
+    def setCanAddressingMode(self, value: Optional[CanAddressingModeType]) -> "CanFrameTriggering":
         """
         The CAN protocol supports two types of frame formats. The standard frame format uses 11-bit identifiers and is defined in the CAN specification 2.0 A. Additionally the extended frame format allows 29-bit identifiers and is defined in the CAN specification 2.0 B.
         A None value is a no-op and does not overwrite an existing canAddressingMode.
@@ -325,11 +326,11 @@ class CanFrameTriggering(FrameTriggering):
             self.canAddressingMode = value
         return self
 
-    def getCanFrameRxBehavior(self) -> Optional[ARLiteral]:
+    def getCanFrameRxBehavior(self) -> Optional[CanFrameRxBehaviorEnum]:
         """Defines which CAN protocol shall be expected for frame reception."""
         return self.canFrameRxBehavior
 
-    def setCanFrameRxBehavior(self, value: Optional[ARLiteral]) -> "CanFrameTriggering":
+    def setCanFrameRxBehavior(self, value: Optional[CanFrameRxBehaviorEnum]) -> "CanFrameTriggering":
         """
         Defines which CAN protocol shall be expected for frame reception.
         A None value is a no-op and does not overwrite an existing canFrameRxBehavior.
@@ -338,11 +339,11 @@ class CanFrameTriggering(FrameTriggering):
             self.canFrameRxBehavior = value
         return self
 
-    def getCanFrameTxBehavior(self) -> Optional[ARLiteral]:
+    def getCanFrameTxBehavior(self) -> Optional[CanFrameTxBehaviorEnum]:
         """Defines which CAN protocol shall be used for frame transmission."""
         return self.canFrameTxBehavior
 
-    def setCanFrameTxBehavior(self, value: Optional[ARLiteral]) -> "CanFrameTriggering":
+    def setCanFrameTxBehavior(self, value: Optional[CanFrameTxBehaviorEnum]) -> "CanFrameTriggering":
         """
         Defines which CAN protocol shall be used for frame transmission.
         A None value is a no-op and does not overwrite an existing canFrameTxBehavior.

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
@@ -1,11 +1,14 @@
 # This module contains AUTOSAR System Template classes for CAN communication
 # It defines CAN frames, frame triggering, and related communication elements for CAN networks
 
-from typing import Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import Frame, FrameTriggering
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, PositiveInteger
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARLiteral, Boolean, Integer, PositiveInteger
+
+if TYPE_CHECKING:
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ttcan.TtcanCommunication import TtcanAbsolutelyScheduledTiming
 
 
 class CanAddressingModeType(AREnum):
@@ -220,13 +223,14 @@ class RxIdentifierRange(ARObject):
 
 class CanFrame(Frame):
     """
-    Represents a CAN frame in the AUTOSAR system, extending the generic Frame class
-    with CAN-specific properties and behavior. This class defines the structure
-    and characteristics of CAN messages in the communication system.
+    CAN specific Frame element. This element shall also be used for TTCan.
     """
 
     # CanFrame method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.109, p.442
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__    [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # (no own attributes; Base = ARObject, CollectableElement, FibexElement, Frame, Identifiable, MultilanguageReferrable, PackageableElement, Referrable)
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
@@ -234,124 +238,193 @@ class CanFrame(Frame):
 
 class CanFrameTriggering(FrameTriggering):
     """
-    Defines the triggering mechanism for CAN frames, specifying how and when
-    CAN frames are transmitted or received on the network, including timing,
-    addressing modes, and frame behavior properties.
+    CAN specific attributes to the FrameTriggering
     """
 
     # CanFrameTriggering method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getAbsolutelyScheduledTimings [x] impl  [ ] docstring  [ ] test
-    # [ ] setAbsolutelyScheduledTimings [x] impl  [ ] docstring  [ ] test
-    # [ ] getCanAddressingMode         [x] impl  [ ] docstring  [ ] test
-    # [ ] setCanAddressingMode         [x] impl  [ ] docstring  [ ] test
-    # [ ] getCanFdFrameSupport         [x] impl  [ ] docstring  [ ] test
-    # [ ] setCanFdFrameSupport         [x] impl  [ ] docstring  [ ] test
-    # [ ] getCanFrameRxBehavior        [x] impl  [ ] docstring  [ ] test
-    # [ ] setCanFrameRxBehavior        [x] impl  [ ] docstring  [ ] test
-    # [ ] getCanFrameTxBehavior        [x] impl  [ ] docstring  [ ] test
-    # [ ] setCanFrameTxBehavior        [x] impl  [ ] docstring  [ ] test
-    # [ ] getCanXlFrameTriggeringProps [x] impl  [ ] docstring  [ ] test
-    # [ ] setCanXlFrameTriggeringProps [x] impl  [ ] docstring  [ ] test
-    # [ ] getIdentifier                [x] impl  [ ] docstring  [ ] test
-    # [ ] setIdentifier                [x] impl  [ ] docstring  [ ] test
-    # [ ] getJ1939requestable          [x] impl  [ ] docstring  [ ] test
-    # [ ] setJ1939requestable          [x] impl  [ ] docstring  [ ] test
-    # [ ] getRxIdentifierRange         [x] impl  [ ] docstring  [ ] test
-    # [ ] setRxIdentifierRange         [x] impl  [ ] docstring  [ ] test
-    # [ ] getRxMask                    [x] impl  [ ] docstring  [ ] test
-    # [ ] setRxMask                    [x] impl  [ ] docstring  [ ] test
-    # [ ] getTxMask                    [x] impl  [ ] docstring  [ ] test
-    # [ ] setTxMask                    [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.110, p.443
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getAbsolutelyScheduledTimings      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addAbsolutelyScheduledTiming       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCanAddressingMode               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCanAddressingMode               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCanFrameRxBehavior              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCanFrameRxBehavior              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCanFrameTxBehavior              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCanFrameTxBehavior              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCanXlFrameTriggeringProps       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCanXlFrameTriggeringProps       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getIdentifier                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setIdentifier                      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getJ1939requestable                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setJ1939requestable                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRxIdentifierRange               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setRxIdentifierRange               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getRxMask                          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setRxMask                          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTxMask                          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTxMask                          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
-    def __init__(self, parent, short_name):
+    def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.absolutelyScheduledTimings = []
-        self.canAddressingMode = None
-        self.canFdFrameSupport = None
-        self.canFrameRxBehavior = None
-        self.canFrameTxBehavior = None
-        self.canXlFrameTriggeringProps = None
-        self.identifier = None
-        self.j1939requestable = None
-        self.rxIdentifierRange: RxIdentifierRange = None
-        self.rxMask = None
-        self.txMask = None
+        # Each frame in TTCAN is identified by its slot id and communication cycle. A description is provided by the usage of AbsolutelyScheduledTiming.
+        self.absolutelyScheduledTimings: "List[TtcanAbsolutelyScheduledTiming]" = []
 
-    def getAbsolutelyScheduledTimings(self):
+        # The CAN protocol supports two types of frame formats. The standard frame format uses 11-bit identifiers and is defined in the CAN specification 2.0 A. Additionally the extended frame format allows 29-bit identifiers and is defined in the CAN specification 2.0 B.
+        self.canAddressingMode: Optional[ARLiteral] = None
+
+        # Defines which CAN protocol shall be expected for frame reception.
+        self.canFrameRxBehavior: Optional[ARLiteral] = None
+
+        # Defines which CAN protocol shall be used for frame transmission.
+        self.canFrameTxBehavior: Optional[ARLiteral] = None
+
+        # Definition of CAN XL specific attributes in case the frame is a CAN XL frame.
+        self.canXlFrameTriggeringProps: Optional[CanXlFrameTriggeringProps] = None
+
+        # This attribute is used to define the identifier this frame shall use on the CAN network.
+        self.identifier: Optional[Integer] = None
+
+        # Frame can be triggered by the J1939 request message.
+        self.j1939requestable: Optional[Boolean] = None
+
+        # Optional definition of a CanId range.
+        self.rxIdentifierRange: Optional[RxIdentifierRange] = None
+
+        # Identifier mask which denotes the relevant bits in the CAN Identifier. Together with the identifier, this parameter defines a CAN identifier range.
+        self.rxMask: Optional[PositiveInteger] = None
+
+        # Identifier mask which denotes static bits in the CAN identifier. The other bits can be set dynamically.
+        self.txMask: Optional[PositiveInteger] = None
+
+    def getAbsolutelyScheduledTimings(self) -> "List[TtcanAbsolutelyScheduledTiming]":
+        """Each frame in TTCAN is identified by its slot id and communication cycle. A description is provided by the usage of AbsolutelyScheduledTiming."""
         return self.absolutelyScheduledTimings
 
-    def setAbsolutelyScheduledTimings(self, value):
-        self.absolutelyScheduledTimings = value
+    def addAbsolutelyScheduledTiming(self, value: "Optional[TtcanAbsolutelyScheduledTiming]") -> "CanFrameTriggering":
+        """
+        Each frame in TTCAN is identified by its slot id and communication cycle. A description is provided by the usage of AbsolutelyScheduledTiming.
+        A None value is a no-op and is not appended to absolutelyScheduledTimings.
+        """
+        if value is not None:
+            self.absolutelyScheduledTimings.append(value)
         return self
 
-    def getCanAddressingMode(self):
+    def getCanAddressingMode(self) -> Optional[ARLiteral]:
+        """The CAN protocol supports two types of frame formats. The standard frame format uses 11-bit identifiers and is defined in the CAN specification 2.0 A. Additionally the extended frame format allows 29-bit identifiers and is defined in the CAN specification 2.0 B."""
         return self.canAddressingMode
 
-    def setCanAddressingMode(self, value):
-        self.canAddressingMode = value
+    def setCanAddressingMode(self, value: Optional[ARLiteral]) -> "CanFrameTriggering":
+        """
+        The CAN protocol supports two types of frame formats. The standard frame format uses 11-bit identifiers and is defined in the CAN specification 2.0 A. Additionally the extended frame format allows 29-bit identifiers and is defined in the CAN specification 2.0 B.
+        A None value is a no-op and does not overwrite an existing canAddressingMode.
+        """
+        if value is not None:
+            self.canAddressingMode = value
         return self
 
-    def getCanFdFrameSupport(self):
-        return self.canFdFrameSupport
-
-    def setCanFdFrameSupport(self, value):
-        self.canFdFrameSupport = value
-        return self
-
-    def getCanFrameRxBehavior(self):
+    def getCanFrameRxBehavior(self) -> Optional[ARLiteral]:
+        """Defines which CAN protocol shall be expected for frame reception."""
         return self.canFrameRxBehavior
 
-    def setCanFrameRxBehavior(self, value):
-        self.canFrameRxBehavior = value
+    def setCanFrameRxBehavior(self, value: Optional[ARLiteral]) -> "CanFrameTriggering":
+        """
+        Defines which CAN protocol shall be expected for frame reception.
+        A None value is a no-op and does not overwrite an existing canFrameRxBehavior.
+        """
+        if value is not None:
+            self.canFrameRxBehavior = value
         return self
 
-    def getCanFrameTxBehavior(self):
+    def getCanFrameTxBehavior(self) -> Optional[ARLiteral]:
+        """Defines which CAN protocol shall be used for frame transmission."""
         return self.canFrameTxBehavior
 
-    def setCanFrameTxBehavior(self, value):
-        self.canFrameTxBehavior = value
+    def setCanFrameTxBehavior(self, value: Optional[ARLiteral]) -> "CanFrameTriggering":
+        """
+        Defines which CAN protocol shall be used for frame transmission.
+        A None value is a no-op and does not overwrite an existing canFrameTxBehavior.
+        """
+        if value is not None:
+            self.canFrameTxBehavior = value
         return self
 
-    def getCanXlFrameTriggeringProps(self):
+    def getCanXlFrameTriggeringProps(self) -> Optional[CanXlFrameTriggeringProps]:
+        """Definition of CAN XL specific attributes in case the frame is a CAN XL frame."""
         return self.canXlFrameTriggeringProps
 
-    def setCanXlFrameTriggeringProps(self, value):
-        self.canXlFrameTriggeringProps = value
+    def setCanXlFrameTriggeringProps(self, value: Optional[CanXlFrameTriggeringProps]) -> "CanFrameTriggering":
+        """
+        Definition of CAN XL specific attributes in case the frame is a CAN XL frame.
+        A None value is a no-op and does not overwrite an existing canXlFrameTriggeringProps.
+        """
+        if value is not None:
+            self.canXlFrameTriggeringProps = value
         return self
 
-    def getIdentifier(self):
+    def getIdentifier(self) -> Optional[Integer]:
+        """This attribute is used to define the identifier this frame shall use on the CAN network."""
         return self.identifier
 
-    def setIdentifier(self, value):
-        self.identifier = value
+    def setIdentifier(self, value: Optional[Integer]) -> "CanFrameTriggering":
+        """
+        This attribute is used to define the identifier this frame shall use on the CAN network.
+        A None value is a no-op and does not overwrite an existing identifier.
+        """
+        if value is not None:
+            self.identifier = value
         return self
 
-    def getJ1939requestable(self):
+    def getJ1939requestable(self) -> Optional[Boolean]:
+        """Frame can be triggered by the J1939 request message."""
         return self.j1939requestable
 
-    def setJ1939requestable(self, value):
-        self.j1939requestable = value
+    def setJ1939requestable(self, value: Optional[Boolean]) -> "CanFrameTriggering":
+        """
+        Frame can be triggered by the J1939 request message.
+        A None value is a no-op and does not overwrite an existing j1939requestable.
+        """
+        if value is not None:
+            self.j1939requestable = value
         return self
 
-    def getRxIdentifierRange(self) -> RxIdentifierRange:
+    def getRxIdentifierRange(self) -> Optional[RxIdentifierRange]:
+        """Optional definition of a CanId range."""
         return self.rxIdentifierRange
 
-    def setRxIdentifierRange(self, value: RxIdentifierRange):
-        self.rxIdentifierRange = value
+    def setRxIdentifierRange(self, value: Optional[RxIdentifierRange]) -> "CanFrameTriggering":
+        """
+        Optional definition of a CanId range.
+        A None value is a no-op and does not overwrite an existing rxIdentifierRange.
+        """
+        if value is not None:
+            self.rxIdentifierRange = value
         return self
 
-    def getRxMask(self):
+    def getRxMask(self) -> Optional[PositiveInteger]:
+        """Identifier mask which denotes the relevant bits in the CAN Identifier. Together with the identifier, this parameter defines a CAN identifier range."""
         return self.rxMask
 
-    def setRxMask(self, value):
-        self.rxMask = value
+    def setRxMask(self, value: Optional[PositiveInteger]) -> "CanFrameTriggering":
+        """
+        Identifier mask which denotes the relevant bits in the CAN Identifier. Together with the identifier, this parameter defines a CAN identifier range.
+        A None value is a no-op and does not overwrite an existing rxMask.
+        """
+        if value is not None:
+            self.rxMask = value
         return self
 
-    def getTxMask(self):
+    def getTxMask(self) -> Optional[PositiveInteger]:
+        """Identifier mask which denotes static bits in the CAN identifier. The other bits can be set dynamically."""
         return self.txMask
 
-    def setTxMask(self, value):
-        self.txMask = value
+    def setTxMask(self, value: Optional[PositiveInteger]) -> "CanFrameTriggering":
+        """
+        Identifier mask which denotes static bits in the CAN identifier. The other bits can be set dynamically.
+        A None value is a no-op and does not overwrite an existing txMask.
+        """
+        if value is not None:
+            self.txMask = value
         return self

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
@@ -244,6 +244,7 @@ class CanFrameTriggering(FrameTriggering):
 
     # CanFrameTriggering method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.110, p.443
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__                           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getAbsolutelyScheduledTimings      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
@@ -3,7 +3,31 @@
 
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import Frame, FrameTriggering
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARPositiveInteger
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARPositiveInteger
+
+
+class CanAddressingModeType(AREnum):
+    """Indicates whether standard or extended CAN identifiers are used"""
+
+    # CanAddressingModeType method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.111, p.443
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods)
+
+    # Extended 29-bit-identifiers are used (CAN 2.0B) Tags: atp.EnumerationLiteralIndex=0
+    ENUM_EXTENDED = "EXTENDED"
+
+    # Standard 11-bit-identifiers are used (CAN 2.0A) Tags: atp.EnumerationLiteralIndex=1
+    ENUM_STANDARD = "STANDARD"
+
+    def __init__(self):
+        super().__init__(
+            [
+                CanAddressingModeType.ENUM_EXTENDED,
+                CanAddressingModeType.ENUM_STANDARD,
+            ]
+        )
 
 
 class RxIdentifierRange(ARObject):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
@@ -1,9 +1,11 @@
 # This module contains AUTOSAR System Template classes for CAN communication
 # It defines CAN frames, frame triggering, and related communication elements for CAN networks
 
+from typing import Optional
+
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import Frame, FrameTriggering
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARPositiveInteger
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARPositiveInteger, PositiveInteger
 
 
 class CanAddressingModeType(AREnum):
@@ -80,6 +82,91 @@ class CanFrameTxBehaviorEnum(AREnum):
                 CanFrameTxBehaviorEnum.ENUM_CAN_FD,
             ]
         )
+
+
+class CanXlFrameTriggeringProps(ARObject):
+    """This element indicates the frame being CAN XL and contains further CAN XL specific attributes."""
+
+    # CanXlFrameTriggeringProps method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table F.27, p.2007
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getAcceptanceField           [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setAcceptanceField           [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getPriorityId                [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setPriorityId                [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getSduType                   [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setSduType                   [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] getVcid                      [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setVcid                      [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # Acceptance field of a CAN XL message.
+        self.acceptanceField: Optional[PositiveInteger] = None
+
+        # Priority ID of a CAN XL message.
+        self.priorityId: Optional[PositiveInteger] = None
+
+        # SDU type of a CAN XL message.
+        self.sduType: Optional[PositiveInteger] = None
+        
+        # Virtual CAN network ID of a CAN XL message.
+        self.vcid: Optional[PositiveInteger] = None
+
+    def getAcceptanceField(self) -> Optional[PositiveInteger]:
+        """Acceptance field of a CAN XL message."""
+        return self.acceptanceField
+
+    def setAcceptanceField(self, value: Optional[PositiveInteger]) -> "CanXlFrameTriggeringProps":
+        """
+        Acceptance field of a CAN XL message.
+        A None value is a no-op and does not overwrite an existing acceptanceField.
+        """
+        if value is not None:
+            self.acceptanceField = value
+        return self
+
+    def getPriorityId(self) -> Optional[PositiveInteger]:
+        """Priority ID of a CAN XL message."""
+        return self.priorityId
+
+    def setPriorityId(self, value: Optional[PositiveInteger]) -> "CanXlFrameTriggeringProps":
+        """
+        Priority ID of a CAN XL message.
+        A None value is a no-op and does not overwrite an existing priorityId.
+        """
+        if value is not None:
+            self.priorityId = value
+        return self
+
+    def getSduType(self) -> Optional[PositiveInteger]:
+        """SDU type of a CAN XL message."""
+        return self.sduType
+
+    def setSduType(self, value: Optional[PositiveInteger]) -> "CanXlFrameTriggeringProps":
+        """
+        SDU type of a CAN XL message.
+        A None value is a no-op and does not overwrite an existing sduType.
+        """
+        if value is not None:
+            self.sduType = value
+        return self
+
+    def getVcid(self) -> Optional[PositiveInteger]:
+        """Virtual CAN network ID of a CAN XL message."""
+        return self.vcid
+
+    def setVcid(self, value: Optional[PositiveInteger]) -> "CanXlFrameTriggeringProps":
+        """
+        Virtual CAN network ID of a CAN XL message.
+        A None value is a no-op and does not overwrite an existing vcid.
+        """
+        if value is not None:
+            self.vcid = value
+        return self
 
 
 class RxIdentifierRange(ARObject):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
@@ -30,6 +30,34 @@ class CanAddressingModeType(AREnum):
         )
 
 
+class CanFrameRxBehaviorEnum(AREnum):
+    """Defines different CAN protocols for frame reception behavior."""
+
+    # CanFrameRxBehaviorEnum method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.113, p.444
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods)
+
+    # This CAN frame may be received as both, CAN 2.0 and CAN FD. Tags: atp.EnumerationLiteralIndex=0
+    ENUM_ANY = "ANY"
+
+    # This CAN frame shall be received as CAN 2.0 only. In case the CAN frame is received as CAN FD it is discarded during reception. Tags: atp.EnumerationLiteralIndex=1
+    ENUM_CAN_20 = "CAN-20"
+
+    # This CAN frame shall be received as CAN FD only. In case the CAN frame is received as CAN 2.0 it is discarded during reception. Tags: atp.EnumerationLiteralIndex=2
+    ENUM_CAN_FD = "CAN-FD"
+
+    def __init__(self):
+        super().__init__(
+            [
+                CanFrameRxBehaviorEnum.ENUM_ANY,
+                CanFrameRxBehaviorEnum.ENUM_CAN_20,
+                CanFrameRxBehaviorEnum.ENUM_CAN_FD,
+            ]
+        )
+
+
 class RxIdentifierRange(ARObject):
     """
     Defines a range of CAN identifiers used for receive filtering in CAN communication.

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import Frame, FrameTriggering
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARPositiveInteger, PositiveInteger
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, PositiveInteger
 
 
 class CanAddressingModeType(AREnum):
@@ -112,7 +112,7 @@ class CanXlFrameTriggeringProps(ARObject):
 
         # SDU type of a CAN XL message.
         self.sduType: Optional[PositiveInteger] = None
-        
+
         # Virtual CAN network ID of a CAN XL message.
         self.vcid: Optional[PositiveInteger] = None
 
@@ -170,37 +170,51 @@ class CanXlFrameTriggeringProps(ARObject):
 
 
 class RxIdentifierRange(ARObject):
-    """
-    Defines a range of CAN identifiers used for receive filtering in CAN communication.
-    This class specifies the lower and upper bounds of CAN message IDs that should
-    be accepted by a CAN controller or communication endpoint.
-    """
+    """Optional definition of a CanId range to reduce the effort of specifying every possible FrameTriggering within the defined Id range during reception. All frames received within a range are mapped to the same Pdu that is passed to a upper layer module (e.g. Nm, CDD, PduR)."""
 
     # RxIdentifierRange method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getLowerCanId                [x] impl  [ ] docstring  [ ] test
-    # [ ] setLowerCanId                [x] impl  [ ] docstring  [ ] test
-    # [ ] getUpperCanId                [x] impl  [ ] docstring  [ ] test
-    # [ ] setUpperCanId                [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.112, p.444
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getLowerCanId                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setLowerCanId                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getUpperCanId                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setUpperCanId                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.lowerCanId: ARPositiveInteger = None
-        self.upperCanId: ARPositiveInteger = None
+        # This attribute can be used together with the upperCanId attribute to define a range of CanIds.
+        self.lowerCanId: Optional[PositiveInteger] = None
 
-    def getLowerCanId(self) -> ARPositiveInteger:
+        # This attribute can be used together with the lowerCanId attribute to define a range of CanIds.
+        self.upperCanId: Optional[PositiveInteger] = None
+
+    def getLowerCanId(self) -> Optional[PositiveInteger]:
+        """This attribute can be used together with the upperCanId attribute to define a range of CanIds."""
         return self.lowerCanId
 
-    def setLowerCanId(self, value: ARPositiveInteger):
-        self.lowerCanId = value
+    def setLowerCanId(self, value: Optional[PositiveInteger]) -> "RxIdentifierRange":
+        """
+        This attribute can be used together with the upperCanId attribute to define a range of CanIds.
+        A None value is a no-op and does not overwrite an existing lowerCanId.
+        """
+        if value is not None:
+            self.lowerCanId = value
         return self
 
-    def getUpperCanId(self) -> ARPositiveInteger:
+    def getUpperCanId(self) -> Optional[PositiveInteger]:
+        """This attribute can be used together with the lowerCanId attribute to define a range of CanIds."""
         return self.upperCanId
 
-    def setUpperCanId(self, value: ARPositiveInteger):
-        self.upperCanId = value
+    def setUpperCanId(self, value: Optional[PositiveInteger]) -> "RxIdentifierRange":
+        """
+        This attribute can be used together with the lowerCanId attribute to define a range of CanIds.
+        A None value is a no-op and does not overwrite an existing upperCanId.
+        """
+        if value is not None:
+            self.upperCanId = value
         return self
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanCommunication.py
@@ -58,6 +58,30 @@ class CanFrameRxBehaviorEnum(AREnum):
         )
 
 
+class CanFrameTxBehaviorEnum(AREnum):
+    """Defines different CAN protocols for frame transmission behavior."""
+
+    # CanFrameTxBehaviorEnum method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.114, p.445
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods)
+
+    # This CAN frame shall be sent as CAN 2.0 only. Tags: atp.EnumerationLiteralIndex=0
+    ENUM_CAN_20 = "CAN-20"
+
+    # This CAN frame shall be sent as CAN FD. Tags: atp.EnumerationLiteralIndex=1
+    ENUM_CAN_FD = "CAN-FD"
+
+    def __init__(self):
+        super().__init__(
+            [
+                CanFrameTxBehaviorEnum.ENUM_CAN_20,
+                CanFrameTxBehaviorEnum.ENUM_CAN_FD,
+            ]
+        )
+
+
 class RxIdentifierRange(ARObject):
     """
     Defines a range of CAN identifiers used for receive filtering in CAN communication.

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology.py
@@ -941,6 +941,7 @@ class AbstractCanPhysicalChannel(PhysicalChannel, ABC):
 
     # AbstractCanPhysicalChannel method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 3.20, p.73
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__    [x] impl  [x] docstring  [x] test  [-] reader  [-] writer
     # (no own attributes; Base = ARObject, Identifiable, MultilanguageReferrable, PhysicalChannel, Referrable)

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology.py
@@ -936,13 +936,14 @@ class CanCommunicationController(AbstractCanCommunicationController):
 
 class AbstractCanCommunicationConnector(CommunicationConnector, ABC):
     """
-    Abstract base class for CAN communication connectors, providing
-    the foundation for connecting CAN controllers to communication
-    channels and network segments.
+    Abstract class that is used to collect the common TtCAN and CAN CommunicationConnector attributes.
     """
 
     # AbstractCanCommunicationConnector method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 3.22, p.73
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # (no own attributes; reader/writer coverage via CAN-COMMUNICATION-CONNECTOR dispatch of subclasses)
 
     def __init__(self, parent: ARObject, short_name: str):
         if type(self) is AbstractCanCommunicationConnector:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology.py
@@ -7,7 +7,7 @@ from typing import Optional
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, Float, Integer, PositiveInteger
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveUnlimitedInteger, TimeValue
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CommunicationConnector, CommunicationController
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CommunicationConnector, CommunicationController, PhysicalChannel
 
 
 class CanControllerFdConfiguration(ARObject):
@@ -929,6 +929,39 @@ class CanCommunicationController(AbstractCanCommunicationController):
     # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__               [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+
+    def __init__(self, parent: ARObject, short_name: str):
+        super().__init__(parent, short_name)
+
+
+class AbstractCanPhysicalChannel(PhysicalChannel, ABC):
+    """
+    Abstract class that is used to collect the common TtCAN and CAN PhysicalChannel attributes.
+    """
+
+    # AbstractCanPhysicalChannel method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 3.20, p.73
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__    [x] impl  [x] docstring  [x] test  [-] reader  [-] writer
+    # (no own attributes; Base = ARObject, Identifiable, MultilanguageReferrable, PhysicalChannel, Referrable)
+
+    def __init__(self, parent: ARObject, short_name: str):
+        if type(self) is AbstractCanPhysicalChannel:
+            raise TypeError("AbstractCanPhysicalChannel is an abstract class.")
+
+        super().__init__(parent, short_name)
+
+
+class CanPhysicalChannel(AbstractCanPhysicalChannel):
+    """
+    CAN bus specific physical channel attributes.
+    """
+
+    # CanPhysicalChannel method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 3.21, p.73
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__    [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # (no own attributes; Base = ARObject, AbstractCanPhysicalChannel, Identifiable, MultilanguageReferrable, PhysicalChannel, Referrable)
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology.py
@@ -959,6 +959,7 @@ class CanPhysicalChannel(AbstractCanPhysicalChannel):
 
     # CanPhysicalChannel method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 3.21, p.73
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__    [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
     # (no own attributes; Base = ARObject, AbstractCanPhysicalChannel, Identifiable, MultilanguageReferrable, PhysicalChannel, Referrable)
@@ -974,6 +975,7 @@ class AbstractCanCommunicationConnector(CommunicationConnector, ABC):
 
     # AbstractCanCommunicationConnector method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 3.22, p.73
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # (no own attributes; reader/writer coverage via CAN-COMMUNICATION-CONNECTOR dispatch of subclasses)

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ttcan/TtcanCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ttcan/TtcanCommunication.py
@@ -19,12 +19,25 @@ class TtcanTriggerType(AREnum):
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # (no methods)
 
+    # Check for message reception Tags: atp.EnumerationLiteralIndex=0
     ENUM_RX_TRIGGER = "RX-TRIGGER"
+
+    # Send reference message in periodic case Tags: atp.EnumerationLiteralIndex=1
     ENUM_TX_REF_TRIGGER = "TX-REF-TRIGGER"
+
+    # Send reference message in event-synchronised case Tags: atp.EnumerationLiteralIndex=2
     ENUM_TX_REF_TRIGGER_GAP = "TX-REF-TRIGGER-GAP"
+
+    # Send message in a merged arbitration window Tags: atp.EnumerationLiteralIndex=3
     ENUM_TX_TRIGGER_MERGED = "TX-TRIGGER-MERGED"
+
+    # Send message in an exclusive time window Tags: atp.EnumerationLiteralIndex=4
     ENUM_TX_TRIGGER_SINGLE = "TX-TRIGGER-SINGLE"
+
+    # Check for missing reference message in periodic case Tags: atp.EnumerationLiteralIndex=5
     ENUM_WATCH_TRIGGER = "WATCH-TRIGGER"
+
+    # Check for missing reference message in event-synchronised case Tags: atp.EnumerationLiteralIndex=6
     ENUM_WATCH_TRIGGER_GAP = "WATCH-TRIGGER-GAP"
 
     def __init__(self):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ttcan/TtcanCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ttcan/TtcanCommunication.py
@@ -1,0 +1,116 @@
+# This module contains AUTOSAR System Template classes for TTCAN communication
+# It defines TTCAN-specific absolutely scheduled timing elements
+
+from typing import Optional
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Integer
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CommunicationCycle
+
+
+class TtcanTriggerType(AREnum):
+    """
+    This type lists all trigger types for a time window.
+    """
+
+    # TtcanTriggerType method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.116, p.450
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods)
+
+    ENUM_RX_TRIGGER = "RX-TRIGGER"
+    ENUM_TX_REF_TRIGGER = "TX-REF-TRIGGER"
+    ENUM_TX_REF_TRIGGER_GAP = "TX-REF-TRIGGER-GAP"
+    ENUM_TX_TRIGGER_MERGED = "TX-TRIGGER-MERGED"
+    ENUM_TX_TRIGGER_SINGLE = "TX-TRIGGER-SINGLE"
+    ENUM_WATCH_TRIGGER = "WATCH-TRIGGER"
+    ENUM_WATCH_TRIGGER_GAP = "WATCH-TRIGGER-GAP"
+
+    def __init__(self):
+        super().__init__(
+            [
+                TtcanTriggerType.ENUM_RX_TRIGGER,
+                TtcanTriggerType.ENUM_TX_REF_TRIGGER,
+                TtcanTriggerType.ENUM_TX_REF_TRIGGER_GAP,
+                TtcanTriggerType.ENUM_TX_TRIGGER_MERGED,
+                TtcanTriggerType.ENUM_TX_TRIGGER_SINGLE,
+                TtcanTriggerType.ENUM_WATCH_TRIGGER,
+                TtcanTriggerType.ENUM_WATCH_TRIGGER_GAP,
+            ]
+        )
+
+
+class TtcanAbsolutelyScheduledTiming(ARObject):
+    """
+    Each frame in TTCAN is identified by its slot id and communication cycle. A description is provided by the usage of AbsolutelyScheduledTiming. A frame can be sent multiple times within one communication cycle. For describing this case multiple AbsolutelyScheduledTimings have to be used. The main use case would be that a frame is sent twice within one communication cycle.
+    """
+
+    # TtcanAbsolutelyScheduledTiming method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.115, p.450
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getCommunicationCycle           [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] setCommunicationCycle           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTimeMark                     [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTimeMark                     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTrigger                      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTrigger                      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+
+    def __init__(self):
+        super().__init__()
+
+        # The communication cycle where the frame is sent.
+        self.communicationCycle: Optional[CommunicationCycle] = None
+
+        # Where FlexRay counts the slots in the static segment, TTCAN requires explicit Tx and Rx time marks.
+        self.timeMark: Optional[Integer] = None
+
+        # Trigger type for this time window.
+        self.trigger: Optional[TtcanTriggerType] = None
+
+    def getCommunicationCycle(self) -> Optional[CommunicationCycle]:
+        """
+        The communication cycle where the frame is sent.
+        """
+        return self.communicationCycle
+
+    def setCommunicationCycle(self, value: Optional[CommunicationCycle]) -> "TtcanAbsolutelyScheduledTiming":
+        """
+        The communication cycle where the frame is sent.
+        A None value is a no-op and does not overwrite an existing communicationCycle.
+        """
+        if value is not None:
+            self.communicationCycle = value
+        return self
+
+    def getTimeMark(self) -> Optional[Integer]:
+        """
+        Where FlexRay counts the slots in the static segment, TTCAN requires explicit Tx and Rx time marks.
+        """
+        return self.timeMark
+
+    def setTimeMark(self, value: Optional[Integer]) -> "TtcanAbsolutelyScheduledTiming":
+        """
+        Where FlexRay counts the slots in the static segment, TTCAN requires explicit Tx and Rx time marks.
+        A None value is a no-op and does not overwrite an existing timeMark.
+        """
+        if value is not None:
+            self.timeMark = value
+        return self
+
+    def getTrigger(self) -> Optional[TtcanTriggerType]:
+        """
+        Trigger type for this time window.
+        """
+        return self.trigger
+
+    def setTrigger(self, value: Optional[TtcanTriggerType]) -> "TtcanAbsolutelyScheduledTiming":
+        """
+        Trigger type for this time window.
+        A None value is a no-op and does not overwrite an existing trigger.
+        """
+        if value is not None:
+            self.trigger = value
+        return self

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ttcan/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ttcan/__init__.py
@@ -1,0 +1,1 @@
+# This package contains AUTOSAR System Template classes for TTCAN communication

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
@@ -1564,19 +1564,20 @@ class PduTriggering(Identifiable):
 
 class FrameTriggering(Identifiable, ABC):
     """
-    Abstract base class for frame triggering mechanisms, defining
-    common properties for triggering frame transmission and reception
-    including frame references and port references.
+    The FrameTriggering describes the instance of a frame sent on a channel and defines the manner of triggering (timing information) and identification of a frame on the channel, on which it is sent. For the same frame, if FrameTriggerings exist on more than one channel of the same cluster the fan-out/ in is handled by the Bus interface.
     """
 
     # FrameTriggering method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getFrameRef                  [x] impl  [ ] docstring  [ ] test
-    # [ ] setFrameRef                  [x] impl  [ ] docstring  [ ] test
-    # [ ] getFramePortRefs             [x] impl  [ ] docstring  [ ] test
-    # [ ] addFramePortRef              [x] impl  [ ] docstring  [ ] test
-    # [ ] getPduTriggeringRefs         [x] impl  [ ] docstring  [ ] test
-    # [ ] addPduTriggeringRef          [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.79, p.418
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__              [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getFrameRef           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] setFrameRef           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFramePortRefs      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addFramePortRef       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPduTriggeringRefs  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addPduTriggeringRef   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent, short_name):
         if type(self) is FrameTriggering:
@@ -1584,28 +1585,40 @@ class FrameTriggering(Identifiable, ABC):
 
         super().__init__(parent, short_name)
 
-        self.frameRef: RefType = None
+        # One frame can be triggered several times, e.g. on different channels. If a frame has no frame triggering, it won't be sent at all. A frame triggering has assigned exactly one frame, which it triggers.
+        self.frameRef: Optional[RefType] = None
+
+        # References to the FramePort on every ECU of the system which sends and/or receives the frame. References for both the sender and the receiver side shall be included when the system is completely defined.
         self.framePortRefs: List[RefType] = []
+
+        # This reference provides the relationship to the Pdu Triggerings that are implemented by the FrameTriggering. The reference is optional since no PduTriggering can be defined for NmPdus and XCP Pdus. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=pduTriggering.pduTriggering, pdu Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
         self.pduTriggeringRefs: List[RefType] = []
 
-    def getFrameRef(self) -> RefType:
+    def getFrameRef(self) -> Optional[RefType]:
+        # One frame can be triggered several times, e.g. on different channels. If a frame has no frame triggering, it won't be sent at all. A frame triggering has assigned exactly one frame, which it triggers.
         return self.frameRef
 
-    def setFrameRef(self, value: RefType):
-        self.frameRef = value
+    def setFrameRef(self, value: Optional[RefType]) -> "FrameTriggering":
+        # One frame can be triggered several times, e.g. on different channels. If a frame has no frame triggering, it won't be sent at all. A frame triggering has assigned exactly one frame, which it triggers.
+        if value is not None:
+            self.frameRef = value
         return self
 
     def getFramePortRefs(self) -> List[RefType]:
+        # References to the FramePort on every ECU of the system which sends and/or receives the frame. References for both the sender and the receiver side shall be included when the system is completely defined.
         return self.framePortRefs
 
-    def addFramePortRef(self, value: RefType):
+    def addFramePortRef(self, value: RefType) -> "FrameTriggering":
+        # References to the FramePort on every ECU of the system which sends and/or receives the frame. References for both the sender and the receiver side shall be included when the system is completely defined.
         self.framePortRefs.append(value)
         return self
 
-    def getPduTriggeringRefs(self) -> RefType:
+    def getPduTriggeringRefs(self) -> List[RefType]:
+        # This reference provides the relationship to the Pdu Triggerings that are implemented by the FrameTriggering. The reference is optional since no PduTriggering can be defined for NmPdus and XCP Pdus. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=pduTriggering.pduTriggering, pdu Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
         return self.pduTriggeringRefs
 
-    def addPduTriggeringRef(self, value: RefType):
+    def addPduTriggeringRef(self, value: RefType) -> "FrameTriggering":
+        # This reference provides the relationship to the Pdu Triggerings that are implemented by the FrameTriggering. The reference is optional since no PduTriggering can be defined for NmPdus and XCP Pdus. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=pduTriggering.pduTriggering, pdu Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
         self.pduTriggeringRefs.append(value)
         return self
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication.py
@@ -92,17 +92,18 @@ class PduToFrameMapping(Identifiable):
 
 class Frame(FibexElement, ABC):
     """
-    Abstract base class for communication frames in the AUTOSAR system,
-    defining common properties for different types of communication
-    frames including frame length and PDU to frame mappings.
+    Data frame which is sent over a communication medium. This element describes the pure Layout of a frame sent on a channel.
     """
 
     # Frame method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getFrameLength               [x] impl  [ ] docstring  [ ] test
-    # [ ] setFrameLength               [x] impl  [ ] docstring  [ ] test
-    # [ ] createPduToFrameMapping      [x] impl  [ ] docstring  [ ] test
-    # [ ] getPduToFrameMappings        [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.78, p.418
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getFrameLength               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFrameLength               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] createPduToFrameMapping      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPduToFrameMappings        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         if type(self) is Frame:
@@ -110,17 +111,31 @@ class Frame(FibexElement, ABC):
 
         super().__init__(parent, short_name)
 
-        self.frameLength = None
+        # The used length (in bytes) of the referencing frame. Should not be confused with a static byte length reserved for each frame by some platforms (e.g. FlexRay). The frameLength of zero bytes is allowed. Please consider also TPS_SYST_02255.
+        self.frameLength: Optional[Integer] = None
+
+        # A frames layout as a sequence of Pdus. atpVariation: The content of a frame can be variable. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=pduToFrameMapping.shortName, pduTo FrameMapping.variationPoint.shortLabel vh.latestBindingTime=postBuild
         self.pduToFrameMappings: List[PduToFrameMapping] = []
 
-    def getFrameLength(self):
+    def getFrameLength(self) -> Optional[Integer]:
+        """
+        The used length (in bytes) of the referencing frame. Should not be confused with a static byte length reserved for each frame by some platforms (e.g. FlexRay). The frameLength of zero bytes is allowed. Please consider also TPS_SYST_02255.
+        """
         return self.frameLength
 
-    def setFrameLength(self, value):
-        self.frameLength = value
+    def setFrameLength(self, value: Optional[Integer]) -> "Frame":
+        """
+        The used length (in bytes) of the referencing frame. Should not be confused with a static byte length reserved for each frame by some platforms (e.g. FlexRay). The frameLength of zero bytes is allowed. Please consider also TPS_SYST_02255.
+        A None value is a no-op and does not overwrite an existing frameLength.
+        """
+        if value is not None:
+            self.frameLength = value
         return self
 
     def createPduToFrameMapping(self, short_name: str) -> PduToFrameMapping:
+        """
+        A frames layout as a sequence of Pdus. atpVariation: The content of a frame can be variable. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=pduToFrameMapping.shortName, pduTo FrameMapping.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
         if not self.IsElementExists(short_name):
             mapping = PduToFrameMapping(self, short_name)
             self.addElement(mapping)
@@ -128,7 +143,10 @@ class Frame(FibexElement, ABC):
         return self.getElement(short_name, PduToFrameMapping)
 
     def getPduToFrameMappings(self) -> List[PduToFrameMapping]:
-        return list(sorted(filter(lambda a: isinstance(a, PduToFrameMapping), self.elements), key=lambda o: o.short_name))
+        """
+        A frames layout as a sequence of Pdus. atpVariation: The content of a frame can be variable. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=pduToFrameMapping.shortName, pduTo FrameMapping.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        return self.pduToFrameMappings
 
 
 class ContainedIPduProps(ARObject):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
@@ -1,6 +1,9 @@
 from abc import ABC
 from enum import Enum
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import CanPhysicalChannel
 
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import FlexrayFrameTriggering
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.Filter import DataFilter
@@ -249,39 +252,6 @@ class PhysicalChannel(Identifiable, ABC):
         return self.getElement(short_name)
 
 
-class AbstractCanPhysicalChannel(PhysicalChannel, ABC):
-    """
-    Abstract class that is used to collect the common TtCAN and CAN PhysicalChannel attributes.
-    """
-
-    # AbstractCanPhysicalChannel method parity checklist:
-    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 3.20, p.73
-    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
-    # [x] __init__    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-    # (no own attributes; Base = ARObject, Identifiable, MultilanguageReferrable, PhysicalChannel, Referrable)
-
-    def __init__(self, parent, short_name):
-        if type(self) is AbstractCanPhysicalChannel:
-            raise TypeError("AbstractCanPhysicalChannel is an abstract class.")
-
-        super().__init__(parent, short_name)
-
-
-class CanPhysicalChannel(AbstractCanPhysicalChannel):
-    """
-    CAN bus specific physical channel attributes.
-    """
-
-    # CanPhysicalChannel method parity checklist:
-    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 3.21, p.73
-    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
-    # [x] __init__    [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
-    # (no own attributes; Base = ARObject, AbstractCanPhysicalChannel, Identifiable, MultilanguageReferrable, PhysicalChannel, Referrable)
-
-    def __init__(self, parent, short_name):
-        super().__init__(parent, short_name)
-
-
 class LinPhysicalChannel(PhysicalChannel):
     """
     Represents a LIN physical channel in the communication system,
@@ -503,10 +473,12 @@ class CommunicationCluster(FibexElement, ABC):
         """
         return list(sorted(self.physicalChannel, key=lambda o: o.getShortName()))
 
-    def getCanPhysicalChannels(self) -> List[CanPhysicalChannel]:
+    def getCanPhysicalChannels(self) -> List["CanPhysicalChannel"]:
         """
         This relationship defines which channel element belongs to which cluster. A channel shall be assigned to exactly one cluster, whereas a cluster may have one or more channels. Note: This atpSplitable property has no atp.Splitkey due to atpVariation (PropertySetPattern). Stereotypes: atpSplitable; atpVariation Tags: vh.latestBindingTime=systemDesignTime
         """
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import CanPhysicalChannel
+
         return list(sorted(filter(lambda a: isinstance(a, CanPhysicalChannel), self.physicalChannel), key=lambda o: o.getShortName()))
 
     def getLinPhysicalChannels(self) -> List[LinPhysicalChannel]:
@@ -525,6 +497,8 @@ class CommunicationCluster(FibexElement, ABC):
         """
         This relationship defines which channel element belongs to which cluster. A channel shall be assigned to exactly one cluster, whereas a cluster may have one or more channels. Note: This atpSplitable property has no atp.Splitkey due to atpVariation (PropertySetPattern). Stereotypes: atpSplitable; atpVariation Tags: vh.latestBindingTime=systemDesignTime
         """
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import CanPhysicalChannel
+
         if short_name not in self.elements:
             channel = CanPhysicalChannel(self, short_name)
             self.addElement(channel)

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
@@ -251,13 +251,14 @@ class PhysicalChannel(Identifiable, ABC):
 
 class AbstractCanPhysicalChannel(PhysicalChannel, ABC):
     """
-    Abstract base class for CAN physical channels, defining
-    common properties for CAN-specific physical communication
-    channels in the AUTOSAR system.
+    Abstract class that is used to collect the common TtCAN and CAN PhysicalChannel attributes.
     """
 
     # AbstractCanPhysicalChannel method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 3.20, p.73
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # (no own attributes; Base = ARObject, Identifiable, MultilanguageReferrable, PhysicalChannel, Referrable)
 
     def __init__(self, parent, short_name):
         if type(self) is AbstractCanPhysicalChannel:
@@ -268,13 +269,14 @@ class AbstractCanPhysicalChannel(PhysicalChannel, ABC):
 
 class CanPhysicalChannel(AbstractCanPhysicalChannel):
     """
-    Represents a CAN physical channel in the communication system,
-    implementing specific properties for CAN bus communication
-    including frame triggering and connector management.
+    CAN bus specific physical channel attributes.
     """
 
     # CanPhysicalChannel method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 3.21, p.73
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__    [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # (no own attributes; Base = ARObject, AbstractCanPhysicalChannel, Identifiable, MultilanguageReferrable, PhysicalChannel, Referrable)
 
     def __init__(self, parent, short_name):
         super().__init__(parent, short_name)

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
@@ -108,26 +108,26 @@ class CycleRepetition(CommunicationCycle):
 
 class PhysicalChannel(Identifiable, ABC):
     """
-    Abstract base class for physical communication channels,
-    defining common properties for different types of physical
-    communication media including connector references and
-    frame triggering mechanisms.
+    A physical channel is the transmission medium that is used to send and receive information between communicating ECUs. Each CommunicationCluster has at least one physical channel. Bus systems like CAN and LIN only have exactly one PhysicalChannel. A FlexRay cluster may have more than one PhysicalChannels that may be used in parallel for redundant communication. An ECU is part of a cluster if it contains at least one controller that is connected to at least one channel of the cluster.
     """
 
     # PhysicalChannel method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getCommConnectorRefs         [x] impl  [ ] docstring  [ ] test
-    # [ ] addCommConnectorRef          [x] impl  [ ] docstring  [ ] test
-    # [ ] getFrameTriggerings          [x] impl  [ ] docstring  [ ] test
-    # [ ] createCanFrameTriggering     [x] impl  [ ] docstring  [ ] test
-    # [ ] createLinFrameTriggering     [x] impl  [ ] docstring  [ ] test
-    # [ ] createFlexrayFrameTriggering [x] impl  [ ] docstring  [ ] test
-    # [ ] getISignalTriggerings        [x] impl  [ ] docstring  [ ] test
-    # [ ] createISignalTriggering      [x] impl  [ ] docstring  [ ] test
-    # [ ] getManagedPhysicalChannelRefs [x] impl  [ ] docstring  [ ] test
-    # [ ] addManagedPhysicalChannelRef [x] impl  [ ] docstring  [ ] test
-    # [ ] getPduTriggerings            [x] impl  [ ] docstring  [ ] test
-    # [ ] createPduTriggering          [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 3.7, p.59
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getCommConnectorRefs            [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] addCommConnectorRef             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFrameTriggerings             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createCanFrameTriggering        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] createLinFrameTriggering        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] createFlexrayFrameTriggering     [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getISignalTriggerings           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createISignalTriggering         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getManagedPhysicalChannelRefs   [x] impl  [x] docstring  [x] test  [x] reader  [x] writer
+    # [x] addManagedPhysicalChannelRef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPduTriggerings               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createPduTriggering             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         if type(self) is PhysicalChannel:
@@ -135,21 +135,46 @@ class PhysicalChannel(Identifiable, ABC):
 
         super().__init__(parent, short_name)
 
+        # Reference to the ECUInstance via a Communication Connector to which the channel is connected. atpVariation: Variable assignment of Physical Channels to different CommunicationConnectors is expressed with this variation. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=commConnector.communicationConnector, commConnector.variationPoint.shortLabel vh.latestBindingTime=postBuild
         self.commConnectorRefs: List[RefType] = []
+
+        # One frame triggering is defined for exactly one channel. Channels may have assigned an arbitrary number of frame triggerings. atpVariation: If signals/PDUs/frames are variable, the corresponding triggerings shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=frameTriggering.shortName, frame Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
         self.frameTriggerings: List[FrameTriggering] = []
+
+        # One ISignalTriggering is defined for exactly one channel. Channels may have assigned an arbitrary number of ISignaltriggerings. atpVariation: If signals/PDUs/frames are variable, the corresponding triggerings shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=iSignalTriggering.shortName, iSignal Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        self.iSignalTriggerings: List[ISignalTriggering] = []
+
+        # Reference between a channel with role managing channel and a channel with role managed channel.
         self.managedPhysicalChannelRefs: List[RefType] = []
 
-    def getCommConnectorRefs(self):
+        # One PduTriggering is defined for exactly one channel. Channels may have assigned an arbitrary number of I-Pdu triggerings. atpVariation: If signals/PDUs/frames are variable, the corresponding triggerings shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=pduTriggering.shortName, pdu Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        self.pduTriggerings: List[PduTriggering] = []
+
+    def getCommConnectorRefs(self) -> List[RefType]:
+        """
+        Reference to the ECUInstance via a Communication Connector to which the channel is connected. atpVariation: Variable assignment of Physical Channels to different CommunicationConnectors is expressed with this variation. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=commConnector.communicationConnector, commConnector.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
         return self.commConnectorRefs
 
-    def addCommConnectorRef(self, value):
-        self.commConnectorRefs.append(value)
+    def addCommConnectorRef(self, value: RefType) -> "PhysicalChannel":
+        """
+        Reference to the ECUInstance via a Communication Connector to which the channel is connected. atpVariation: Variable assignment of Physical Channels to different CommunicationConnectors is expressed with this variation. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=commConnector.communicationConnector, commConnector.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        A None value is a no-op and does not overwrite an existing commConnectorRefs.
+        """
+        if value is not None:
+            self.commConnectorRefs.append(value)
         return self
 
     def getFrameTriggerings(self) -> List[FrameTriggering]:
-        return list(sorted(filter(lambda a: isinstance(a, FrameTriggering), self.elements), key=lambda o: o.getShortName()))
+        """
+        One frame triggering is defined for exactly one channel. Channels may have assigned an arbitrary number of frame triggerings. atpVariation: If signals/PDUs/frames are variable, the corresponding triggerings shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=frameTriggering.shortName, frame Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        return list(sorted(self.frameTriggerings, key=lambda o: o.getShortName()))
 
     def createCanFrameTriggering(self, short_name: str) -> CanFrameTriggering:
+        """
+        One frame triggering is defined for exactly one channel. Channels may have assigned an arbitrary number of frame triggerings. atpVariation: If signals/PDUs/frames are variable, the corresponding triggerings shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=frameTriggering.shortName, frame Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
         if short_name not in self.elements:
             triggering = CanFrameTriggering(self, short_name)
             self.addElement(triggering)
@@ -157,6 +182,9 @@ class PhysicalChannel(Identifiable, ABC):
         return self.getElement(short_name)
 
     def createLinFrameTriggering(self, short_name: str) -> LinFrameTriggering:
+        """
+        One frame triggering is defined for exactly one channel. Channels may have assigned an arbitrary number of frame triggerings. atpVariation: If signals/PDUs/frames are variable, the corresponding triggerings shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=frameTriggering.shortName, frame Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
         if short_name not in self.elements:
             triggering = LinFrameTriggering(self, short_name)
             self.addElement(triggering)
@@ -164,6 +192,9 @@ class PhysicalChannel(Identifiable, ABC):
         return self.getElement(short_name)
 
     def createFlexrayFrameTriggering(self, short_name: str) -> FlexrayFrameTriggering:
+        """
+        One frame triggering is defined for exactly one channel. Channels may have assigned an arbitrary number of frame triggerings. atpVariation: If signals/PDUs/frames are variable, the corresponding triggerings shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=frameTriggering.shortName, frame Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
         if short_name not in self.elements:
             triggering = FlexrayFrameTriggering(self, short_name)
             self.addElement(triggering)
@@ -171,28 +202,50 @@ class PhysicalChannel(Identifiable, ABC):
         return self.getElement(short_name)
 
     def getISignalTriggerings(self) -> List[ISignalTriggering]:
-        return list(sorted(filter(lambda a: isinstance(a, ISignalTriggering), self.elements), key=lambda o: o.getShortName()))
+        """
+        One ISignalTriggering is defined for exactly one channel. Channels may have assigned an arbitrary number of ISignaltriggerings. atpVariation: If signals/PDUs/frames are variable, the corresponding triggerings shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=iSignalTriggering.shortName, iSignal Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        return list(sorted(self.iSignalTriggerings, key=lambda o: o.getShortName()))
 
-    def createISignalTriggering(self, short_name: str):
+    def createISignalTriggering(self, short_name: str) -> ISignalTriggering:
+        """
+        One ISignalTriggering is defined for exactly one channel. Channels may have assigned an arbitrary number of ISignaltriggerings. atpVariation: If signals/PDUs/frames are variable, the corresponding triggerings shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=iSignalTriggering.shortName, iSignal Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
         if short_name not in self.elements:
             triggering = ISignalTriggering(self, short_name)
             self.addElement(triggering)
+            self.iSignalTriggerings.append(triggering)
         return self.getElement(short_name)
 
-    def getManagedPhysicalChannelRefs(self):
+    def getManagedPhysicalChannelRefs(self) -> List[RefType]:
+        """
+        Reference between a channel with role managing channel and a channel with role managed channel.
+        """
         return self.managedPhysicalChannelRefs
 
-    def addManagedPhysicalChannelRef(self, value):
-        self.managedPhysicalChannelRefs.append(value)
+    def addManagedPhysicalChannelRef(self, value: RefType) -> "PhysicalChannel":
+        """
+        Reference between a channel with role managing channel and a channel with role managed channel.
+        A None value is a no-op and does not overwrite an existing managedPhysicalChannelRefs.
+        """
+        if value is not None:
+            self.managedPhysicalChannelRefs.append(value)
         return self
 
     def getPduTriggerings(self) -> List[PduTriggering]:
-        return list(sorted(filter(lambda a: isinstance(a, PduTriggering), self.elements), key=lambda o: o.getShortName()))
+        """
+        One PduTriggering is defined for exactly one channel. Channels may have assigned an arbitrary number of I-Pdu triggerings. atpVariation: If signals/PDUs/frames are variable, the corresponding triggerings shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=pduTriggering.shortName, pdu Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        return list(sorted(self.pduTriggerings, key=lambda o: o.getShortName()))
 
-    def createPduTriggering(self, short_name: str):
+    def createPduTriggering(self, short_name: str) -> PduTriggering:
+        """
+        One PduTriggering is defined for exactly one channel. Channels may have assigned an arbitrary number of I-Pdu triggerings. atpVariation: If signals/PDUs/frames are variable, the corresponding triggerings shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=pduTriggering.shortName, pdu Triggering.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
         if short_name not in self.elements:
             triggering = PduTriggering(self, short_name)
             self.addElement(triggering)
+            self.pduTriggerings.append(triggering)
         return self.getElement(short_name)
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology.py
@@ -1016,28 +1016,28 @@ class ISignalPort(CommConnectorPort):
 
 class CommunicationConnector(Identifiable, ABC):
     """
-    Abstract base class for communication connectors,
-    defining common properties for connecting communication
-    controllers to communication channels and managing
-    port instances and gateway types.
+    The connection between the referencing ECU and the referenced channel via the referenced controller. Connectors are used to describe the bus interfaces of the ECUs and to specify the sending/receiving behavior. Each CommunicationConnector has a reference to exactly one communicationController. Note: Several CommunicationConnectors can be assigned to one PhysicalChannel in the scope of one ECU Instance.
     """
 
     # CommunicationConnector method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getCommControllerRef         [x] impl  [ ] docstring  [ ] test
-    # [ ] setCommControllerRef         [x] impl  [ ] docstring  [ ] test
-    # [ ] getCreateEcuWakeupSource     [x] impl  [ ] docstring  [ ] test
-    # [ ] setCreateEcuWakeupSource     [x] impl  [ ] docstring  [ ] test
-    # [ ] getDynamicPncToChannelMappingEnabled [x] impl  [ ] docstring  [ ] test
-    # [ ] setDynamicPncToChannelMappingEnabled [x] impl  [ ] docstring  [ ] test
-    # [ ] getEcuCommPortInstances      [x] impl  [ ] docstring  [ ] test
-    # [ ] createFramePort              [x] impl  [ ] docstring  [ ] test
-    # [ ] createIPduPort               [x] impl  [ ] docstring  [ ] test
-    # [ ] createISignalPort            [x] impl  [ ] docstring  [ ] test
-    # [ ] getPncFilterArrayMasks       [x] impl  [ ] docstring  [ ] test
-    # [ ] addPncFilterArrayMask        [x] impl  [ ] docstring  [ ] test
-    # [ ] getPncGatewayType            [x] impl  [ ] docstring  [ ] test
-    # [ ] setPncGatewayType            [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 3.4, p.54
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                                [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getCommControllerRef                    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCommControllerRef                    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCreateEcuWakeupSource                [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCreateEcuWakeupSource                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDynamicPncToChannelMappingEnabled    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDynamicPncToChannelMappingEnabled    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getEcuCommPortInstances                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createFramePort                         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] createIPduPort                          [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] createISignalPort                       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPncFilterArrayMasks                  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addPncFilterArrayMask                   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPncGatewayType                       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setPncGatewayType                       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         if type(self) is CommunicationConnector:
@@ -1045,68 +1045,139 @@ class CommunicationConnector(Identifiable, ABC):
 
         super().__init__(parent, short_name)
 
-        self.commControllerRef: RefType = None
-        self.createEcuWakeupSource: Boolean = None
-        self.dynamicPncToChannelMappingEnabled: Boolean = None
-        self.ecuCommPortInstances: List[CommConnectorPort] = []
-        self.pncFilterArrayMasks: List[PositiveInteger] = []
-        self.pncGatewayType: PncGatewayTypeEnum = None
+        # Reference to the communication controller. The CommunicationConnector and referenced CommunicationController shall be aggregated by the same ECUInstance. The communicationController can be referenced by several CommunicationConnector elements. This is important for the FlexRay Bus. FlexRay communicates via two physical channels. But only one controller in an ECU is responsible for both channels. Thus, two connectors (for channel A and for channel B) shall reference to the same controller.
+        self.commControllerRef: Optional[RefType] = None
 
-    def getCommControllerRef(self):
+        # If this parameter is available and set to true then a channel wakeup source shall be created for the Physical Channel referencing this CommunicationConnector.
+        self.createEcuWakeupSource: Optional[Boolean] = None
+
+        # Defines if this EcuInstance shall implement the dynamic PNC-to-channel-mapping functionality on this CommunicationConnector and its respective Physical Channel. Tags: atp.Status=draft
+        self.dynamicPncToChannelMappingEnabled: Optional[Boolean] = None
+
+        # An ECUs reception or send ports. atpVariation: If signals/PDUs/frames are variable, the corresponding ports shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=ecuCommPortInstance.shortName, ecu CommPortInstance.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        self.ecuCommPortInstances: List[CommConnectorPort] = []
+
+        # Bit mask for NM-Pdu Payload used to configure the NM filter mask for the Network Management.
+        self.pncFilterArrayMasks: List[PositiveInteger] = []
+
+        # Defines if this EcuInstance shall implement the Pnc Gateway functionality on this CommunicationConnector and its respective PhysicalChannel. Several Ecu Instances on the same PhysicalChannel can have the PncGateway functionality enabled, but only one of them shall have the pncGatewayType "active".
+        self.pncGatewayType: Optional[PncGatewayTypeEnum] = None
+
+    def getCommControllerRef(self) -> Optional[RefType]:
+        """
+        Reference to the communication controller. The CommunicationConnector and referenced CommunicationController shall be aggregated by the same ECUInstance. The communicationController can be referenced by several CommunicationConnector elements. This is important for the FlexRay Bus. FlexRay communicates via two physical channels. But only one controller in an ECU is responsible for both channels. Thus, two connectors (for channel A and for channel B) shall reference to the same controller.
+        """
         return self.commControllerRef
 
-    def setCommControllerRef(self, value):
-        self.commControllerRef = value
+    def setCommControllerRef(self, value: Optional[RefType]) -> "CommunicationConnector":
+        """
+        Reference to the communication controller. The CommunicationConnector and referenced CommunicationController shall be aggregated by the same ECUInstance. The communicationController can be referenced by several CommunicationConnector elements. This is important for the FlexRay Bus. FlexRay communicates via two physical channels. But only one controller in an ECU is responsible for both channels. Thus, two connectors (for channel A and for channel B) shall reference to the same controller.
+        A None value is a no-op and does not overwrite an existing commControllerRef.
+        """
+        if value is not None:
+            self.commControllerRef = value
         return self
 
-    def getCreateEcuWakeupSource(self):
+    def getCreateEcuWakeupSource(self) -> Optional[Boolean]:
+        """
+        If this parameter is available and set to true then a channel wakeup source shall be created for the Physical Channel referencing this CommunicationConnector.
+        """
         return self.createEcuWakeupSource
 
-    def setCreateEcuWakeupSource(self, value):
-        self.createEcuWakeupSource = value
+    def setCreateEcuWakeupSource(self, value: Optional[Boolean]) -> "CommunicationConnector":
+        """
+        If this parameter is available and set to true then a channel wakeup source shall be created for the Physical Channel referencing this CommunicationConnector.
+        A None value is a no-op and does not overwrite an existing createEcuWakeupSource.
+        """
+        if value is not None:
+            if not isinstance(value, Boolean):
+                boolean = Boolean()
+                boolean.setValue(value)
+                value = boolean
+            self.createEcuWakeupSource = value
         return self
 
-    def getDynamicPncToChannelMappingEnabled(self):
+    def getDynamicPncToChannelMappingEnabled(self) -> Optional[Boolean]:
+        """
+        Defines if this EcuInstance shall implement the dynamic PNC-to-channel-mapping functionality on this CommunicationConnector and its respective Physical Channel. Tags: atp.Status=draft
+        """
         return self.dynamicPncToChannelMappingEnabled
 
-    def setDynamicPncToChannelMappingEnabled(self, value):
-        self.dynamicPncToChannelMappingEnabled = value
+    def setDynamicPncToChannelMappingEnabled(self, value: Optional[Boolean]) -> "CommunicationConnector":
+        """
+        Defines if this EcuInstance shall implement the dynamic PNC-to-channel-mapping functionality on this CommunicationConnector and its respective Physical Channel. Tags: atp.Status=draft
+        A None value is a no-op and does not overwrite an existing dynamicPncToChannelMappingEnabled.
+        """
+        if value is not None:
+            if not isinstance(value, Boolean):
+                boolean = Boolean()
+                boolean.setValue(value)
+                value = boolean
+            self.dynamicPncToChannelMappingEnabled = value
         return self
 
-    def getEcuCommPortInstances(self):
-        return list(sorted(filter(lambda a: isinstance(a, CommConnectorPort), self.elements), key=lambda o: o.getShortName()))
+    def getEcuCommPortInstances(self) -> List[CommConnectorPort]:
+        """
+        An ECUs reception or send ports. atpVariation: If signals/PDUs/frames are variable, the corresponding ports shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=ecuCommPortInstance.shortName, ecu CommPortInstance.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        return list(sorted(self.ecuCommPortInstances, key=lambda o: o.getShortName()))
 
     def createFramePort(self, short_name) -> FramePort:
-        if short_name not in self.elements:
+        """
+        An ECUs reception or send ports. atpVariation: If signals/PDUs/frames are variable, the corresponding ports shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=ecuCommPortInstance.shortName, ecu CommPortInstance.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        if self.getElement(short_name) is None:
             port = FramePort(self, short_name)
             self.addElement(port)
             self.ecuCommPortInstances.append(port)
         return self.getElement(short_name)
 
     def createIPduPort(self, short_name) -> IPduPort:
-        if short_name not in self.elements:
+        """
+        An ECUs reception or send ports. atpVariation: If signals/PDUs/frames are variable, the corresponding ports shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=ecuCommPortInstance.shortName, ecu CommPortInstance.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        if self.getElement(short_name) is None:
             port = IPduPort(self, short_name)
             self.addElement(port)
             self.ecuCommPortInstances.append(port)
         return self.getElement(short_name)
 
     def createISignalPort(self, short_name) -> ISignalPort:
-        if short_name not in self.elements:
+        """
+        An ECUs reception or send ports. atpVariation: If signals/PDUs/frames are variable, the corresponding ports shall be variable, too. Stereotypes: atpSplitable; atpVariation Tags: atp.Splitkey=ecuCommPortInstance.shortName, ecu CommPortInstance.variationPoint.shortLabel vh.latestBindingTime=postBuild
+        """
+        if self.getElement(short_name) is None:
             port = ISignalPort(self, short_name)
             self.addElement(port)
             self.ecuCommPortInstances.append(port)
         return self.getElement(short_name)
 
-    def getPncFilterArrayMasks(self):
+    def getPncFilterArrayMasks(self) -> List[PositiveInteger]:
+        """
+        Bit mask for NM-Pdu Payload used to configure the NM filter mask for the Network Management.
+        """
         return self.pncFilterArrayMasks
 
-    def addPncFilterArrayMask(self, value):
-        self.pncFilterArrayMasks.append(value)
+    def addPncFilterArrayMask(self, value: Optional[PositiveInteger]) -> "CommunicationConnector":
+        """
+        Bit mask for NM-Pdu Payload used to configure the NM filter mask for the Network Management.
+        A None value is a no-op and does not overwrite an existing pncFilterArrayMasks.
+        """
+        if value is not None:
+            self.pncFilterArrayMasks.append(value)
         return self
 
-    def getPncGatewayType(self):
+    def getPncGatewayType(self) -> Optional[PncGatewayTypeEnum]:
+        """
+        Defines if this EcuInstance shall implement the Pnc Gateway functionality on this CommunicationConnector and its respective PhysicalChannel. Several Ecu Instances on the same PhysicalChannel can have the PncGateway functionality enabled, but only one of them shall have the pncGatewayType "active".
+        """
         return self.pncGatewayType
 
-    def setPncGatewayType(self, value):
-        self.pncGatewayType = value
+    def setPncGatewayType(self, value: Optional[PncGatewayTypeEnum]) -> "CommunicationConnector":
+        """
+        Defines if this EcuInstance shall implement the Pnc Gateway functionality on this CommunicationConnector and its respective PhysicalChannel. Several Ecu Instances on the same PhysicalChannel can have the PncGateway functionality enabled, but only one of them shall have the pncGatewayType "active".
+        A None value is a no-op and does not overwrite an existing pncGatewayType.
+        """
+        if value is not None:
+            self.pncGatewayType = value
         return self

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
@@ -742,6 +742,7 @@ class CanNmEcu(BusspecificNmEcu):
 
     # CanNmEcu method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.312, p.683
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # (no own attributes; reader/writer coverage via BUS-DEPENDENT-NM-ECUS dispatch)

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
@@ -720,13 +720,14 @@ class UdpNmNode(NmNode):
 
 class BusspecificNmEcu(ARObject, ABC):
     """
-    Abstract base class for bus-specific network management ECU
-    configurations, defining common properties for different
-    types of bus-specific NM implementations.
+    Busspecific NmEcu attributes.
     """
 
     # BusspecificNmEcu method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.301, p.675
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
 
     def __init__(self):
         if type(self) is BusspecificNmEcu:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py
@@ -737,12 +737,14 @@ class BusspecificNmEcu(ARObject, ABC):
 
 class CanNmEcu(BusspecificNmEcu):
     """
-    Defines CAN-specific network management ECU properties,
-    implementing bus-specific NM features for CAN communication.
+    CAN specific attributes.
     """
 
     # CanNmEcu method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.312, p.683
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # (no own attributes; reader/writer coverage via BUS-DEPENDENT-NM-ECUS dispatch)
 
     def __init__(self):
         super().__init__()

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -238,7 +238,7 @@ class CanTpConnection(TpConnection):
         super().__init__()
 
         # Declares which communication addressing mode is supported.
-        self.addressingFormat: Optional[ARLiteral] = None
+        self.addressingFormat: Optional[CanTpAddressingFormatType] = None
 
         # With this switch Tx Cancellation can be turned on or off. Please note that the Rx Cancellation is always enabled.
         self.cancellation: Optional[Boolean] = None
@@ -285,11 +285,11 @@ class CanTpConnection(TpConnection):
         # The source of the TP connection.
         self.transmitterRef: Optional[RefType] = None
 
-    def getAddressingFormat(self) -> Optional[ARLiteral]:
+    def getAddressingFormat(self) -> Optional[CanTpAddressingFormatType]:
         """Declares which communication addressing mode is supported."""
         return self.addressingFormat
 
-    def setAddressingFormat(self, value: Optional[ARLiteral]) -> "CanTpConnection":
+    def setAddressingFormat(self, value: Optional[CanTpAddressingFormatType]) -> "CanTpConnection":
         """
         Declares which communication addressing mode is supported.
         A None value is a no-op and does not overwrite an existing addressingFormat.

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -4,8 +4,9 @@
 from abc import ABC
 from typing import List, Optional
 
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import TpConnection
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DoIp import AbstractDoIpLogicAddressProps
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, Referrable
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, Integer, PositiveInteger, RefType, TimeValue
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import FibexElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
@@ -130,49 +131,6 @@ class CanTpChannel(Identifiable):
         if value is not None:
             self.channelId = value
         return self
-
-
-class TpConnectionIdent(Referrable):
-    """
-    Represents a transport protocol connection identifier,
-    providing a referenceable identifier for transport protocol
-    connections in the communication system.
-    """
-
-    # TpConnectionIdent method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-
-    def __init__(self, parent, short_name):
-        super().__init__(parent, short_name)
-
-
-class TpConnection(ARObject, ABC):
-    """
-    Abstract base class for transport protocol connections,
-    defining common properties for different types of transport
-    protocol connections including connection identification.
-    """
-
-    # TpConnection method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getIdent                     [x] impl  [ ] docstring  [ ] test
-    # [ ] createTpConnectionIdent      [x] impl  [ ] docstring  [ ] test
-
-    def __init__(self):
-        if type(self) is TpConnection:
-            raise TypeError("TpConnection is an abstract class.")
-
-        super().__init__()
-
-        self.ident: TpConnectionIdent = None
-
-    def getIdent(self):
-        return self.ident
-
-    def createTpConnectionIdent(self, short_name: str):
-        ident = TpConnectionIdent(self, short_name)
-        self.ident = ident
-        return ident
 
 
 class CanTpConnection(TpConnection):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -546,80 +546,121 @@ class CanTpEcu(ARObject):
 
 class CanTpNode(Identifiable):
     """
-    Represents a CAN transport protocol node in the system,
-    defining connector references, timing parameters, and
-    address references for CAN TP node configuration.
+    TP Node (Sender or Receiver) provides the TP Address and the connection to the Topology description.
     """
 
     # CanTpNode method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getConnectorRef              [x] impl  [ ] docstring  [ ] test
-    # [ ] setConnectorRef              [x] impl  [ ] docstring  [ ] test
-    # [ ] getMaxFcWait                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setMaxFcWait                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getStMin                     [x] impl  [ ] docstring  [ ] test
-    # [ ] setStMin                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getTimeoutAr                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setTimeoutAr                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getTimeoutAs                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setTimeoutAs                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getTpAddressRef              [x] impl  [ ] docstring  [ ] test
-    # [ ] setTpAddressRef              [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.257, p.611
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getConnectorRef    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setConnectorRef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMaxFcWait       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMaxFcWait       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getStMin           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setStMin           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTimeoutAr       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTimeoutAr       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTimeoutAs       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTimeoutAs       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTpAddressRef    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTpAddressRef    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.connectorRef: RefType = None
-        self.maxFcWait: Integer = None
-        self.stMin: TimeValue = None
-        self.timeoutAr: TimeValue = None
-        self.timeoutAs: TimeValue = None
-        self.tpAddressRef: RefType = None
+        # Association to a CommunicationConnector in the topology description. In a System Description this reference is mandatory. In an ECU Extract this reference is optional (references to ECUs that are not part of the ECU Extract shall be avoided).
+        self.connectorRef: Optional[RefType] = None
 
-    def getConnectorRef(self):
+        # This attribute defines the maximum number of flow control PDUs that can be consecutively be transmitted by a receiver.
+        self.maxFcWait: Optional[Integer] = None
+
+        # Sets the duration of the minimum time the CanTp sender shall wait between the transmissions of two CF N-PDUs.
+        self.stMin: Optional[TimeValue] = None
+
+        # This attribute states the timeout between the PDU transmit request of the Transport Layer to the Can Interface and the corresponding confirmation of the Can Interface on the receiver side (for FC or AF). Specified in seconds.
+        self.timeoutAr: Optional[TimeValue] = None
+
+        # This attribute states the timeout between the PDU transmit request for the first PDU of the group used in the current connection of the Transport Layer to the Can Interface and the corresponding confirmation of the Can Interface (when having sent the last PDU of the group used in this connection) on the sender side (SF-x, FF-x, CF or FC (in case of Transmit Cancellation)). Specified in seconds.
+        self.timeoutAs: Optional[TimeValue] = None
+
+        # Reference to the TP Address that is used by the TpNode. This reference is optional in case that the multicast TP Address is used (reference from TpConnection).
+        self.tpAddressRef: Optional[RefType] = None
+
+    def getConnectorRef(self) -> Optional[RefType]:
+        """Association to a CommunicationConnector in the topology description. In a System Description this reference is mandatory. In an ECU Extract this reference is optional (references to ECUs that are not part of the ECU Extract shall be avoided)."""
         return self.connectorRef
 
-    def setConnectorRef(self, value):
+    def setConnectorRef(self, value: Optional[RefType]) -> "CanTpNode":
+        """
+        Association to a CommunicationConnector in the topology description. In a System Description this reference is mandatory. In an ECU Extract this reference is optional (references to ECUs that are not part of the ECU Extract shall be avoided).
+        A None value is a no-op and does not overwrite an existing connectorRef.
+        """
         if value is not None:
             self.connectorRef = value
         return self
 
-    def getMaxFcWait(self):
+    def getMaxFcWait(self) -> Optional[Integer]:
+        """This attribute defines the maximum number of flow control PDUs that can be consecutively be transmitted by a receiver."""
         return self.maxFcWait
 
-    def setMaxFcWait(self, value):
+    def setMaxFcWait(self, value: Optional[Integer]) -> "CanTpNode":
+        """
+        This attribute defines the maximum number of flow control PDUs that can be consecutively be transmitted by a receiver.
+        A None value is a no-op and does not overwrite an existing maxFcWait.
+        """
         if value is not None:
             self.maxFcWait = value
         return self
 
-    def getStMin(self):
+    def getStMin(self) -> Optional[TimeValue]:
+        """Sets the duration of the minimum time the CanTp sender shall wait between the transmissions of two CF N-PDUs."""
         return self.stMin
 
-    def setStMin(self, value):
+    def setStMin(self, value: Optional[TimeValue]) -> "CanTpNode":
+        """
+        Sets the duration of the minimum time the CanTp sender shall wait between the transmissions of two CF N-PDUs.
+        A None value is a no-op and does not overwrite an existing stMin.
+        """
         if value is not None:
             self.stMin = value
         return self
 
-    def getTimeoutAr(self):
+    def getTimeoutAr(self) -> Optional[TimeValue]:
+        """This attribute states the timeout between the PDU transmit request of the Transport Layer to the Can Interface and the corresponding confirmation of the Can Interface on the receiver side (for FC or AF). Specified in seconds."""
         return self.timeoutAr
 
-    def setTimeoutAr(self, value):
+    def setTimeoutAr(self, value: Optional[TimeValue]) -> "CanTpNode":
+        """
+        This attribute states the timeout between the PDU transmit request of the Transport Layer to the Can Interface and the corresponding confirmation of the Can Interface on the receiver side (for FC or AF). Specified in seconds.
+        A None value is a no-op and does not overwrite an existing timeoutAr.
+        """
         if value is not None:
             self.timeoutAr = value
         return self
 
-    def getTimeoutAs(self):
+    def getTimeoutAs(self) -> Optional[TimeValue]:
+        """This attribute states the timeout between the PDU transmit request for the first PDU of the group used in the current connection of the Transport Layer to the Can Interface and the corresponding confirmation of the Can Interface (when having sent the last PDU of the group used in this connection) on the sender side (SF-x, FF-x, CF or FC (in case of Transmit Cancellation)). Specified in seconds."""
         return self.timeoutAs
 
-    def setTimeoutAs(self, value):
+    def setTimeoutAs(self, value: Optional[TimeValue]) -> "CanTpNode":
+        """
+        This attribute states the timeout between the PDU transmit request for the first PDU of the group used in the current connection of the Transport Layer to the Can Interface and the corresponding confirmation of the Can Interface (when having sent the last PDU of the group used in this connection) on the sender side (SF-x, FF-x, CF or FC (in case of Transmit Cancellation)). Specified in seconds.
+        A None value is a no-op and does not overwrite an existing timeoutAs.
+        """
         if value is not None:
             self.timeoutAs = value
         return self
 
-    def getTpAddressRef(self):
+    def getTpAddressRef(self) -> Optional[RefType]:
+        """Reference to the TP Address that is used by the TpNode. This reference is optional in case that the multicast TP Address is used (reference from TpConnection)."""
         return self.tpAddressRef
 
-    def setTpAddressRef(self, value):
+    def setTpAddressRef(self, value: Optional[RefType]) -> "CanTpNode":
+        """
+        Reference to the TP Address that is used by the TpNode. This reference is optional in case that the multicast TP Address is used (reference from TpConnection).
+        A None value is a no-op and does not overwrite an existing tpAddressRef.
+        """
         if value is not None:
             self.tpAddressRef = value
         return self

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -52,36 +52,49 @@ class TpConfig(FibexElement, ABC):
 
 class CanTpAddress(Identifiable):
     """
-    Represents a CAN transport protocol address in the system,
-    defining the transport address and address extension values
-    for CAN communication endpoints.
+    An ECUs TP address on the referenced channel. This represents the diagnostic Address.
     """
 
     # CanTpAddress method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getTpAddress                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setTpAddress                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getTpAddressExtensionValue   [x] impl  [ ] docstring  [ ] test
-    # [ ] setTpAddressExtensionValue   [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.255, p.610
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getTpAddress                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTpAddress                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTpAddressExtensionValue   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTpAddressExtensionValue   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.tpAddress: Integer = None
-        self.tpAddressExtensionValue: Integer = None
+        # An ECUs TP address on the referenced channel. This represents the diagnostic Address.
+        self.tpAddress: Optional[Integer] = None
 
-    def getTpAddress(self):
+        # If the mixed addressing format is used, this parameter contains the transport protocol address extension value.
+        self.tpAddressExtensionValue: Optional[Integer] = None
+
+    def getTpAddress(self) -> Optional[Integer]:
+        """An ECUs TP address on the referenced channel. This represents the diagnostic Address."""
         return self.tpAddress
 
-    def setTpAddress(self, value):
+    def setTpAddress(self, value: Optional[Integer]) -> "CanTpAddress":
+        """
+        An ECUs TP address on the referenced channel. This represents the diagnostic Address.
+        A None value is a no-op and does not overwrite an existing tpAddress.
+        """
         if value is not None:
             self.tpAddress = value
         return self
 
-    def getTpAddressExtensionValue(self):
+    def getTpAddressExtensionValue(self) -> Optional[Integer]:
+        """If the mixed addressing format is used, this parameter contains the transport protocol address extension value."""
         return self.tpAddressExtensionValue
 
-    def setTpAddressExtensionValue(self, value):
+    def setTpAddressExtensionValue(self, value: Optional[Integer]) -> "CanTpAddress":
+        """
+        If the mixed addressing format is used, this parameter contains the transport protocol address extension value.
+        A None value is a no-op and does not overwrite an existing tpAddressExtensionValue.
+        """
         if value is not None:
             self.tpAddressExtensionValue = value
         return self

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -668,77 +668,102 @@ class CanTpNode(Identifiable):
 
 class CanTpConfig(TpConfig):
     """
-    Represents CAN transport protocol configuration in the system,
-    organizing addresses, channels, connections, ECUs, and nodes
-    for comprehensive CAN TP communication setup.
+    This element defines exactly one CAN TP Configuration. One CanTpConfig element shall be created for each CAN Network in the System.
     """
 
     # CanTpConfig method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getTpAddresses               [x] impl  [ ] docstring  [ ] test
-    # [ ] createCanTpAddress           [x] impl  [ ] docstring  [ ] test
-    # [ ] getTpChannels                [x] impl  [ ] docstring  [ ] test
-    # [ ] createCanTpChannel           [x] impl  [ ] docstring  [ ] test
-    # [ ] getTpConnections             [x] impl  [ ] docstring  [ ] test
-    # [ ] addTpConnection              [x] impl  [ ] docstring  [ ] test
-    # [ ] getTpEcus                    [x] impl  [ ] docstring  [ ] test
-    # [ ] addTpEcu                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getTpNodes                   [x] impl  [ ] docstring  [ ] test
-    # [ ] createCanTpNode              [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.251, p.607
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getTpAddresses          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createCanTpAddress      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTpChannels           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createCanTpChannel      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTpConnections        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addTpConnection         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTpEcus               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addTpEcu                [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTpNodes              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] createCanTpNode         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
+        # Collection of TP Addresses.
         self.tpAddresses: List[CanTpAddress] = []
+
+        # Configuration of CAN TP channels.
         self.tpChannels: List[CanTpChannel] = []
+
+        # Senders and receivers of CAN TP messages.
         self.tpConnections: List[CanTpConnection] = []
+
+        # Collection of TP Ecus
         self.tpEcus: List[CanTpEcu] = []
+
+        # Senders and receivers of Can TP messages.
         self.tpNodes: List[CanTpNode] = []
 
-    def getTpAddresses(self):
+    def getTpAddresses(self) -> List[CanTpAddress]:
+        """Collection of TP Addresses."""
         return self.tpAddresses
 
-    def createCanTpAddress(self, short_name: str):
+    def createCanTpAddress(self, short_name: str) -> CanTpAddress:
+        """Collection of TP Addresses."""
         if not self.IsElementExists(short_name):
             address = CanTpAddress(self, short_name)
             self.addElement(address)
             self.tpAddresses.append(address)
         return self.getElement(short_name)
 
-    def getTpChannels(self):
+    def getTpChannels(self) -> List[CanTpChannel]:
+        """Configuration of CAN TP channels."""
         return self.tpChannels
 
-    def createCanTpChannel(self, short_name: str):
+    def createCanTpChannel(self, short_name: str) -> CanTpChannel:
+        """Configuration of CAN TP channels."""
         if not self.IsElementExists(short_name):
-            address = CanTpChannel(self, short_name)
-            self.addElement(address)
-            self.tpChannels.append(address)
+            channel = CanTpChannel(self, short_name)
+            self.addElement(channel)
+            self.tpChannels.append(channel)
         return self.getElement(short_name)
 
-    def getTpConnections(self):
+    def getTpConnections(self) -> List[CanTpConnection]:
+        """Senders and receivers of CAN TP messages."""
         return self.tpConnections
 
-    def addTpConnection(self, value):
+    def addTpConnection(self, value: Optional[CanTpConnection]) -> "CanTpConfig":
+        """
+        Senders and receivers of CAN TP messages.
+        A None value is a no-op and is not appended to tpConnections.
+        """
         if value is not None:
             self.tpConnections.append(value)
         return self
 
-    def getTpEcus(self):
+    def getTpEcus(self) -> List[CanTpEcu]:
+        """Collection of TP Ecus"""
         return self.tpEcus
 
-    def addTpEcu(self, value):
+    def addTpEcu(self, value: Optional[CanTpEcu]) -> "CanTpConfig":
+        """
+        Collection of TP Ecus
+        A None value is a no-op and is not appended to tpEcus.
+        """
         if value is not None:
             self.tpEcus.append(value)
         return self
 
-    def getTpNodes(self):
+    def getTpNodes(self) -> List[CanTpNode]:
+        """Senders and receivers of Can TP messages."""
         return self.tpNodes
 
-    def createCanTpNode(self, short_name: str):
+    def createCanTpNode(self, short_name: str) -> CanTpNode:
+        """Senders and receivers of Can TP messages."""
         if not self.IsElementExists(short_name):
-            address = CanTpNode(self, short_name)
-            self.addElement(address)
-            self.tpNodes.append(address)
+            node = CanTpNode(self, short_name)
+            self.addElement(node)
+            self.tpNodes.append(node)
         return self.getElement(short_name)
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import TpConnection
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DoIp import AbstractDoIpLogicAddressProps
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Boolean, Integer, PositiveInteger, RefType, TimeValue
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Boolean, Integer, PositiveInteger, RefType, TimeValue, ARLiteral
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import FibexElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 
@@ -193,190 +193,302 @@ class NetworkTargetAddressType(AREnum):
 
 class CanTpConnection(TpConnection):
     """
-    Represents a CAN transport protocol connection in the system,
-    defining addressing format, cancellation settings, channel
-    configuration, and timing parameters for CAN TP communication.
+    A connection identifies the sender and the receiver of this particular communication. The CanTp module routes a Pdu
+    through this connection. atpVariation: Derived, because TpNode can vary.
     """
 
     # CanTpConnection method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getAddressingFormat          [x] impl  [ ] docstring  [ ] test
-    # [ ] setAddressingFormat          [x] impl  [ ] docstring  [ ] test
-    # [ ] getCancellation              [x] impl  [ ] docstring  [ ] test
-    # [ ] setCancellation              [x] impl  [ ] docstring  [ ] test
-    # [ ] getCanTpChannelRef           [x] impl  [ ] docstring  [ ] test
-    # [ ] setCanTpChannelRef           [x] impl  [ ] docstring  [ ] test
-    # [ ] getDataPduRef                [x] impl  [ ] docstring  [ ] test
-    # [ ] setDataPduRef                [x] impl  [ ] docstring  [ ] test
-    # [ ] getFlowControlPduRef         [x] impl  [ ] docstring  [ ] test
-    # [ ] setFlowControlPduRef         [x] impl  [ ] docstring  [ ] test
-    # [ ] getMaxBlockSize              [x] impl  [ ] docstring  [ ] test
-    # [ ] setMaxBlockSize              [x] impl  [ ] docstring  [ ] test
-    # [ ] getMulticastRef              [x] impl  [ ] docstring  [ ] test
-    # [ ] setMulticastRef              [x] impl  [ ] docstring  [ ] test
-    # [ ] getPaddingActivation         [x] impl  [ ] docstring  [ ] test
-    # [ ] setPaddingActivation         [x] impl  [ ] docstring  [ ] test
-    # [ ] getReceiverRefs              [x] impl  [ ] docstring  [ ] test
-    # [ ] addReceiverRef               [x] impl  [ ] docstring  [ ] test
-    # [ ] getTaType                    [x] impl  [ ] docstring  [ ] test
-    # [ ] setTaType                    [x] impl  [ ] docstring  [ ] test
-    # [ ] getTimeoutBr                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setTimeoutBr                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getTimeoutBs                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setTimeoutBs                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getTimeoutCr                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setTimeoutCr                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getTimeoutCs                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setTimeoutCs                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getTpSduRef                  [x] impl  [ ] docstring  [ ] test
-    # [ ] setTpSduRef                  [x] impl  [ ] docstring  [ ] test
-    # [ ] getTransmitterRef            [x] impl  [ ] docstring  [ ] test
-    # [ ] setTransmitterRef            [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.253 (with Table 6.252 block), p.608-609
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getAddressingFormat       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setAddressingFormat       [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCancellation           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCancellation           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getCanTpChannelRef        [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCanTpChannelRef        [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getDataPduRef             [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setDataPduRef             [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getFlowControlPduRef      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setFlowControlPduRef      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMaxBlockSize           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMaxBlockSize           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getMulticastRef           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setMulticastRef           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getPaddingActivation      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setPaddingActivation      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getReceiverRefs           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] addReceiverRef            [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTaType                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTaType                 [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTimeoutBr              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTimeoutBr              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTimeoutBs              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTimeoutBs              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTimeoutCr              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTimeoutCr              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTimeoutCs              [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTimeoutCs              [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTpSduRef               [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTpSduRef               [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getTransmitterRef         [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setTransmitterRef         [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.addressingFormat = None
-        self.cancellation: Boolean = None
-        self.canTpChannelRef: RefType = None
-        self.dataPduRef: RefType = None
-        self.flowControlPduRef: RefType = None
-        self.maxBlockSize: Integer = None
-        self.multicastRef: RefType = None
-        self.paddingActivation: Boolean = None
-        self.receiverRefs: List[RefType] = []
-        self.taType = None
-        self.timeoutBr: TimeValue = None
-        self.timeoutBs: TimeValue = None
-        self.timeoutCr: TimeValue = None
-        self.timeoutCs: TimeValue = None
-        self.tpSduRef: RefType = None
-        self.transmitterRef: RefType = None
+        # Declares which communication addressing mode is supported.
+        self.addressingFormat: Optional[ARLiteral] = None
 
-    def getAddressingFormat(self):
+        # With this switch Tx Cancellation can be turned on or off. Please note that the Rx Cancellation is always enabled.
+        self.cancellation: Optional[Boolean] = None
+
+        # Reference to the CanTpChannel on which this CanTp Connection is realized.
+        self.canTpChannelRef: Optional[RefType] = None
+
+        # Reference to an Data NPdu.
+        self.dataPduRef: Optional[RefType] = None
+
+        # Reference to the Flow Control NPdu.
+        self.flowControlPduRef: Optional[RefType] = None
+
+        # The maximum number of N-PDUs the CanTp receiver allows the sender to send, before waiting for an authorization to continue transmission of the following N-PDUs. For further details on this parameter value see ISO 15765-2 specification. Note: For reasons of buffer length, the CAN Transport Layer can adapt the BS value within the limit of this maximum BS
+        self.maxBlockSize: Optional[Integer] = None
+
+        # TP address for 1:n connections.
+        self.multicastRef: Optional[RefType] = None
+
+        # This specifies whether or not Sfs, FCs and the last CF shall be padded to 8 bytes length in case it contains less payload. true: The N-PDU received uses padding for SF, FC and the last CF. (N-PDU length is always 8 bytes) false: The N-PDU received does not use padding for SF, CF and the last CF. (N-PDU length is dynamic)
+        self.paddingActivation: Optional[Boolean] = None
+
+        # The target of the TP connection.
+        self.receiverRefs: List[RefType] = []
+
+        # Network Target Address type.
+        self.taType: Optional[ARLiteral] = None
+
+        # Value in seconds of the performance requirement for (N_ Br + N_Ar). N_Br is the elapsed time between the receiving indication of a FF or CF or the transmit confirmation of a FC, until the transmit request of the next FC.
+        self.timeoutBr: Optional[TimeValue] = None
+
+        # This parameter defines the timeout for waiting for an FC or AF on the sender side in an 1:1 connection. Specified in seconds.
+        self.timeoutBs: Optional[TimeValue] = None
+
+        # This parameter defines the timeout value for waiting for a CF or FF-x (in case of retry) after receiving the last CF or after sending an FC or AF on the receiver side. Specified in seconds.
+        self.timeoutCr: Optional[TimeValue] = None
+
+        # The attribute timeoutCs represents the time (in seconds) which elapses between the transmit request of a CF N-PDU until the transmit request of the next CF N-PDU.
+        self.timeoutCs: Optional[TimeValue] = None
+
+        # Reference to an IPdu that is segmented by the Transport Protocol.
+        self.tpSduRef: Optional[RefType] = None
+
+        # The source of the TP connection.
+        self.transmitterRef: Optional[RefType] = None
+
+    def getAddressingFormat(self) -> Optional[ARLiteral]:
+        """Declares which communication addressing mode is supported."""
         return self.addressingFormat
 
-    def setAddressingFormat(self, value):
+    def setAddressingFormat(self, value: Optional[ARLiteral]) -> "CanTpConnection":
+        """
+        Declares which communication addressing mode is supported.
+        A None value is a no-op and does not overwrite an existing addressingFormat.
+        """
         if value is not None:
             self.addressingFormat = value
         return self
 
-    def getCancellation(self):
+    def getCancellation(self) -> Optional[Boolean]:
+        """With this switch Tx Cancellation can be turned on or off. Please note that the Rx Cancellation is always enabled."""
         return self.cancellation
 
-    def setCancellation(self, value):
+    def setCancellation(self, value: Optional[Boolean]) -> "CanTpConnection":
+        """
+        With this switch Tx Cancellation can be turned on or off. Please note that the Rx Cancellation is always enabled.
+        A None value is a no-op and does not overwrite an existing cancellation.
+        """
         if value is not None:
             self.cancellation = value
         return self
 
-    def getCanTpChannelRef(self):
+    def getCanTpChannelRef(self) -> Optional[RefType]:
+        """Reference to the CanTpChannel on which this CanTp Connection is realized."""
         return self.canTpChannelRef
 
-    def setCanTpChannelRef(self, value):
+    def setCanTpChannelRef(self, value: Optional[RefType]) -> "CanTpConnection":
+        """
+        Reference to the CanTpChannel on which this CanTp Connection is realized.
+        A None value is a no-op and does not overwrite an existing canTpChannelRef.
+        """
         if value is not None:
             self.canTpChannelRef = value
         return self
 
-    def getDataPduRef(self):
+    def getDataPduRef(self) -> Optional[RefType]:
+        """Reference to an Data NPdu."""
         return self.dataPduRef
 
-    def setDataPduRef(self, value):
+    def setDataPduRef(self, value: Optional[RefType]) -> "CanTpConnection":
+        """
+        Reference to an Data NPdu.
+        A None value is a no-op and does not overwrite an existing dataPduRef.
+        """
         if value is not None:
             self.dataPduRef = value
         return self
 
-    def getFlowControlPduRef(self):
+    def getFlowControlPduRef(self) -> Optional[RefType]:
+        """Reference to the Flow Control NPdu."""
         return self.flowControlPduRef
 
-    def setFlowControlPduRef(self, value):
+    def setFlowControlPduRef(self, value: Optional[RefType]) -> "CanTpConnection":
+        """
+        Reference to the Flow Control NPdu.
+        A None value is a no-op and does not overwrite an existing flowControlPduRef.
+        """
         if value is not None:
             self.flowControlPduRef = value
         return self
 
-    def getMaxBlockSize(self):
+    def getMaxBlockSize(self) -> Optional[Integer]:
+        """The maximum number of N-PDUs the CanTp receiver allows the sender to send, before waiting for an authorization to continue transmission of the following N-PDUs. For further details on this parameter value see ISO 15765-2 specification. Note: For reasons of buffer length, the CAN Transport Layer can adapt the BS value within the limit of this maximum BS"""
         return self.maxBlockSize
 
-    def setMaxBlockSize(self, value):
+    def setMaxBlockSize(self, value: Optional[Integer]) -> "CanTpConnection":
+        """
+        The maximum number of N-PDUs the CanTp receiver allows the sender to send, before waiting for an authorization to continue transmission of the following N-PDUs. For further details on this parameter value see ISO 15765-2 specification. Note: For reasons of buffer length, the CAN Transport Layer can adapt the BS value within the limit of this maximum BS
+        A None value is a no-op and does not overwrite an existing maxBlockSize.
+        """
         if value is not None:
             self.maxBlockSize = value
         return self
 
-    def getMulticastRef(self):
+    def getMulticastRef(self) -> Optional[RefType]:
+        """TP address for 1:n connections."""
         return self.multicastRef
 
-    def setMulticastRef(self, value):
+    def setMulticastRef(self, value: Optional[RefType]) -> "CanTpConnection":
+        """
+        TP address for 1:n connections.
+        A None value is a no-op and does not overwrite an existing multicastRef.
+        """
         if value is not None:
             self.multicastRef = value
         return self
 
-    def getPaddingActivation(self):
+    def getPaddingActivation(self) -> Optional[Boolean]:
+        """This specifies whether or not Sfs, FCs and the last CF shall be padded to 8 bytes length in case it contains less payload. true: The N-PDU received uses padding for SF, FC and the last CF. (N-PDU length is always 8 bytes) false: The N-PDU received does not use padding for SF, CF and the last CF. (N-PDU length is dynamic)"""
         return self.paddingActivation
 
-    def setPaddingActivation(self, value):
+    def setPaddingActivation(self, value: Optional[Boolean]) -> "CanTpConnection":
+        """
+        This specifies whether or not Sfs, FCs and the last CF shall be padded to 8 bytes length in case it contains less payload. true: The N-PDU received uses padding for SF, FC and the last CF. (N-PDU length is always 8 bytes) false: The N-PDU received does not use padding for SF, CF and the last CF. (N-PDU length is dynamic)
+        A None value is a no-op and does not overwrite an existing paddingActivation.
+        """
         if value is not None:
             self.paddingActivation = value
         return self
 
-    def getReceiverRefs(self):
+    def getReceiverRefs(self) -> List[RefType]:
+        """The target of the TP connection."""
         return self.receiverRefs
 
-    def addReceiverRef(self, value):
+    def addReceiverRef(self, value: Optional[RefType]) -> "CanTpConnection":
+        """
+        The target of the TP connection.
+        A None value is a no-op and is not appended to receiverRefs.
+        """
         if value is not None:
             self.receiverRefs.append(value)
         return self
 
-    def getTaType(self):
+    def getTaType(self) -> Optional[ARLiteral]:
+        """Network Target Address type."""
         return self.taType
 
-    def setTaType(self, value):
+    def setTaType(self, value: Optional[ARLiteral]) -> "CanTpConnection":
+        """
+        Network Target Address type.
+        A None value is a no-op and does not overwrite an existing taType.
+        """
         if value is not None:
             self.taType = value
         return self
 
-    def getTimeoutBr(self):
+    def getTimeoutBr(self) -> Optional[TimeValue]:
+        """Value in seconds of the performance requirement for (N_ Br + N_Ar). N_Br is the elapsed time between the receiving indication of a FF or CF or the transmit confirmation of a FC, until the transmit request of the next FC."""
         return self.timeoutBr
 
-    def setTimeoutBr(self, value):
+    def setTimeoutBr(self, value: Optional[TimeValue]) -> "CanTpConnection":
+        """
+        Value in seconds of the performance requirement for (N_ Br + N_Ar). N_Br is the elapsed time between the receiving indication of a FF or CF or the transmit confirmation of a FC, until the transmit request of the next FC.
+        A None value is a no-op and does not overwrite an existing timeoutBr.
+        """
         if value is not None:
             self.timeoutBr = value
         return self
 
-    def getTimeoutBs(self):
+    def getTimeoutBs(self) -> Optional[TimeValue]:
+        """This parameter defines the timeout for waiting for an FC or AF on the sender side in an 1:1 connection. Specified in seconds."""
         return self.timeoutBs
 
-    def setTimeoutBs(self, value):
+    def setTimeoutBs(self, value: Optional[TimeValue]) -> "CanTpConnection":
+        """
+        This parameter defines the timeout for waiting for an FC or AF on the sender side in an 1:1 connection. Specified in seconds.
+        A None value is a no-op and does not overwrite an existing timeoutBs.
+        """
         if value is not None:
             self.timeoutBs = value
         return self
 
-    def getTimeoutCr(self):
+    def getTimeoutCr(self) -> Optional[TimeValue]:
+        """This parameter defines the timeout value for waiting for a CF or FF-x (in case of retry) after receiving the last CF or after sending an FC or AF on the receiver side. Specified in seconds."""
         return self.timeoutCr
 
-    def setTimeoutCr(self, value):
+    def setTimeoutCr(self, value: Optional[TimeValue]) -> "CanTpConnection":
+        """
+        This parameter defines the timeout value for waiting for a CF or FF-x (in case of retry) after receiving the last CF or after sending an FC or AF on the receiver side. Specified in seconds.
+        A None value is a no-op and does not overwrite an existing timeoutCr.
+        """
         if value is not None:
             self.timeoutCr = value
         return self
 
-    def getTimeoutCs(self):
+    def getTimeoutCs(self) -> Optional[TimeValue]:
+        """The attribute timeoutCs represents the time (in seconds) which elapses between the transmit request of a CF N-PDU until the transmit request of the next CF N-PDU."""
         return self.timeoutCs
 
-    def setTimeoutCs(self, value):
+    def setTimeoutCs(self, value: Optional[TimeValue]) -> "CanTpConnection":
+        """
+        The attribute timeoutCs represents the time (in seconds) which elapses between the transmit request of a CF N-PDU until the transmit request of the next CF N-PDU.
+        A None value is a no-op and does not overwrite an existing timeoutCs.
+        """
         if value is not None:
             self.timeoutCs = value
         return self
 
-    def getTpSduRef(self):
+    def getTpSduRef(self) -> Optional[RefType]:
+        """Reference to an IPdu that is segmented by the Transport Protocol."""
         return self.tpSduRef
 
-    def setTpSduRef(self, value):
+    def setTpSduRef(self, value: Optional[RefType]) -> "CanTpConnection":
+        """
+        Reference to an IPdu that is segmented by the Transport Protocol.
+        A None value is a no-op and does not overwrite an existing tpSduRef.
+        """
         if value is not None:
             self.tpSduRef = value
         return self
 
-    def getTransmitterRef(self):
+    def getTransmitterRef(self) -> Optional[RefType]:
+        """The source of the TP connection."""
         return self.transmitterRef
 
-    def setTransmitterRef(self, value):
+    def setTransmitterRef(self, value: Optional[RefType]) -> "CanTpConnection":
+        """
+        The source of the TP connection.
+        A None value is a no-op and does not overwrite an existing transmitterRef.
+        """
         if value is not None:
             self.transmitterRef = value
         return self

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -679,6 +679,7 @@ class CanTpConfig(TpConfig):
 
     # CanTpConfig method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.251, p.607
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__                [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getTpAddresses          [x] impl  [x] docstring  [x] test  [—] reader  [x] writer

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -202,6 +202,7 @@ class CanTpConnection(TpConnection):
 
     # CanTpConnection method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.253 (with Table 6.252 block), p.608-609
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__                  [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getAddressingFormat       [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
@@ -504,6 +505,7 @@ class CanTpEcu(ARObject):
 
     # CanTpEcu method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.256, p.610
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__                    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getCycleTimeMainFunction    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
@@ -554,6 +556,7 @@ class CanTpNode(Identifiable):
 
     # CanTpNode method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.257, p.611
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__           [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getConnectorRef    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -102,37 +102,33 @@ class CanTpAddress(Identifiable):
 
 class CanTpChannel(Identifiable):
     """
-    Represents a CAN transport protocol channel in the system,
-    defining the channel ID and channel mode for CAN TP communication.
+    Configuration parameters of the CanTp channel.
     """
 
     # CanTpChannel method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getChannelId                 [x] impl  [ ] docstring  [ ] test
-    # [ ] setChannelId                 [x] impl  [ ] docstring  [ ] test
-    # [ ] getChannelMode               [x] impl  [ ] docstring  [ ] test
-    # [ ] setChannelMode               [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.252, p.608
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getChannelId    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setChannelId    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.channelId: PositiveInteger = None
-        self.channelMode = None
+        # The id of the channel. The value shall be unique for each channel.
+        self.channelId: Optional[PositiveInteger] = None
 
-    def getChannelId(self):
+    def getChannelId(self) -> Optional[PositiveInteger]:
+        """The id of the channel. The value shall be unique for each channel."""
         return self.channelId
 
-    def setChannelId(self, value):
+    def setChannelId(self, value: Optional[PositiveInteger]) -> "CanTpChannel":
+        """
+        The id of the channel. The value shall be unique for each channel.
+        A None value is a no-op and does not overwrite an existing channelId.
+        """
         if value is not None:
             self.channelId = value
-        return self
-
-    def getChannelMode(self):
-        return self.channelMode
-
-    def setChannelMode(self, value):
-        if value is not None:
-            self.channelMode = value
         return self
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import TpConnection
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DoIp import AbstractDoIpLogicAddressProps
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, Integer, PositiveInteger, RefType, TimeValue
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Boolean, Integer, PositiveInteger, RefType, TimeValue
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import FibexElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 
@@ -131,6 +131,64 @@ class CanTpChannel(Identifiable):
         if value is not None:
             self.channelId = value
         return self
+
+
+class CanTpAddressingFormatType(AREnum):
+    """Declares which communication addressing mode is supported."""
+
+    # CanTpAddressingFormatType method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.254, p.610
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods)
+
+    # To use extended addressing format. Tags: atp.EnumerationLiteralIndex=0
+    ENUM_EXTENDED = "EXTENDED"
+
+    # To use mixed 11bit addressing format. Tags: atp.EnumerationLiteralIndex=1
+    ENUM_MIXED = "MIXED"
+
+    # To use mixed 29bit addressing format Tags: atp.EnumerationLiteralIndex=2
+    ENUM_MIXED_29BIT = "MIXED-29-BIT"
+
+    # To use normal fixed addressing format Tags: atp.EnumerationLiteralIndex=3
+    ENUM_NORMALFIXED = "NORMALFIXED"
+
+    # To use normal addressing format. Tags: atp.EnumerationLiteralIndex=4
+    ENUM_STANDARD = "STANDARD"
+
+    def __init__(self):
+        super().__init__(
+            [
+                CanTpAddressingFormatType.ENUM_EXTENDED,
+                CanTpAddressingFormatType.ENUM_MIXED,
+                CanTpAddressingFormatType.ENUM_MIXED_29BIT,
+                CanTpAddressingFormatType.ENUM_NORMALFIXED,
+                CanTpAddressingFormatType.ENUM_STANDARD,
+            ]
+        )
+
+
+class NetworkTargetAddressType(AREnum):
+    """Network Target Address type (see ISO 15765-2)."""
+
+    # NetworkTargetAddressType method parity checklist:
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.258, p.611
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # (no methods)
+
+    # Functional request type Tags: atp.EnumerationLiteralIndex=0
+    ENUM_FUNCTIONAL = "FUNCTIONAL"
+
+    # Physical request type Tags: atp.EnumerationLiteralIndex=2
+    ENUM_PHYSICAL = "PHYSICAL"
+
+    def __init__(self):
+        super().__init__(
+            [
+                NetworkTargetAddressType.ENUM_FUNCTIONAL,
+                NetworkTargetAddressType.ENUM_PHYSICAL,
+            ]
+        )
 
 
 class CanTpConnection(TpConnection):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -496,36 +496,49 @@ class CanTpConnection(TpConnection):
 
 class CanTpEcu(ARObject):
     """
-    Represents a CAN transport protocol ECU configuration,
-    defining cycle time for the main function and ECU instance
-    references for CAN TP communication management.
+    ECU specific TP configuration parameters. Each TpEcu element has a reference to exactly one ECUInstance in the topology.
     """
 
     # CanTpEcu method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getCycleTimeMainFunction     [x] impl  [ ] docstring  [ ] test
-    # [ ] setCycleTimeMainFunction     [x] impl  [ ] docstring  [ ] test
-    # [ ] getEcuInstanceRef            [x] impl  [ ] docstring  [ ] test
-    # [ ] setEcuInstanceRef            [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.256, p.610
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                    [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getCycleTimeMainFunction    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCycleTimeMainFunction    [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
+    # [x] getEcuInstanceRef           [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setEcuInstanceRef           [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self):
         super().__init__()
 
-        self.cycleTimeMainFunction: TimeValue = None
-        self.ecuInstanceRef: RefType = None
+        # The period between successive calls to the Main Function of the AUTOSAR TP. Specified in seconds.
+        self.cycleTimeMainFunction: Optional[TimeValue] = None
 
-    def getCycleTimeMainFunction(self):
+        # Connection to the ECUInstance in the Topology
+        self.ecuInstanceRef: Optional[RefType] = None
+
+    def getCycleTimeMainFunction(self) -> Optional[TimeValue]:
+        """The period between successive calls to the Main Function of the AUTOSAR TP. Specified in seconds."""
         return self.cycleTimeMainFunction
 
-    def setCycleTimeMainFunction(self, value):
+    def setCycleTimeMainFunction(self, value: Optional[TimeValue]) -> "CanTpEcu":
+        """
+        The period between successive calls to the Main Function of the AUTOSAR TP. Specified in seconds.
+        A None value is a no-op and does not overwrite an existing cycleTimeMainFunction.
+        """
         if value is not None:
             self.cycleTimeMainFunction = value
         return self
 
-    def getEcuInstanceRef(self):
+    def getEcuInstanceRef(self) -> Optional[RefType]:
+        """Connection to the ECUInstance in the Topology"""
         return self.ecuInstanceRef
 
-    def setEcuInstanceRef(self, value):
+    def setEcuInstanceRef(self, value: Optional[RefType]) -> "CanTpEcu":
+        """
+        Connection to the ECUInstance in the Topology
+        A None value is a no-op and does not overwrite an existing ecuInstanceRef.
+        """
         if value is not None:
             self.ecuInstanceRef = value
         return self

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -176,6 +176,7 @@ class NetworkTargetAddressType(AREnum):
 
     # NetworkTargetAddressType method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.258, p.611
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # (no methods)
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -58,6 +58,7 @@ class CanTpAddress(Identifiable):
 
     # CanTpAddress method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.255, p.610
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getTpAddress                 [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
@@ -108,6 +109,7 @@ class CanTpChannel(Identifiable):
 
     # CanTpChannel method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.252, p.608
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # [x] __init__        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
     # [x] getChannelId    [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
@@ -138,6 +140,7 @@ class CanTpAddressingFormatType(AREnum):
 
     # CanTpAddressingFormatType method parity checklist:
     # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.254, p.610
+    # Spec verified: R23-11
     # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
     # (no methods)
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols.py
@@ -2,7 +2,7 @@
 # It defines CAN, DoIP, and LIN transport protocol configurations and connections
 
 from abc import ABC
-from typing import List
+from typing import List, Optional
 
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DoIp import AbstractDoIpLogicAddressProps
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, Referrable
@@ -13,15 +13,17 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 
 class TpConfig(FibexElement, ABC):
     """
-    Abstract base class for transport protocol configurations,
-    defining common properties for different types of transport
-    protocol implementations including communication cluster references.
+    Contains all configuration elements for AUTOSAR TP.
     """
 
     # TpConfig method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getCommunicationClusterRef   [x] impl  [ ] docstring  [ ] test
-    # [ ] setCommunicationClusterRef   [x] impl  [ ] docstring  [ ] test
+    # Spec: AUTOSAR_CP_TPS_SystemTemplate.pdf, Table 6.237, p.588
+    # Spec verified: R23-11
+    # Note: class Note taken from XSD TP-CONFIG group documentation (PDF table has no Note row)
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [x] getCommunicationClusterRef      [x] impl  [x] docstring  [x] test  [—] reader  [x] writer
+    # [x] setCommunicationClusterRef      [x] impl  [x] docstring  [x] test  [x] reader  [—] writer
 
     def __init__(self, parent: ARObject, short_name: str):
         if type(self) is TpConfig:
@@ -29,12 +31,20 @@ class TpConfig(FibexElement, ABC):
 
         super().__init__(parent, short_name)
 
-        self.communicationClusterRef: RefType = None
+        # A TpConfig is existing always in the context of exactly one CommunicationCluster.
+        self.communicationClusterRef: Optional[RefType] = None
 
-    def getCommunicationClusterRef(self):
+    def getCommunicationClusterRef(self) -> Optional[RefType]:
+        """
+        A TpConfig is existing always in the context of exactly one CommunicationCluster.
+        """
         return self.communicationClusterRef
 
-    def setCommunicationClusterRef(self, value):
+    def setCommunicationClusterRef(self, value: Optional[RefType]) -> "TpConfig":
+        """
+        A TpConfig is existing always in the context of exactly one CommunicationCluster.
+        A None value is a no-op and does not overwrite an existing communicationClusterRef.
+        """
         if value is not None:
             self.communicationClusterRef = value
         return self

--- a/src/armodel/models/__init__.py
+++ b/src/armodel/models/__init__.py
@@ -84,6 +84,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.Netw
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetCommunication import *  # noqa: F403
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import *  # noqa: F403
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import *  # noqa: F403
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ttcan.TtcanCommunication import *  # noqa: F403
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import *  # noqa: F403
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import *  # noqa: F403
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.EcuInstance import *  # noqa: F403

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -463,8 +463,11 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DataMapping import (
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection, TpConnection
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.ECUResourceMapping import ECUMapping
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
+    CanAddressingModeType,
     CanFrame,
+    CanFrameRxBehaviorEnum,
     CanFrameTriggering,
+    CanFrameTxBehaviorEnum,
     CanXlFrameTriggeringProps,
     RxIdentifierRange,
 )
@@ -5856,9 +5859,21 @@ class ARXMLParser(AbstractARXMLParser):
         self.logger.debug("Read CanFrameTriggering %s" % triggering.getShortName())
         self.readFrameTriggering(element, triggering)
         self.readCanFrameTriggeringAbsolutelyScheduledTimings(element, triggering)
-        triggering.setCanAddressingMode(self.getChildElementOptionalLiteral(element, "CAN-ADDRESSING-MODE"))
-        triggering.setCanFrameRxBehavior(self.getChildElementOptionalLiteral(element, "CAN-FRAME-RX-BEHAVIOR"))
-        triggering.setCanFrameTxBehavior(self.getChildElementOptionalLiteral(element, "CAN-FRAME-TX-BEHAVIOR"))
+        addressing_mode_literal = self.getChildElementOptionalLiteral(element, "CAN-ADDRESSING-MODE")
+        if addressing_mode_literal is not None:
+            addressing_mode = CanAddressingModeType()
+            addressing_mode.setValue(addressing_mode_literal.getValue())
+            triggering.setCanAddressingMode(addressing_mode)
+        rx_behavior_literal = self.getChildElementOptionalLiteral(element, "CAN-FRAME-RX-BEHAVIOR")
+        if rx_behavior_literal is not None:
+            rx_behavior = CanFrameRxBehaviorEnum()
+            rx_behavior.setValue(rx_behavior_literal.getValue())
+            triggering.setCanFrameRxBehavior(rx_behavior)
+        tx_behavior_literal = self.getChildElementOptionalLiteral(element, "CAN-FRAME-TX-BEHAVIOR")
+        if tx_behavior_literal is not None:
+            tx_behavior = CanFrameTxBehaviorEnum()
+            tx_behavior.setValue(tx_behavior_literal.getValue())
+            triggering.setCanFrameTxBehavior(tx_behavior)
         triggering.setCanXlFrameTriggeringProps(self.getCanXlFrameTriggeringProps(element, "CAN-XL-FRAME-TRIGGERING-PROPS"))
         triggering.setIdentifier(self.getChildElementOptionalNumericalValue(element, "IDENTIFIER"))
         triggering.setJ1939requestable(self.getChildElementOptionalBooleanValue(element, "J-1939-REQUESTABLE"))

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -610,6 +610,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import 
     CanNmCluster,
     CanNmClusterCoupling,
     CanNmNode,
+    CanNmEcu,
     J1939NmNode,
     J1939NodeName,
     NmCluster,
@@ -7034,6 +7035,9 @@ class ARXMLParser(AbstractARXMLParser):
     def readUdpNmEcu(self, element: ET.Element, ecu: UdpNmEcu):
         ecu.setNmSynchronizationPointEnabled(self.getChildElementOptionalBooleanValue(element, "NM-SYNCHRONIZATION-POINT-ENABLED"))
 
+    def readCanNmEcu(self, element: ET.Element, ecu: CanNmEcu):
+        pass
+
     def readBusDependentNmEcus(self, element: ET.Element, nm_ecu: NmEcu):
         for child_element in self.findall(element, "BUS-DEPENDENT-NM-ECUS/*"):
             tag_name = self.getTagName(child_element)
@@ -7041,6 +7045,10 @@ class ARXMLParser(AbstractARXMLParser):
                 udp_nm_ecu = UdpNmEcu()
                 self.readUdpNmEcu(child_element, udp_nm_ecu)
                 nm_ecu.addBusDependentNmEcu(udp_nm_ecu)
+            elif tag_name == "CAN-NM-ECU":
+                can_nm_ecu = CanNmEcu()
+                self.readCanNmEcu(child_element, can_nm_ecu)
+                nm_ecu.addBusDependentNmEcu(can_nm_ecu)
             else:
                 self.notImplemented("Unsupported BusDependentNmEcu <%s>" % tag_name)
 

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -5953,6 +5953,10 @@ class ARXMLParser(AbstractARXMLParser):
             else:
                 self.notImplemented("Unsupported Frame Triggering <%s>" % tag_name)
 
+    def readPhysicalChannelManagedPhysicalChannelRefs(self, element: ET.Element, channel: PhysicalChannel):
+        for child_element in self.findall(element, "MANAGED-PHYSICAL-CHANNEL-REFS/MANAGED-PHYSICAL-CHANNEL-REF"):
+            channel.addManagedPhysicalChannelRef(self._getChildElementRefTypeDestAndValue(child_element))
+
     def readPhysicalChannel(self, element: ET.Element, channel: PhysicalChannel):
         self.readIdentifiable(element, channel)
 
@@ -5960,6 +5964,7 @@ class ARXMLParser(AbstractARXMLParser):
         self.readPhysicalChannelFrameTriggerings(element, channel)
         self.readPhysicalChannelISignalTriggerings(element, channel)
         self.readPhysicalChannelPduTriggerings(element, channel)
+        self.readPhysicalChannelManagedPhysicalChannelRefs(element, channel)
 
     def readCanPhysicalChannel(self, element: ET.Element, channel: CanPhysicalChannel):
         self.readPhysicalChannel(element, channel)

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -7096,7 +7096,6 @@ class ARXMLParser(AbstractARXMLParser):
     def readCanTpChannel(self, element: ET.Element, channel: CanTpChannel):
         self.readIdentifiable(element, channel)
         channel.setChannelId(self.getChildElementOptionalPositiveInteger(element, "CHANNEL-ID"))
-        channel.setChannelMode(self.getChildElementOptionalLiteral(element, "CHANNEL-MODE"))
 
     def readCanTpConfigTpChannels(self, element: ET.Element, config: CanTpConfig):
         for child_element in self.findall(element, "TP-CHANNELS/*"):

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -5851,12 +5851,26 @@ class ARXMLParser(AbstractARXMLParser):
     def readCanFrameTriggering(self, element: ET.Element, triggering: CanFrameTriggering):
         self.logger.debug("Read CanFrameTriggering %s" % triggering.getShortName())
         self.readFrameTriggering(element, triggering)
+        self.readCanFrameTriggeringAbsolutelyScheduledTimings(element, triggering)
         triggering.setCanAddressingMode(self.getChildElementOptionalLiteral(element, "CAN-ADDRESSING-MODE"))
-        triggering.setCanFdFrameSupport(self.getChildElementOptionalBooleanValue(element, "CAN-FD-FRAME-SUPPORT"))
         triggering.setCanFrameRxBehavior(self.getChildElementOptionalLiteral(element, "CAN-FRAME-RX-BEHAVIOR"))
         triggering.setCanFrameTxBehavior(self.getChildElementOptionalLiteral(element, "CAN-FRAME-TX-BEHAVIOR"))
+        triggering.setCanXlFrameTriggeringProps(self.getCanXlFrameTriggeringProps(element, "CAN-XL-FRAME-TRIGGERING-PROPS"))
         triggering.setIdentifier(self.getChildElementOptionalNumericalValue(element, "IDENTIFIER"))
+        triggering.setJ1939requestable(self.getChildElementOptionalBooleanValue(element, "J-1939-REQUESTABLE"))
         triggering.setRxIdentifierRange(self.getChildElementRxIdentifierRange(element, "RX-IDENTIFIER-RANGE"))
+        triggering.setRxMask(self.getChildElementOptionalPositiveInteger(element, "RX-MASK"))
+        triggering.setTxMask(self.getChildElementOptionalPositiveInteger(element, "TX-MASK"))
+
+    def readCanFrameTriggeringAbsolutelyScheduledTimings(self, element: ET.Element, triggering: CanFrameTriggering):
+        for child_element in self.findall(element, "ABSOLUTELY-SCHEDULED-TIMINGS/*"):
+            tag_name = self.getTagName(child_element)
+            if tag_name == "TTCAN-ABSOLUTELY-SCHEDULED-TIMING":
+                timing = TtcanAbsolutelyScheduledTiming()
+                self.readTtcanAbsolutelyScheduledTiming(child_element, timing)
+                triggering.addAbsolutelyScheduledTiming(timing)
+            else:
+                self.notImplemented("Unsupported AbsolutelyScheduledTiming <%s>" % tag_name)
 
     def getCanXlFrameTriggeringProps(self, element: ET.Element, key: str) -> CanXlFrameTriggeringProps:
         props = None

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -462,7 +462,12 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DataMapping import (
 )
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.ECUResourceMapping import ECUMapping
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame, CanFrameTriggering, RxIdentifierRange
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
+    CanFrame,
+    CanFrameTriggering,
+    CanXlFrameTriggeringProps,
+    RxIdentifierRange,
+)
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ttcan.TtcanCommunication import TtcanAbsolutelyScheduledTiming
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import (
     AbstractCanCommunicationController,
@@ -5852,6 +5857,17 @@ class ARXMLParser(AbstractARXMLParser):
         triggering.setCanFrameTxBehavior(self.getChildElementOptionalLiteral(element, "CAN-FRAME-TX-BEHAVIOR"))
         triggering.setIdentifier(self.getChildElementOptionalNumericalValue(element, "IDENTIFIER"))
         triggering.setRxIdentifierRange(self.getChildElementRxIdentifierRange(element, "RX-IDENTIFIER-RANGE"))
+
+    def getCanXlFrameTriggeringProps(self, element: ET.Element, key: str) -> CanXlFrameTriggeringProps:
+        props = None
+        child_element = self.find(element, key)
+        if child_element is not None:
+            props = CanXlFrameTriggeringProps()
+            props.setAcceptanceField(self.getChildElementOptionalPositiveInteger(child_element, "ACCEPTANCE-FIELD"))
+            props.setPriorityId(self.getChildElementOptionalPositiveInteger(child_element, "PRIORITY-ID"))
+            props.setSduType(self.getChildElementOptionalPositiveInteger(child_element, "SDU-TYPE"))
+            props.setVcid(self.getChildElementOptionalPositiveInteger(child_element, "VCID"))
+        return props
 
     def readLinFrameTriggering(self, element: ET.Element, triggering: LinFrameTriggering):
         self.logger.debug("Read LinFrameTriggering %s" % triggering.getShortName())

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -756,8 +756,8 @@ class ARXMLParser(AbstractARXMLParser):
         range = None
         if child_element is not None:
             range = RxIdentifierRange()
-            range.setLowerCanId(self.getChildElementOptionalNumericalValue(child_element, "LOWER-CAN-ID"))
-            range.setUpperCanId(self.getChildElementOptionalNumericalValue(child_element, "UPPER-CAN-ID"))
+            range.setLowerCanId(self.getChildElementOptionalPositiveInteger(child_element, "LOWER-CAN-ID"))
+            range.setUpperCanId(self.getChildElementOptionalPositiveInteger(child_element, "UPPER-CAN-ID"))
         return range
 
     def getChildElementJ1939NodeName(self, element: ET.Element, key: str) -> J1939NodeName:

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -463,6 +463,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DataMapping import (
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.ECUResourceMapping import ECUMapping
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame, CanFrameTriggering, RxIdentifierRange
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ttcan.TtcanCommunication import TtcanAbsolutelyScheduledTiming
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import (
     AbstractCanCommunicationController,
     AbstractCanCommunicationControllerAttributes,
@@ -5890,6 +5891,22 @@ class ARXMLParser(AbstractARXMLParser):
                 triggering.addAbsolutelyScheduledTiming(timing)
             else:
                 self.notImplemented("Unsupported AbsolutelyScheduledTiming <%s>" % tag_name)
+
+    def readTtcanAbsolutelyScheduledTimingCommunicationCycle(self, element: ET.Element, timing: TtcanAbsolutelyScheduledTiming):
+        for child_element in self.findall(element, "COMMUNICATION-CYCLE/*"):
+            tag_name = self.getTagName(child_element)
+            if tag_name == "CYCLE-REPETITION":
+                repetition = CycleRepetition()
+                self.readCycleRepetition(child_element, repetition)
+                timing.setCommunicationCycle(repetition)
+            else:
+                self.notImplemented("Unsupported CommunicationCycle <%s>" % tag_name)
+
+    def readTtcanAbsolutelyScheduledTiming(self, element: ET.Element, timing: TtcanAbsolutelyScheduledTiming):
+        self.readARObjectAttributes(element, timing)
+        self.readTtcanAbsolutelyScheduledTimingCommunicationCycle(element, timing)
+        timing.setTimeMark(self.getChildElementOptionalIntegerValue(element, "TIME-MARK"))
+        timing.setTrigger(self.getChildElementOptionalLiteral(element, "TRIGGER"))
 
     def readFlexrayFrameTriggering(self, element: ET.Element, triggering: FlexrayFrameTriggering):
         self.logger.debug("Read FlexrayFrameTriggering %s" % triggering.getShortName())

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -460,7 +460,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DataMapping import (
     SenderRecRecordElementMapping,
     SenderRecRecordTypeMapping,
 )
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection, TpConnection
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.ECUResourceMapping import ECUMapping
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
     CanFrame,
@@ -653,7 +653,6 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import
     LinTpNode,
     TpAddress,
     TpConfig,
-    TpConnection,
 )
 from armodel.models.M2.MSR.AsamHdo.AdminData import AdminData, DocRevision, Modification
 from armodel.models.M2.MSR.AsamHdo.BaseTypes import BaseTypeDirectDefinition, SwBaseType

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -577,11 +577,14 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommu
     UserDefinedIPdu,
     UserDefinedPdu,
 )
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import (  # noqa: F401
+    AbstractCanPhysicalChannel,
+    CanPhysicalChannel,
+)
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import (
     AbstractCanCluster,
     CanCluster,
     CanClusterBusOffRecovery,
-    CanPhysicalChannel,
     CommConnectorPort,
     CommunicationCluster,
     CommunicationConnector,

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -8317,7 +8317,12 @@ class ARXMLParser(AbstractARXMLParser):
     def readCommunicationConnector(self, element: ET.Element, connector: CommunicationConnector):
         self.readIdentifiable(element, connector)
         connector.setCommControllerRef(self.getChildElementOptionalRefType(element, "COMM-CONTROLLER-REF"))
+        connector.setCreateEcuWakeupSource(self.getChildElementOptionalBooleanValue(element, "CREATE-ECU-WAKEUP-SOURCE"))
+        connector.setDynamicPncToChannelMappingEnabled(self.getChildElementOptionalBooleanValue(element, "DYNAMIC-PNC-TO-CHANNEL-MAPPING-ENABLED"))
         self.readCommunicationConnectorEcuCommPortInstances(element, connector)
+        for mask in self.findall(element, "PNC-FILTER-ARRAY-MASKS/PNC-FILTER-ARRAY-MASK"):
+            if mask.text is not None:
+                connector.addPncFilterArrayMask(int(mask.text.strip()))
         connector.setPncGatewayType(self.getChildElementOptionalLiteral(element, "PNC-GATEWAY-TYPE"))
 
     def readCanCommunicationConnector(self, element: ET.Element, connector: CanCommunicationConnector):

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -641,6 +641,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import (
 )
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import (
     CanTpAddress,
+    CanTpAddressingFormatType,
     CanTpChannel,
     CanTpConfig,
     CanTpConnection,
@@ -7140,7 +7141,11 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readCanTpConnection(self, element: ET.Element, connection: CanTpConnection):
         self.readTpConnection(element, connection)
-        connection.setAddressingFormat(self.getChildElementOptionalLiteral(element, "ADDRESSING-FORMAT"))
+        addressing_format_literal = self.getChildElementOptionalLiteral(element, "ADDRESSING-FORMAT")
+        if addressing_format_literal is not None:
+            addressing_format = CanTpAddressingFormatType()
+            addressing_format.setValue(addressing_format_literal.getValue())
+            connection.setAddressingFormat(addressing_format)
         connection.setCanTpChannelRef(self.getChildElementOptionalRefType(element, "CAN-TP-CHANNEL-REF"))
         connection.setCancellation(self.getChildElementOptionalBooleanValue(element, "CANCELLATION"))
         connection.setDataPduRef(self.getChildElementOptionalRefType(element, "DATA-PDU-REF"))

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -6780,7 +6780,7 @@ class ARXMLParser(AbstractARXMLParser):
 
     def readFrame(self, element: ET.Element, frame: Frame):
         self.readIdentifiable(element, frame)
-        frame.frameLength = self.getChildElementOptionalNumericalValue(element, "FRAME-LENGTH")
+        frame.frameLength = self.getChildElementOptionalIntegerValue(element, "FRAME-LENGTH")
         self.readPduToFrameMappings(element, frame)
 
     def readLinUnconditionalFrame(self, element: ET.Element, frame: LinUnconditionalFrame):

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -580,6 +580,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.Timing im
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.InstanceRefs import ComponentInSystemInstanceRef, VariableDataPrototypeInSystemInstanceRef
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import (
     CanNmCluster,
+    CanNmEcu,
     CanNmClusterCoupling,
     CanNmNode,
     J1939NmNode,
@@ -6004,6 +6005,10 @@ class ARXMLWriter(AbstractARXMLWriter):
             child_element = ET.SubElement(element, "UDP-NM-ECU")
             self.setChildElementOptionalBooleanValue(child_element, "NM-SYNCHRONIZATION-POINT-ENABLED", ecu.getNmSynchronizationPointEnabled())
 
+    def writeCanNmEcu(self, element: ET.Element, ecu: CanNmEcu):
+        if ecu is not None:
+            ET.SubElement(element, "CAN-NM-ECU")
+
     def writeBusDependentNmEcus(self, element: ET.Element, nm_ecu: NmEcu):
         dependent_nm_ecus = nm_ecu.getBusDependentNmEcus()
         if len(dependent_nm_ecus) > 0:
@@ -6011,6 +6016,8 @@ class ARXMLWriter(AbstractARXMLWriter):
             for dependent_nm_ecu in dependent_nm_ecus:
                 if isinstance(dependent_nm_ecu, UdpNmEcu):
                     self.writeUdpNmEcu(child_element, dependent_nm_ecu)
+                elif isinstance(dependent_nm_ecu, CanNmEcu):
+                    self.writeCanNmEcu(child_element, dependent_nm_ecu)
                 else:
                     self.notImplemented("Unsupported BusDependentNmEcu <%s>" % type(dependent_nm_ecu))
 

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -6173,7 +6173,10 @@ class ARXMLWriter(AbstractARXMLWriter):
         if connection is not None:
             child_element = ET.SubElement(element, "CAN-TP-CONNECTION")
             self.writeTpConnection(child_element, connection)
-            self.setChildElementOptionalLiteral(child_element, "ADDRESSING-FORMAT", connection.getAddressingFormat())
+            addressing_format = connection.getAddressingFormat()
+            if addressing_format is not None:
+                addressing_format_element = ET.SubElement(child_element, "ADDRESSING-FORMAT")
+                addressing_format_element.text = addressing_format.getValue()
             self.setChildElementOptionalRefType(child_element, "CAN-TP-CHANNEL-REF", connection.getCanTpChannelRef())
             self.setChildElementOptionalBooleanValue(child_element, "CANCELLATION", connection.getCancellation())
             self.setChildElementOptionalRefType(child_element, "DATA-PDU-REF", connection.getDataPduRef())

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -549,11 +549,14 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommu
     UserDefinedIPdu,
     UserDefinedPdu,
 )
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import (  # noqa: F401
+    AbstractCanPhysicalChannel,
+    CanPhysicalChannel,
+)
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import (
     AbstractCanCluster,
     CanCluster,
     CanClusterBusOffRecovery,
-    CanPhysicalChannel,
     CommConnectorPort,
     CommunicationCluster,
     CommunicationConnector,

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -6138,7 +6138,6 @@ class ARXMLWriter(AbstractARXMLWriter):
             child_element = ET.SubElement(element, "CAN-TP-CHANNEL")
             self.writeIdentifiable(child_element, channel)
             self.setChildElementOptionalPositiveInteger(child_element, "CHANNEL-ID", channel.getChannelId())
-            self.setChildElementOptionalLiteral(child_element, "CHANNEL-MODE", channel.getChannelMode())
 
     def writeCanTpConfigTpChannels(self, element: ET.Element, config: CanTpConfig):
         channels = config.getTpChannels()

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -436,7 +436,12 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DataMapping import (
 )
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.ECUResourceMapping import ECUMapping
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame, CanFrameTriggering, RxIdentifierRange
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
+    CanFrame,
+    CanFrameTriggering,
+    CanXlFrameTriggeringProps,
+    RxIdentifierRange,
+)
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ttcan.TtcanCommunication import TtcanAbsolutelyScheduledTiming
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import (
     AbstractCanCommunicationController,
@@ -9215,6 +9220,14 @@ class ARXMLWriter(AbstractARXMLWriter):
             child_element = ET.SubElement(element, key)
             self.setChildElementOptionalRefType(child_element, "FRAME-REF", frame.getFrameRef())
             self.setChildElementOptionalPositiveInteger(child_element, "MESSAGE-ID", frame.getMessageId())
+
+    def setCanXlFrameTriggeringProps(self, element: ET.Element, key: str, props: CanXlFrameTriggeringProps):
+        if props is not None:
+            child_element = ET.SubElement(element, key)
+            self.setChildElementOptionalPositiveInteger(child_element, "ACCEPTANCE-FIELD", props.getAcceptanceField())
+            self.setChildElementOptionalPositiveInteger(child_element, "PRIORITY-ID", props.getPriorityId())
+            self.setChildElementOptionalPositiveInteger(child_element, "SDU-TYPE", props.getSduType())
+            self.setChildElementOptionalPositiveInteger(child_element, "VCID", props.getVcid())
 
     def setLinOrderedConfigurableFrame(self, element: ET.Element, key: str, frame: LinOrderedConfigurableFrame):
         if frame is not None:

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -6334,12 +6334,29 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.logger.debug("WRite CanFrameTriggering %s" % triggering.getShortName())
         child_element = ET.SubElement(element, "CAN-FRAME-TRIGGERING")
         self.writeFrameTriggering(child_element, triggering)
+        timings = triggering.getAbsolutelyScheduledTimings()
+        if len(timings) > 0:
+            timings_element = ET.SubElement(child_element, "ABSOLUTELY-SCHEDULED-TIMINGS")
+            for timing in timings:
+                if isinstance(timing, TtcanAbsolutelyScheduledTiming):
+                    self.writeTtcanAbsolutelyScheduledTiming(timings_element, timing)
+                else:
+                    self.notImplemented("Unsupported AbsolutelyScheduledTiming <%s>" % type(timing))
         self.setChildElementOptionalLiteral(child_element, "CAN-ADDRESSING-MODE", triggering.getCanAddressingMode())
-        self.setChildElementOptionalBooleanValue(child_element, "CAN-FD-FRAME-SUPPORT", triggering.getCanFdFrameSupport())
         self.setChildElementOptionalLiteral(child_element, "CAN-FRAME-RX-BEHAVIOR", triggering.getCanFrameRxBehavior())
         self.setChildElementOptionalLiteral(child_element, "CAN-FRAME-TX-BEHAVIOR", triggering.getCanFrameTxBehavior())
+        props = triggering.getCanXlFrameTriggeringProps()
+        if props is not None:
+            props_element = ET.SubElement(child_element, "CAN-XL-FRAME-TRIGGERING-PROPS")
+            self.setChildElementOptionalPositiveInteger(props_element, "ACCEPTANCE-FIELD", props.getAcceptanceField())
+            self.setChildElementOptionalPositiveInteger(props_element, "PRIORITY-ID", props.getPriorityId())
+            self.setChildElementOptionalPositiveInteger(props_element, "SDU-TYPE", props.getSduType())
+            self.setChildElementOptionalPositiveInteger(props_element, "VCID", props.getVcid())
         self.setChildElementOptionalNumericalValue(child_element, "IDENTIFIER", triggering.getIdentifier())
+        self.setChildElementOptionalBooleanValue(child_element, "J-1939-REQUESTABLE", triggering.getJ1939requestable())
         self.setChildElementRxIdentifierRange(child_element, "RX-IDENTIFIER-RANGE", triggering.getRxIdentifierRange())
+        self.setChildElementOptionalPositiveInteger(child_element, "RX-MASK", triggering.getRxMask())
+        self.setChildElementOptionalPositiveInteger(child_element, "TX-MASK", triggering.getTxMask())
 
     def writeLinFrameTriggering(self, element: ET.Element, triggering: LinFrameTriggering):
         self.logger.debug("Write LinFrameTriggering %s" % triggering.getShortName())

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -437,6 +437,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DataMapping import (
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.ECUResourceMapping import ECUMapping
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame, CanFrameTriggering, RxIdentifierRange
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ttcan.TtcanCommunication import TtcanAbsolutelyScheduledTiming
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import (
     AbstractCanCommunicationController,
     AbstractCanCommunicationControllerAttributes,
@@ -6372,6 +6373,23 @@ class ARXMLWriter(AbstractARXMLWriter):
                     self.writeFlexrayAbsolutelyScheduledTiming(child_element, timing)
                 else:
                     self.notImplemented("Unsupported AbsolutelyScheduledTiming <%s>" % type(timing))
+
+    def writeTtcanAbsolutelyScheduledTimingCommunicationCycle(self, element: ET.Element, timing: TtcanAbsolutelyScheduledTiming):
+        cycle = timing.getCommunicationCycle()
+        if cycle is not None:
+            child_element = ET.SubElement(element, "COMMUNICATION-CYCLE")
+            if isinstance(cycle, CycleRepetition):
+                self.writeCycleRepetition(child_element, cycle)
+            else:
+                self.notImplemented("Unsupported CommunicationCycle <%s>" % type(cycle))
+
+    def writeTtcanAbsolutelyScheduledTiming(self, element: ET.Element, timing: TtcanAbsolutelyScheduledTiming):
+        if timing is not None:
+            child_element = ET.SubElement(element, "TTCAN-ABSOLUTELY-SCHEDULED-TIMING")
+            self.writeARObjectAttributes(child_element, timing)
+            self.writeTtcanAbsolutelyScheduledTimingCommunicationCycle(child_element, timing)
+            self.setChildElementOptionalIntegerValue(child_element, "TIME-MARK", timing.getTimeMark())
+            self.setChildElementOptionalLiteral(child_element, "TRIGGER", timing.getTrigger())
 
     def writeFlexrayFrameTriggering(self, element: ET.Element, triggering: FlexrayFrameTriggering):
         self.logger.debug("Write FlexrayFrameTriggering %s" % triggering.getShortName())

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -434,7 +434,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DataMapping import (
     SenderRecRecordElementMapping,
     SenderRecRecordTypeMapping,
 )
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection, TpConnection
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.ECUResourceMapping import ECUMapping
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
     CanFrame,
@@ -625,7 +625,6 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import
     LinTpNode,
     TpAddress,
     TpConfig,
-    TpConnection,
 )
 from armodel.models.M2.MSR.AsamHdo.AdminData import AdminData, DocRevision, Modification
 from armodel.models.M2.MSR.AsamHdo.BaseTypes import BaseTypeDirectDefinition, SwBaseType

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -6453,6 +6453,13 @@ class ARXMLWriter(AbstractARXMLWriter):
                 else:
                     self.notImplemented("Unsupported PduTriggering <%s>" % type(triggering))
 
+    def writePhysicalChannelManagedPhysicalChannelRefs(self, element, channel):
+        refs = channel.getManagedPhysicalChannelRefs()
+        if len(refs) > 0:
+            refs_tag = ET.SubElement(element, "MANAGED-PHYSICAL-CHANNEL-REFS")
+            for ref in refs:
+                self.setChildElementOptionalRefType(refs_tag, "MANAGED-PHYSICAL-CHANNEL-REF", ref)
+
     def writePhysicalChannel(self, element: ET.Element, channel: PhysicalChannel):
         self.writeIdentifiable(element, channel)
 
@@ -6460,6 +6467,7 @@ class ARXMLWriter(AbstractARXMLWriter):
         self.writePhysicalChannelFrameTriggerings(element, channel)
         self.writePhysicalChannelISignalTriggerings(element, channel)
         self.writePhysicalChannelPduTriggerings(element, channel)
+        self.writePhysicalChannelManagedPhysicalChannelRefs(element, channel)
 
     def writeCanPhysicalChannel(self, element: ET.Element, channel: CanPhysicalChannel):
         self.logger.debug("Set CanPhysicalChannel %s" % channel.getShortName())

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -6348,9 +6348,18 @@ class ARXMLWriter(AbstractARXMLWriter):
                     self.writeTtcanAbsolutelyScheduledTiming(timings_element, timing)
                 else:
                     self.notImplemented("Unsupported AbsolutelyScheduledTiming <%s>" % type(timing))
-        self.setChildElementOptionalLiteral(child_element, "CAN-ADDRESSING-MODE", triggering.getCanAddressingMode())
-        self.setChildElementOptionalLiteral(child_element, "CAN-FRAME-RX-BEHAVIOR", triggering.getCanFrameRxBehavior())
-        self.setChildElementOptionalLiteral(child_element, "CAN-FRAME-TX-BEHAVIOR", triggering.getCanFrameTxBehavior())
+        addressing_mode = triggering.getCanAddressingMode()
+        if addressing_mode is not None:
+            addressing_mode_element = ET.SubElement(child_element, "CAN-ADDRESSING-MODE")
+            addressing_mode_element.text = addressing_mode.getValue()
+        rx_behavior = triggering.getCanFrameRxBehavior()
+        if rx_behavior is not None:
+            rx_behavior_element = ET.SubElement(child_element, "CAN-FRAME-RX-BEHAVIOR")
+            rx_behavior_element.text = rx_behavior.getValue()
+        tx_behavior = triggering.getCanFrameTxBehavior()
+        if tx_behavior is not None:
+            tx_behavior_element = ET.SubElement(child_element, "CAN-FRAME-TX-BEHAVIOR")
+            tx_behavior_element.text = tx_behavior.getValue()
         props = triggering.getCanXlFrameTriggeringProps()
         if props is not None:
             props_element = ET.SubElement(child_element, "CAN-XL-FRAME-TRIGGERING-PROPS")

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -5838,7 +5838,7 @@ class ARXMLWriter(AbstractARXMLWriter):
 
     def writeFrame(self, element: ET.Element, frame: Frame):
         self.writeIdentifiable(element, frame)
-        self.setChildElementOptionalNumericalValue(element, "FRAME-LENGTH", frame.frameLength)
+        self.setChildElementOptionalIntegerValue(element, "FRAME-LENGTH", frame.frameLength)
         self.writePduToFrameMappings(element, frame)
 
     def writeLinUnconditionalFrame(self, element: ET.Element, frame: LinUnconditionalFrame):

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -217,6 +217,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     ARLiteral,
     ARNumerical,
     Limit,
+    PositiveInteger,
     RefType,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import LifeCycleInfo, LifeCycleInfoSet, LifeCyclePeriod
@@ -7832,7 +7833,16 @@ class ARXMLWriter(AbstractARXMLWriter):
     def writeCommunicationConnector(self, element: ET.Element, connector: CommunicationConnector):
         self.writeIdentifiable(element, connector)
         self.setChildElementOptionalRefType(element, "COMM-CONTROLLER-REF", connector.getCommControllerRef())
+        self.setChildElementOptionalBooleanValue(element, "CREATE-ECU-WAKEUP-SOURCE", connector.getCreateEcuWakeupSource())
+        self.setChildElementOptionalBooleanValue(element, "DYNAMIC-PNC-TO-CHANNEL-MAPPING-ENABLED", connector.getDynamicPncToChannelMappingEnabled())
         self.writeCommunicationConnectorEcuCommPortInstances(element, connector)
+        masks = connector.getPncFilterArrayMasks()
+        if len(masks) > 0:
+            masks_tag = ET.SubElement(element, "PNC-FILTER-ARRAY-MASKS")
+            for mask in masks:
+                mask_value = PositiveInteger()
+                mask_value.setValue(mask)
+                self.setChildElementOptionalPositiveInteger(masks_tag, "PNC-FILTER-ARRAY-MASK", mask_value)
         self.setChildElementOptionalLiteral(element, "PNC-GATEWAY-TYPE", connector.getPncGatewayType())
 
     def writeCanCommunicationConnector(self, element: ET.Element, connector: CanCommunicationConnector):

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
@@ -11,6 +11,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
     CanAddressingModeType,
     CanFrame,
+    CanFrameRxBehaviorEnum,
     CanFrameTriggering,
     RxIdentifierRange,
 )
@@ -164,3 +165,19 @@ class Test_Fibex4CanCommunication:
         result = triggering.setTxMask("tx_mask")
         assert triggering.getTxMask() == "tx_mask"
         assert result == triggering  # Test method chaining
+
+    def test_CanFrameRxBehaviorEnum(self):
+        """Test CanFrameRxBehaviorEnum enum (Table 6.113)."""
+        enum = CanFrameRxBehaviorEnum()
+        assert enum is not None
+        enum.setValue(CanFrameRxBehaviorEnum.ENUM_ANY)
+        assert enum.getValue() == "ANY"
+
+        assert CanFrameRxBehaviorEnum.ENUM_ANY == "ANY"
+        assert CanFrameRxBehaviorEnum.ENUM_CAN_20 == "CAN-20"
+        assert CanFrameRxBehaviorEnum.ENUM_CAN_FD == "CAN-FD"
+
+        assert CanFrameRxBehaviorEnum.ENUM_ANY in enum.getEnumValues()
+        assert CanFrameRxBehaviorEnum.ENUM_CAN_20 in enum.getEnumValues()
+        assert CanFrameRxBehaviorEnum.ENUM_CAN_FD in enum.getEnumValues()
+        assert len(enum.getEnumValues()) == 3

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
@@ -8,12 +8,14 @@ of the respective classes.
 """
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
     CanAddressingModeType,
     CanFrame,
     CanFrameRxBehaviorEnum,
     CanFrameTriggering,
     CanFrameTxBehaviorEnum,
+    CanXlFrameTriggeringProps,
     RxIdentifierRange,
 )
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import Frame, FrameTriggering
@@ -196,3 +198,37 @@ class Test_Fibex4CanCommunication:
         assert CanFrameTxBehaviorEnum.ENUM_CAN_20 in enum.getEnumValues()
         assert CanFrameTxBehaviorEnum.ENUM_CAN_FD in enum.getEnumValues()
         assert len(enum.getEnumValues()) == 2
+
+    def test_CanXlFrameTriggeringProps_initialization(self):
+        """Test CanXlFrameTriggeringProps default state (Table F.27)."""
+        obj = CanXlFrameTriggeringProps()
+
+        assert isinstance(obj, ARObject)
+        assert obj.getAcceptanceField() is None
+        assert obj.getPriorityId() is None
+        assert obj.getSduType() is None
+        assert obj.getVcid() is None
+
+    def test_CanXlFrameTriggeringProps_get_set(self):
+        """Test CanXlFrameTriggeringProps getter/setter with None no-op (Table F.27)."""
+        obj = CanXlFrameTriggeringProps()
+
+        assert obj == obj.setAcceptanceField(PositiveInteger().setValue(1))
+        assert obj.getAcceptanceField().getValue() == 1
+        assert obj == obj.setAcceptanceField(None)
+        assert obj.getAcceptanceField().getValue() == 1
+
+        assert obj == obj.setPriorityId(PositiveInteger().setValue(2))
+        assert obj.getPriorityId().getValue() == 2
+        assert obj == obj.setPriorityId(None)
+        assert obj.getPriorityId().getValue() == 2
+
+        assert obj == obj.setSduType(PositiveInteger().setValue(3))
+        assert obj.getSduType().getValue() == 3
+        assert obj == obj.setSduType(None)
+        assert obj.getSduType().getValue() == 3
+
+        assert obj == obj.setVcid(PositiveInteger().setValue(4))
+        assert obj.getVcid().getValue() == 4
+        assert obj == obj.setVcid(None)
+        assert obj.getVcid().getValue() == 4

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
@@ -8,7 +8,7 @@ of the respective classes.
 """
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, Boolean, Integer, PositiveInteger
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
     CanAddressingModeType,
     CanFrame,
@@ -18,6 +18,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommun
     CanXlFrameTriggeringProps,
     RxIdentifierRange,
 )
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ttcan.TtcanCommunication import TtcanAbsolutelyScheduledTiming
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import Frame, FrameTriggering
 
 
@@ -80,41 +81,21 @@ class Test_Fibex4CanCommunication:
         assert range_obj.getUpperCanId().getValue() == 0x1FF
 
     def test_CanFrame(self):
-        """
-        Test CanFrame class functionality.
-
-        This test verifies that CanFrame can be instantiated with a parent
-        object and short name, properly inherits from both ARObject and Frame,
-        and that its default properties are correctly initialized.
-        """
+        """Test CanFrame class functionality (Table 6.109)."""
         parent = MockParent()
-        frame = CanFrame(parent, "test_can_frame")
+        frame = CanFrame(parent, "CanFrame")
 
         assert isinstance(frame, ARObject)
         assert isinstance(frame, Frame)
 
-        # Test default values
-        assert frame.getFrameLength() is None
-        assert frame.getPduToFrameMappings() == []
-
-    def test_CanFrameTriggering(self):
-        """
-        Test CanFrameTriggering class functionality.
-
-        This test ensures that CanFrameTriggering is properly instantiated,
-        inherits from FrameTriggering, and all its properties can be set
-        and retrieved correctly. It tests both simple properties and
-        object references.
-        """
+    def test_CanFrameTriggering_initialization(self):
+        """Test CanFrameTriggering default state (Table 6.110)."""
         parent = MockParent()
-        triggering = CanFrameTriggering(parent, "test_can_frame_triggering")
+        triggering = CanFrameTriggering(parent, "CanFrameTriggering")
 
         assert isinstance(triggering, FrameTriggering)
-
-        # Test default values
         assert triggering.getAbsolutelyScheduledTimings() == []
         assert triggering.getCanAddressingMode() is None
-        assert triggering.getCanFdFrameSupport() is None
         assert triggering.getCanFrameRxBehavior() is None
         assert triggering.getCanFrameTxBehavior() is None
         assert triggering.getCanXlFrameTriggeringProps() is None
@@ -124,25 +105,65 @@ class Test_Fibex4CanCommunication:
         assert triggering.getRxMask() is None
         assert triggering.getTxMask() is None
 
-        # Test setter/getter methods
-        triggering.setCanAddressingMode("standard")
-        assert triggering.getCanAddressingMode() == "standard"
+    def test_CanFrameTriggering_get_set_attributes(self):
+        """Test CanFrameTriggering attribute getters/setters with None no-op (Table 6.110)."""
+        parent = MockParent()
+        triggering = CanFrameTriggering(parent, "CanFrameTriggering")
 
-        triggering.setCanFdFrameSupport(True)
-        assert triggering.getCanFdFrameSupport() is True
+        mode = ARLiteral()
+        mode.setValue("STANDARD")
+        assert triggering == triggering.setCanAddressingMode(mode)
+        assert triggering.getCanAddressingMode() == mode
+        assert triggering == triggering.setCanAddressingMode(None)
+        assert triggering.getCanAddressingMode() == mode
 
-        mock_range = RxIdentifierRange()
-        triggering.setRxIdentifierRange(mock_range)
-        assert triggering.getRxIdentifierRange() == mock_range
+        rx = ARLiteral()
+        rx.setValue(CanFrameRxBehaviorEnum.ENUM_CAN_FD)
+        assert triggering == triggering.setCanFrameRxBehavior(rx)
+        assert triggering.getCanFrameRxBehavior() == rx
 
-        # Test additional setter methods and method chaining functionality
-        result = triggering.setAbsolutelyScheduledTimings(["timing1", "timing2"])
-        assert triggering.getAbsolutelyScheduledTimings() == ["timing1", "timing2"]
-        assert result == triggering  # Test method chaining
+        tx = ARLiteral()
+        tx.setValue(CanFrameTxBehaviorEnum.ENUM_CAN_20)
+        assert triggering == triggering.setCanFrameTxBehavior(tx)
+        assert triggering.getCanFrameTxBehavior() == tx
 
-        result = triggering.setCanFrameRxBehavior("rx_behavior")
-        assert triggering.getCanFrameRxBehavior() == "rx_behavior"
-        assert result == triggering  # Test method chaining
+        assert triggering == triggering.setIdentifier(Integer().setValue(0x100))
+        assert triggering.getIdentifier().getValue() == 0x100
+        assert triggering == triggering.setIdentifier(None)
+        assert triggering.getIdentifier().getValue() == 0x100
+
+        assert triggering == triggering.setJ1939requestable(Boolean().setValue(True))
+        assert triggering.getJ1939requestable().getValue() is True
+
+        assert triggering == triggering.setRxMask(PositiveInteger().setValue(0x7FF))
+        assert triggering.getRxMask().getValue() == 0x7FF
+        assert triggering == triggering.setRxMask(None)
+        assert triggering.getRxMask().getValue() == 0x7FF
+
+        assert triggering == triggering.setTxMask(PositiveInteger().setValue(0x100))
+        assert triggering.getTxMask().getValue() == 0x100
+
+    def test_CanFrameTriggering_aggregations(self):
+        """Test CanFrameTriggering aggregation members (Table 6.110)."""
+        parent = MockParent()
+        triggering = CanFrameTriggering(parent, "CanFrameTriggering")
+
+        rng = RxIdentifierRange()
+        rng.setLowerCanId(PositiveInteger().setValue(0x100))
+        assert triggering == triggering.setRxIdentifierRange(rng)
+        assert triggering.getRxIdentifierRange() == rng
+        assert triggering == triggering.setRxIdentifierRange(None)
+        assert triggering.getRxIdentifierRange() == rng
+
+        timing = CanXlFrameTriggeringProps()
+        assert triggering == triggering.setCanXlFrameTriggeringProps(timing)
+        assert triggering.getCanXlFrameTriggeringProps() == timing
+
+        ttcan_timing = TtcanAbsolutelyScheduledTiming()
+        assert triggering == triggering.addAbsolutelyScheduledTiming(ttcan_timing)
+        assert triggering.getAbsolutelyScheduledTimings() == [ttcan_timing]
+        assert triggering == triggering.addAbsolutelyScheduledTiming(None)
+        assert triggering.getAbsolutelyScheduledTimings() == [ttcan_timing]
 
         result = triggering.setCanFrameTxBehavior("tx_behavior")
         assert triggering.getCanFrameTxBehavior() == "tx_behavior"

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
@@ -13,6 +13,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommun
     CanFrame,
     CanFrameRxBehaviorEnum,
     CanFrameTriggering,
+    CanFrameTxBehaviorEnum,
     RxIdentifierRange,
 )
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import Frame, FrameTriggering
@@ -181,3 +182,17 @@ class Test_Fibex4CanCommunication:
         assert CanFrameRxBehaviorEnum.ENUM_CAN_20 in enum.getEnumValues()
         assert CanFrameRxBehaviorEnum.ENUM_CAN_FD in enum.getEnumValues()
         assert len(enum.getEnumValues()) == 3
+
+    def test_CanFrameTxBehaviorEnum(self):
+        """Test CanFrameTxBehaviorEnum enum (Table 6.114)."""
+        enum = CanFrameTxBehaviorEnum()
+        assert enum is not None
+        enum.setValue(CanFrameTxBehaviorEnum.ENUM_CAN_20)
+        assert enum.getValue() == "CAN-20"
+
+        assert CanFrameTxBehaviorEnum.ENUM_CAN_20 == "CAN-20"
+        assert CanFrameTxBehaviorEnum.ENUM_CAN_FD == "CAN-FD"
+
+        assert CanFrameTxBehaviorEnum.ENUM_CAN_20 in enum.getEnumValues()
+        assert CanFrameTxBehaviorEnum.ENUM_CAN_FD in enum.getEnumValues()
+        assert len(enum.getEnumValues()) == 2

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
@@ -8,7 +8,12 @@ of the respective classes.
 """
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame, CanFrameTriggering, RxIdentifierRange
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
+    CanAddressingModeType,
+    CanFrame,
+    CanFrameTriggering,
+    RxIdentifierRange,
+)
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import Frame, FrameTriggering
 
 
@@ -33,6 +38,20 @@ class Test_Fibex4CanCommunication:
     CAN communication classes, including their initialization,
     inheritance relationships, and property accessors.
     """
+
+    def test_CanAddressingModeType(self):
+        """Test CanAddressingModeType enum (Table 6.111)."""
+        enum = CanAddressingModeType()
+        assert enum is not None
+        enum.setValue(CanAddressingModeType.ENUM_EXTENDED)
+        assert enum.getValue() == "EXTENDED"
+
+        assert CanAddressingModeType.ENUM_EXTENDED == "EXTENDED"
+        assert CanAddressingModeType.ENUM_STANDARD == "STANDARD"
+
+        assert CanAddressingModeType.ENUM_EXTENDED in enum.getEnumValues()
+        assert CanAddressingModeType.ENUM_STANDARD in enum.getEnumValues()
+        assert len(enum.getEnumValues()) == 2
 
     def test_RxIdentifierRange(self):
         """

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
@@ -57,28 +57,27 @@ class Test_Fibex4CanCommunication:
         assert CanAddressingModeType.ENUM_STANDARD in enum.getEnumValues()
         assert len(enum.getEnumValues()) == 2
 
-    def test_RxIdentifierRange(self):
-        """
-        Test RxIdentifierRange class functionality.
-
-        This test validates that RxIdentifierRange can be instantiated,
-        properly inherits from ARObject, and that its setter/getter methods
-        work correctly for lower and upper CAN ID values.
-        """
+    def test_RxIdentifierRange_initialization(self):
+        """Test RxIdentifierRange default state (Table 6.112)."""
         range_obj = RxIdentifierRange()
 
         assert isinstance(range_obj, ARObject)
-
-        # Test default values
         assert range_obj.getLowerCanId() is None
         assert range_obj.getUpperCanId() is None
 
-        # Test setter/getter methods
-        range_obj.setLowerCanId(100)
-        assert range_obj.getLowerCanId() == 100
+    def test_RxIdentifierRange_get_set(self):
+        """Test RxIdentifierRange getter/setter with None no-op (Table 6.112)."""
+        range_obj = RxIdentifierRange()
 
-        range_obj.setUpperCanId(200)
-        assert range_obj.getUpperCanId() == 200
+        assert range_obj == range_obj.setLowerCanId(PositiveInteger().setValue(0x100))
+        assert range_obj.getLowerCanId().getValue() == 0x100
+        assert range_obj == range_obj.setLowerCanId(None)
+        assert range_obj.getLowerCanId().getValue() == 0x100
+
+        assert range_obj == range_obj.setUpperCanId(PositiveInteger().setValue(0x1FF))
+        assert range_obj.getUpperCanId().getValue() == 0x1FF
+        assert range_obj == range_obj.setUpperCanId(None)
+        assert range_obj.getUpperCanId().getValue() == 0x1FF
 
     def test_CanFrame(self):
         """

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanCommunication.py
@@ -8,7 +8,7 @@ of the respective classes.
 """
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, Boolean, Integer, PositiveInteger
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, Integer, PositiveInteger
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
     CanAddressingModeType,
     CanFrame,
@@ -110,21 +110,24 @@ class Test_Fibex4CanCommunication:
         parent = MockParent()
         triggering = CanFrameTriggering(parent, "CanFrameTriggering")
 
-        mode = ARLiteral()
-        mode.setValue("STANDARD")
+        mode = CanAddressingModeType()
+        mode.setValue(CanAddressingModeType.ENUM_STANDARD)
         assert triggering == triggering.setCanAddressingMode(mode)
+        assert isinstance(triggering.getCanAddressingMode(), CanAddressingModeType)
         assert triggering.getCanAddressingMode() == mode
         assert triggering == triggering.setCanAddressingMode(None)
         assert triggering.getCanAddressingMode() == mode
 
-        rx = ARLiteral()
+        rx = CanFrameRxBehaviorEnum()
         rx.setValue(CanFrameRxBehaviorEnum.ENUM_CAN_FD)
         assert triggering == triggering.setCanFrameRxBehavior(rx)
+        assert isinstance(triggering.getCanFrameRxBehavior(), CanFrameRxBehaviorEnum)
         assert triggering.getCanFrameRxBehavior() == rx
 
-        tx = ARLiteral()
+        tx = CanFrameTxBehaviorEnum()
         tx.setValue(CanFrameTxBehaviorEnum.ENUM_CAN_20)
         assert triggering == triggering.setCanFrameTxBehavior(tx)
+        assert isinstance(triggering.getCanFrameTxBehavior(), CanFrameTxBehaviorEnum)
         assert triggering.getCanFrameTxBehavior() == tx
 
         assert triggering == triggering.setIdentifier(Integer().setValue(0x100))

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanTopology.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/test_CanTopology.py
@@ -465,7 +465,7 @@ class Test_Fibex4CanTopology:
         assert controller == controller.setCanControllerAttributes(attrs)  # Test method chaining
 
     def test_AbstractCanCommunicationConnector(self):
-        """Test AbstractCanCommunicationConnector abstract class instantiation."""
+        """Test AbstractCanCommunicationConnector abstract class instantiation (Table 3.22)."""
         parent = MockParent()
         with pytest.raises(TypeError):
             AbstractCanCommunicationConnector(parent, "test_abstract_connector")
@@ -476,6 +476,7 @@ class Test_Fibex4CanTopology:
         connector = CanCommunicationConnector(parent, "test_can_comm_connector")
 
         assert isinstance(connector, CommunicationConnector)
+        assert isinstance(connector, AbstractCanCommunicationConnector)
 
         # Test default values
         assert connector.getPncWakeupCanId() is None

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ttcan/test_TtcanCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ttcan/test_TtcanCommunication.py
@@ -1,0 +1,67 @@
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ttcan.TtcanCommunication import (
+    TtcanAbsolutelyScheduledTiming,
+    TtcanTriggerType,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CycleRepetition
+
+
+class TestTtcanAbsolutelyScheduledTiming:
+    def test_initialization(self):
+        timing = TtcanAbsolutelyScheduledTiming()
+
+        assert timing.getCommunicationCycle() is None
+        assert timing.getTimeMark() is None
+        assert timing.getTrigger() is None
+
+    def test_communicationCycle(self):
+        timing = TtcanAbsolutelyScheduledTiming()
+
+        cycle = CycleRepetition()
+        timing.setCommunicationCycle(cycle)
+        assert timing.getCommunicationCycle() == cycle
+        assert timing == timing.setCommunicationCycle(cycle)  # method chaining
+        assert timing == timing.setCommunicationCycle(None)  # None no-op
+        assert timing.getCommunicationCycle() == cycle  # unchanged
+
+    def test_timeMark(self):
+        timing = TtcanAbsolutelyScheduledTiming()
+
+        timing.setTimeMark(16)
+        assert timing.getTimeMark() == 16
+        assert timing == timing.setTimeMark(16)  # method chaining
+        assert timing == timing.setTimeMark(None)  # None no-op
+        assert timing.getTimeMark() == 16  # unchanged
+
+    def test_trigger(self):
+        timing = TtcanAbsolutelyScheduledTiming()
+
+        trigger = TtcanTriggerType()
+        trigger.setValue(TtcanTriggerType.ENUM_RX_TRIGGER)
+        timing.setTrigger(trigger)
+        assert timing.getTrigger() == trigger
+        assert timing.getTrigger().getValue() == "RX-TRIGGER"
+        assert timing == timing.setTrigger(trigger)  # method chaining
+        assert timing == timing.setTrigger(None)  # None no-op
+        assert timing.getTrigger() == trigger  # unchanged
+
+
+class TestTtcanTriggerType:
+    def test_initialization(self):
+        trigger_type = TtcanTriggerType()
+        assert trigger_type is not None
+        trigger_type.setValue(TtcanTriggerType.ENUM_RX_TRIGGER)
+        assert trigger_type.getValue() == "RX-TRIGGER"
+
+    def test_literals(self):
+        assert TtcanTriggerType.ENUM_RX_TRIGGER == "RX-TRIGGER"
+        assert TtcanTriggerType.ENUM_TX_REF_TRIGGER == "TX-REF-TRIGGER"
+        assert TtcanTriggerType.ENUM_TX_REF_TRIGGER_GAP == "TX-REF-TRIGGER-GAP"
+        assert TtcanTriggerType.ENUM_TX_TRIGGER_MERGED == "TX-TRIGGER-MERGED"
+        assert TtcanTriggerType.ENUM_TX_TRIGGER_SINGLE == "TX-TRIGGER-SINGLE"
+        assert TtcanTriggerType.ENUM_WATCH_TRIGGER == "WATCH-TRIGGER"
+        assert TtcanTriggerType.ENUM_WATCH_TRIGGER_GAP == "WATCH-TRIGGER-GAP"
+
+        enum = TtcanTriggerType()
+        assert TtcanTriggerType.ENUM_RX_TRIGGER in enum.getEnumValues()
+        assert TtcanTriggerType.ENUM_WATCH_TRIGGER_GAP in enum.getEnumValues()
+        assert len(enum.getEnumValues()) == 7

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
@@ -2,6 +2,7 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement, Describable, Identifiable
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (
     ContainedIPduProps,
     DcmIPdu,
@@ -107,10 +108,15 @@ class Test_FibexCoreCommunication:
         assert frame.getFrameLength() is None
         assert frame.getPduToFrameMappings() == []
 
-        # Test setter/getter methods with method chaining
-        frame.setFrameLength(100)
-        assert frame.getFrameLength() == 100
-        assert frame == frame.setFrameLength(100)  # Test method chaining
+        # Test setter/getter methods with method chaining - with actual Integer value
+        value = Integer().setValue("100")
+        frame.setFrameLength(value)
+        assert frame.getFrameLength().getValue() == 100
+        assert frame == frame.setFrameLength(value)  # Test method chaining
+
+        # Test setter/getter methods with method chaining - with None (no-op)
+        assert frame == frame.setFrameLength(None)  # Test method chaining with None
+        assert frame.getFrameLength().getValue() == 100  # Should remain unchanged
 
         # Test PduToFrameMapping creation methods
         mapping = frame.createPduToFrameMapping("test_mapping")

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreCommunication.py
@@ -743,19 +743,25 @@ class Test_FibexCoreCommunication:
         # Test default values
         assert triggering.getFrameRef() is None
         assert triggering.getFramePortRefs() == []
-        assert triggering.getPduTriggeringRefs() == []  # This is the line with potential type annotation issue
+        assert triggering.getPduTriggeringRefs() == []
 
-        # Test setter/getter methods with method chaining
+        # Test frame ref setter/getter with method chaining
         ref1 = object()
         triggering.setFrameRef(ref1)
         assert triggering.getFrameRef() == ref1
         assert triggering == triggering.setFrameRef(ref1)  # Test method chaining
 
+        # Test setFrameRef(None) is a no-op
+        triggering.setFrameRef(None)
+        assert triggering.getFrameRef() == ref1
+
+        # Test frame port refs add/get with method chaining
         ref2 = object()
         triggering.addFramePortRef(ref2)
         assert ref2 in triggering.getFramePortRefs()
         assert triggering == triggering.addFramePortRef(ref2)  # Test method chaining
 
+        # Test pdu triggering refs add/get with method chaining
         ref3 = object()
         triggering.addPduTriggeringRef(ref3)
         assert ref3 in triggering.getPduTriggeringRefs()

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreTopology.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreTopology.py
@@ -629,6 +629,51 @@ class Test_FibexCoreTopology:
         assert isinstance(flexray_channel, FlexrayPhysicalChannel)
         assert len(cluster.getPhysicalChannels()) >= 4  # Another channel created
 
+    def test_PhysicalChannel_spec_attributes(self):
+        """Test PhysicalChannel spec attributes (Table 3.7) per Rule 0001."""
+
+        class ConcretePhysicalChannel(PhysicalChannel):
+            def __init__(self, parent, short_name):
+                super().__init__(parent, short_name)
+
+        parent = MockParent()
+        channel = ConcretePhysicalChannel(parent, "test_physical_channel")
+
+        # commConnector (ref, CommunicationConnector, *)
+        assert channel.getCommConnectorRefs() == []
+        ref1 = object()
+        channel.addCommConnectorRef(ref1)
+        assert ref1 in channel.getCommConnectorRefs()
+        assert channel == channel.addCommConnectorRef(ref1)  # chaining
+
+        # managedPhysicalChannel (ref, PhysicalChannel, *)
+        assert channel.getManagedPhysicalChannelRefs() == []
+        ref2 = object()
+        channel.addManagedPhysicalChannelRef(ref2)
+        assert ref2 in channel.getManagedPhysicalChannelRefs()
+        assert channel == channel.addManagedPhysicalChannelRef(ref2)  # chaining
+
+        # frameTriggering (aggr, FrameTriggering, *) -> dedicated list
+        assert channel.getFrameTriggerings() == []
+        can_triggering = channel.createCanFrameTriggering("can_triggering")
+        assert isinstance(can_triggering, CanFrameTriggering)
+        assert can_triggering in channel.getFrameTriggerings()
+        lin_triggering = channel.createLinFrameTriggering("lin_triggering")
+        assert isinstance(lin_triggering, LinFrameTriggering)
+        assert len(channel.getFrameTriggerings()) == 2
+
+        # iSignalTriggering (aggr, ISignalTriggering, *) -> dedicated list
+        assert channel.getISignalTriggerings() == []
+        isignal_triggering = channel.createISignalTriggering("isignal_triggering")
+        assert isinstance(isignal_triggering, ISignalTriggering)
+        assert isignal_triggering in channel.getISignalTriggerings()
+
+        # pduTriggering (aggr, PduTriggering, *) -> dedicated list
+        assert channel.getPduTriggerings() == []
+        pdu_triggering = channel.createPduTriggering("pdu_triggering")
+        assert isinstance(pdu_triggering, PduTriggering)
+        assert pdu_triggering in channel.getPduTriggerings()
+
     def test_CommunicationConnector_methods(self):
         """Test CommunicationConnector concrete implementation methods."""
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreTopology.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreTopology.py
@@ -3,16 +3,18 @@ import pytest
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrameTriggering
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import (
+    AbstractCanPhysicalChannel,
+    CanPhysicalChannel,
+)
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.NetworkEndpoint import NetworkEndpoint
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import FlexrayFrameTriggering
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommunication import LinFrameTriggering, LinScheduleTable
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignalTriggering, PduTriggering
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import (
     AbstractCanCluster,
-    AbstractCanPhysicalChannel,
     CanCluster,
     CanClusterBusOffRecovery,
-    CanPhysicalChannel,
     CommConnectorPort,
     CommunicationCluster,
     CommunicationConnector,

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreTopology.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreTopology.py
@@ -675,7 +675,7 @@ class Test_FibexCoreTopology:
         assert pdu_triggering in channel.getPduTriggerings()
 
     def test_CommunicationConnector_methods(self):
-        """Test CommunicationConnector concrete implementation methods."""
+        """Test CommunicationConnector concrete implementation methods (Table 3.4)."""
 
         class ConcreteCommunicationConnector(CommunicationConnector):
             def __init__(self, parent, short_name):
@@ -692,38 +692,58 @@ class Test_FibexCoreTopology:
         assert connector.getPncFilterArrayMasks() == []
         assert connector.getPncGatewayType() is None
 
-        # Test setter/getter methods with method chaining
+        # commController (ref, CommunicationController, 0..1)
         ref1 = object()
         connector.setCommControllerRef(ref1)
         assert connector.getCommControllerRef() == ref1
-        assert connector == connector.setCommControllerRef(ref1)  # Test method chaining
+        assert connector == connector.setCommControllerRef(ref1)  # method chaining
+        assert connector == connector.setCommControllerRef(None)  # None no-op
+        assert connector.getCommControllerRef() == ref1  # unchanged
 
+        # createEcuWakeupSource (attr, Boolean, 0..1)
         connector.setCreateEcuWakeupSource(True)
-        assert connector.getCreateEcuWakeupSource() is True
-        assert connector == connector.setCreateEcuWakeupSource(True)  # Test method chaining
+        assert connector.getCreateEcuWakeupSource().getValue() is True
+        assert connector == connector.setCreateEcuWakeupSource(True)  # method chaining
+        assert connector == connector.setCreateEcuWakeupSource(None)  # None no-op
+        assert connector.getCreateEcuWakeupSource().getValue() is True  # unchanged
 
+        # dynamicPncToChannelMappingEnabled (attr, Boolean, 0..1)
         connector.setDynamicPncToChannelMappingEnabled(False)
-        assert connector.getDynamicPncToChannelMappingEnabled() is False
-        assert connector == connector.setDynamicPncToChannelMappingEnabled(False)  # Test method chaining
+        assert connector.getDynamicPncToChannelMappingEnabled().getValue() is False
+        assert connector == connector.setDynamicPncToChannelMappingEnabled(False)  # method chaining
+        assert connector == connector.setDynamicPncToChannelMappingEnabled(None)  # None no-op
+        assert connector.getDynamicPncToChannelMappingEnabled().getValue() is False  # unchanged
 
+        # pncGatewayType (attr, PncGatewayTypeEnum, 0..1)
         connector.setPncGatewayType(PncGatewayTypeEnum.ENUM_ACTIVE)
         assert connector.getPncGatewayType() == PncGatewayTypeEnum.ENUM_ACTIVE
-        assert connector == connector.setPncGatewayType(PncGatewayTypeEnum.ENUM_ACTIVE)  # Test method chaining
+        assert connector == connector.setPncGatewayType(PncGatewayTypeEnum.ENUM_ACTIVE)  # method chaining
+        assert connector == connector.setPncGatewayType(None)  # None no-op
+        assert connector.getPncGatewayType() == PncGatewayTypeEnum.ENUM_ACTIVE  # unchanged
 
-        # Test PNC filter array mask methods
+        # pncFilterArrayMask (ordered, attr, PositiveInteger, *)
         connector.addPncFilterArrayMask(0xFF)
-        assert 0xFF in connector.getPncFilterArrayMasks()
-        assert connector == connector.addPncFilterArrayMask(0xFF)  # Test method chaining
+        connector.addPncFilterArrayMask(0x01)
+        assert connector.getPncFilterArrayMasks() == [0xFF, 0x01]  # ordered
+        assert connector == connector.addPncFilterArrayMask(0x01)  # method chaining
 
-        # Test port creation methods
+        # ecuCommPortInstance (aggr, CommConnectorPort, *) -> dedicated typed list
         frame_port = connector.createFramePort("frame_port")
         assert isinstance(frame_port, FramePort)
-        assert len(connector.getEcuCommPortInstances()) >= 1  # At least one port created
+        assert frame_port in connector.getEcuCommPortInstances()
+        assert len(connector.getEcuCommPortInstances()) == 1  # exactly one port
 
         ipdu_port = connector.createIPduPort("ipdu_port")
         assert isinstance(ipdu_port, IPduPort)
-        assert len(connector.getEcuCommPortInstances()) >= 2  # Another port created
+        assert ipdu_port in connector.getEcuCommPortInstances()
+        assert len(connector.getEcuCommPortInstances()) == 2
 
         isignal_port = connector.createISignalPort("isignal_port")
         assert isinstance(isignal_port, ISignalPort)
-        assert len(connector.getEcuCommPortInstances()) >= 3  # Another port created
+        assert isignal_port in connector.getEcuCommPortInstances()
+        assert len(connector.getEcuCommPortInstances()) == 3
+
+        # createXxx returns the existing element on duplicate short name
+        dup = connector.createFramePort("frame_port")
+        assert dup is frame_port
+        assert len(connector.getEcuCommPortInstances()) == 3  # no duplicate

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreTopology.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/test_CoreTopology.py
@@ -118,11 +118,12 @@ class Test_FibexCoreTopology:
             AbstractCanPhysicalChannel(parent, "test_abstract_can_physical_channel")
 
     def test_CanPhysicalChannel(self):
-        """Test CanPhysicalChannel class functionality."""
+        """Test CanPhysicalChannel class functionality (Table 3.21)."""
         parent = MockParent()
         channel = CanPhysicalChannel(parent, "test_can_physical_channel")
 
         assert isinstance(channel, PhysicalChannel)
+        assert isinstance(channel, AbstractCanPhysicalChannel)
 
     def test_LinPhysicalChannel(self):
         """Test LinPhysicalChannel class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/test_NetworkManagement.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/test_NetworkManagement.py
@@ -278,6 +278,22 @@ class TestNetworkManagement:
         with pytest.raises(TypeError):
             BusspecificNmEcu()
 
+
+class TestBusspecificNmEcu:
+    """Spec-driven tests for the abstract BusspecificNmEcu (Table 6.301)."""
+
+    def test_abstract(self):
+        """BusspecificNmEcu is abstract and cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            BusspecificNmEcu()
+
+    def test_subclasses_inherit_base(self):
+        """Every spec subclass instantiates and is a BusspecificNmEcu."""
+        for subclass in (CanNmEcu, FlexrayNmEcu, J1939NmEcu, UdpNmEcu):
+            ecu = subclass()
+            assert isinstance(ecu, BusspecificNmEcu)
+            assert isinstance(ecu, ARObject)
+
     def test_can_nm_ecu(self):
         """
         Test CanNmEcu class functionality.

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/test_TransportProtocols.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/test_TransportProtocols.py
@@ -1,6 +1,7 @@
 import pytest
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import TpConnection, TpConnectionIdent
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import (
     CanTpAddress,
     CanTpChannel,
@@ -16,8 +17,6 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import
     LinTpNode,
     TpAddress,
     TpConfig,
-    TpConnection,
-    TpConnectionIdent,
 )
 
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/test_TransportProtocols.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/test_TransportProtocols.py
@@ -104,23 +104,15 @@ class TestTransportProtocols:
 
         # Test default values
         assert channel.getChannelId() is None
-        assert channel.getChannelMode() is None
 
         # Test setter/getter methods with method chaining - with None values
         assert channel == channel.setChannelId(None)
         assert channel.getChannelId() is None
 
-        assert channel == channel.setChannelMode(None)
-        assert channel.getChannelMode() is None
-
         # Test setter/getter methods with method chaining - with actual values
         channel.setChannelId(1)
         assert channel.getChannelId() == 1
         assert channel == channel.setChannelId(1)
-
-        channel.setChannelMode("normal")
-        assert channel.getChannelMode() == "normal"
-        assert channel == channel.setChannelMode("normal")
 
     def test_tp_connection_ident(self):
         """

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/test_TransportProtocols.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/test_TransportProtocols.py
@@ -41,6 +41,27 @@ class TestTransportProtocols:
         with pytest.raises(TypeError):
             TpConfig(MockParent(), "test_tp_config")
 
+    def test_tp_config_methods(self):
+        """Test TpConfig concrete implementation methods (Table 6.237)."""
+
+        class ConcreteTpConfig(TpConfig):
+            def __init__(self, parent, short_name):
+                super().__init__(parent, short_name)
+
+        parent = MockParent()
+        config = ConcreteTpConfig(parent, "test_tp_config")
+
+        # Test default values
+        assert config.getCommunicationClusterRef() is None
+
+        # communicationCluster (ref, CommunicationCluster, 0..1)
+        ref1 = object()
+        config.setCommunicationClusterRef(ref1)
+        assert config.getCommunicationClusterRef() == ref1
+        assert config == config.setCommunicationClusterRef(ref1)  # method chaining
+        assert config == config.setCommunicationClusterRef(None)  # None no-op
+        assert config.getCommunicationClusterRef() == ref1  # unchanged
+
     def test_can_tp_address(self):
         """
         Test CanTpAddress class functionality with method chaining and None handling.

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_NetworkManagement.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_NetworkManagement.py
@@ -164,7 +164,7 @@ class Test_NetworkManagement:
             BusspecificNmEcu()
 
     def test_CanNmEcu(self):
-        """Test CanNmEcu class functionality."""
+        """Test CanNmEcu class functionality (Table 6.312)."""
         ecu = CanNmEcu()
 
         assert isinstance(ecu, BusspecificNmEcu)

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
@@ -2,6 +2,7 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, Referrable
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DoIp import AbstractDoIpLogicAddressProps
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import FibexElement
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import (
@@ -38,23 +39,34 @@ class Test_TransportProtocols:
         with pytest.raises(TypeError):
             TpConfig(parent, "test_tp_config")
 
-    def test_CanTpAddress(self):
-        """Test CanTpAddress class functionality."""
+    def test_CanTpAddress_initialization(self):
+        """Test CanTpAddress default state (Table 6.255)."""
         parent = MockParent()
-        address = CanTpAddress(parent, "test_can_tp_address")
+        address = CanTpAddress(parent, "CanTpAddress")
 
         assert isinstance(address, Identifiable)
-
-        # Test default values
         assert address.getTpAddress() is None
         assert address.getTpAddressExtensionValue() is None
 
-        # Test setter/getter methods
-        address.setTpAddress(123)
-        assert address.getTpAddress() == 123
+    def test_CanTpAddress_get_set_tpAddress(self):
+        """Test tpAddress getter/setter with None no-op (Table 6.255)."""
+        parent = MockParent()
+        address = CanTpAddress(parent, "CanTpAddress")
 
-        address.setTpAddressExtensionValue(456)
-        assert address.getTpAddressExtensionValue() == 456
+        assert address == address.setTpAddress(Integer().setValue(0x7FF))
+        assert address.getTpAddress().getValue() == 0x7FF
+        assert address == address.setTpAddress(None)
+        assert address.getTpAddress().getValue() == 0x7FF
+
+    def test_CanTpAddress_get_set_tpAddressExtensionValue(self):
+        """Test tpAddressExtensionValue getter/setter with None no-op (Table 6.255)."""
+        parent = MockParent()
+        address = CanTpAddress(parent, "CanTpAddress")
+
+        assert address == address.setTpAddressExtensionValue(Integer().setValue(6))
+        assert address.getTpAddressExtensionValue().getValue() == 6
+        assert address == address.setTpAddressExtensionValue(None)
+        assert address.getTpAddressExtensionValue().getValue() == 6
 
     def test_CanTpChannel(self):
         """Test CanTpChannel class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
@@ -3,6 +3,7 @@ import pytest
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, Referrable
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer, PositiveInteger
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import TpConnection, TpConnectionIdent
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DoIp import AbstractDoIpLogicAddressProps
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import FibexElement
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import (
@@ -20,8 +21,6 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import
     LinTpNode,
     TpAddress,
     TpConfig,
-    TpConnection,
-    TpConnectionIdent,
 )
 
 
@@ -86,17 +85,27 @@ class Test_TransportProtocols:
         assert channel == channel.setChannelId(None)
         assert channel.getChannelId().getValue() == 1
 
-    def test_TpConnectionIdent(self):
-        """Test TpConnectionIdent class functionality."""
+    def test_TpConnectionIdent_initialization(self):
+        """Test TpConnectionIdent default state (Table 6.273)."""
         parent = MockParent()
-        ident = TpConnectionIdent(parent, "test_tp_connection_ident")
+        ident = TpConnectionIdent(parent, "TpConnectionIdent")
 
         assert isinstance(ident, Referrable)
 
-    def test_TpConnection(self):
-        """Test TpConnection abstract class instantiation."""
+    def test_TpConnection_abstract(self):
+        """Test TpConnection abstract class instantiation (Table 6.272)."""
         with pytest.raises(TypeError):
             TpConnection()
+
+    def test_TpConnection_create_ident(self):
+        """Test TpConnection ident creation via concrete subclass (Table 6.272)."""
+        connection = CanTpConnection()
+
+        assert connection.getIdent() is None
+        ident = connection.createTpConnectionIdent("connIdent")
+        assert isinstance(ident, TpConnectionIdent)
+        assert connection.getIdent() == ident
+        assert connection.createTpConnectionIdent("other") == ident
 
     def test_CanTpConnection(self):
         """Test CanTpConnection class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
@@ -2,7 +2,7 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, Referrable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer, PositiveInteger
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DoIp import AbstractDoIpLogicAddressProps
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import FibexElement
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import (
@@ -68,23 +68,23 @@ class Test_TransportProtocols:
         assert address == address.setTpAddressExtensionValue(None)
         assert address.getTpAddressExtensionValue().getValue() == 6
 
-    def test_CanTpChannel(self):
-        """Test CanTpChannel class functionality."""
+    def test_CanTpChannel_initialization(self):
+        """Test CanTpChannel default state (Table 6.252)."""
         parent = MockParent()
-        channel = CanTpChannel(parent, "test_can_tp_channel")
+        channel = CanTpChannel(parent, "CanTpChannel")
 
         assert isinstance(channel, Identifiable)
-
-        # Test default values
         assert channel.getChannelId() is None
-        assert channel.getChannelMode() is None
 
-        # Test setter/getter methods
-        channel.setChannelId(1)
-        assert channel.getChannelId() == 1
+    def test_CanTpChannel_get_set_channelId(self):
+        """Test channelId getter/setter with None no-op (Table 6.252)."""
+        parent = MockParent()
+        channel = CanTpChannel(parent, "CanTpChannel")
 
-        channel.setChannelMode("normal")
-        assert channel.getChannelMode() == "normal"
+        assert channel == channel.setChannelId(PositiveInteger().setValue(1))
+        assert channel.getChannelId().getValue() == 1
+        assert channel == channel.setChannelId(None)
+        assert channel.getChannelId().getValue() == 1
 
     def test_TpConnectionIdent(self):
         """Test TpConnectionIdent class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
@@ -175,9 +175,10 @@ class Test_TransportProtocols:
         """Test CanTpConnection attribute getters/setters with None no-op (Table 6.253)."""
         connection = CanTpConnection()
 
-        fmt = ARLiteral()
+        fmt = CanTpAddressingFormatType()
         fmt.setValue(CanTpAddressingFormatType.ENUM_STANDARD)
         assert connection == connection.setAddressingFormat(fmt)
+        assert isinstance(connection.getAddressingFormat(), CanTpAddressingFormatType)
         assert connection.getAddressingFormat() == fmt
         assert connection == connection.setAddressingFormat(None)
         assert connection.getAddressingFormat() == fmt

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
@@ -280,14 +280,12 @@ class Test_TransportProtocols:
         assert ecu == ecu.setEcuInstanceRef(None)
         assert ecu.getEcuInstanceRef() == ref
 
-    def test_CanTpNode(self):
-        """Test CanTpNode class functionality."""
+    def test_CanTpNode_initialization(self):
+        """Test CanTpNode default state (Table 6.257)."""
         parent = MockParent()
-        node = CanTpNode(parent, "test_can_tp_node")
+        node = CanTpNode(parent, "CanTpNode")
 
         assert isinstance(node, Identifiable)
-
-        # Test default values
         assert node.getConnectorRef() is None
         assert node.getMaxFcWait() is None
         assert node.getStMin() is None
@@ -295,15 +293,37 @@ class Test_TransportProtocols:
         assert node.getTimeoutAs() is None
         assert node.getTpAddressRef() is None
 
-        # Test setter/getter methods
-        node.setConnectorRef("connector_ref")
-        assert node.getConnectorRef() == "connector_ref"
+    def test_CanTpNode_get_set(self):
+        """Test CanTpNode getters/setters with None no-op (Table 6.257)."""
+        parent = MockParent()
+        node = CanTpNode(parent, "CanTpNode")
 
-        node.setMaxFcWait(10)
-        assert node.getMaxFcWait() == 10
+        connector_ref = RefType()
+        connector_ref.setValue("/Connector")
+        assert node == node.setConnectorRef(connector_ref)
+        assert node.getConnectorRef() == connector_ref
+        assert node == node.setConnectorRef(None)
+        assert node.getConnectorRef() == connector_ref
 
-        node.setStMin("5ms")
-        assert node.getStMin() == "5ms"
+        assert node == node.setMaxFcWait(Integer().setValue(10))
+        assert node.getMaxFcWait().getValue() == 10
+        assert node == node.setMaxFcWait(None)
+        assert node.getMaxFcWait().getValue() == 10
+
+        assert node == node.setStMin(TimeValue().setValue(0.005))
+        assert node.getStMin().getValue() == 0.005
+
+        for setter, getter in (("setTimeoutAr", "getTimeoutAr"), ("setTimeoutAs", "getTimeoutAs")):
+            value = TimeValue().setValue(0.075)
+            getattr(node, setter)(value)
+            assert getattr(node, getter)().getValue() == 0.075
+            getattr(node, setter)(None)
+            assert getattr(node, getter)().getValue() == 0.075
+
+        address_ref = RefType()
+        address_ref.setValue("/TpAddress")
+        assert node == node.setTpAddressRef(address_ref)
+        assert node.getTpAddressRef() == address_ref
 
     def test_CanTpConfig(self):
         """Test CanTpConfig class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
@@ -8,6 +8,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DoIp import AbstractDoIpL
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import FibexElement
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import (
     CanTpAddress,
+    CanTpAddressingFormatType,
     CanTpChannel,
     CanTpConfig,
     CanTpConnection,
@@ -19,6 +20,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import
     LinTpConfig,
     LinTpConnection,
     LinTpNode,
+    NetworkTargetAddressType,
     TpAddress,
     TpConfig,
 )
@@ -106,6 +108,46 @@ class Test_TransportProtocols:
         assert isinstance(ident, TpConnectionIdent)
         assert connection.getIdent() == ident
         assert connection.createTpConnectionIdent("other") == ident
+
+    def test_CanTpAddressingFormatType(self):
+        """Test CanTpAddressingFormatType enum (Table 6.254)."""
+        enum = CanTpAddressingFormatType()
+        assert enum is not None
+        enum.setValue(CanTpAddressingFormatType.ENUM_STANDARD)
+        assert enum.getValue() == "STANDARD"
+
+        assert CanTpAddressingFormatType.ENUM_EXTENDED == "EXTENDED"
+        assert CanTpAddressingFormatType.ENUM_MIXED == "MIXED"
+        assert CanTpAddressingFormatType.ENUM_MIXED_29BIT == "MIXED-29-BIT"
+        assert CanTpAddressingFormatType.ENUM_NORMALFIXED == "NORMALFIXED"
+        assert CanTpAddressingFormatType.ENUM_STANDARD == "STANDARD"
+
+        assert len(enum.getEnumValues()) == 5
+        for literal in (
+            CanTpAddressingFormatType.ENUM_EXTENDED,
+            CanTpAddressingFormatType.ENUM_MIXED,
+            CanTpAddressingFormatType.ENUM_MIXED_29BIT,
+            CanTpAddressingFormatType.ENUM_NORMALFIXED,
+            CanTpAddressingFormatType.ENUM_STANDARD,
+        ):
+            assert literal in enum.getEnumValues()
+
+    def test_NetworkTargetAddressType(self):
+        """Test NetworkTargetAddressType enum (Table 6.258)."""
+        enum = NetworkTargetAddressType()
+        assert enum is not None
+        enum.setValue(NetworkTargetAddressType.ENUM_PHYSICAL)
+        assert enum.getValue() == "PHYSICAL"
+
+        assert NetworkTargetAddressType.ENUM_FUNCTIONAL == "FUNCTIONAL"
+        assert NetworkTargetAddressType.ENUM_PHYSICAL == "PHYSICAL"
+
+        assert len(enum.getEnumValues()) == 2
+        for literal in (
+            NetworkTargetAddressType.ENUM_FUNCTIONAL,
+            NetworkTargetAddressType.ENUM_PHYSICAL,
+        ):
+            assert literal in enum.getEnumValues()
 
     def test_CanTpConnection(self):
         """Test CanTpConnection class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
@@ -325,31 +325,60 @@ class Test_TransportProtocols:
         assert node == node.setTpAddressRef(address_ref)
         assert node.getTpAddressRef() == address_ref
 
-    def test_CanTpConfig(self):
-        """Test CanTpConfig class functionality."""
+    def test_CanTpConfig_initialization(self):
+        """Test CanTpConfig default state (Table 6.251)."""
         parent = MockParent()
-        config = CanTpConfig(parent, "test_can_tp_config")
+        config = CanTpConfig(parent, "CanTpConfig")
 
-        assert isinstance(config, FibexElement)
-
-        # Test default values
+        assert isinstance(config, TpConfig)
         assert config.getTpAddresses() == []
         assert config.getTpChannels() == []
         assert config.getTpConnections() == []
         assert config.getTpEcus() == []
         assert config.getTpNodes() == []
 
-        # Test communicationClusterRef getter and setter to cover lines 28, 31-33
-        assert config.getCommunicationClusterRef() is None
+    def test_CanTpConfig_create_address_duplicate_returns_existing(self):
+        """Test tpAddress aggregation create (Table 6.251)."""
+        parent = MockParent()
+        config = CanTpConfig(parent, "CanTpConfig")
 
-        result = config.setCommunicationClusterRef("cluster_ref")
-        assert config.getCommunicationClusterRef() == "cluster_ref"
-        assert result == config  # Test method chaining
+        addr = config.createCanTpAddress("Addr")
+        assert isinstance(addr, CanTpAddress)
+        assert config.getTpAddresses() == [addr]
+        assert config.createCanTpAddress("Addr") == addr
+        assert len(config.getTpAddresses()) == 1
 
-        # Test setting None (should not change the value due to if value is not None check)
-        result = config.setCommunicationClusterRef(None)
-        assert config.getCommunicationClusterRef() == "cluster_ref"  # Value remains unchanged
-        assert result == config  # Test method chaining
+    def test_CanTpConfig_create_channel_node_duplicate_returns_existing(self):
+        """Test tpChannel/tpNode aggregation creates (Table 6.251)."""
+        parent = MockParent()
+        config = CanTpConfig(parent, "CanTpConfig")
+
+        channel = config.createCanTpChannel("Ch")
+        assert isinstance(channel, CanTpChannel)
+        assert config.getTpChannels() == [channel]
+        assert config.createCanTpChannel("Ch") == channel
+
+        node = config.createCanTpNode("Node")
+        assert isinstance(node, CanTpNode)
+        assert config.getTpNodes() == [node]
+        assert config.createCanTpNode("Node") == node
+
+    def test_CanTpConfig_add_connection_ecu(self):
+        """Test tpConnection/tpEcu aggregation adds with None no-op (Table 6.251)."""
+        parent = MockParent()
+        config = CanTpConfig(parent, "CanTpConfig")
+
+        connection = CanTpConnection()
+        assert config == config.addTpConnection(connection)
+        assert config.getTpConnections() == [connection]
+        assert config == config.addTpConnection(None)
+        assert config.getTpConnections() == [connection]
+
+        ecu = CanTpEcu()
+        assert config == config.addTpEcu(ecu)
+        assert config.getTpEcus() == [ecu]
+        assert config == config.addTpEcu(None)
+        assert config.getTpEcus() == [ecu]
 
     def test_DoIpLogicAddress(self):
         """Test DoIpLogicAddress class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
@@ -256,22 +256,29 @@ class Test_TransportProtocols:
         assert connection == connection.addReceiverRef(None)
         assert connection.getReceiverRefs() == [ref1]
 
-    def test_CanTpEcu(self):
-        """Test CanTpEcu class functionality."""
+    def test_CanTpEcu_initialization(self):
+        """Test CanTpEcu default state (Table 6.256)."""
         ecu = CanTpEcu()
 
         assert isinstance(ecu, ARObject)
-
-        # Test default values
         assert ecu.getCycleTimeMainFunction() is None
         assert ecu.getEcuInstanceRef() is None
 
-        # Test setter/getter methods
-        ecu.setCycleTimeMainFunction("10ms")
-        assert ecu.getCycleTimeMainFunction() == "10ms"
+    def test_CanTpEcu_get_set(self):
+        """Test CanTpEcu getters/setters with None no-op (Table 6.256)."""
+        ecu = CanTpEcu()
 
-        ecu.setEcuInstanceRef("ecu_ref")
-        assert ecu.getEcuInstanceRef() == "ecu_ref"
+        assert ecu == ecu.setCycleTimeMainFunction(TimeValue().setValue(0.01))
+        assert ecu.getCycleTimeMainFunction().getValue() == 0.01
+        assert ecu == ecu.setCycleTimeMainFunction(None)
+        assert ecu.getCycleTimeMainFunction().getValue() == 0.01
+
+        ref = RefType()
+        ref.setValue("/EcuInstance")
+        assert ecu == ecu.setEcuInstanceRef(ref)
+        assert ecu.getEcuInstanceRef() == ref
+        assert ecu == ecu.setEcuInstanceRef(None)
+        assert ecu.getEcuInstanceRef() == ref
 
     def test_CanTpNode(self):
         """Test CanTpNode class functionality."""

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SystemTemplate/test_TransportProtocols.py
@@ -2,7 +2,7 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, Referrable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer, PositiveInteger
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, Boolean, Integer, PositiveInteger, RefType, TimeValue
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import TpConnection, TpConnectionIdent
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DoIp import AbstractDoIpLogicAddressProps
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import FibexElement
@@ -149,13 +149,11 @@ class Test_TransportProtocols:
         ):
             assert literal in enum.getEnumValues()
 
-    def test_CanTpConnection(self):
-        """Test CanTpConnection class functionality."""
+    def test_CanTpConnection_initialization(self):
+        """Test CanTpConnection default state (Table 6.253)."""
         connection = CanTpConnection()
 
         assert isinstance(connection, TpConnection)
-
-        # Test default values
         assert connection.getAddressingFormat() is None
         assert connection.getCancellation() is None
         assert connection.getCanTpChannelRef() is None
@@ -173,20 +171,90 @@ class Test_TransportProtocols:
         assert connection.getTpSduRef() is None
         assert connection.getTransmitterRef() is None
 
-        # Test setter/getter methods
-        connection.setAddressingFormat("extended")
-        assert connection.getAddressingFormat() == "extended"
+    def test_CanTpConnection_get_set_attributes(self):
+        """Test CanTpConnection attribute getters/setters with None no-op (Table 6.253)."""
+        connection = CanTpConnection()
 
-        connection.setCancellation(True)
-        assert connection.getCancellation() is True
+        fmt = ARLiteral()
+        fmt.setValue(CanTpAddressingFormatType.ENUM_STANDARD)
+        assert connection == connection.setAddressingFormat(fmt)
+        assert connection.getAddressingFormat() == fmt
+        assert connection == connection.setAddressingFormat(None)
+        assert connection.getAddressingFormat() == fmt
 
-        # Test adding receiver refs
-        mock_receiver_ref = "receiver_ref"
-        connection.addReceiverRef(mock_receiver_ref)
-        assert connection.getReceiverRefs() == [mock_receiver_ref]
+        assert connection == connection.setCancellation(Boolean().setValue(True))
+        assert connection.getCancellation().getValue() is True
+        assert connection == connection.setCancellation(None)
+        assert connection.getCancellation().getValue() is True
 
-        connection.setTaType("physical")
-        assert connection.getTaType() == "physical"
+        assert connection == connection.setMaxBlockSize(Integer().setValue(8))
+        assert connection.getMaxBlockSize().getValue() == 8
+        assert connection == connection.setMaxBlockSize(None)
+        assert connection.getMaxBlockSize().getValue() == 8
+
+        assert connection == connection.setPaddingActivation(Boolean().setValue(False))
+        assert connection.getPaddingActivation().getValue() is False
+        assert connection == connection.setPaddingActivation(None)
+        assert connection.getPaddingActivation().getValue() is False
+
+        ta = ARLiteral()
+        ta.setValue(NetworkTargetAddressType.ENUM_PHYSICAL)
+        assert connection == connection.setTaType(ta)
+        assert connection.getTaType() == ta
+        assert connection == connection.setTaType(None)
+        assert connection.getTaType() == ta
+
+    def test_CanTpConnection_get_set_timeouts(self):
+        """Test CanTpConnection timeout getters/setters with None no-op (Table 6.253)."""
+        connection = CanTpConnection()
+
+        for setter, getter in (
+            ("setTimeoutBr", "getTimeoutBr"),
+            ("setTimeoutBs", "getTimeoutBs"),
+            ("setTimeoutCr", "getTimeoutCr"),
+            ("setTimeoutCs", "getTimeoutCs"),
+        ):
+            value = TimeValue().setValue(0.1)
+            assert getattr(connection, setter)(value) == connection
+            assert getattr(connection, getter)().getValue() == 0.1
+            getattr(connection, setter)(None)
+            assert getattr(connection, getter)().getValue() == 0.1
+
+    def test_CanTpConnection_get_set_refs(self):
+        """Test CanTpConnection reference getters/setters with None no-op (Table 6.253)."""
+        connection = CanTpConnection()
+
+        channel_ref = RefType()
+        channel_ref.setValue("/CanTpChannel")
+        assert connection == connection.setCanTpChannelRef(channel_ref)
+        assert connection.getCanTpChannelRef() == channel_ref
+        assert connection == connection.setCanTpChannelRef(None)
+        assert connection.getCanTpChannelRef() == channel_ref
+
+        for setter, getter, path in (
+            ("setDataPduRef", "getDataPduRef", "/DataPdu"),
+            ("setFlowControlPduRef", "getFlowControlPduRef", "/FcPdu"),
+            ("setMulticastRef", "getMulticastRef", "/Multicast"),
+            ("setTpSduRef", "getTpSduRef", "/TpSdu"),
+            ("setTransmitterRef", "getTransmitterRef", "/TxNode"),
+        ):
+            ref = RefType()
+            ref.setValue(path)
+            assert getattr(connection, setter)(ref) == connection
+            assert getattr(connection, getter)() == ref
+            getattr(connection, setter)(None)
+            assert getattr(connection, getter)() == ref
+
+    def test_CanTpConnection_receiver_refs(self):
+        """Test receiverRefs add with None no-op (Table 6.253)."""
+        connection = CanTpConnection()
+
+        ref1 = RefType()
+        ref1.setValue("/r1")
+        assert connection == connection.addReceiverRef(ref1)
+        assert connection.getReceiverRefs() == [ref1]
+        assert connection == connection.addReceiverRef(None)
+        assert connection.getReceiverRefs() == [ref1]
 
     def test_CanTpEcu(self):
         """Test CanTpEcu class functionality."""

--- a/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
@@ -1160,19 +1160,21 @@ class TestFrameAndPduHandlers:
         assert triggering.getCanAddressingMode() is not None
         assert triggering.getCanAddressingMode().getValue() == "standard"
 
-    def test_readCanFrameTriggering_sets_canFdFrameSupport(self, parser):
+    def test_readCanFrameTriggering_sets_masks_and_j1939(self, parser):
         from armodel.models import CanCluster, CanFrameTriggering, CanPhysicalChannel
 
         cluster = CanCluster(parent=_autosar_root(), short_name="c")
         channel = CanPhysicalChannel(parent=cluster, short_name="ch")
         triggering = CanFrameTriggering(parent=channel, short_name="ft")
         element = _snip(
-            "<SHORT-NAME>ft</SHORT-NAME>" "<CAN-FD-FRAME-SUPPORT>true</CAN-FD-FRAME-SUPPORT>",
+            "<SHORT-NAME>ft</SHORT-NAME>" "<J-1939-REQUESTABLE>true</J-1939-REQUESTABLE>" "<RX-MASK>511</RX-MASK>" "<TX-MASK>255</TX-MASK>",
             root_tag="CAN-FRAME-TRIGGERING",
         )
         parser.readCanFrameTriggering(element, triggering)
-        assert triggering.getCanFdFrameSupport() is not None
-        assert triggering.getCanFdFrameSupport().getValue()
+        assert triggering.getJ1939requestable() is not None
+        assert triggering.getJ1939requestable().getValue()
+        assert triggering.getRxMask().getValue() == 511
+        assert triggering.getTxMask().getValue() == 255
 
     def test_readCanFrameTriggering_sets_identifier(self, parser):
         from armodel.models import CanCluster, CanFrameTriggering, CanPhysicalChannel

--- a/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
@@ -527,6 +527,28 @@ class TestFlexrayClusterHandlers:
         parser.readFlexrayFrameTriggeringAbsolutelyScheduledTimings(element, triggering)
         assert len(triggering.getAbsolutelyScheduledTimings()) == 1
 
+    def test_readTtcanAbsolutelyScheduledTiming_sets_fields(self, parser):
+        from armodel.models import TtcanAbsolutelyScheduledTiming
+
+        timing = TtcanAbsolutelyScheduledTiming()
+        element = _snip(
+            "<COMMUNICATION-CYCLE>"
+            "<CYCLE-REPETITION>"
+            "<BASE-CYCLE>1</BASE-CYCLE>"
+            "<CYCLE-REPETITION>cyclic</CYCLE-REPETITION>"
+            "</CYCLE-REPETITION>"
+            "</COMMUNICATION-CYCLE>"
+            "<TIME-MARK>16</TIME-MARK>"
+            "<TRIGGER>RX-TRIGGER</TRIGGER>",
+            root_tag="TTCAN-ABSOLUTELY-SCHEDULED-TIMING",
+        )
+        parser.readTtcanAbsolutelyScheduledTiming(element, timing)
+        assert timing.getCommunicationCycle() is not None
+        assert timing.getCommunicationCycle().getBaseCycle().getValue() == 1
+        assert timing.getCommunicationCycle().getCycleRepetition().getValue() == "cyclic"
+        assert timing.getTimeMark().getValue() == 16
+        assert timing.getTrigger().getValue() == "RX-TRIGGER"
+
 
 class TestEthernetClusterHandlers:
     def test_readEthernetCluster_sets_short_name(self, parser):

--- a/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
@@ -2630,6 +2630,28 @@ class TestEcuInstanceHandlers:
         with pytest.raises(Exception):
             parser.readCommunicationConnectorEcuCommPortInstances(element, conn)
 
+    def test_readCommunicationConnector_sets_optional_attributes(self, parser):
+        from armodel.models import CanCommunicationConnector, EcuInstance
+
+        instance = EcuInstance(parent=_autosar_root(), short_name="ecu")
+        conn = CanCommunicationConnector(parent=instance, short_name="conn")
+        element = _snip(
+            "<SHORT-NAME>conn</SHORT-NAME>"
+            "<CREATE-ECU-WAKEUP-SOURCE>true</CREATE-ECU-WAKEUP-SOURCE>"
+            "<DYNAMIC-PNC-TO-CHANNEL-MAPPING-ENABLED>false</DYNAMIC-PNC-TO-CHANNEL-MAPPING-ENABLED>"
+            "<PNC-FILTER-ARRAY-MASKS>"
+            "<PNC-FILTER-ARRAY-MASK>255</PNC-FILTER-ARRAY-MASK>"
+            "<PNC-FILTER-ARRAY-MASK>1</PNC-FILTER-ARRAY-MASK>"
+            "</PNC-FILTER-ARRAY-MASKS>"
+            "<PNC-GATEWAY-TYPE>active</PNC-GATEWAY-TYPE>",
+            root_tag="CAN-COMMUNICATION-CONNECTOR",
+        )
+        parser.readCommunicationConnector(element, conn)
+        assert conn.getCreateEcuWakeupSource().getValue() is True
+        assert conn.getDynamicPncToChannelMappingEnabled().getValue() is False
+        assert conn.getPncFilterArrayMasks() == [255, 1]
+        assert conn.getPncGatewayType().getValue() == "active"
+
     def test_readFramePort_sets_communicationDirection(self, parser):
         from armodel.models import CanCommunicationConnector, EcuInstance, FramePort
 

--- a/tests/test_armodel/parser/test_arxml_parser_nm_tp.py
+++ b/tests/test_armodel/parser/test_arxml_parser_nm_tp.py
@@ -495,4 +495,27 @@ class TestCanTpChannelHandler:
         assert len(config.getTpChannels()) == 0
 
 
+# ==================== TpConnection (Table 6.272) / TpConnectionIdent (Table 6.273) ====================
+
+
+class TestTpConnectionHandler:
+    def test_readTpConnection_creates_ident(self, parser):
+        from armodel.models import CanTpConnection
+
+        connection = CanTpConnection()
+        element = _snip("<IDENT><SHORT-NAME>connIdent</SHORT-NAME></IDENT>", root_tag="CAN-TP-CONNECTION")
+        parser.readTpConnection(element, connection)
+        ident = connection.getIdent()
+        assert ident is not None
+        assert ident.getShortName() == "connIdent"
+
+    def test_readTpConnection_without_ident(self, parser):
+        from armodel.models import CanTpConnection
+
+        connection = CanTpConnection()
+        element = _snip("", root_tag="CAN-TP-CONNECTION")
+        parser.readTpConnection(element, connection)
+        assert connection.getIdent() is None
+
+
 # ==================== BufferProperties (L4311-4313) ====================

--- a/tests/test_armodel/parser/test_arxml_parser_nm_tp.py
+++ b/tests/test_armodel/parser/test_arxml_parser_nm_tp.py
@@ -415,4 +415,48 @@ class TestTpConfigGaps:
         assert any("Unsupported TpAddress" in r.getMessage() for r in caplog.records)
 
 
+# ==================== CanTpAddress (Table 6.255) ====================
+
+
+class TestCanTpAddressHandler:
+    def test_readCanTpConfigTpAddresses_creates_address(self, parser):
+        from armodel.models import CanTpConfig
+
+        config = CanTpConfig(parent=_autosar_root(), short_name="Ctp")
+        element = _snip(
+            "<TP-ADDRESSS>"
+            "<CAN-TP-ADDRESS>"
+            "<SHORT-NAME>addr</SHORT-NAME>"
+            "<TP-ADDRESS>2047</TP-ADDRESS>"
+            "<TP-ADDRESS-EXTENSION-VALUE>5</TP-ADDRESS-EXTENSION-VALUE>"
+            "</CAN-TP-ADDRESS>"
+            "</TP-ADDRESSS>",
+        )
+        parser.readCanTpConfigTpAddresses(element, config)
+        addresses = config.getTpAddresses()
+        assert len(addresses) == 1
+        assert addresses[0].getShortName() == "addr"
+        assert addresses[0].getTpAddress().getValue() == 2047
+        assert addresses[0].getTpAddressExtensionValue().getValue() == 5
+
+    def test_readCanTpAddress_without_optional_fields(self, parser):
+        from armodel.models import CanTpAddress, CanTpConfig
+
+        config = CanTpConfig(parent=_autosar_root(), short_name="Ctp")
+        address = CanTpAddress(parent=config, short_name="addr")
+        element = _snip("<SHORT-NAME>addr</SHORT-NAME>", root_tag="CAN-TP-ADDRESS")
+        parser.readCanTpAddress(element, address)
+        assert address.getShortName() == "addr"
+        assert address.getTpAddress() is None
+        assert address.getTpAddressExtensionValue() is None
+
+    def test_readCanTpConfigTpAddresses_empty(self, parser):
+        from armodel.models import CanTpConfig
+
+        config = CanTpConfig(parent=_autosar_root(), short_name="Ctp")
+        element = _snip("<TP-ADDRESSS></TP-ADDRESSS>")
+        parser.readCanTpConfigTpAddresses(element, config)
+        assert len(config.getTpAddresses()) == 0
+
+
 # ==================== BufferProperties (L4311-4313) ====================

--- a/tests/test_armodel/parser/test_arxml_parser_nm_tp.py
+++ b/tests/test_armodel/parser/test_arxml_parser_nm_tp.py
@@ -57,6 +57,21 @@ class TestBusDependentNmEcusHandler:
         assert dependents[0].getNmSynchronizationPointEnabled() is not None
         assert dependents[0].getNmSynchronizationPointEnabled().getValue() is True
 
+    def test_readBusDependentNmEcus_udp_ecu_is_busspecific_nm_ecu(self, parser):
+        from armodel.models import BusspecificNmEcu, NmConfig, NmEcu, UdpNmEcu
+
+        config = NmConfig(parent=_autosar_root(), short_name="nmConfig")
+        nm_ecu = NmEcu(parent=config, short_name="ecu")
+        element = _snip(
+            "<BUS-DEPENDENT-NM-ECUS>" "<UDP-NM-ECU>" "<NM-SYNCHRONIZATION-POINT-ENABLED>true</NM-SYNCHRONIZATION-POINT-ENABLED>" "</UDP-NM-ECU>" "</BUS-DEPENDENT-NM-ECUS>",
+            root_tag="NM-ECU",
+        )
+        parser.readBusDependentNmEcus(element, nm_ecu)
+        dependents = nm_ecu.getBusDependentNmEcus()
+        assert len(dependents) == 1
+        assert isinstance(dependents[0], UdpNmEcu)
+        assert isinstance(dependents[0], BusspecificNmEcu)
+
     def test_readBusDependentNmEcus_unsupported_warns(self, warning_parser, caplog):
         from armodel.models import NmConfig, NmEcu
 

--- a/tests/test_armodel/parser/test_arxml_parser_nm_tp.py
+++ b/tests/test_armodel/parser/test_arxml_parser_nm_tp.py
@@ -57,6 +57,20 @@ class TestBusDependentNmEcusHandler:
         assert dependents[0].getNmSynchronizationPointEnabled() is not None
         assert dependents[0].getNmSynchronizationPointEnabled().getValue() is True
 
+    def test_readBusDependentNmEcus_creates_canNmEcu(self, parser):
+        from armodel.models import CanNmEcu, NmConfig, NmEcu
+
+        config = NmConfig(parent=_autosar_root(), short_name="nmConfig")
+        nm_ecu = NmEcu(parent=config, short_name="ecu")
+        element = _snip(
+            "<BUS-DEPENDENT-NM-ECUS><CAN-NM-ECU/></BUS-DEPENDENT-NM-ECUS>",
+            root_tag="NM-ECU",
+        )
+        parser.readBusDependentNmEcus(element, nm_ecu)
+        dependents = nm_ecu.getBusDependentNmEcus()
+        assert len(dependents) == 1
+        assert isinstance(dependents[0], CanNmEcu)
+
     def test_readBusDependentNmEcus_udp_ecu_is_busspecific_nm_ecu(self, parser):
         from armodel.models import BusspecificNmEcu, NmConfig, NmEcu, UdpNmEcu
 

--- a/tests/test_armodel/parser/test_arxml_parser_nm_tp.py
+++ b/tests/test_armodel/parser/test_arxml_parser_nm_tp.py
@@ -459,4 +459,40 @@ class TestCanTpAddressHandler:
         assert len(config.getTpAddresses()) == 0
 
 
+# ==================== CanTpChannel (Table 6.252) ====================
+
+
+class TestCanTpChannelHandler:
+    def test_readCanTpConfigTpChannels_creates_channel(self, parser):
+        from armodel.models import CanTpConfig
+
+        config = CanTpConfig(parent=_autosar_root(), short_name="Ctp")
+        element = _snip(
+            "<TP-CHANNELS>" "<CAN-TP-CHANNEL>" "<SHORT-NAME>channel</SHORT-NAME>" "<CHANNEL-ID>1</CHANNEL-ID>" "</CAN-TP-CHANNEL>" "</TP-CHANNELS>",
+        )
+        parser.readCanTpConfigTpChannels(element, config)
+        channels = config.getTpChannels()
+        assert len(channels) == 1
+        assert channels[0].getShortName() == "channel"
+        assert channels[0].getChannelId().getValue() == 1
+
+    def test_readCanTpChannel_without_optional_fields(self, parser):
+        from armodel.models import CanTpChannel, CanTpConfig
+
+        config = CanTpConfig(parent=_autosar_root(), short_name="Ctp")
+        channel = CanTpChannel(parent=config, short_name="channel")
+        element = _snip("<SHORT-NAME>channel</SHORT-NAME>", root_tag="CAN-TP-CHANNEL")
+        parser.readCanTpChannel(element, channel)
+        assert channel.getShortName() == "channel"
+        assert channel.getChannelId() is None
+
+    def test_readCanTpConfigTpChannels_empty(self, parser):
+        from armodel.models import CanTpConfig
+
+        config = CanTpConfig(parent=_autosar_root(), short_name="Ctp")
+        element = _snip("<TP-CHANNELS></TP-CHANNELS>")
+        parser.readCanTpConfigTpChannels(element, config)
+        assert len(config.getTpChannels()) == 0
+
+
 # ==================== BufferProperties (L4311-4313) ====================

--- a/tests/test_armodel/parser/test_can_xl_frame_triggering_props.py
+++ b/tests/test_armodel/parser/test_can_xl_frame_triggering_props.py
@@ -1,0 +1,29 @@
+"""Parser tests for getCanXlFrameTriggeringProps (Table F.27, p.447).
+
+Shared fixtures (``parser``) are provided by ``conftest.py``; the ``_snip``
+helper lives in ``_helpers.py``.
+"""
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanXlFrameTriggeringProps
+from tests.test_armodel.parser._helpers import _snip
+
+
+class TestGetCanXlFrameTriggeringProps:
+    def test_returns_none_when_child_absent(self, parser):
+        element = _snip("<OTHER/>")
+        result = parser.getCanXlFrameTriggeringProps(element, "CAN-XL-FRAME-TRIGGERING-PROPS")
+        assert result is None
+
+    def test_returns_props_when_child_present(self, parser):
+        element = _snip(
+            "<CAN-XL-FRAME-TRIGGERING-PROPS>" "<ACCEPTANCE-FIELD>0</ACCEPTANCE-FIELD>" "<PRIORITY-ID>7</PRIORITY-ID>" "<SDU-TYPE>8</SDU-TYPE>" "<VCID>10</VCID>" "</CAN-XL-FRAME-TRIGGERING-PROPS>"
+        )
+        result = parser.getCanXlFrameTriggeringProps(element, "CAN-XL-FRAME-TRIGGERING-PROPS")
+        assert isinstance(result, CanXlFrameTriggeringProps)
+        acceptance = result.getAcceptanceField()
+        assert isinstance(acceptance, PositiveInteger)
+        assert acceptance.getValue() == 0
+        assert result.getPriorityId().getValue() == 7
+        assert result.getSduType().getValue() == 8
+        assert result.getVcid().getValue() == 10

--- a/tests/test_armodel/parser/test_frame.py
+++ b/tests/test_armodel/parser/test_frame.py
@@ -1,0 +1,37 @@
+"""Tests for Frame reader (Table 6.78: Frame)."""
+
+import xml.etree.cElementTree as ET
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame
+
+_NS = "http://autosar.org/schema/r4.0"
+
+
+def _snip(inner: str) -> ET.Element:
+    return ET.fromstring("<CAN-FRAME xmlns='%s'>%s</CAN-FRAME>" % (_NS, inner))
+
+
+def test_read_frame_frame_length(parser):
+    element = _snip("<SHORT-NAME>MyFrame</SHORT-NAME>" "<FRAME-LENGTH>100</FRAME-LENGTH>")
+    frame = CanFrame(None, "MyFrame")
+    parser.readCanFrame(element, frame)
+    assert isinstance(frame.getFrameLength(), Integer)
+    assert frame.getFrameLength().getValue() == 100
+
+
+def test_read_frame_pdu_to_frame_mapping(parser):
+    element = _snip(
+        "<SHORT-NAME>MyFrame</SHORT-NAME>"
+        "<PDU-TO-FRAME-MAPPINGS>"
+        "<PDU-TO-FRAME-MAPPING>"
+        "<SHORT-NAME>Map1</SHORT-NAME>"
+        "<START-POSITION>8</START-POSITION>"
+        "</PDU-TO-FRAME-MAPPING>"
+        "</PDU-TO-FRAME-MAPPINGS>"
+    )
+    frame = CanFrame(None, "MyFrame")
+    parser.readCanFrame(element, frame)
+    mappings = frame.getPduToFrameMappings()
+    assert len(mappings) == 1
+    assert mappings[0].getShortName() == "Map1"

--- a/tests/test_armodel/writer/test_can_xl_frame_triggering_props.py
+++ b/tests/test_armodel/writer/test_can_xl_frame_triggering_props.py
@@ -1,0 +1,56 @@
+"""Writer round-trip tests for CanXlFrameTriggeringProps (Table F.27, p.447).
+
+Verifies that the singleton wrapper serializes its four PositiveInteger
+attributes into a ``CAN-XL-FRAME-TRIGGERING-PROPS`` element tree and is
+skipped when the props are absent.
+"""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from armodel.models import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanXlFrameTriggeringProps
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+def _parent():
+    return ET.Element("PARENT")
+
+
+def test_write_can_xl_frame_triggering_props_all_fields(writer):
+    parent = _parent()
+    props = CanXlFrameTriggeringProps()
+    props.setAcceptanceField(PositiveInteger().setValue(0))
+    props.setPriorityId(PositiveInteger().setValue(7))
+    props.setSduType(PositiveInteger().setValue(8))
+    props.setVcid(PositiveInteger().setValue(10))
+
+    writer.setCanXlFrameTriggeringProps(parent, "CAN-XL-FRAME-TRIGGERING-PROPS", props)
+
+    el = parent.find("CAN-XL-FRAME-TRIGGERING-PROPS")
+    assert el is not None
+    assert el.find("ACCEPTANCE-FIELD").text == "0"
+    assert el.find("PRIORITY-ID").text == "7"
+    assert el.find("SDU-TYPE").text == "8"
+    assert el.find("VCID").text == "10"
+
+
+def test_write_can_xl_frame_triggering_props_none(writer):
+    parent = _parent()
+    writer.setCanXlFrameTriggeringProps(parent, "CAN-XL-FRAME-TRIGGERING-PROPS", None)
+    assert parent.find("CAN-XL-FRAME-TRIGGERING-PROPS") is None

--- a/tests/test_armodel/writer/test_writer_controllers_ecu.py
+++ b/tests/test_armodel/writer/test_writer_controllers_ecu.py
@@ -743,6 +743,21 @@ class TestWriterCommunicationConnector:
         assert parent.find("ECU-COMM-PORT-INSTANCES") is not None
         assert parent.find("PNC-GATEWAY-TYPE").text == "active"
 
+    def test_optional_attributes(self, writer):
+        instance = _make_ecu_instance()
+        connector = instance.createCanCommunicationConnector("cc")
+        connector.setCreateEcuWakeupSource(True)
+        connector.setDynamicPncToChannelMappingEnabled(False)
+        connector.addPncFilterArrayMask(255)
+        connector.addPncFilterArrayMask(1)
+        parent = _parent()
+        writer.writeCommunicationConnector(parent, connector)
+        assert parent.find("CREATE-ECU-WAKEUP-SOURCE").text == "true"
+        assert parent.find("DYNAMIC-PNC-TO-CHANNEL-MAPPING-ENABLED").text == "false"
+        masks = parent.find("PNC-FILTER-ARRAY-MASKS")
+        assert masks is not None
+        assert [m.text for m in masks.findall("PNC-FILTER-ARRAY-MASK")] == ["255", "1"]
+
 
 class TestWriterCanCommunicationConnector:
     def test_can_connector(self, writer):

--- a/tests/test_armodel/writer/test_writer_frame.py
+++ b/tests/test_armodel/writer/test_writer_frame.py
@@ -1,0 +1,59 @@
+"""Tests for Frame writer and round-trip (Table 6.78: Frame)."""
+
+import xml.etree.cElementTree as ET
+
+import pytest
+
+from armodel.models import AUTOSAR
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame
+from armodel.parser.arxml_parser import ARXMLParser
+from armodel.writer.arxml_writer import ARXMLWriter
+
+
+@pytest.fixture(autouse=True)
+def reset_autosar():
+    AUTOSAR.getInstance().new()
+    yield
+    AUTOSAR.getInstance().new()
+
+
+@pytest.fixture
+def writer():
+    AUTOSAR.getInstance().new()
+    return ARXMLWriter()
+
+
+def test_write_frame_frame_length(writer):
+    pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+    frame = pkg.createCanFrame("MyFrame")
+    frame.setFrameLength(Integer().setValue("100"))
+    parent = ET.Element("CAN-FRAMES")
+    writer.writeCanFrame(parent, frame)
+    cf = parent.find("CAN-FRAME")
+    assert cf.find("FRAME-LENGTH").text == "100"
+
+
+def test_round_trip_frame(writer, tmp_path):
+    pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+    frame = pkg.createCanFrame("MyFrame")
+    frame.setFrameLength(Integer().setValue("100"))
+    frame.createPduToFrameMapping("Map1")
+
+    out_file = str(tmp_path / "frame.arxml")
+    writer.save(out_file, AUTOSAR.getInstance())
+
+    AUTOSAR.getInstance().new()
+    parser = ARXMLParser(options={"warning": True})
+    document = AUTOSAR.getInstance()
+    document.setARRelease("R23-11")
+    parser.load(out_file, document)
+
+    re_pkg = document.find("Pkg")
+    re_frame = re_pkg.getElement("MyFrame", CanFrame)
+    assert re_frame is not None
+    assert isinstance(re_frame.getFrameLength(), Integer)
+    assert re_frame.getFrameLength().getValue() == 100
+    mappings = re_frame.getPduToFrameMappings()
+    assert len(mappings) == 1
+    assert mappings[0].getShortName() == "Map1"

--- a/tests/test_armodel/writer/test_writer_frame_channel.py
+++ b/tests/test_armodel/writer/test_writer_frame_channel.py
@@ -77,7 +77,15 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopol
     FlexrayPhysicalChannel,
     LinPhysicalChannel,
 )
+from armodel.parser.arxml_parser import ARXMLParser
 from armodel.writer.arxml_writer import ARXMLWriter
+
+
+_NS = "http://autosar.org/schema/r4.0"
+
+
+def _snip(inner: str, root_tag: str = "ROOT") -> ET.Element:
+    return ET.fromstring("<%s xmlns='%s'>%s</%s>" % (root_tag, _NS, inner, root_tag))
 
 
 @pytest.fixture(autouse=True)
@@ -489,6 +497,84 @@ class TestWriteCanPhysicalChannel:
         writer.writeCanPhysicalChannel(parent, ch)
         cpc = parent.find("CAN-PHYSICAL-CHANNEL")
         assert cpc is not None
+
+
+class TestPhysicalChannelRoundTrip:
+    def test_reader_physical_channel(self):
+        inner = (
+            "<SHORT-NAME>Ch</SHORT-NAME>"
+            "<COMM-CONNECTORS>"
+            "<COMMUNICATION-CONNECTOR-REF-CONDITIONAL>"
+            "<COMMUNICATION-CONNECTOR-REF DEST=\"COMMUNICATION-CONNECTOR\">/cc1</COMMUNICATION-CONNECTOR-REF>"
+            "</COMMUNICATION-CONNECTOR-REF-CONDITIONAL>"
+            "</COMM-CONNECTORS>"
+            "<MANAGED-PHYSICAL-CHANNEL-REFS>"
+            "<MANAGED-PHYSICAL-CHANNEL-REF DEST=\"PHYSICAL-CHANNEL\">/pc2</MANAGED-PHYSICAL-CHANNEL-REF>"
+            "</MANAGED-PHYSICAL-CHANNEL-REFS>"
+            "<FRAME-TRIGGERINGS>"
+            "<CAN-FRAME-TRIGGERING><SHORT-NAME>Cft</SHORT-NAME></CAN-FRAME-TRIGGERING>"
+            "</FRAME-TRIGGERINGS>"
+            "<I-SIGNAL-TRIGGERINGS>"
+            "<I-SIGNAL-TRIGGERING><SHORT-NAME>Ist</SHORT-NAME></I-SIGNAL-TRIGGERING>"
+            "</I-SIGNAL-TRIGGERINGS>"
+            "<PDU-TRIGGERINGS>"
+            "<PDU-TRIGGERING><SHORT-NAME>Pt</SHORT-NAME></PDU-TRIGGERING>"
+            "</PDU-TRIGGERINGS>"
+        )
+        el = _snip(inner, "CAN-PHYSICAL-CHANNEL")
+
+        pkg = _pkg()
+        channel = CanPhysicalChannel(pkg, "Ch2")
+        ARXMLParser().readPhysicalChannel(el, channel)
+
+        cc_refs = [r.getValue() for r in channel.getCommConnectorRefs()]
+        assert "/cc1" in cc_refs
+        mp_refs = [r.getValue() for r in channel.getManagedPhysicalChannelRefs()]
+        assert "/pc2" in mp_refs
+        assert [t.getShortName() for t in channel.getFrameTriggerings()] == ["Cft"]
+        assert [t.getShortName() for t in channel.getISignalTriggerings()] == ["Ist"]
+        assert [t.getShortName() for t in channel.getPduTriggerings()] == ["Pt"]
+
+    def test_writer_physical_channel(self, writer):
+        pkg = _pkg()
+        ch = CanPhysicalChannel(pkg, "Ch")
+        ch.addCommConnectorRef(_ref("COMMUNICATION-CONNECTOR", "/cc1"))
+        ch.addManagedPhysicalChannelRef(_ref("PHYSICAL-CHANNEL", "/pc2"))
+        ch.createCanFrameTriggering("Cft")
+        ch.createISignalTriggering("Ist")
+        ch.createPduTriggering("Pt")
+        parent = _parent()
+        writer.writeCanPhysicalChannel(parent, ch)
+
+        el = parent.find("CAN-PHYSICAL-CHANNEL")
+        assert el is not None
+
+        conns = el.find("COMM-CONNECTORS")
+        assert conns is not None
+        cc_ref = conns.find("COMMUNICATION-CONNECTOR-REF-CONDITIONAL/COMMUNICATION-CONNECTOR-REF")
+        assert cc_ref is not None
+        assert cc_ref.text == "/cc1"
+
+        mp_refs = el.find("MANAGED-PHYSICAL-CHANNEL-REFS")
+        assert mp_refs is not None
+        mp_ref = mp_refs.find("MANAGED-PHYSICAL-CHANNEL-REF")
+        assert mp_ref is not None
+        assert mp_ref.text == "/pc2"
+
+        assert el.find("FRAME-TRIGGERINGS/CAN-FRAME-TRIGGERING/SHORT-NAME").text == "Cft"
+        assert el.find("I-SIGNAL-TRIGGERINGS/I-SIGNAL-TRIGGERING/SHORT-NAME").text == "Ist"
+        assert el.find("PDU-TRIGGERINGS/PDU-TRIGGERING/SHORT-NAME").text == "Pt"
+
+    def test_writer_physical_channel_empty(self, writer):
+        pkg = _pkg()
+        ch = CanPhysicalChannel(pkg, "Ch")
+        parent = _parent()
+        writer.writeCanPhysicalChannel(parent, ch)
+        assert parent.find("COMM-CONNECTORS") is None
+        assert parent.find("MANAGED-PHYSICAL-CHANNEL-REFS") is None
+        assert parent.find("FRAME-TRIGGERINGS") is None
+        assert parent.find("I-SIGNAL-TRIGGERINGS") is None
+        assert parent.find("PDU-TRIGGERINGS") is None
 
 
 class TestWriteScheduleTableEntry:

--- a/tests/test_armodel/writer/test_writer_frame_channel.py
+++ b/tests/test_armodel/writer/test_writer_frame_channel.py
@@ -17,6 +17,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 )
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (  # noqa: E501
     CanFrameTriggering,
+    CanXlFrameTriggeringProps,
     RxIdentifierRange,
 )
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetCommunication import (  # noqa: E501
@@ -206,7 +207,6 @@ class TestWriteCanFrameTriggering:
         pkg = _pkg()
         ft = CanFrameTriggering(pkg, "CanFt")
         ft.setCanAddressingMode(_literal("STANDARD"))
-        ft.setCanFdFrameSupport(_boolean("true"))
         ft.setCanFrameRxBehavior(_literal("CAN-FD"))
         ft.setCanFrameTxBehavior(_literal("CAN-FD"))
         ft.setIdentifier(_pos_int("100"))
@@ -219,7 +219,7 @@ class TestWriteCanFrameTriggering:
         cft = parent.find("CAN-FRAME-TRIGGERING")
         assert cft is not None
         assert cft.find("CAN-ADDRESSING-MODE").text == "STANDARD"
-        assert cft.find("CAN-FD-FRAME-SUPPORT").text == "true"
+        assert cft.find("CAN-FD-FRAME-SUPPORT") is None
         assert cft.find("CAN-FRAME-RX-BEHAVIOR").text == "CAN-FD"
         assert cft.find("CAN-FRAME-TX-BEHAVIOR").text == "CAN-FD"
         assert cft.find("IDENTIFIER").text == "100"
@@ -266,6 +266,39 @@ class TestWriteCanFrameTriggering:
         assert reloaded_rng is not None
         assert reloaded_rng.getLowerCanId() is None
         assert reloaded_rng.getUpperCanId() is None
+
+    def test_roundtrip_can_frame_triggering_full(self, writer):
+        pkg = _pkg()
+        ft = CanFrameTriggering(pkg, "CanFt")
+        ft.setCanAddressingMode(_literal("STANDARD"))
+        ft.setCanFrameRxBehavior(_literal("CAN-FD"))
+        ft.setCanFrameTxBehavior(_literal("CAN-FD"))
+        ft.setIdentifier(_pos_int("0x200"))
+        ft.setJ1939requestable(_boolean("true"))
+        ft.setRxMask(_pos_int("0x7FF"))
+        ft.setTxMask(_pos_int("0x100"))
+        timing = TtcanAbsolutelyScheduledTiming()
+        ft.addAbsolutelyScheduledTiming(timing)
+        props = CanXlFrameTriggeringProps()
+        props.setPriorityId(_pos_int("5"))
+        ft.setCanXlFrameTriggeringProps(props)
+        parent = _parent()
+        writer.writeCanFrameTriggering(parent, ft)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanFrameTriggering(pkg, "CanFt2")
+        parser.readCanFrameTriggering(parser.find(ET.fromstring(xml_str), "CAN-FRAME-TRIGGERING"), reloaded)
+        assert reloaded.getCanAddressingMode().getValue() == "STANDARD"
+        assert reloaded.getCanFrameRxBehavior().getValue() == "CAN-FD"
+        assert reloaded.getCanFrameTxBehavior().getValue() == "CAN-FD"
+        assert reloaded.getIdentifier().getValue() == 512
+        assert reloaded.getJ1939requestable().getValue() is True
+        assert reloaded.getRxMask().getValue() == 2047
+        assert reloaded.getTxMask().getValue() == 256
+        assert len(reloaded.getAbsolutelyScheduledTimings()) == 1
+        assert reloaded.getCanXlFrameTriggeringProps() is not None
+        assert reloaded.getCanXlFrameTriggeringProps().getPriorityId().getValue() == 5
 
 
 class TestWriteLinFrameTriggering:

--- a/tests/test_armodel/writer/test_writer_frame_channel.py
+++ b/tests/test_armodel/writer/test_writer_frame_channel.py
@@ -80,7 +80,6 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopol
 from armodel.parser.arxml_parser import ARXMLParser
 from armodel.writer.arxml_writer import ARXMLWriter
 
-
 _NS = "http://autosar.org/schema/r4.0"
 
 
@@ -505,11 +504,11 @@ class TestPhysicalChannelRoundTrip:
             "<SHORT-NAME>Ch</SHORT-NAME>"
             "<COMM-CONNECTORS>"
             "<COMMUNICATION-CONNECTOR-REF-CONDITIONAL>"
-            "<COMMUNICATION-CONNECTOR-REF DEST=\"COMMUNICATION-CONNECTOR\">/cc1</COMMUNICATION-CONNECTOR-REF>"
+            '<COMMUNICATION-CONNECTOR-REF DEST="COMMUNICATION-CONNECTOR">/cc1</COMMUNICATION-CONNECTOR-REF>'
             "</COMMUNICATION-CONNECTOR-REF-CONDITIONAL>"
             "</COMM-CONNECTORS>"
             "<MANAGED-PHYSICAL-CHANNEL-REFS>"
-            "<MANAGED-PHYSICAL-CHANNEL-REF DEST=\"PHYSICAL-CHANNEL\">/pc2</MANAGED-PHYSICAL-CHANNEL-REF>"
+            '<MANAGED-PHYSICAL-CHANNEL-REF DEST="PHYSICAL-CHANNEL">/pc2</MANAGED-PHYSICAL-CHANNEL-REF>'
             "</MANAGED-PHYSICAL-CHANNEL-REFS>"
             "<FRAME-TRIGGERINGS>"
             "<CAN-FRAME-TRIGGERING><SHORT-NAME>Cft</SHORT-NAME></CAN-FRAME-TRIGGERING>"

--- a/tests/test_armodel/writer/test_writer_frame_channel.py
+++ b/tests/test_armodel/writer/test_writer_frame_channel.py
@@ -180,6 +180,27 @@ class TestWriteFrameTriggering:
         assert trigs is not None
         assert len(trigs.findall("PDU-TRIGGERING-REF-CONDITIONAL")) == 1
 
+    def test_roundtrip_frame_triggering_refs(self, writer):
+        pkg = _pkg()
+        ft = CanFrameTriggering(pkg, "Ft")
+        ft.setFrameRef(_ref("FRAME", "/frame1"))
+        ft.addFramePortRef(_ref("FRAME-PORT", "/fp1"))
+        ft.addFramePortRef(_ref("FRAME-PORT", "/fp2"))
+        ft.addPduTriggeringRef(_ref("PDU-TRIGGERING", "/pt1"))
+        parent = _parent()
+        writer.writeFrameTriggering(parent, ft)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace(
+            "<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1
+        )
+        reloaded = CanFrameTriggering(pkg, "Ft2")
+        ARXMLParser().readFrameTriggering(ET.fromstring(xml_str), reloaded)
+        assert reloaded.getFrameRef().getValue() == "/frame1"
+        ports = [r.getValue() for r in reloaded.getFramePortRefs()]
+        assert ports == ["/fp1", "/fp2"]
+        pds = [r.getValue() for r in reloaded.getPduTriggeringRefs()]
+        assert pds == ["/pt1"]
+
 
 class TestWriteCanFrameTriggering:
     def test_write_can_frame_triggering_full(self, writer):

--- a/tests/test_armodel/writer/test_writer_frame_channel.py
+++ b/tests/test_armodel/writer/test_writer_frame_channel.py
@@ -20,6 +20,9 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommun
     CanXlFrameTriggeringProps,
     RxIdentifierRange,
 )
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import (  # noqa: E501
+    CanPhysicalChannel,
+)
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetCommunication import (  # noqa: E501
     SocketConnection,
     SocketConnectionBundle,
@@ -73,7 +76,6 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommu
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import (  # noqa: E501
     CanCluster,
     CanClusterBusOffRecovery,
-    CanPhysicalChannel,
     CycleRepetition,
     EthernetPhysicalChannel,
     FlexrayPhysicalChannel,

--- a/tests/test_armodel/writer/test_writer_frame_channel.py
+++ b/tests/test_armodel/writer/test_writer_frame_channel.py
@@ -497,6 +497,19 @@ class TestWritePhysicalChannelHelpers:
         writer.writePhysicalChannelCommConnectorRefs(parent, ch)
         assert len(parent) == 0
 
+    def test_roundtrip_can_physical_channel(self, writer):
+        pkg = _pkg()
+        ch = CanPhysicalChannel(pkg, "Ch")
+        ch.addCommConnectorRef(_ref("COMMUNICATION-CONNECTOR", "/cc"))
+        parent = _parent()
+        writer.writeCanPhysicalChannel(parent, ch)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanPhysicalChannel(pkg, "Ch2")
+        parser.readCanPhysicalChannel(parser.find(ET.fromstring(xml_str), "CAN-PHYSICAL-CHANNEL"), reloaded)
+        assert reloaded.getCommConnectorRefs()[0].getValue() == "/cc"
+
     def test_write_pc_comm_connector_refs(self, writer):
         pkg = _pkg()
         ch = CanPhysicalChannel(pkg, "Ch")

--- a/tests/test_armodel/writer/test_writer_frame_channel.py
+++ b/tests/test_armodel/writer/test_writer_frame_channel.py
@@ -191,9 +191,7 @@ class TestWriteFrameTriggering:
         parent = _parent()
         writer.writeFrameTriggering(parent, ft)
 
-        xml_str = ET.tostring(parent, encoding="unicode").replace(
-            "<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1
-        )
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
         reloaded = CanFrameTriggering(pkg, "Ft2")
         ARXMLParser().readFrameTriggering(ET.fromstring(xml_str), reloaded)
         assert reloaded.getFrameRef().getValue() == "/frame1"
@@ -229,6 +227,45 @@ class TestWriteCanFrameTriggering:
         assert rng_tag is not None
         assert rng_tag.find("LOWER-CAN-ID").text == "10"
         assert rng_tag.find("UPPER-CAN-ID").text == "20"
+
+    def test_roundtrip_can_frame_triggering_rx_identifier_range(self, writer):
+        pkg = _pkg()
+        ft = CanFrameTriggering(pkg, "CanFt")
+        rng = RxIdentifierRange()
+        rng.setLowerCanId(_pos_int("0x100"))
+        rng.setUpperCanId(_pos_int("0x1FF"))
+        ft.setRxIdentifierRange(rng)
+        parent = _parent()
+        writer.writeCanFrameTriggering(parent, ft)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanFrameTriggering(pkg, "CanFt2")
+        parser.readCanFrameTriggering(parser.find(ET.fromstring(xml_str), "CAN-FRAME-TRIGGERING"), reloaded)
+        reloaded_rng = reloaded.getRxIdentifierRange()
+        assert reloaded_rng is not None
+        assert reloaded_rng.getLowerCanId().getValue() == 256
+        assert reloaded_rng.getUpperCanId().getValue() == 511
+
+    def test_roundtrip_rx_identifier_range_empty_wrapper(self, writer):
+        pkg = _pkg()
+        ft = CanFrameTriggering(pkg, "CanFt")
+        ft.setRxIdentifierRange(RxIdentifierRange())
+        parent = _parent()
+        writer.writeCanFrameTriggering(parent, ft)
+        cft = parent.find("CAN-FRAME-TRIGGERING")
+        assert cft is not None
+        rng_tag = cft.find("RX-IDENTIFIER-RANGE")
+        assert rng_tag is not None
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanFrameTriggering(pkg, "CanFt2")
+        parser.readCanFrameTriggering(parser.find(ET.fromstring(xml_str), "CAN-FRAME-TRIGGERING"), reloaded)
+        reloaded_rng = reloaded.getRxIdentifierRange()
+        assert reloaded_rng is not None
+        assert reloaded_rng.getLowerCanId() is None
+        assert reloaded_rng.getUpperCanId() is None
 
 
 class TestWriteLinFrameTriggering:

--- a/tests/test_armodel/writer/test_writer_frame_channel.py
+++ b/tests/test_armodel/writer/test_writer_frame_channel.py
@@ -64,6 +64,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommun
     LinScheduleTable,
 )
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import LinCluster
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ttcan.TtcanCommunication import TtcanAbsolutelyScheduledTiming
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (  # noqa: E501
     ISignalTriggering,
     PduTriggering,
@@ -311,6 +312,45 @@ class TestWriteFlexrayAbsolutelyScheduledTiming:
         assert tag is not None
         assert tag.find("COMMUNICATION-CYCLE") is not None
         assert tag.find("SLOT-ID").text == "7"
+
+
+class TestWriteTtcanAbsolutelyScheduledTiming:
+    def test_write_none(self, writer):
+        parent = _parent()
+        writer.writeTtcanAbsolutelyScheduledTiming(parent, None)
+        assert len(parent) == 0
+
+    def test_write_full(self, writer):
+        from armodel.models import TtcanTriggerType
+
+        timing = TtcanAbsolutelyScheduledTiming()
+        cycle = CycleRepetition()
+        cycle.setBaseCycle(_integer("2"))
+        timing.setCommunicationCycle(cycle)
+        timing.setTimeMark(_integer("16"))
+        trigger = TtcanTriggerType()
+        trigger.setValue(TtcanTriggerType.ENUM_RX_TRIGGER)
+        timing.setTrigger(trigger)
+        parent = _parent()
+        writer.writeTtcanAbsolutelyScheduledTiming(parent, timing)
+        tag = parent.find("TTCAN-ABSOLUTELY-SCHEDULED-TIMING")
+        assert tag is not None
+        cc = tag.find("COMMUNICATION-CYCLE")
+        assert cc is not None
+        assert cc.find("CYCLE-REPETITION") is not None
+        assert cc.find("CYCLE-REPETITION/BASE-CYCLE").text == "2"
+        assert tag.find("TIME-MARK").text == "16"
+        assert tag.find("TRIGGER").text == "RX-TRIGGER"
+
+    def test_write_empty(self, writer):
+        timing = TtcanAbsolutelyScheduledTiming()
+        parent = _parent()
+        writer.writeTtcanAbsolutelyScheduledTiming(parent, timing)
+        tag = parent.find("TTCAN-ABSOLUTELY-SCHEDULED-TIMING")
+        assert tag is not None
+        assert tag.find("COMMUNICATION-CYCLE") is None
+        assert tag.find("TIME-MARK") is None
+        assert tag.find("TRIGGER") is None
 
 
 class TestWriteFlexrayFrameTriggering:

--- a/tests/test_armodel/writer/test_writer_nm.py
+++ b/tests/test_armodel/writer/test_writer_nm.py
@@ -24,6 +24,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommun
     LinUnconditionalFrame,
 )
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import (  # noqa: E501
+    BusspecificNmEcu,
     CanNmCluster,
     CanNmClusterCoupling,
     CanNmNode,
@@ -38,6 +39,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import 
     UdpNmEcu,
     UdpNmNode,
 )
+from armodel.parser.arxml_parser import ARXMLParser
 from armodel.writer.arxml_writer import ARXMLWriter
 
 
@@ -52,6 +54,22 @@ def reset_autosar():
 def writer():
     AUTOSAR.getInstance().new()
     return ARXMLWriter()
+
+
+@pytest.fixture
+def parser():
+    AUTOSAR.getInstance().new()
+    document = AUTOSAR.getInstance()
+    document.setARRelease("R23-11")
+    return ARXMLParser(options={"warning": True})
+
+
+def _reload(parser, path):
+    AUTOSAR.getInstance().new()
+    document = AUTOSAR.getInstance()
+    document.setARRelease("R23-11")
+    parser.load(path, document)
+    return document
 
 
 def _parent():
@@ -652,3 +670,51 @@ class TestWriteNmConfig:
         assert cfg.find("NM-CLUSTERS") is not None
         assert cfg.find("NM-CLUSTER-COUPLINGS") is not None
         assert cfg.find("NM-IF-ECUS") is not None
+
+
+class TestBusspecificNmEcuRoundTrip:
+    """Full set -> save -> reload round-trip through NmEcu.busDependentNmEcus."""
+
+    def test_udp_nm_ecu_round_trip(self, writer, parser, tmp_path):
+        pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+        config = pkg.createNmConfig("NmConfig")
+        nm_ecu = config.createNmEcu("nm_ecu")
+        udp = UdpNmEcu()
+        udp.setNmSynchronizationPointEnabled(_bool(True))
+        nm_ecu.addBusDependentNmEcu(udp)
+
+        out_file = str(tmp_path / "bus_dependent_nm_ecus.arxml")
+        writer.save(out_file, AUTOSAR.getInstance())
+
+        document = _reload(parser, out_file)
+        re_pkg = document.find("Pkg")
+        re_config = re_pkg.getElement("NmConfig", NmConfig)
+        assert re_config is not None
+        re_ecu = re_config.getElement("nm_ecu", NmEcu)
+        assert re_ecu is not None
+
+        dependents = re_ecu.getBusDependentNmEcus()
+        assert len(dependents) == 1
+        assert isinstance(dependents[0], UdpNmEcu)
+        assert isinstance(dependents[0], BusspecificNmEcu)
+        value = dependents[0].getNmSynchronizationPointEnabled()
+        assert value is not None
+        assert value.getValue() is True
+
+    def test_empty_bus_dependent_nm_ecus_round_trip(self, writer, parser, tmp_path):
+        pkg = AUTOSAR.getInstance().createARPackage("Pkg")
+        config = pkg.createNmConfig("NmConfig")
+        config.createNmEcu("bare_ecu")
+
+        out_file = str(tmp_path / "empty_bus_dependent_nm_ecus.arxml")
+        writer.save(out_file, AUTOSAR.getInstance())
+
+        with open(out_file, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "BUS-DEPENDENT-NM-ECUS" not in content
+
+        document = _reload(parser, out_file)
+        re_config = document.find("Pkg").getElement("NmConfig", NmConfig)
+        re_ecu = re_config.getElement("bare_ecu", NmEcu)
+        assert re_ecu is not None
+        assert re_ecu.getBusDependentNmEcus() == []

--- a/tests/test_armodel/writer/test_writer_nm.py
+++ b/tests/test_armodel/writer/test_writer_nm.py
@@ -597,6 +597,26 @@ class TestWriteBusDependentNmEcus:
         deps = parent.find("BUS-DEPENDENT-NM-ECUS")
         assert deps.find("UDP-NM-ECU") is not None
 
+    def test_roundtrip_with_can_nm_ecu(self, writer):
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import CanNmEcu
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        nm_ecu = NmEcu(MockParent(), "nm_ecu")
+        nm_ecu.addBusDependentNmEcu(CanNmEcu())
+        parent = _parent()
+        writer.writeBusDependentNmEcus(parent, nm_ecu)
+        deps = parent.find("BUS-DEPENDENT-NM-ECUS")
+        assert deps is not None
+        assert deps.find("CAN-NM-ECU") is not None
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = NmEcu(MockParent(), "nm_ecu2")
+        parser.readBusDependentNmEcus(ET.fromstring(xml_str), reloaded)
+        dependents = reloaded.getBusDependentNmEcus()
+        assert len(dependents) == 1
+        assert isinstance(dependents[0], CanNmEcu)
+
 
 class TestWriteNmEcu:
     def test_full_nm_ecu(self, writer):

--- a/tests/test_armodel/writer/test_writer_pdu_tp.py
+++ b/tests/test_armodel/writer/test_writer_pdu_tp.py
@@ -566,6 +566,9 @@ class TestWriteCanTpConnection:
         reloaded = CanTpConnection()
         parser.readCanTpConnection(ET.fromstring(xml_str)[0], reloaded)
         assert reloaded.getIdent() is not None
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import CanTpAddressingFormatType
+
+        assert isinstance(reloaded.getAddressingFormat(), CanTpAddressingFormatType)
         assert reloaded.getAddressingFormat().getValue() == "MIXED"
         assert reloaded.getCanTpChannelRef().getValue() == "/ch"
         assert reloaded.getCancellation().getValue() is True

--- a/tests/test_armodel/writer/test_writer_pdu_tp.py
+++ b/tests/test_armodel/writer/test_writer_pdu_tp.py
@@ -735,6 +735,50 @@ class TestWriteCanTpNode:
         assert child.find("TIMEOUT-AS").text == "0.06"
         assert child.find("TP-ADDRESS-REF").text == "/ta"
 
+    def test_roundtrip_can_tp_node_fields(self, writer):
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        pkg = _pkg()
+        node = CanTpNode(pkg, "Node")
+        node.setConnectorRef(_ref("COMMUNICATION-CONNECTOR", "/conn"))
+        node.setMaxFcWait(_int("10"))
+        node.setStMin(_time("0.005"))
+        node.setTimeoutAr(_time("0.05"))
+        node.setTimeoutAs(_time("0.06"))
+        node.setTpAddressRef(_ref("CAN-TP-ADDRESS", "/ta"))
+        parent = _parent()
+        writer.writeCanTpNode(parent, node)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanTpNode(pkg, "Node2")
+        parser.readCanTpNode(ET.fromstring(xml_str)[0], reloaded)
+        assert reloaded.getConnectorRef().getValue() == "/conn"
+        assert reloaded.getMaxFcWait().getValue() == 10
+        assert reloaded.getStMin().getValue() == 0.005
+        assert reloaded.getTimeoutAr().getValue() == 0.05
+        assert reloaded.getTimeoutAs().getValue() == 0.06
+        assert reloaded.getTpAddressRef().getValue() == "/ta"
+
+    def test_roundtrip_can_tp_node_empty_fields(self, writer):
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        pkg = _pkg()
+        node = CanTpNode(pkg, "Node")
+        parent = _parent()
+        writer.writeCanTpNode(parent, node)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanTpNode(pkg, "Node2")
+        parser.readCanTpNode(ET.fromstring(xml_str)[0], reloaded)
+        assert reloaded.getConnectorRef() is None
+        assert reloaded.getMaxFcWait() is None
+        assert reloaded.getStMin() is None
+        assert reloaded.getTimeoutAr() is None
+        assert reloaded.getTimeoutAs() is None
+        assert reloaded.getTpAddressRef() is None
+
 
 class TestWriteCanTpConfigTpNodes:
     def test_empty(self, writer):

--- a/tests/test_armodel/writer/test_writer_pdu_tp.py
+++ b/tests/test_armodel/writer/test_writer_pdu_tp.py
@@ -620,6 +620,41 @@ class TestWriteCanTpConfigTpConnections:
         assert parent[0].tag == "TP-CONNECTIONS"
         assert len(parent[0]) == 1
 
+    def test_roundtrip_can_tp_config_full(self, writer):
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        pkg = _pkg()
+        cfg = CanTpConfig(pkg, "Cfg")
+        addr = cfg.createCanTpAddress("Addr")
+        addr.setTpAddress(_int("2047"))
+        ch = cfg.createCanTpChannel("Ch")
+        ch.setChannelId(_pos_int("1"))
+        conn = CanTpConnection()
+        conn.setTransmitterRef(_ref("ECU-INSTANCE", "/tx"))
+        cfg.addTpConnection(conn)
+        ecu = CanTpEcu()
+        ecu.setCycleTimeMainFunction(_time("0.01"))
+        cfg.addTpEcu(ecu)
+        node = cfg.createCanTpNode("Node")
+        node.setMaxFcWait(_int("10"))
+        parent = _parent()
+        writer.writeCanTpConfig(parent, cfg)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanTpConfig(pkg, "Cfg2")
+        parser.readCanTpConfig(parser.find(ET.fromstring(xml_str), "CAN-TP-CONFIG"), reloaded)
+        assert len(reloaded.getTpAddresses()) == 1
+        assert reloaded.getTpAddresses()[0].getTpAddress().getValue() == 2047
+        assert len(reloaded.getTpChannels()) == 1
+        assert reloaded.getTpChannels()[0].getChannelId().getValue() == 1
+        assert len(reloaded.getTpConnections()) == 1
+        assert reloaded.getTpConnections()[0].getTransmitterRef().getValue() == "/tx"
+        assert len(reloaded.getTpEcus()) == 1
+        assert reloaded.getTpEcus()[0].getCycleTimeMainFunction().getValue() == 0.01
+        assert len(reloaded.getTpNodes()) == 1
+        assert reloaded.getTpNodes()[0].getMaxFcWait().getValue() == 10
+
     def test_unsupported_warns(self):
         w = ARXMLWriter(options={"warning": True})
         cfg = MagicMock()

--- a/tests/test_armodel/writer/test_writer_pdu_tp.py
+++ b/tests/test_armodel/writer/test_writer_pdu_tp.py
@@ -312,6 +312,38 @@ class TestWriteCanTpAddress:
         assert child.find("TP-ADDRESS").text == "1"
         assert child.find("TP-ADDRESS-EXTENSION-VALUE").text == "2"
 
+    def test_roundtrip_can_tp_address_fields(self, writer):
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        pkg = _pkg()
+        addr = CanTpAddress(pkg, "Addr")
+        addr.setTpAddress(_int("2047"))
+        addr.setTpAddressExtensionValue(_int("5"))
+        parent = _parent()
+        writer.writeCanTpAddress(parent, addr)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanTpAddress(pkg, "Addr2")
+        parser.readCanTpAddress(ET.fromstring(xml_str)[0], reloaded)
+        assert reloaded.getTpAddress().getValue() == 2047
+        assert reloaded.getTpAddressExtensionValue().getValue() == 5
+
+    def test_roundtrip_can_tp_address_empty_fields(self, writer):
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        pkg = _pkg()
+        addr = CanTpAddress(pkg, "Addr")
+        parent = _parent()
+        writer.writeCanTpAddress(parent, addr)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanTpAddress(pkg, "Addr2")
+        parser.readCanTpAddress(ET.fromstring(xml_str)[0], reloaded)
+        assert reloaded.getTpAddress() is None
+        assert reloaded.getTpAddressExtensionValue() is None
+
 
 class TestWriteCanTpConfigTpAddresses:
     def test_empty(self, writer):

--- a/tests/test_armodel/writer/test_writer_pdu_tp.py
+++ b/tests/test_armodel/writer/test_writer_pdu_tp.py
@@ -536,6 +536,71 @@ class TestWriteCanTpConnection:
         assert child.find("TP-SDU-REF").text == "/sdu"
         assert child.find("TRANSMITTER-REF").text == "/tx"
 
+    def test_roundtrip_can_tp_connection_fields(self, writer):
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        conn = CanTpConnection()
+        conn.createTpConnectionIdent("ConnIdent")
+        conn.setAddressingFormat(_literal("MIXED"))
+        conn.setCanTpChannelRef(_ref("CAN-TP-CHANNEL", "/ch"))
+        conn.setCancellation(_bool("true"))
+        conn.setDataPduRef(_ref("I-PDU", "/dp"))
+        conn.setFlowControlPduRef(_ref("I-PDU", "/fc"))
+        conn.setMaxBlockSize(_int("8"))
+        conn.setMulticastRef(_ref("I-PDU", "/mc"))
+        conn.setPaddingActivation(_bool("false"))
+        conn.addReceiverRef(_ref("ECU-INSTANCE", "/r1"))
+        conn.addReceiverRef(_ref("ECU-INSTANCE", "/r2"))
+        conn.setTaType(_literal("PHYSICAL"))
+        conn.setTimeoutBr(_time("0.1"))
+        conn.setTimeoutBs(_time("0.2"))
+        conn.setTimeoutCr(_time("0.3"))
+        conn.setTimeoutCs(_time("0.4"))
+        conn.setTpSduRef(_ref("I-PDU", "/sdu"))
+        conn.setTransmitterRef(_ref("ECU-INSTANCE", "/tx"))
+        parent = _parent()
+        writer.writeCanTpConnection(parent, conn)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanTpConnection()
+        parser.readCanTpConnection(ET.fromstring(xml_str)[0], reloaded)
+        assert reloaded.getIdent() is not None
+        assert reloaded.getAddressingFormat().getValue() == "MIXED"
+        assert reloaded.getCanTpChannelRef().getValue() == "/ch"
+        assert reloaded.getCancellation().getValue() is True
+        assert reloaded.getDataPduRef().getValue() == "/dp"
+        assert reloaded.getFlowControlPduRef().getValue() == "/fc"
+        assert reloaded.getMaxBlockSize().getValue() == 8
+        assert reloaded.getMulticastRef().getValue() == "/mc"
+        assert reloaded.getPaddingActivation().getValue() is False
+        refs = [r.getValue() for r in reloaded.getReceiverRefs()]
+        assert refs == ["/r1", "/r2"]
+        assert reloaded.getTaType().getValue() == "PHYSICAL"
+        assert reloaded.getTimeoutBr().getValue() == 0.1
+        assert reloaded.getTimeoutBs().getValue() == 0.2
+        assert reloaded.getTimeoutCr().getValue() == 0.3
+        assert reloaded.getTimeoutCs().getValue() == 0.4
+        assert reloaded.getTpSduRef().getValue() == "/sdu"
+        assert reloaded.getTransmitterRef().getValue() == "/tx"
+
+    def test_roundtrip_can_tp_connection_empty(self, writer):
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        conn = CanTpConnection()
+        parent = _parent()
+        writer.writeCanTpConnection(parent, conn)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanTpConnection()
+        parser.readCanTpConnection(ET.fromstring(xml_str)[0], reloaded)
+        assert reloaded.getIdent() is None
+        assert reloaded.getAddressingFormat() is None
+        assert reloaded.getCancellation() is None
+        assert reloaded.getReceiverRefs() == []
+        assert reloaded.getTransmitterRef() is None
+
 
 class TestWriteCanTpConfigTpConnections:
     def test_empty(self, writer):

--- a/tests/test_armodel/writer/test_writer_pdu_tp.py
+++ b/tests/test_armodel/writer/test_writer_pdu_tp.py
@@ -383,7 +383,6 @@ class TestWriteCanTpChannel:
         pkg = _pkg()
         ch = CanTpChannel(pkg, "Ch")
         ch.setChannelId(_pos_int("1"))
-        ch.setChannelMode(_literal("FULL-DUPLEX"))
         parent = _parent()
         writer.writeCanTpChannel(parent, ch)
         assert len(parent) == 1
@@ -391,7 +390,36 @@ class TestWriteCanTpChannel:
         assert child.tag == "CAN-TP-CHANNEL"
         assert child.find("SHORT-NAME").text == "Ch"
         assert child.find("CHANNEL-ID").text == "1"
-        assert child.find("CHANNEL-MODE").text == "FULL-DUPLEX"
+        assert child.find("CHANNEL-MODE") is None
+
+    def test_roundtrip_can_tp_channel_fields(self, writer):
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        pkg = _pkg()
+        ch = CanTpChannel(pkg, "Ch")
+        ch.setChannelId(_pos_int("7"))
+        parent = _parent()
+        writer.writeCanTpChannel(parent, ch)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanTpChannel(pkg, "Ch2")
+        parser.readCanTpChannel(ET.fromstring(xml_str)[0], reloaded)
+        assert reloaded.getChannelId().getValue() == 7
+
+    def test_roundtrip_can_tp_channel_empty_fields(self, writer):
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        pkg = _pkg()
+        ch = CanTpChannel(pkg, "Ch")
+        parent = _parent()
+        writer.writeCanTpChannel(parent, ch)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanTpChannel(pkg, "Ch2")
+        parser.readCanTpChannel(ET.fromstring(xml_str)[0], reloaded)
+        assert reloaded.getChannelId() is None
 
 
 class TestWriteCanTpConfigTpChannels:

--- a/tests/test_armodel/writer/test_writer_pdu_tp.py
+++ b/tests/test_armodel/writer/test_writer_pdu_tp.py
@@ -648,6 +648,36 @@ class TestWriteCanTpEcu:
         assert child.find("CYCLE-TIME-MAIN-FUNCTION").text == "0.01"
         assert child.find("ECU-INSTANCE-REF").text == "/ecu"
 
+    def test_roundtrip_can_tp_ecu_fields(self, writer):
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        ecu = CanTpEcu()
+        ecu.setCycleTimeMainFunction(_time("0.01"))
+        ecu.setEcuInstanceRef(_ref("ECU-INSTANCE", "/ecu"))
+        parent = _parent()
+        writer.writeCanTpEcu(parent, ecu)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanTpEcu()
+        parser.readCanTpEcu(ET.fromstring(xml_str)[0], reloaded)
+        assert reloaded.getCycleTimeMainFunction().getValue() == 0.01
+        assert reloaded.getEcuInstanceRef().getValue() == "/ecu"
+
+    def test_roundtrip_can_tp_ecu_empty_fields(self, writer):
+        from armodel.parser.arxml_parser import ARXMLParser
+
+        ecu = CanTpEcu()
+        parent = _parent()
+        writer.writeCanTpEcu(parent, ecu)
+
+        xml_str = ET.tostring(parent, encoding="unicode").replace("<PARENT>", "<PARENT xmlns='http://autosar.org/schema/r4.0'>", 1)
+        parser = ARXMLParser()
+        reloaded = CanTpEcu()
+        parser.readCanTpEcu(ET.fromstring(xml_str)[0], reloaded)
+        assert reloaded.getCycleTimeMainFunction() is None
+        assert reloaded.getEcuInstanceRef() is None
+
 
 class TestWriteCanTpConfigTpEcus:
     def test_empty(self, writer):


### PR DESCRIPTION
Closes #669

## Summary

Syncs the CAN-related classes of `AUTOSAR_CP_TPS_SystemTemplate` (R23-11) against their PDF spec tables using the 9-step TDD workflow. **All 17 classes now carry the `# Spec verified: R23-11` marker** — the review gate for reviewed classes.

### Classes (17)

| Role | Classes |
|---|---|
| Inputs | AbstractCanPhysicalChannel · CanPhysicalChannel · CanNmEcu · CanTpConfig · CanFrame · CanFrameTriggering · AbstractCanCommunicationConnector |
| Bases | TpConnection · TpConnectionIdent (moved to DiagnosticConnection.py per spec Package) |
| Members | RxIdentifierRange · CanTpAddress · CanTpChannel · CanTpConnection · CanTpEcu · CanTpNode · CanTpAddressingFormatType (new) · NetworkTargetAddressType (new) |

### Spec-drift fixes

- Removed removed-status members: `CanTpChannel.channelMode`, `CanFrameTriggering.canFdFrameSupport`
- Added missing reader/writer coverage: CAN-NM-ECU dispatch, absolutelyScheduledTimings, canXlFrameTriggeringProps, j1939requestable, rxMask, txMask
- Retyped enum members to spec enums (`addressingFormat`, `canAddressingMode`, `canFrameRxBehavior`, `canFrameTxBehavior`) — parser constructs typed instances, writer serializes via `getValue()`
- Moved physical-channel classes to `Fibex4Can/CanTopology.py` per spec Package rows
- Docstrings verbatim from spec Notes; PEP 526 annotations; None-no-op setters; per-class method-parity checklists

### Verification

- ✅ 7129 unit tests + integration round-trip pass
- ✅ flake8 / ruff / black clean