### PR TITLE
fix: implement writeInternalTriggerOccurredEvent (was a pass stub)

### DIFF
--- a/docs/development/parser_writer_conventions.md
+++ b/docs/development/parser_writer_conventions.md
@@ -80,12 +80,13 @@ Borderline case: `setRootSwCompositionPrototype(ARElement)` on the `AUTOSAR` roo
 
 Each item: location, what violates which rule, impact.
 
-### D1 — `writeInternalTriggerOccurredEvent` is a `pass` stub (round-trip data loss)
+### D1 — `writeInternalTriggerOccurredEvent` is a `pass` stub (round-trip data loss) — FIXED
 
-- [arxml_writer.py:2782](../../src/armodel/writer/arxml_writer.py#L2782): `def writeInternalTriggerOccurredEvent(self, element, event: DataReceivedEvent): pass`
-- Violates §1.2 (a class-level writer must serialize its instance) and uses the **wrong type annotation** (`DataReceivedEvent` instead of `InternalTriggerOccurredEvent`).
-- It **is dispatched** by the SWC events writer (arxml_writer.py:2828), while the parser reads the event normally (arxml_parser.py:4063, dispatched at 4108 via `createInternalTriggerOccurredEvent(getShortName(...))`).
-- Impact: any SWC `INTERNAL-TRIGGER-OCCURRED-EVENT` is silently dropped on write — parse → write → re-parse loses the event.
+- [arxml_writer.py:2851](../../src/armodel/writer/arxml_writer.py#L2851): was `def writeInternalTriggerOccurredEvent(self, element, event: DataReceivedEvent): pass`
+- Violated §1.2 (a class-level writer must serialize its instance) and used the **wrong type annotation** (`DataReceivedEvent` instead of `InternalTriggerOccurredEvent`).
+- It **is dispatched** by the SWC events writer (arxml_writer.py:2896-2897), while the parser reads the event normally (arxml_parser.py:4471, dispatched via `readSwcInternalBehaviorEvents` tag dispatch).
+- Impact: any SWC `INTERNAL-TRIGGER-OCCURRED-EVENT` was silently dropped on write — parse → write → re-parse lost the event.
+- **Fix applied**: implemented the writer mirroring the parser and the sibling `writeAsynchronousServerCallReturnsEvent` — element creation → `setRTEEvent` → `EVENT-SOURCE-REF`; annotation corrected to `InternalTriggerOccurredEvent`. The writer test that previously *asserted the empty-output bug* (`assert len(parent) == 0`) now asserts the event and its `EVENT-SOURCE-REF` are emitted, plus a `None` no-op case and the dispatch assertion in `test_writeSwcInternalBehaviorEvents`.
 
 ### D2 — Parser `read*` methods that create elements
 

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -2848,8 +2848,11 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.setRTEEvent(child_element, event)
             self.setRVariableInAtomicSwcInstanceRef(child_element, event.dataIRef)
 
-    def writeInternalTriggerOccurredEvent(self, element: ET.Element, event: DataReceivedEvent):
-        pass
+    def writeInternalTriggerOccurredEvent(self, element: ET.Element, event: InternalTriggerOccurredEvent):
+        if event is not None:
+            child_element = ET.SubElement(element, "INTERNAL-TRIGGER-OCCURRED-EVENT")
+            self.setRTEEvent(child_element, event)
+            self.setChildElementOptionalRefType(child_element, "EVENT-SOURCE-REF", event.getEventSourceRef())
 
     def writeInitEvent(self, element: ET.Element, event: InitEvent):
         if event is not None:
@@ -8991,7 +8994,7 @@ class ARXMLWriter(AbstractARXMLWriter):
             self.setChildElementOptionalFloatValue(child_element, "MIN-SAMPLE-POINT", requirements.getMinSamplePoint())
             self.setChildElementOptionalFloatValue(child_element, "MIN-SYNC-JUMP-WIDTH", requirements.getMinSyncJumpWidth())
 
-    def writeAbstractCanCommunicationControllerCanControllerAttributes(self, element: ET.SubElement, controller: AbstractCanCommunicationController):
+    def writeAbstractCanCommunicationControllerCanControllerAttributes(self, element: ET.Element, controller: AbstractCanCommunicationController):
         attributes = controller.getCanControllerAttributes()
         if attributes is not None:
             child_element = ET.SubElement(element, "CAN-CONTROLLER-ATTRIBUTES")

--- a/tests/test_armodel/writer/test_writer_swc_behavior.py
+++ b/tests/test_armodel/writer/test_writer_swc_behavior.py
@@ -242,8 +242,17 @@ class TestWriterRteEvents:
     def test_writeInternalTriggerOccurredEvent(self, writer):
         behavior = _make_behavior()
         event = behavior.createInternalTriggerOccurredEvent("ito")
+        event.setEventSourceRef(_ref("/tp", "INTERNAL-TRIGGERING-POINT"))
         parent = _parent()
         writer.writeInternalTriggerOccurredEvent(parent, event)
+        evt = parent[0]
+        assert evt.tag == "INTERNAL-TRIGGER-OCCURRED-EVENT"
+        assert evt.find("EVENT-SOURCE-REF") is not None
+        assert evt.find("EVENT-SOURCE-REF").get("DEST") == "INTERNAL-TRIGGERING-POINT"
+
+    def test_writeInternalTriggerOccurredEvent_none(self, writer):
+        parent = _parent()
+        writer.writeInternalTriggerOccurredEvent(parent, None)
         assert len(parent) == 0
 
     def test_writeInitEvent(self, writer):
@@ -338,6 +347,7 @@ class TestWriterSwcInternalBehaviorEventsDispatch:
         assert "MODE-SWITCHED-ACK-EVENT" in tags
         assert "DATA-SEND-COMPLETED-EVENT" in tags
         assert "ASYNCHRONOUS-SERVER-CALL-RETURNS-EVENT" in tags
+        assert "INTERNAL-TRIGGER-OCCURRED-EVENT" in tags
 
     def test_dispatches_operation_and_data_events(self, writer):
         behavior = _make_behavior()


### PR DESCRIPTION
## D1 — round-trip data loss
`writeInternalTriggerOccurredEvent` was a `pass` stub that was dispatched by the SWC events writer, so any SWC `INTERNAL-TRIGGER-OCCURRED-EVENT` was silently dropped on write. Implemented mirroring the parser read chain (setRTEEvent + EVENT-SOURCE-REF) and corrected the wrong `DataReceivedEvent` annotation. The writer test that asserted the empty-output bug now asserts the emitted event.

## D9 — cosmetic
`ET.SubElement` (a function) was used as a type annotation in `writeAbstractCanCommunicationControllerCanControllerAttributes`; corrected to `ET.Element`.

Documentation: deviations tracked in docs/development/parser_writer_conventions.md (D1 marked FIXED; D9 entry on docs/guard-convention-wording, PR #687).

Verification: 8187 unit tests, integration tests, ruff, black-check all pass.