### PR TITLE
feat: sync core model classes (ARObject, ARElement, ARPackage) to R23-11 spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,17 @@
 **Lint:** `npm run lint` — runs flake8 syntax checks (E9, F63, F7, F82) **and** ruff (`ruff check src tests scripts`, E/F/W/I rules per `[tool.ruff]` in pyproject.toml). Always use this; do not run flake8 alone
 - CI also runs: `--max-complexity=10 --max-line-length=127` (warnings, exit-zero)
 - **Exclude `build/`** from lint (generated code)
+- **Do NOT re-sort imports in `src/armodel/models/**`, `parser/arxml_parser.py`, `writer/arxml_writer.py`** — ruff's I001 is intentionally disabled there (`[tool.ruff.lint.per-file-ignores]` in pyproject.toml) because import order avoids circular imports; auto-fixing it triggers ImportError at package load
 - **Black formatter:** `npm run black` — formats code with 200 character line length
 - **Black check:** `npm run black-check` — checks code formatting without modifying files
 
 **Build:** `python -m build` (requires `pip install build`)
 **Dev install:** `pip install -e .`
+
+**Environment (uv):** The repo is uv-managed — `uv.lock` and a uv-managed `.venv` (Python 3.11) exist. The `pytest` extra (`pytest`, `pytest-cov`, `pyyaml`) and `lint` extra (`ruff`, `black`) are in `pyproject.toml`.
+- `uv sync --extra pytest` — create/update `.venv` with test deps (plain `pip install -e .` does NOT install pytest)
+- `uv run pytest ...` or `uv run python scripts/run_tests.py` — run inside `.venv` without activating
+- Or `source .venv/bin/activate` first; do not commit changes to `.venv`
 
 ## Critical: AUTOSAR Version MUST Be Set
 

--- a/docs/examples/method_deviation_by_class_v2.md
+++ b/docs/examples/method_deviation_by_class_v2.md
@@ -112,13 +112,13 @@ the Python sources. Classes whose checklist carries `# Spec verified: R<YY>-<MM>
 | `asynchronousServerCallPointRef` | `RefType` | `asynchronousServerCallPoint` | ``AsynchronousServer CallPoint`` | ref | type (PDF AsynchronousServer CallPoint vs py RefType) |
 
 ## `ARElement`
-- **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** —
-- **Package:** `M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::Identifiable`
-- **Source:** `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py`
+- **PDF:** `AUTOSAR_FO_TPS_GenericStructureTemplate.pdf`  | **page:** 55  | **table:** Table 4.3
+- **Package:** `M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::ARPackage`
+- **Source:** `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py`
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — *(missing)* | `—` | `-` | ``-`` | - | missing |
+| — *(no own members)* | `—` | — | — | - | none (2026-08-30 sync: Table 4.3 has no Attribute rows — abstract marker class; all members inherited from the PackageableElement chain) |
 
 ## `BswInternalBehavior`
 - **PDF:** `AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf`  | **page:** 68  | **table:** Table 5.2

--- a/docs/examples/method_deviation_by_class_v2.md
+++ b/docs/examples/method_deviation_by_class_v2.md
@@ -1711,14 +1711,20 @@ the Python sources. Classes whose checklist carries `# Spec verified: R<YY>-<MM>
 | — *(missing)* | `—` | `-` | ``-`` | - | missing |
 
 ## `ARObject`
-- **PDF:** `AUTOSAR_FO_TPS_GenericStructureTemplate.pdf`  | **page:** —
+- **PDF:** `AUTOSAR_FO_TPS_GenericStructureTemplate.pdf`  | **page:** 192
 - **Package:** `M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::ArObject`
 - **Source:** `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ArObject.py`
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| — *(missing)* | `—` | `checksum` | ``String`` | attr | missing |
-| — *(missing)* | `—` | `timestamp` | ``DateTime`` | attr | missing |
+| `checksum` | `Optional[String]` | `checksum` | `String` | attr | resolved (2026-08-30 sync: accessors + S attribute read/write added) |
+| `timestamp` | `Optional[DateTime]` | `timestamp` | `DateTime` | attr | resolved (2026-08-30 sync: accessors + T attribute typed conversion added) |
+
+- **Note:** `parent`, `uuid` and `getTagName` are py-armodel internal infrastructure members with no
+  AUTOSAR meta-class counterpart (structural link / UUID duplicate-check extension / parser helper),
+  kept as-is per the same decision as `CollectableElement`. `uuid` is round-tripped as the `UUID`
+  XML attribute by the abstract parser/writer; `checksum`/`timestamp` round-trip as the XSD global
+  attributes `S`/`T` (AUTOSAR_00052.xsd lines 4901/4907).
 
 ## `CollectableElement`
 - **PDF:** — *(no spec counterpart)*

--- a/docs/examples/sync_class_groups.md
+++ b/docs/examples/sync_class_groups.md
@@ -1,0 +1,266 @@
+# Sync Class Groups (dependency-ordered)
+
+Batched class list for running `sync-autosar-class`, derived from
+`docs/examples/method_deviation_by_class_v2.md` (outstanding deviations, 2026-08-30).
+**185 tracker classes + 13 member classes missing from `src` (NEW) + 8 existing-but-unstamped
+member classes = 206 entries in 7 groups of 20–30.**
+
+## Usage
+
+- One class per `sync-autosar-class` invocation; Phase 1 is one class per fresh session
+  (Rule 0017.1). A "group" is one batch of sessions — work through it top to bottom.
+- **Order matters**: member-type classes are listed before the classes that reference them.
+  Missing member classes (`NEW`) must be created (skill Rule 0016.4: Derive-from-XSD) before
+  their parent is synced.
+- Existing-but-unstamped member classes not listed here are auto-queued dependency-first by
+  the skill's Phase 0 closure — no action needed.
+- After a class is synced and stamped, tick its box here; the tracker section
+  (`method_deviation_by_class_v2.md`) is then dropped (deviation-tracker convention).
+- `CollectableElement` is intentionally NOT listed (internal helper, no AUTOSAR meta-class,
+  no stamp — 2026-08-20 decision). Appendices of the tracker (no-spec-table classes, Rule 0007
+  location audit) are informational only, not sync targets.
+
+## Group 1 — Framework & core, PortInterface basics (29)
+
+- [ ] `ARObject`
+- [ ] `ARElement`
+- [ ] `ARPackage`
+- [ ] `AUTOSAR`
+- [ ] `FileInfoComment`
+- [ ] `Collection`
+- [ ] `AtpType`
+- [ ] `AtpPrototype`
+- [ ] `AtpStructureElement`
+- [ ] `AtpDefinition`
+- [ ] `AtpBlueprintable`
+- [ ] `AtpBlueprintMapping`
+- [ ] `BlueprintMappingSet` — after `AtpBlueprintMapping` (aggr `blueprintMap`)
+- [ ] `ApplicationDeferredDataType`
+- [ ] `AbstractImplementationDataType`
+- [ ] `AbstractImplementationDataTypeElement`
+- [ ] `Implementation`
+- [ ] `FlatMap`
+- [ ] `ModeAccessPointIdent`
+- [ ] `IdentCaption`
+- [ ] `DataInterface`
+- [ ] `NvDataInterface`
+- [ ] `SenderReceiverInterface`
+- [ ] `ParameterInterface`
+- [ ] `TriggerInterface`
+- [ ] `PortInterfaceMapping`
+- [ ] `SubElementMapping`
+- [ ] `TriggerInterfaceMapping`
+- [ ] `ModeDeclarationMappingSet` — after `ModeDeclarationMapping` (auto-queued, exists)
+
+## Group 2 — PortInterface sets, components, SWC behavior, datatypes (30)
+
+- [ ] `PortInterfaceMappingSet` — after `PortInterfaceMapping` (Group 1)
+- [ ] `MetaDataItemSet` — after `MetaDataItem` (auto-queued, exists)
+- [ ] `ApplicationCompositeElementInPortInterfaceInstanceRef`
+- [ ] `SymbolProps`
+- [ ] `PPortPrototype`
+- [ ] `RPortPrototype`
+- [ ] `PRPortPrototype`
+- [ ] `PortGroup`
+- [ ] `InnerPortGroupInCompositionInstanceRef` — member type of `PortGroup.innerGroup`
+- [ ] `VariableInAtomicSwcInstanceRef`
+- [ ] `CompositionSwComponentType`
+- [ ] `DelegationSwConnector`
+- [ ] `SwcInternalBehavior`
+- [ ] `ArVariableInImplementationDataInstanceRef`
+- [ ] `VariableInAtomicSWCTypeInstanceRef`
+- [ ] `IncludedModeDeclarationGroupSet`
+- [ ] `RunnableEntityArgument`
+- [ ] `AsynchronousServerCallPoint`
+- [ ] `AsynchronousServerCallResultPoint` — ref target of the point class above
+- [ ] `SynchronousServerCallPoint`
+- [ ] `InitEvent`
+- [ ] `BackgroundEvent`
+- [ ] `ExternalTriggeringPointIdent`
+- [ ] `PortDefinedArgumentValue` *(existing member)*
+- [ ] `PortAPIOption` — after `PortDefinedArgumentValue` (aggr `portArgValue`)
+- [ ] `ApplicationPrimitiveDataType`
+- [ ] `ApplicationDataType`
+- [ ] `ApplicationCompositeDataType`
+- [ ] `ApplicationRecordElement` *(existing member)*
+- [ ] `ApplicationRecordDataType` — after `ApplicationRecordElement` (aggr `element`)
+
+## Group 3 — Constants, CompuMethod, DataDictionary, Documentation (29)
+
+- [ ] `RecordValueSpecification`
+- [ ] `ArrayValueSpecification`
+- [ ] `CompositeValueSpecification`
+- [ ] `CompositeRuleBasedValueArgument`
+- [ ] `CompositeRuleBasedValueSpecification` — after `CompositeRuleBasedValueArgument` (aggr)
+- [ ] `DataConstrRule`
+- [ ] `CompuContent`
+- [ ] `CompuConstContent`
+- [ ] `CompuScaleContents`
+- [ ] `CompuNominatorDenominator`
+- [ ] `CompuScales` — after `CompuScale` (auto-queued, exists)
+- [ ] `SwValueCont`
+- [ ] `SwCalprmAxisSet`
+- [ ] `SwAxisIndividual`
+- [ ] `SwAxisGrouped`
+- [ ] `SwRecordLayoutGroup`
+- [ ] `SwRecordLayoutV`
+- [ ] `GeneralAnnotation`
+- [ ] `MultiLanguageParagraph`
+- [ ] `Area` **(NEW)**
+- [ ] `Map` — after `Area` (aggr `area`)
+- [ ] `LGraphic` *(existing member)*
+- [ ] `MlFigure` — after `LGraphic` (aggr `lGraphic`)
+- [ ] `DocumentViewSelectable`
+- [ ] `MsrQueryResultChapter` **(NEW)**
+- [ ] `MsrQueryResultTopic1` **(NEW)**
+- [ ] `MsrQueryChapter` — after `MsrQueryResultChapter` (aggr)
+- [ ] `MsrQueryTopic1` — after `MsrQueryResultTopic1` (aggr)
+- [ ] `MsrQueryP1`
+
+## Group 4 — BSW behavior policies & ServiceNeeds A (29)
+
+- [ ] `BswPerInstanceMemoryPolicy` **(NEW)**
+- [ ] `BswClientPolicy` **(NEW)**
+- [ ] `BswInternalTriggeringPointPolicy` **(NEW)**
+- [ ] `BswParameterPolicy` **(NEW)**
+- [ ] `BswReleasedTriggerPolicy` **(NEW)**
+- [ ] `BswDataSendPolicy` **(NEW)**
+- [ ] `BswInternalBehavior` — after all 6 NEW policy classes above (deferred full sync;
+      sibling policy classes `BswModeSenderPolicy`/`BswModeReceiverPolicy`/
+      `BswExclusiveAreaPolicy`/`BswDataReceptionPolicy`/`BswSchedulerNamePrefix`/
+      `BswTriggerDirectImplementation` exist and are auto-queued first)
+- [ ] `ServiceNeeds`
+- [ ] `DiagEventDebounceAlgorithm`
+- [ ] `DiagEventDebounceMonitorInternal`
+- [ ] `EcuStateMgrUserNeeds`
+- [ ] `DltUserNeeds`
+- [ ] `DiagnosticComponentNeeds`
+- [ ] `DiagnosticUploadDownloadNeeds`
+- [ ] `DiagnosticsCommunicationSecurityNeeds`
+- [ ] `FunctionInhibitionNeeds`
+- [ ] `GlobalSupervisionNeeds`
+- [ ] `HardwareTestNeeds`
+- [ ] `SupervisedEntityCheckpointNeeds`
+- [ ] `SyncTimeBaseMgrUserNeeds`
+- [ ] `BswMgrNeeds`
+- [ ] `CryptoKeyManagementNeeds`
+- [ ] `CryptoServiceJobNeeds`
+- [ ] `DiagnosticControlNeeds`
+- [ ] `DiagnosticEventManagerNeeds`
+- [ ] `DiagnosticRequestFileTransferNeeds`
+- [ ] `DoIpActivationLineNeeds`
+- [ ] `DoIpGidNeeds`
+- [ ] `DoIpGidSynchronizationNeeds`
+
+## Group 5 — ServiceNeeds B, SystemTemplate, Fibex core, SWC Communication & E2E (30)
+
+- [ ] `DoIpPowerModeStatusNeeds`
+- [ ] `FurtherActionByteNeeds`
+- [ ] `IdsMgrCustomTimestampNeeds`
+- [ ] `J1939DcmDm19Support`
+- [ ] `J1939RmIncomingRequestServiceNeeds`
+- [ ] `J1939RmOutgoingRequestServiceNeeds`
+- [ ] `V2xDataManagerNeeds`
+- [ ] `V2xFacUserNeeds`
+- [ ] `V2xMUserNeeds`
+- [ ] `VendorSpecificServiceNeeds`
+- [ ] `WarningIndicatorRequestedBitNeeds`
+- [ ] `System`
+- [ ] `J1939SharedAddressCluster`
+- [ ] `ComManagementMapping`
+- [ ] `EcuInstance`
+- [ ] `DiagnosticConnection`
+- [ ] `EthernetPhysicalChannel`
+- [ ] `FrameTriggering`
+- [ ] `ContainedIPduProps`
+- [ ] `ModeDrivenTransmissionModeCondition`
+- [ ] `StaticPart`
+- [ ] `DynamicPartAlternative`
+- [ ] `GeneralPurposePdu`
+- [ ] `GeneralPurposeIPdu`
+- [ ] `CommunicationCycle`
+- [ ] `FramePort`
+- [ ] `QueuedSenderComSpec`
+- [ ] `UserDefinedTransformationComSpecProps`
+- [ ] `EndToEndProtectionVariablePrototype`
+- [ ] `EndToEndProtectionSet` — after `EndToEndProtection` (auto-queued, exists)
+
+## Group 6 — Ethernet/Flexray Fibex, SecureCommunication, Transformer, DataMapping, NM (30)
+
+- [ ] `AbstractEthernetFrame`
+- [ ] `GenericEthernetFrame`
+- [ ] `CouplingPortStructuralElement`
+- [ ] `CouplingPortScheduler`
+- [ ] `VlanMembership`
+- [ ] `NetworkEndpointAddress`
+- [ ] `OrderedMaster` *(existing member)*
+- [ ] `TimeSyncClientConfiguration` — after `OrderedMaster` (aggr `orderedMaster`)
+- [ ] `TransportProtocolConfiguration`
+- [ ] `TcpUdpConfig`
+- [ ] `FlexrayFrame`
+- [ ] `CryptoServiceMapping`
+- [ ] `TlsCryptoServiceMapping`
+- [ ] `DataTransformationSet` — after `DataTransformation`/`TransformationTechnology`
+      (auto-queued, exist)
+- [ ] `DataPrototypeTransformationProps` *(existing member)*
+- [ ] `TransformationISignalProps` — after `DataPrototypeTransformationProps` (aggr)
+- [ ] `SenderRecCompositeTypeMapping`
+- [ ] `SenderRecArrayTypeMapping` — after `SenderRecArrayElementMapping`/`TextTableMapping`
+      (auto-queued, exist)
+- [ ] `NmClusterCoupling`
+- [ ] `NmCluster`
+- [ ] `FlexrayNmCluster`
+- [ ] `FlexrayNmEcu`
+- [ ] `FlexrayNmNode`
+- [ ] `UdpNmEcu`
+- [ ] `J1939NmCluster`
+- [ ] `J1939NmEcu`
+- [ ] `NmConfig` — after all NM classes above (aggrs `nmCluster`, `nmClusterCoupling`, `nmIfEcu`)
+- [ ] `IPduMapping`
+- [ ] `PduMappingDefaultValue`
+- [ ] `RtePluginProps`
+
+## Group 7 — ECU resource, Crypto/IDS, DoIP, Firewall, remaining (29)
+
+- [ ] `HwAttributeDef` *(existing member)*
+- [ ] `HwCategory` — after `HwAttributeDef` (aggr `hwAttributeDef`)
+- [ ] `HwAttributeValue`
+- [ ] `HwAttributeLiteralDef`
+- [ ] `HwType`
+- [ ] `CryptoKeySlot`
+- [ ] `AbstractDoIpLogicAddressProps`
+- [ ] `DoIpLogicTargetAddressProps`
+- [ ] `DoIpLogicTesterAddressProps`
+- [ ] `DoIpTpConfig` — after the DoIp props classes
+- [ ] `FirewallActionEnum` **(NEW)**
+- [ ] `FirewallRule` — after `FirewallActionEnum`
+- [ ] `FirewallRuleProps` — after `FirewallRule` (refs `matchingEgressRule`/`matchingIngressRule`)
+- [ ] `StateDependentFirewall` — after `FirewallRuleProps` (aggr `firewallRuleProps`)
+- [ ] `IdsPlatformInstantiation`
+- [ ] `IdsmModuleInstantiation`
+- [ ] `PlatformModuleEthernetEndpointConfiguration`
+- [ ] `CommunicationControllerMapping` **(NEW)**
+- [ ] `HwPortMapping` **(NEW)**
+- [ ] `ECUMapping` — after both NEW classes above (aggrs)
+- [ ] `VariableDataPrototypeInSystemInstanceRef`
+- [ ] `ComponentInSystemInstanceRef`
+- [ ] `PortPrototypeBlueprintInitValue` *(existing member)*
+- [ ] `PortPrototypeBlueprint` — after `PortPrototypeBlueprintInitValue` (aggr `initValue`)
+- [ ] `Keyword` *(existing member)*
+- [ ] `KeywordSet` — after `Keyword` (aggr `keyword`)
+- [ ] `DiagnosticServiceInstance` **(NEW)**
+- [ ] `DiagnosticServiceTable` — after `DiagnosticServiceInstance` (ref `serviceInstance`)
+- [ ] `DiagnosticCommonElement`
+
+## Progress
+
+| Group | Entries | Tracker | NEW | Existing member | Done |
+|---|---|---|---|---|---|
+| 1 | 29 | 29 | 0 | 0 | 0/29 |
+| 2 | 30 | 28 | 0 | 2 | 0/30 |
+| 3 | 29 | 25 | 3 | 1 | 0/29 |
+| 4 | 29 | 23 | 6 | 0 | 0/29 |
+| 5 | 30 | 30 | 0 | 0 | 0/30 |
+| 6 | 30 | 28 | 0 | 2 | 0/30 |
+| 7 | 29 | 22 | 4 | 3 | 0/29 |
+| **Total** | **206** | **185** | **13** | **8** | **0/206** |

--- a/docs/plan/sync-todo/Group1.md
+++ b/docs/plan/sync-todo/Group1.md
@@ -26,7 +26,12 @@ Input: `Group 1 — Framework & core, PortInterface basics` of `docs/examples/sy
   - [x] Step 8 — Deviations — none (stale "missing" tracker row replaced with resolved entry)
   - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] `ARPackage` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 4.1)
-  - [ ] Step 1 — Sync members & description from spec
+  - [x] Step 1 — Sync members & description from spec
+    - Spec facts (extracted 2026-08-30, PDF-confirmed): Table 4.1 spans **p.53–54** (summary rows p.53, attribute rows + caption p.54). NOTE: in this markdown/PDF, table **content precedes its caption**; Table 4.3 (ARElement) is split across p.54–55 with the caption sitting mid-table.
+    - Note (verbatim, for Step 4): "AUTOSAR package, allowing to create top level packages to structure the contained ARElements. ARPackages are open sets. This means that in a file based description system multiple files can be used to partially describe the contents of a package. This is an extended version of MSR's SW-SYSTEM."
+    - Base (flattened): ARObject, AtpBlueprint, AtpBlueprintable, CollectableElement, Identifiable, MultilanguageReferrable, Referrable. Since PackageableElement is NOT in the list but AtpBlueprintable IS, and per Tables E.10/E.11 both AtpBlueprint and AtpBlueprintable have Base = ARObject, Identifiable, MultilanguageReferrable, Referrable (no PackageableElement) — direct bases ≈ {AtpBlueprint, AtpBlueprintable, CollectableElement}. Current code has `ARPackage(CollectableElement)` only → Step 3 must decide whether to add AtpBlueprint/AtpBlueprintable mixins (check their attribute blueprintPolicy / blueprintColor impact).
+    - Attributes: `arPackage` (ARPackage, *, aggr) / `element` (PackageableElement, *, aggr) / `referenceBase` (ReferenceBase, *, aggr) — implemented via createARPackage/getARPackages, addElement/getElement, addReferenceBase/referenceBases.
+    - ARElement confirmation (user gate): ARElement = Table 4.3 (content p.54 + p.55 subclasses block, caption p.55); Note/Base/no-own-attributes all match the stamped implementation — ARElement sync confirmed correct, no changes needed.
   - [ ] Step 2 — Write model class unit test (Red)
   - [ ] Step 3 — Implement model class (Green)
   - [ ] Step 4 — Sync docstrings (wipe + rewrite)

--- a/docs/plan/sync-todo/Group1.md
+++ b/docs/plan/sync-todo/Group1.md
@@ -15,16 +15,16 @@ Input: `Group 1 — Framework & core, PortInterface basics` of `docs/examples/sy
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] `ARElement` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 4.3)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [x] `ARElement` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 4.3) — `# Spec verified: R23-11`
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red) — N/A: Table 4.3 has no Attribute rows; no own XML element, round-trip covered by concrete subclasses
+  - [x] Step 6 — Update parser & writer (Green) — N/A: same reason as Step 5
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations — none (stale "missing" tracker row replaced with resolved entry)
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] `ARPackage` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 4.1)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/Group1.md
+++ b/docs/plan/sync-todo/Group1.md
@@ -1,0 +1,305 @@
+# Sync todo: Group 1 — Framework & core, PortInterface basics
+
+Input: `Group 1 — Framework & core, PortInterface basics` of `docs/examples/sync_class_groups.md` · Generated: 2026-08-30 · Queue order = row order
+(resume = first class row still `[ ]`; all class rows `[x]` = sync finished — Rule 0017.3)
+
+## Queue (dependency-first)
+
+- [ ] `ARObject` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 6.1)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ARElement` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 4.3)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ARPackage` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 4.1)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `AUTOSAR` (tracker input · R4.3.1 markdown · AUTOSAR_TPS_ARXMLSerializationRules · Table 1.1 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `FileInfoComment` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 2.1)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `Collection` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 13.1)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `AtpType` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 5.6)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `AtpPrototype` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 5.4)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `AtpStructureElement` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 5.5)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `AtpDefinition` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 11.3)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `AtpBlueprintable` (tracker input · R4.3.1 markdown · AUTOSAR_TPS_StandardizationTemplate · Table 4.3)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `AtpBlueprintMapping` (tracker input · R4.3.1 markdown · AUTOSAR_TPS_StandardizationTemplate · Table 4.4)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `BlueprintMappingSet` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 3.1 (multiple tables — resolve in per-class Phase 0) · after `AtpBlueprintMapping` (aggr `blueprintMap`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ApplicationDeferredDataType` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_AbstractPlatformSpecification · Table 3.17)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `AbstractImplementationDataType` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.14)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `AbstractImplementationDataTypeElement` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.16)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `Implementation` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 7.1 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `FlatMap` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 14.1)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ModeAccessPointIdent` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 14.5)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `IdentCaption` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 14.4)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DataInterface` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.19)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `NvDataInterface` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 11.5)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SenderReceiverInterface` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.1)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ParameterInterface` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 2.2)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `TriggerInterface` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.12)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `PortInterfaceMapping` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.20)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SubElementMapping` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.32)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `TriggerInterfaceMapping` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.30)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ModeDeclarationMappingSet` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.28 · after `ModeDeclarationMapping` (auto-queued, exists))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+
+## Pending 16.4 resolution (NEW — not in src)
+
+_(none)_
+
+## Not queued
+
+_(none)_

--- a/docs/plan/sync-todo/Group1.md
+++ b/docs/plan/sync-todo/Group1.md
@@ -5,16 +5,16 @@ Input: `Group 1 — Framework & core, PortInterface basics` of `docs/examples/sy
 
 ## Queue (dependency-first)
 
-- [ ] `ARObject` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 6.1)
+- [x] `ARObject` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 6.1) — `# Spec verified: R23-11`
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)
   - [x] Step 4 — Sync docstrings (wipe + rewrite)
   - [x] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] `ARElement` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 4.3)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/docs/plan/sync-todo/Group2.md
+++ b/docs/plan/sync-todo/Group2.md
@@ -1,0 +1,315 @@
+# Sync todo: Group 2 — PortInterface sets, components, SWC behavior, datatypes
+
+Input: `Group 2 — PortInterface sets, components, SWC behavior, datatypes` of `docs/examples/sync_class_groups.md` · Generated: 2026-08-30 · Queue order = row order
+(resume = first class row still `[ ]`; all class rows `[x]` = sync finished — Rule 0017.3)
+
+## Queue (dependency-first)
+
+- [ ] `PortInterfaceMappingSet` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.19 · after `PortInterfaceMapping` (Group 1))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `MetaDataItemSet` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.5 · after `MetaDataItem` (auto-queued, exists))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ApplicationCompositeElementInPortInterfaceInstanceRef` (tracker input · no R23-11/R4.3.1 table found → XSD-only candidate (confirm in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SymbolProps` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.21)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `PPortPrototype` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.6)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `RPortPrototype` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.5)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `PRPortPrototype` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.7)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `PortGroup` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.94)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `InnerPortGroupInCompositionInstanceRef` (tracker input · no R23-11/R4.3.1 table found → XSD-only candidate (confirm in per-class Phase 0) · — member type of `PortGroup.innerGroup`)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `VariableInAtomicSwcInstanceRef` (tracker input · no R23-11/R4.3.1 table found → XSD-only candidate (confirm in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CompositionSwComponentType` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.10 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DelegationSwConnector` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.14)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SwcInternalBehavior` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 7.2)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ArVariableInImplementationDataInstanceRef` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.37)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `VariableInAtomicSWCTypeInstanceRef` (tracker input · no R23-11/R4.3.1 table found → XSD-only candidate (confirm in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `IncludedModeDeclarationGroupSet` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 7.51)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `RunnableEntityArgument` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 7.5)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `AsynchronousServerCallPoint` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 7.37)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `AsynchronousServerCallResultPoint` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 7.38 · — ref target of the point class above)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SynchronousServerCallPoint` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 7.36)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `InitEvent` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 7.22)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `BackgroundEvent` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 7.16)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ExternalTriggeringPointIdent` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 14.6)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `PortDefinedArgumentValue` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 7.45 · *(existing member)*)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `PortAPIOption` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 7.42 · after `PortDefinedArgumentValue` (aggr `portArgValue`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ApplicationPrimitiveDataType` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_DiagnosticExtractTemplate · Table 5.6 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ApplicationDataType` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.2 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ApplicationCompositeDataType` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.6 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ApplicationRecordElement` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.13 · *(existing member)*)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ApplicationRecordDataType` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.12 (multiple tables — resolve in per-class Phase 0) · after `ApplicationRecordElement` (aggr `element`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+
+## Pending 16.4 resolution (NEW — not in src)
+
+_(none)_
+
+## Not queued
+
+_(none)_

--- a/docs/plan/sync-todo/Group3.md
+++ b/docs/plan/sync-todo/Group3.md
@@ -1,0 +1,277 @@
+# Sync todo: Group 3 — Constants, CompuMethod, DataDictionary, Documentation
+
+Input: `Group 3 — Constants, CompuMethod, DataDictionary, Documentation` of `docs/examples/sync_class_groups.md` · Generated: 2026-08-30 · Queue order = row order
+(resume = first class row still `[ ]`; all class rows `[x]` = sync finished — Rule 0017.3)
+
+## Queue (dependency-first)
+
+- [ ] `RecordValueSpecification` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.112)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ArrayValueSpecification` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.111)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CompositeValueSpecification` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.110)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CompositeRuleBasedValueArgument` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.136)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CompositeRuleBasedValueSpecification` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.135 · after `CompositeRuleBasedValueArgument` (aggr))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DataConstrRule` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.83)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CompuContent` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.63)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CompuConstContent` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.72)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CompuScaleContents` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.66)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CompuNominatorDenominator` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.75)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CompuScales` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.65 · after `CompuScale` (auto-queued, exists))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SwValueCont` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.121)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SwCalprmAxisSet` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.46)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SwAxisIndividual` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.50)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SwAxisGrouped` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.55)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SwRecordLayoutGroup` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.99)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SwRecordLayoutV` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 5.98)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `GeneralAnnotation` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.56 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `MultiLanguageParagraph` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 9.4)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `Map` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 9.23 · after `Area` (aggr `area`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `LGraphic` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 9.25 · *(existing member)*)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `MlFigure` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 9.24 · after `LGraphic` (aggr `lGraphic`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DocumentViewSelectable` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 9.77)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `MsrQueryChapter` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 9.84 · after `MsrQueryResultChapter` (aggr))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `MsrQueryTopic1` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 9.83 · after `MsrQueryResultTopic1` (aggr))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `MsrQueryP1` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_GenericStructureTemplate · Table 9.82)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+
+## Pending 16.4 resolution (NEW — not in src)
+
+- `Area` — not in `src` (NEW) · R23-11 markdown · Table 9.17 · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+- `MsrQueryResultChapter` — not in `src` (NEW) · R23-11 markdown · Table 9.87 · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+- `MsrQueryResultTopic1` — not in `src` (NEW) · R23-11 markdown · Table 9.88 · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+
+## Not queued
+
+_(none)_

--- a/docs/plan/sync-todo/Group4.md
+++ b/docs/plan/sync-todo/Group4.md
@@ -1,0 +1,250 @@
+# Sync todo: Group 4 — BSW behavior policies & ServiceNeeds A
+
+Input: `Group 4 — BSW behavior policies & ServiceNeeds A` of `docs/examples/sync_class_groups.md` · Generated: 2026-08-30 · Queue order = row order
+(resume = first class row still `[ ]`; all class rows `[x]` = sync finished — Rule 0017.3)
+
+## Queue (dependency-first)
+
+- [ ] `BswInternalBehavior` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 5.2 (multiple tables — resolve in per-class Phase 0) · after all 6 NEW policy classes above (deferred full sync;)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ServiceNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 12.6 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DiagEventDebounceAlgorithm` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 12.32 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DiagEventDebounceMonitorInternal` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 12.35 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `EcuStateMgrUserNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 12.14 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DltUserNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 12.16 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DiagnosticComponentNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.64)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DiagnosticUploadDownloadNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 12.29 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DiagnosticsCommunicationSecurityNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 12.27 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `FunctionInhibitionNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 12.19 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `GlobalSupervisionNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.4)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `HardwareTestNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 12.40 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SupervisedEntityCheckpointNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 12.30 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SyncTimeBaseMgrUserNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate · Table 12.17 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `BswMgrNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.8)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CryptoKeyManagementNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.11)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CryptoServiceJobNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.10)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DiagnosticControlNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.63)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DiagnosticEventManagerNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.14)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DiagnosticRequestFileTransferNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.43)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DoIpActivationLineNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.60)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DoIpGidNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.55)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DoIpGidSynchronizationNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.56)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+
+## Pending 16.4 resolution (NEW — not in src)
+
+- `BswPerInstanceMemoryPolicy` — not in `src` (NEW) · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+- `BswClientPolicy` — not in `src` (NEW) · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+- `BswInternalTriggeringPointPolicy` — not in `src` (NEW) · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+- `BswParameterPolicy` — not in `src` (NEW) · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+- `BswReleasedTriggerPolicy` — not in `src` (NEW) · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+- `BswDataSendPolicy` — not in `src` (NEW) · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+
+## Not queued
+
+_(none)_

--- a/docs/plan/sync-todo/Group5.md
+++ b/docs/plan/sync-todo/Group5.md
@@ -1,0 +1,315 @@
+# Sync todo: Group 5 — ServiceNeeds B, SystemTemplate, Fibex core, SWC Communication & E2E
+
+Input: `Group 5 — ServiceNeeds B, SystemTemplate, Fibex core, SWC Communication & E2E` of `docs/examples/sync_class_groups.md` · Generated: 2026-08-30 · Queue order = row order
+(resume = first class row still `[ ]`; all class rows `[x]` = sync finished — Rule 0017.3)
+
+## Queue (dependency-first)
+
+- [ ] `DoIpPowerModeStatusNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.57)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `FurtherActionByteNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.62)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `IdsMgrCustomTimestampNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.82)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `J1939DcmDm19Support` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.72)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `J1939RmIncomingRequestServiceNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.71)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `J1939RmOutgoingRequestServiceNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.70)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `V2xDataManagerNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.79)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `V2xFacUserNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.77)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `V2xMUserNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.78)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `VendorSpecificServiceNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 7.53)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `WarningIndicatorRequestedBitNeeds` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 13.61)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `System` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 2.1 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `J1939SharedAddressCluster` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.324)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ComManagementMapping` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 5.46)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `EcuInstance` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 3.1)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DiagnosticConnection` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_DiagnosticExtractTemplate · Table 4.17 (multiple tables — resolve in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `EthernetPhysicalChannel` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 3.49)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `FrameTriggering` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.79)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ContainedIPduProps` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.39)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ModeDrivenTransmissionModeCondition` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.61)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `StaticPart` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.73)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DynamicPartAlternative` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.75)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `GeneralPurposePdu` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.25)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `GeneralPurposeIPdu` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.26)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CommunicationCycle` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.83)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `FramePort` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.2)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `QueuedSenderComSpec` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.68)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `UserDefinedTransformationComSpecProps` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.91)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `EndToEndProtectionVariablePrototype` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.98)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `EndToEndProtectionSet` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 4.96 (multiple tables — resolve in per-class Phase 0) · after `EndToEndProtection` (auto-queued, exists))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+
+## Pending 16.4 resolution (NEW — not in src)
+
+_(none)_
+
+## Not queued
+
+_(none)_

--- a/docs/plan/sync-todo/Group6.md
+++ b/docs/plan/sync-todo/Group6.md
@@ -1,0 +1,315 @@
+# Sync todo: Group 6 — Ethernet/Flexray Fibex, SecureCommunication, Transformer, DataMapping, NM
+
+Input: `Group 6 — Ethernet/Flexray Fibex, SecureCommunication, Transformer, DataMapping, NM` of `docs/examples/sync_class_groups.md` · Generated: 2026-08-30 · Queue order = row order
+(resume = first class row still `[ ]`; all class rows `[x]` = sync finished — Rule 0017.3)
+
+## Queue (dependency-first)
+
+- [ ] `AbstractEthernetFrame` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.229)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `GenericEthernetFrame` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.231)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CouplingPortStructuralElement` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 3.64)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CouplingPortScheduler` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 3.65)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `VlanMembership` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 3.59)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `NetworkEndpointAddress` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.135)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `OrderedMaster` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.148 · *(existing member)*)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `TimeSyncClientConfiguration` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.146 · after `OrderedMaster` (aggr `orderedMaster`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `TransportProtocolConfiguration` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.125)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `TcpUdpConfig` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.127)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `FlexrayFrame` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.80)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CryptoServiceMapping` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.48)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `TlsCryptoServiceMapping` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.211)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DataTransformationSet` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 7.1 · after `DataTransformation`/`TransformationTechnology`)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DataPrototypeTransformationProps` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 7.17 · *(existing member)*)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `TransformationISignalProps` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 7.8 · after `DataPrototypeTransformationProps` (aggr))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SenderRecCompositeTypeMapping` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 5.27)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `SenderRecArrayTypeMapping` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 5.28 · after `SenderRecArrayElementMapping`/`TextTableMapping`)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `NmClusterCoupling` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.305)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `NmCluster` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.299)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `FlexrayNmCluster` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.306)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `FlexrayNmEcu` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.307)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `FlexrayNmNode` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.309)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `UdpNmEcu` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.316)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `J1939NmCluster` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.319)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `J1939NmEcu` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.323)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `NmConfig` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.298 · after all NM classes above (aggrs `nmCluster`, `nmClusterCoupling`, `nmIfEcu`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `IPduMapping` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 8.3)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `PduMappingDefaultValue` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 8.5)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `RtePluginProps` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 14.5)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+
+## Pending 16.4 resolution (NEW — not in src)
+
+_(none)_
+
+## Not queued
+
+_(none)_

--- a/docs/plan/sync-todo/Group7.md
+++ b/docs/plan/sync-todo/Group7.md
@@ -1,0 +1,268 @@
+# Sync todo: Group 7 — ECU resource, Crypto/IDS, DoIP, Firewall, remaining
+
+Input: `Group 7 — ECU resource, Crypto/IDS, DoIP, Firewall, remaining` of `docs/examples/sync_class_groups.md` · Generated: 2026-08-30 · Queue order = row order
+(resume = first class row still `[ ]`; all class rows `[x]` = sync finished — Rule 0017.3)
+
+## Queue (dependency-first)
+
+- [ ] `HwAttributeDef` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_ECUResourceTemplate · Table 2.13 · *(existing member)*)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `HwCategory` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_ECUResourceTemplate · Table 2.11 · after `HwAttributeDef` (aggr `hwAttributeDef`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `HwAttributeValue` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_ECUResourceTemplate · Table 2.2)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `HwAttributeLiteralDef` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_ECUResourceTemplate · Table 2.14)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `HwType` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_ECUResourceTemplate · Table 2.3)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `CryptoKeySlot` (tracker input · no R23-11/R4.3.1 table found → XSD-only candidate (confirm in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `AbstractDoIpLogicAddressProps` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.208)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DoIpLogicTargetAddressProps` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.209)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DoIpLogicTesterAddressProps` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.210)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DoIpTpConfig` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.205 · after the DoIp props classes)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `FirewallRule` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.236 · after `FirewallActionEnum`)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `FirewallRuleProps` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.235 · after `FirewallRule` (refs `matchingEgressRule`/`matchingIngressRule`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `StateDependentFirewall` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 6.234 · after `FirewallRuleProps` (aggr `firewallRuleProps`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `IdsPlatformInstantiation` (tracker input · no R23-11/R4.3.1 table found → XSD-only candidate (confirm in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `IdsmModuleInstantiation` (tracker input · no R23-11/R4.3.1 table found → XSD-only candidate (confirm in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `PlatformModuleEthernetEndpointConfiguration` (tracker input · no R23-11/R4.3.1 table found → XSD-only candidate (confirm in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ECUMapping` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SystemTemplate · Table 3.133 · after both NEW classes above (aggrs))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `VariableDataPrototypeInSystemInstanceRef` (tracker input · no R23-11/R4.3.1 table found → XSD-only candidate (confirm in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `ComponentInSystemInstanceRef` (tracker input · no R23-11/R4.3.1 table found → XSD-only candidate (confirm in per-class Phase 0))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `PortPrototypeBlueprintInitValue` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_StandardizationTemplate · Table 4.10 · *(existing member)*)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `PortPrototypeBlueprint` (tracker input · R23-11 markdown · AUTOSAR_FO_TPS_StandardizationTemplate · Table 4.9 · after `PortPrototypeBlueprintInitValue` (aggr `initValue`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `Keyword` (tracker input · R4.3.1 markdown · AUTOSAR_TPS_StandardizationTemplate · Table 6.2 · *(existing member)*)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `KeywordSet` (tracker input · R4.3.1 markdown · AUTOSAR_TPS_StandardizationTemplate · Table 6.1 · after `Keyword` (aggr `keyword`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DiagnosticServiceTable` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_DiagnosticExtractTemplate · Table 4.16 · after `DiagnosticServiceInstance` (ref `serviceInstance`))
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+- [ ] `DiagnosticCommonElement` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_DiagnosticExtractTemplate · Table 4.1)
+  - [ ] Step 1 — Sync members & description from spec
+  - [ ] Step 2 — Write model class unit test (Red)
+  - [ ] Step 3 — Implement model class (Green)
+  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
+  - [ ] Step 5 — Write reader/writer round-trip test (Red)
+  - [ ] Step 6 — Update parser & writer (Green)
+  - [ ] Step 7 — Update checklist comment
+  - [ ] Step 8 — Deviations
+  - [ ] Step 9 — Verify (9a) + confirm (9b)
+
+## Pending 16.4 resolution (NEW — not in src)
+
+- `FirewallActionEnum` — not in `src` (NEW) · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+- `CommunicationControllerMapping` — not in `src` (NEW) · R23-11 markdown · Table 3.134 · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+- `HwPortMapping` — not in `src` (NEW) · R23-11 markdown · Table 3.135 · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+- `DiagnosticServiceInstance` — not in `src` (NEW) · R23-11 markdown · Table 4.26 · **(NEW)**; 16.4 decision required: **Skip** (deviation row) or **Derive-from-XSD** (then move into the queue with a 9-step sub-checklist)
+
+## Not queued
+
+_(none)_

--- a/src/armodel/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/__init__.py
@@ -10,7 +10,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.InternalBehavior import 
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation import Implementation
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Referrable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import CollectableElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationDataType, DataTypeMap

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Constants/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Constants/__init__.py
@@ -11,7 +11,7 @@ from abc import ABC
 from typing import List, Optional
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARNumerical, RefType
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     ARLiteral,
     AREnum as AREnum,

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/FlatMap.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/FlatMap.py
@@ -12,7 +12,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import AnyInstanceRef
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 
 
 class FlatInstanceDescriptor(Identifiable):

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Implementation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Implementation.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, List, Optional
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import McSupportData
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.EngineeringObject import AutosarEngineeringObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, Referrable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger, RefType, String, RevisionLabelString, AREnum, CIdentifier
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/McGroups.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/McGroups.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds.py
@@ -10,9 +10,11 @@ from abc import ABC
 from typing import List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.DataElements import (
+        AutosarParameterRef,
+        AutosarVariableRef,
+    )
     from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.ServiceMapping import RoleBasedDataTypeAssignment
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.DataElements import AutosarParameterRef
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.DataElements import AutosarVariableRef
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation import ImplementationProps
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/AbstractBlueprintStructure/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/AbstractBlueprintStructure/__init__.py
@@ -11,7 +11,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import (
     Identifiable,
 )
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import PackageableElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import PackageableElement
 
 
 class AtpBlueprintable(PackageableElement, ABC):

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingExtensions.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingExtensions.py
@@ -17,7 +17,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingDescription
     TimingDescription,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate.py
@@ -15,7 +15,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 )
 from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucConfigurationVariantEnum
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 
 
 class EcucValueCollection(ARElement):

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/DocumentationOnM1/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/DocumentationOnM1/__init__.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.AnyInstanceRef import AnyInstanceRef
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import MultilanguageReferrable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
 from armodel.models.M2.MSR.Documentation.Chapters import PredefinedChapter
 

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
@@ -6,18 +6,286 @@ primary organizational unit for grouping related AUTOSAR model elements such as
 components, interfaces, data types, and other packages.
 """
 
+from __future__ import annotations
 from typing import Dict, List, Optional, Any
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import Collection
+from abc import ABC
 
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import (  # noqa: F401
-    ARElement,
-    Identifiable,
-    PackageableElement,
-    Referrable,
-)
+if TYPE_CHECKING:
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import (
+        Collection,
+    )
+
+    # Names re-exported lazily at runtime via _LAZY_IMPORTS; imported here only
+    # so that deferred annotations (PEP 563) resolve for static analysis.
+    from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import (
+        BswImplementation,
+    )
+    from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import (
+        BswModuleEntry,
+    )
+    from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import (
+        BswModuleDescription,
+    )
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure import (
+        ConstantSpecification,
+    )
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.FlatMap import (
+        FlatMap,
+    )
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation import (
+        Implementation,
+    )
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes import (
+        ImplementationDataType,
+    )
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.McGroups import (
+        McGroup,
+    )
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import (
+        McFunction,
+    )
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import (
+        ModeDeclarationGroup,
+    )
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.SignalServiceTranslation import (
+        SignalServiceTranslationPropsSet,
+    )
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint import (
+        PortPrototypeBlueprint,
+    )
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword import (
+        KeywordSet,
+    )
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping import (
+        SwcBswMapping,
+    )
+    from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingExtensions import (
+        SwcTiming,
+    )
+    from armodel.models.M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticContribution import (
+        DiagnosticServiceTable,
+    )
+    from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import (
+        EcucModuleConfigurationValues,
+        EcucValueCollection,
+    )
+    from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
+        EcucDefinitionCollection,
+        EcucDestinationUriDefSet,
+        EcucModuleDef,
+    )
+    from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import (
+        HwElement,
+    )
+    from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import (
+        HwCategory,
+        HwType,
+    )
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import (
+        Documentation,
+    )
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import (
+        LifeCycleInfoSet,
+    )
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
+        PostBuildVariantCriterion,
+        PredefinedVariant,
+        SwSystemconstantValueSet,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import (
+        ApplicationSwComponentType,
+        AtomicSwComponentType,
+        ComplexDeviceDriverSwComponentType,
+        EcuAbstractionSwComponentType,
+        NvBlockSwComponentType,
+        SensorActuatorSwComponentType,
+        ServiceProxySwComponentType,
+        ServiceSwComponentType,
+        SwComponentType,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition import (
+        CompositionSwComponentType,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import (
+        ApplicationArrayDataType,
+        ApplicationDataType,
+        ApplicationPrimitiveDataType,
+        ApplicationRecordDataType,
+        DataTypeMappingSet,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection import (
+        EndToEndProtectionSet,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import (
+        ConsistencyNeeds,
+        DataPrototypeGroup,
+        RunnableEntityGroup,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import (
+        ClientServerInterface,
+        ModeDeclarationMappingSet,
+        ModeSwitchInterface,
+        NvDataInterface,
+        ParameterInterface,
+        PortInterfaceMappingSet,
+        SenderReceiverInterface,
+        TriggerInterface,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation import (
+        SwcImplementation,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate import (
+        System,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import (
+        DiagnosticConnection,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
+        CanFrame,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import (
+        CanXlProps,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetFrame import (
+        GenericEthernetFrame,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetTopology import (
+        EthernetCluster,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ObsoleteModel import (
+        SoAdRoutingGroup,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import (
+        SomeipSdClientEventGroupTimingConfig,
+        SomeipSdClientServiceInstanceConfig,
+        SomeipSdServerEventGroupTimingConfig,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.TcpOptionFilterSet import (
+        TcpOptionFilterSet,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import (
+        FlexrayFrame,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology import (
+        FlexrayCluster,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommunication import (
+        LinUnconditionalFrame,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import (
+        LinCluster,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform import (
+        Gateway,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (
+        DcmIPdu,
+        GeneralPurposeIPdu,
+        GeneralPurposePdu,
+        ISignal,
+        ISignalGroup,
+        ISignalIPdu,
+        ISignalIPduGroup,
+        MultiplexedIPdu,
+        NPdu,
+        NmPdu,
+        SecureCommunicationPropsSet,
+        SecuredIPdu,
+        SystemSignal,
+        SystemSignalGroup,
+        UserDefinedIPdu,
+        UserDefinedPdu,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import (
+        CanCluster,
+        EcuInstance,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import (
+        NmConfig,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import (
+        DataTransformationSet,
+        E2EProfileCompatibilityProps,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import (
+        CanTpConfig,
+        DoIpTpConfig,
+        LinTpConfig,
+    )
+    from armodel.models.M2.MSR.AsamHdo.AdminData import (
+        AdminData,
+    )
+    from armodel.models.M2.MSR.AsamHdo.BaseTypes import (
+        SwBaseType,
+    )
+    from armodel.models.M2.MSR.AsamHdo.ComputationMethod import (
+        CompuMethod,
+    )
+    from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import (
+        DataConstr,
+    )
+    from armodel.models.M2.MSR.AsamHdo.Units import (
+        PhysicalDimension,
+        Unit,
+    )
+    from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import (
+        SwAddrMethod,
+    )
+    from armodel.models.M2.MSR.DataDictionary.RecordLayout import (
+        SwRecordLayout,
+    )
+    from armodel.models.M2.MSR.DataDictionary.SystemConstant import (
+        SwSystemconst,
+    )
+    from armodel.models.M2.MSR.Documentation.Annotation import (
+        Annotation,
+    )
+    from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import (
+        DocumentationBlock,
+    )
+    from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import (
+        MultiLanguageOverviewParagraph,
+        MultilanguageLongName,
+    )
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, Referrable
+
+
+class PackageableElement(Identifiable, ABC):
+    """
+    This meta-class specifies the ability to be a member of an AUTOSAR package.
+    """
+
+    # PackageableElement method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.2, p.54
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+
+    def __init__(self, parent: ARObject, short_name: str):
+        if type(self) is PackageableElement:
+            raise TypeError("PackageableElement is an abstract class.")
+        super().__init__(parent, short_name)
+
+
+class ARElement(PackageableElement, ABC):
+    """
+    An element that can be defined stand-alone, i.e. without being part of another element (except for packages of course).
+    """
+
+    # ARElement method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.3, p.55
+    # Columns: impl / docstring / test / reader / writer / release   ([—] = no XML element)
+    # [x] __init__   [x] impl  [x] docstring  [x] test  [—] reader  [—] writer  R23-11
+
+    def __init__(self, parent: ARObject, short_name: str):
+        if type(self) is ARElement:
+            raise TypeError("ARElement is an abstract class.")
+        super().__init__(parent, short_name)
+
 
 # Initialize the CommonStructure package before any import that transitively touches
 # AbstractStructure: AbstractStructure's own import of AbstractBlueprintStructure requires
@@ -27,97 +295,256 @@ import armodel.models.M2.AUTOSARTemplates.CommonStructure  # noqa: F401,E402
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import CollectableElement  # noqa: E402
 
 
-from armodel.models.M2.MSR.DataDictionary.SystemConstant import SwSystemconst
-from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import Documentation
-from armodel.models.M2.MSR.AsamHdo.AdminData import AdminData
-from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultilanguageLongName
-from armodel.models.M2.MSR.Documentation.Annotation import Annotation
-from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import MultiLanguageOverviewParagraph
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import CategoryString
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
-    PostBuildVariantCriterion,
-    PredefinedVariant,
-    SwSystemconstantValueSet,
-)
+# Element-class names are re-exported lazily (PEP 562) so that `from ARPackage import X`
+# and wildcard imports keep working; each element module imports ARElement from this
+# module, so eager imports here would create a 2-ring deadlock.
+from importlib import import_module as _import_module  # noqa: E402
 
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SensorActuatorSwComponentType
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import (
-    ConsistencyNeeds,
-    DataPrototypeGroup,
-    RunnableEntityGroup,
-)
-from armodel.models.M2.MSR.AsamHdo.BaseTypes import SwBaseType
-from armodel.models.M2.MSR.AsamHdo.Units import PhysicalDimension, Unit
-from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import DataConstr
-from armodel.models.M2.MSR.AsamHdo.ComputationMethod import CompuMethod
-from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod
-from armodel.models.M2.MSR.DataDictionary.RecordLayout import SwRecordLayout
+_LAZY_IMPORTS = {
+    "AdminData": "armodel.models.M2.MSR.AsamHdo.AdminData",
+    "Annotation": "armodel.models.M2.MSR.Documentation.Annotation",
+    "ApplicationArrayDataType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes",
+    "ApplicationDataType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes",
+    "ApplicationPrimitiveDataType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes",
+    "ApplicationRecordDataType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes",
+    "ApplicationSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
+    "AtomicSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
+    "BswImplementation": "armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation",
+    "BswModuleDescription": "armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview",
+    "BswModuleEntry": "armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces",
+    "CanCluster": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology",
+    "CanFrame": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication",
+    "CanTpConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols",
+    "CanXlProps": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology",
+    "ClientServerInterface": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
+    "ComplexDeviceDriverSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
+    "CompositionSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition",
+    "CompuMethod": "armodel.models.M2.MSR.AsamHdo.ComputationMethod",
+    "ConsistencyNeeds": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior",
+    "ConstantSpecification": "armodel.models.M2.AUTOSARTemplates.CommonStructure",
+    "DataConstr": "armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints",
+    "DataPrototypeGroup": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior",
+    "DataTransformationSet": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer",
+    "DataTypeMappingSet": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes",
+    "DcmIPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "DiagnosticConnection": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection",
+    "DiagnosticServiceTable": "armodel.models.M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticContribution",
+    "DoIpTpConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols",
+    "Documentation": "armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1",
+    "DocumentationBlock": "armodel.models.M2.MSR.Documentation.TextModel.BlockElements",
+    "E2EProfileCompatibilityProps": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer",
+    "EcuAbstractionSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
+    "EcuInstance": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology",
+    "EcucDefinitionCollection": "armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate",
+    "EcucDestinationUriDefSet": "armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate",
+    "EcucModuleConfigurationValues": "armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate",
+    "EcucModuleDef": "armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate",
+    "EcucValueCollection": "armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate",
+    "EndToEndProtectionSet": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection",
+    "EthernetCluster": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetTopology",
+    "FlatMap": "armodel.models.M2.AUTOSARTemplates.CommonStructure.FlatMap",
+    "FlexrayCluster": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology",
+    "FlexrayFrame": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication",
+    "Gateway": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform",
+    "GeneralPurposeIPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "GeneralPurposePdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "GenericEthernetFrame": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetFrame",
+    "HwCategory": "armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory",
+    "HwElement": "armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate",
+    "HwType": "armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory",
+    "ISignal": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "ISignalGroup": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "ISignalIPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "ISignalIPduGroup": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "Implementation": "armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation",
+    "ImplementationDataType": "armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes",
+    "KeywordSet": "armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword",
+    "LifeCycleInfoSet": "armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles",
+    "LinCluster": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology",
+    "LinTpConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols",
+    "LinUnconditionalFrame": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommunication",
+    "McFunction": "armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport",
+    "McGroup": "armodel.models.M2.AUTOSARTemplates.CommonStructure.McGroups",
+    "ModeDeclarationGroup": "armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration",
+    "ModeDeclarationMappingSet": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
+    "ModeSwitchInterface": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
+    "MultiLanguageOverviewParagraph": "armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData",
+    "MultilanguageLongName": "armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData",
+    "MultiplexedIPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "NPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "NmConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement",
+    "NmPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "NvBlockSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
+    "NvDataInterface": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
+    "ParameterInterface": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
+    "PhysicalDimension": "armodel.models.M2.MSR.AsamHdo.Units",
+    "PortInterfaceMappingSet": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
+    "PortPrototypeBlueprint": "armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint",
+    "PostBuildVariantCriterion": "armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling",
+    "PredefinedVariant": "armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling",
+    "RunnableEntityGroup": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior",
+    "SecureCommunicationPropsSet": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "SecuredIPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "SenderReceiverInterface": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
+    "SensorActuatorSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
+    "ServiceProxySwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
+    "ServiceSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
+    "SignalServiceTranslationPropsSet": "armodel.models.M2.AUTOSARTemplates.CommonStructure.SignalServiceTranslation",
+    "SoAdRoutingGroup": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ObsoleteModel",
+    "SomeipSdClientEventGroupTimingConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances",
+    "SomeipSdClientServiceInstanceConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances",
+    "SomeipSdServerEventGroupTimingConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances",
+    "SwAddrMethod": "armodel.models.M2.MSR.DataDictionary.AuxillaryObjects",
+    "SwBaseType": "armodel.models.M2.MSR.AsamHdo.BaseTypes",
+    "SwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
+    "SwRecordLayout": "armodel.models.M2.MSR.DataDictionary.RecordLayout",
+    "SwSystemconst": "armodel.models.M2.MSR.DataDictionary.SystemConstant",
+    "SwSystemconstantValueSet": "armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling",
+    "SwcBswMapping": "armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping",
+    "SwcImplementation": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation",
+    "SwcTiming": "armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingExtensions",
+    "System": "armodel.models.M2.AUTOSARTemplates.SystemTemplate",
+    "SystemSignal": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "SystemSignalGroup": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "TcpOptionFilterSet": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.TcpOptionFilterSet",
+    "TriggerInterface": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
+    "Unit": "armodel.models.M2.MSR.AsamHdo.Units",
+    "UserDefinedIPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+    "UserDefinedPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
+}
 
-from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import BswImplementation
-from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import BswModuleDescription
-from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleEntry
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes import ImplementationDataType
-from armodel.models.M2.AUTOSARTemplates.CommonStructure import ConstantSpecification
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation import Implementation
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.FlatMap import FlatMap
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.McGroups import McGroup
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import McFunction
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import ModeDeclarationGroup
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.SignalServiceTranslation import SignalServiceTranslationPropsSet
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping import SwcBswMapping
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint import PortPrototypeBlueprint
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword import KeywordSet
-from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingExtensions import SwcTiming
-from armodel.models.M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticContribution import DiagnosticServiceTable
-from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import EcucModuleConfigurationValues, EcucValueCollection
-from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwElement
-from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucDefinitionCollection, EcucDestinationUriDefSet, EcucModuleDef
-from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwCategory, HwType
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, Identifier, RefType, ReferrableSubtypesEnum
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import LifeCycleInfoSet
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition import CompositionSwComponentType
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ServiceSwComponentType, SwComponentType
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ApplicationSwComponentType, AtomicSwComponentType
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ComplexDeviceDriverSwComponentType, EcuAbstractionSwComponentType
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import NvBlockSwComponentType, ServiceProxySwComponentType
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationArrayDataType, ApplicationDataType
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationPrimitiveDataType, ApplicationRecordDataType
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import DataTypeMappingSet
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection import EndToEndProtectionSet
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ClientServerInterface, ModeDeclarationMappingSet, ModeSwitchInterface
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import PortInterfaceMappingSet, SenderReceiverInterface, TriggerInterface
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import NvDataInterface, ParameterInterface
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation import SwcImplementation
 
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate import System
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform import Gateway
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import DcmIPdu, GeneralPurposeIPdu, GeneralPurposePdu, ISignal
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignalGroup, ISignalIPdu, ISignalIPduGroup, MultiplexedIPdu
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import NPdu, NmPdu, SecureCommunicationPropsSet, SecuredIPdu
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SystemSignal, SystemSignalGroup, UserDefinedIPdu, UserDefinedPdu
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CanCluster
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import EcuInstance
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommunication import LinUnconditionalFrame
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import LinCluster
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetFrame import GenericEthernetFrame
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetTopology import EthernetCluster
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.TcpOptionFilterSet import TcpOptionFilterSet
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ObsoleteModel import SoAdRoutingGroup
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import CanXlProps
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import (
-    SomeipSdClientEventGroupTimingConfig,
-    SomeipSdClientServiceInstanceConfig,
-    SomeipSdServerEventGroupTimingConfig,
-)
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import FlexrayFrame
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology import FlexrayCluster
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import NmConfig
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import DataTransformationSet, E2EProfileCompatibilityProps
-from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import CanTpConfig, DoIpTpConfig, LinTpConfig
+def __getattr__(name):
+    module_path = _LAZY_IMPORTS.get(name)
+    if module_path is None:
+        raise AttributeError("module %r has no attribute %r" % (__name__, name))
+    value = getattr(_import_module(module_path), name)
+    globals()[name] = value
+    return value
+
+
+__all__ = [
+    "AdminData",
+    "Annotation",
+    "ApplicationArrayDataType",
+    "ApplicationDataType",
+    "ApplicationPrimitiveDataType",
+    "ApplicationRecordDataType",
+    "ApplicationSwComponentType",
+    "AtomicSwComponentType",
+    "BswImplementation",
+    "BswModuleDescription",
+    "BswModuleEntry",
+    "CanCluster",
+    "CanFrame",
+    "CanTpConfig",
+    "CanXlProps",
+    "ClientServerInterface",
+    "ComplexDeviceDriverSwComponentType",
+    "CompositionSwComponentType",
+    "CompuMethod",
+    "ConsistencyNeeds",
+    "ConstantSpecification",
+    "DataConstr",
+    "DataPrototypeGroup",
+    "DataTransformationSet",
+    "DataTypeMappingSet",
+    "DcmIPdu",
+    "DiagnosticConnection",
+    "DiagnosticServiceTable",
+    "DoIpTpConfig",
+    "Documentation",
+    "DocumentationBlock",
+    "E2EProfileCompatibilityProps",
+    "EcuAbstractionSwComponentType",
+    "EcuInstance",
+    "EcucDefinitionCollection",
+    "EcucDestinationUriDefSet",
+    "EcucModuleConfigurationValues",
+    "EcucModuleDef",
+    "EcucValueCollection",
+    "EndToEndProtectionSet",
+    "EthernetCluster",
+    "FlatMap",
+    "FlexrayCluster",
+    "FlexrayFrame",
+    "Gateway",
+    "GeneralPurposeIPdu",
+    "GeneralPurposePdu",
+    "GenericEthernetFrame",
+    "HwCategory",
+    "HwElement",
+    "HwType",
+    "ISignal",
+    "ISignalGroup",
+    "ISignalIPdu",
+    "ISignalIPduGroup",
+    "Implementation",
+    "ImplementationDataType",
+    "KeywordSet",
+    "LifeCycleInfoSet",
+    "LinCluster",
+    "LinTpConfig",
+    "LinUnconditionalFrame",
+    "McFunction",
+    "McGroup",
+    "ModeDeclarationGroup",
+    "ModeDeclarationMappingSet",
+    "ModeSwitchInterface",
+    "MultiLanguageOverviewParagraph",
+    "MultilanguageLongName",
+    "MultiplexedIPdu",
+    "NPdu",
+    "NmConfig",
+    "NmPdu",
+    "NvBlockSwComponentType",
+    "NvDataInterface",
+    "ParameterInterface",
+    "PhysicalDimension",
+    "PortInterfaceMappingSet",
+    "PortPrototypeBlueprint",
+    "PostBuildVariantCriterion",
+    "PredefinedVariant",
+    "RunnableEntityGroup",
+    "SecureCommunicationPropsSet",
+    "SecuredIPdu",
+    "SenderReceiverInterface",
+    "SensorActuatorSwComponentType",
+    "ServiceProxySwComponentType",
+    "ServiceSwComponentType",
+    "SignalServiceTranslationPropsSet",
+    "SoAdRoutingGroup",
+    "SomeipSdClientEventGroupTimingConfig",
+    "SomeipSdClientServiceInstanceConfig",
+    "SomeipSdServerEventGroupTimingConfig",
+    "SwAddrMethod",
+    "SwBaseType",
+    "SwComponentType",
+    "SwRecordLayout",
+    "SwSystemconst",
+    "SwSystemconstantValueSet",
+    "SwcBswMapping",
+    "SwcImplementation",
+    "SwcTiming",
+    "System",
+    "SystemSignal",
+    "SystemSignalGroup",
+    "TcpOptionFilterSet",
+    "TriggerInterface",
+    "Unit",
+    "UserDefinedIPdu",
+    "UserDefinedPdu",
+    "ARElement",
+    "ARPackage",
+    "PackageableElement",
+    "ReferenceBase",
+]
+
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import CategoryString  # noqa: E402,F401
+
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, Identifier, RefType, ReferrableSubtypesEnum  # noqa: E402
 
 
 class ReferenceBase(ARObject):
@@ -149,6 +576,7 @@ class ReferenceBase(ARObject):
         Initializes a ReferenceBase instance with default values for
         package reference properties.
         """
+
         super().__init__()
 
         # List of global elements that can be referenced
@@ -518,7 +946,10 @@ class ARPackage(CollectableElement):
             parent: The parent ARObject that contains this package
             short_name: The unique identifier for this package within its parent
         """
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+
         # Initialize CollectableElement (which inherits from ARObject)
+
         CollectableElement.__init__(self)
         # Explicitly initialize ARObject attributes since CollectableElement doesn't call super().__init__()
         ARObject.__init__(self)
@@ -677,6 +1108,8 @@ class ARPackage(CollectableElement):
         Returns:
             self for method chaining
         """
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import CategoryString
+
         if isinstance(value, str):
             self.category = CategoryString().setValue(value)
         else:
@@ -772,6 +1205,8 @@ class ARPackage(CollectableElement):
         return CollectableElement.getElement(self, short_name, type)
 
     def createEcuAbstractionSwComponentType(self, short_name: str) -> EcuAbstractionSwComponentType:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import EcuAbstractionSwComponentType
+
         if not self.IsElementExists(short_name, EcuAbstractionSwComponentType):
             sw_component = EcuAbstractionSwComponentType(self, short_name)
             self.addElement(sw_component)
@@ -792,42 +1227,56 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing ApplicationSwComponentType instance
         """
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ApplicationSwComponentType
+
         if not self.IsElementExists(short_name, ApplicationSwComponentType):
             sw_component = ApplicationSwComponentType(self, short_name)
             self.addElement(sw_component)
         return self.getElement(short_name, ApplicationSwComponentType)
 
     def createComplexDeviceDriverSwComponentType(self, short_name: str) -> ComplexDeviceDriverSwComponentType:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ComplexDeviceDriverSwComponentType
+
         if not self.IsElementExists(short_name, ComplexDeviceDriverSwComponentType):
             sw_component = ComplexDeviceDriverSwComponentType(self, short_name)
             self.addElement(sw_component)
         return self.getElement(short_name, ComplexDeviceDriverSwComponentType)
 
     def createServiceSwComponentType(self, short_name: str) -> ServiceSwComponentType:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ServiceSwComponentType
+
         if not self.IsElementExists(short_name, ServiceSwComponentType):
             sw_component = ServiceSwComponentType(self, short_name)
             self.addElement(sw_component)
         return self.getElement(short_name, ServiceSwComponentType)
 
     def createSensorActuatorSwComponentType(self, short_name: str) -> SensorActuatorSwComponentType:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SensorActuatorSwComponentType
+
         if not self.IsElementExists(short_name, SensorActuatorSwComponentType):
             sw_component = SensorActuatorSwComponentType(self, short_name)
             self.addElement(sw_component)
         return self.getElement(short_name, SensorActuatorSwComponentType)
 
     def createNvBlockSwComponentType(self, short_name: str) -> NvBlockSwComponentType:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import NvBlockSwComponentType
+
         if not self.IsElementExists(short_name, NvBlockSwComponentType):
             sw_component = NvBlockSwComponentType(self, short_name)
             self.addElement(sw_component)
         return self.getElement(short_name, NvBlockSwComponentType)
 
     def createServiceProxySwComponentType(self, short_name: str) -> ServiceProxySwComponentType:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ServiceProxySwComponentType
+
         if not self.IsElementExists(short_name, ServiceProxySwComponentType):
             sw_component = ServiceProxySwComponentType(self, short_name)
             self.addElement(sw_component)
         return self.getElement(short_name, ServiceProxySwComponentType)
 
     def createCompositionSwComponentType(self, short_name: str) -> CompositionSwComponentType:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition import CompositionSwComponentType
+
         if not self.IsElementExists(short_name, CompositionSwComponentType):
             sw_component = CompositionSwComponentType(self, short_name)
             self.addElement(sw_component)
@@ -848,54 +1297,72 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing SenderReceiverInterface instance
         """
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import SenderReceiverInterface
+
         if not self.IsElementExists(short_name, SenderReceiverInterface):
             sr_interface = SenderReceiverInterface(self, short_name)
             self.addElement(sr_interface)
         return self.getElement(short_name, SenderReceiverInterface)
 
     def createParameterInterface(self, short_name: str) -> ParameterInterface:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ParameterInterface
+
         if not self.IsElementExists(short_name, ParameterInterface):
             sr_interface = ParameterInterface(self, short_name)
             self.addElement(sr_interface)
         return self.getElement(short_name, ParameterInterface)
 
     def createNvDataInterface(self, short_name: str) -> NvDataInterface:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import NvDataInterface
+
         if not self.IsElementExists(short_name, NvDataInterface):
             nv_interface = NvDataInterface(self, short_name)
             self.addElement(nv_interface)
         return self.getElement(short_name, NvDataInterface)
 
     def createGenericEthernetFrame(self, short_name: str) -> GenericEthernetFrame:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetFrame import GenericEthernetFrame
+
         if not self.IsElementExists(short_name, GenericEthernetFrame):
             frame = GenericEthernetFrame(self, short_name)
             self.addElement(frame)
         return self.getElement(short_name, GenericEthernetFrame)
 
     def createLifeCycleInfoSet(self, short_name: str) -> LifeCycleInfoSet:
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import LifeCycleInfoSet
+
         if not self.IsElementExists(short_name, LifeCycleInfoSet):
             set = LifeCycleInfoSet(self, short_name)
             self.addElement(set)
         return self.getElement(short_name, LifeCycleInfoSet)
 
     def createDocumentation(self, short_name: str) -> Documentation:
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import Documentation
+
         if not self.IsElementExists(short_name, Documentation):
             documentation = Documentation(self, short_name)
             self.addElement(documentation)
         return self.getElement(short_name, Documentation)
 
     def createClientServerInterface(self, short_name: str) -> ClientServerInterface:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ClientServerInterface
+
         if not self.IsElementExists(short_name, ClientServerInterface):
             cs_interface = ClientServerInterface(self, short_name)
             self.addElement(cs_interface)
         return self.getElement(short_name, ClientServerInterface)
 
     def createApplicationPrimitiveDataType(self, short_name: str) -> ApplicationPrimitiveDataType:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationPrimitiveDataType
+
         if not self.IsElementExists(short_name, ApplicationPrimitiveDataType):
             data_type = ApplicationPrimitiveDataType(self, short_name)
             self.addElement(data_type)
         return self.getElement(short_name, ApplicationPrimitiveDataType)
 
     def createApplicationRecordDataType(self, short_name: str) -> ApplicationPrimitiveDataType:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationRecordDataType
+
         if not self.IsElementExists(short_name, ApplicationRecordDataType):
             data_type = ApplicationRecordDataType(self, short_name)
             self.addElement(data_type)
@@ -916,24 +1383,32 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing ImplementationDataType instance
         """
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes import ImplementationDataType
+
         if not self.IsElementExists(short_name, ImplementationDataType):
             data_type = ImplementationDataType(self, short_name)
             self.addElement(data_type)
         return self.getElement(short_name, ImplementationDataType)
 
     def createSwBaseType(self, short_name: str) -> SwBaseType:
+        from armodel.models.M2.MSR.AsamHdo.BaseTypes import SwBaseType
+
         if not self.IsElementExists(short_name, SwBaseType):
             base_type = SwBaseType(self, short_name)
             self.addElement(base_type)
         return self.getElement(short_name, SwBaseType)
 
     def createDataTypeMappingSet(self, short_name: str) -> DataTypeMappingSet:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import DataTypeMappingSet
+
         if not self.IsElementExists(short_name, DataTypeMappingSet):
             mapping_set = DataTypeMappingSet(self, short_name)
             self.addElement(mapping_set)
         return self.getElement(short_name, DataTypeMappingSet)
 
     def createCompuMethod(self, short_name: str) -> CompuMethod:
+        from armodel.models.M2.MSR.AsamHdo.ComputationMethod import CompuMethod
+
         if not self.IsElementExists(short_name, CompuMethod):
             compu_method = CompuMethod(self, short_name)
             self.addElement(compu_method)
@@ -954,30 +1429,40 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing BswModuleDescription instance
         """
+        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import BswModuleDescription
+
         if not self.IsElementExists(short_name, BswModuleDescription):
             desc = BswModuleDescription(self, short_name)
             self.addElement(desc)
         return self.getElement(short_name, BswModuleDescription)
 
     def createBswModuleEntry(self, short_name: str) -> BswModuleEntry:
+        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleEntry
+
         if not self.IsElementExists(short_name, BswModuleEntry):
             entry = BswModuleEntry(self, short_name)
             self.addElement(entry)
         return self.getElement(short_name, BswModuleEntry)
 
     def createBswImplementation(self, short_name: str) -> BswImplementation:
+        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import BswImplementation
+
         if not self.IsElementExists(short_name, BswImplementation):
             impl = BswImplementation(self, short_name)
             self.addElement(impl)
         return self.getElement(short_name, BswImplementation)
 
     def createSwcImplementation(self, short_name: str) -> SwcImplementation:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation import SwcImplementation
+
         if not self.IsElementExists(short_name, SwcImplementation):
             impl = SwcImplementation(self, short_name)
             self.addElement(impl)
         return self.getElement(short_name, SwcImplementation)
 
     def createSwcBswMapping(self, short_name: str) -> SwcBswMapping:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping import SwcBswMapping
+
         if not self.IsElementExists(short_name, SwcBswMapping):
             mapping = SwcBswMapping(self, short_name)
             self.addElement(mapping)
@@ -994,6 +1479,8 @@ class ARPackage(CollectableElement):
         Returns:
             The created (or existing) McFunction
         """
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import McFunction
+
         if not self.IsElementExists(short_name, McFunction):
             func = McFunction(self, short_name)
             self.addElement(func)
@@ -1010,150 +1497,200 @@ class ARPackage(CollectableElement):
         Returns:
             The created (or existing) McGroup
         """
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.McGroups import McGroup
+
         if not self.IsElementExists(short_name, McGroup):
             group = McGroup(self, short_name)
             self.addElement(group)
         return self.getElement(short_name, McGroup)
 
     def createConstantSpecification(self, short_name: str) -> ConstantSpecification:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure import ConstantSpecification
+
         if not self.IsElementExists(short_name, ConstantSpecification):
             spec = ConstantSpecification(self, short_name)
             self.addElement(spec)
         return self.getElement(short_name, ConstantSpecification)
 
     def createDataConstr(self, short_name: str) -> DataConstr:
+        from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import DataConstr
+
         if not self.IsElementExists(short_name, DataConstr):
             constr = DataConstr(self, short_name)
             self.addElement(constr)
         return self.getElement(short_name, DataConstr)
 
     def createUnit(self, short_name: str) -> Unit:
+        from armodel.models.M2.MSR.AsamHdo.Units import Unit
+
         if not self.IsElementExists(short_name, Unit):
             unit = Unit(self, short_name)
             self.addElement(unit)
         return self.getElement(short_name, Unit)
 
     def createEndToEndProtectionSet(self, short_name: str) -> EndToEndProtectionSet:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection import EndToEndProtectionSet
+
         if not self.IsElementExists(short_name, EndToEndProtectionSet):
             e2d_set = EndToEndProtectionSet(self, short_name)
             self.addElement(e2d_set)
         return self.getElement(short_name, EndToEndProtectionSet)
 
     def createApplicationArrayDataType(self, short_name: str) -> ApplicationArrayDataType:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationArrayDataType
+
         if not self.IsElementExists(short_name, ApplicationArrayDataType):
             data_type = ApplicationArrayDataType(self, short_name)
             self.addElement(data_type)
         return self.getElement(short_name, ApplicationArrayDataType)
 
     def createSwRecordLayout(self, short_name: str) -> SwRecordLayout:
+        from armodel.models.M2.MSR.DataDictionary.RecordLayout import SwRecordLayout
+
         if not self.IsElementExists(short_name, SwRecordLayout):
             layout = SwRecordLayout(self, short_name)
             self.addElement(layout)
         return self.getElement(short_name, SwRecordLayout)
 
     def createSwAddrMethod(self, short_name: str) -> SwAddrMethod:
+        from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod
+
         if not self.IsElementExists(short_name, SwAddrMethod):
             method = SwAddrMethod(self, short_name)
             self.addElement(method)
         return self.getElement(short_name, SwAddrMethod)
 
     def createTriggerInterface(self, short_name: str) -> TriggerInterface:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import TriggerInterface
+
         if not self.IsElementExists(short_name, TriggerInterface):
             trigger_interface = TriggerInterface(self, short_name)
             self.addElement(trigger_interface)
         return self.getElement(short_name, TriggerInterface)
 
     def createDataPrototypeGroup(self, short_name: str) -> DataPrototypeGroup:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import DataPrototypeGroup
+
         if not self.IsElementExists(short_name, DataPrototypeGroup):
             data_group = DataPrototypeGroup(self, short_name)
             self.addElement(data_group)
         return self.getElement(short_name, DataPrototypeGroup)
 
     def createRunnableEntityGroup(self, short_name: str) -> RunnableEntityGroup:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import RunnableEntityGroup
+
         if not self.IsElementExists(short_name, RunnableEntityGroup):
             runnable_group = RunnableEntityGroup(self, short_name)
             self.addElement(runnable_group)
         return self.getElement(short_name, RunnableEntityGroup)
 
     def createConsistencyNeeds(self, short_name: str) -> ConsistencyNeeds:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import ConsistencyNeeds
+
         if not self.IsElementExists(short_name, ConsistencyNeeds):
             consistency_needs = ConsistencyNeeds(self, short_name)
             self.addElement(consistency_needs)
         return self.getElement(short_name, ConsistencyNeeds)
 
     def createModeDeclarationGroup(self, short_name: str) -> ModeDeclarationGroup:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import ModeDeclarationGroup
+
         if not self.IsElementExists(short_name, ModeDeclarationGroup):
             group = ModeDeclarationGroup(self, short_name)
             self.addElement(group)
         return self.getElement(short_name, ModeDeclarationGroup)
 
     def createModeSwitchInterface(self, short_name: str) -> ModeSwitchInterface:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ModeSwitchInterface
+
         if not self.IsElementExists(short_name, ModeSwitchInterface):
             switch_interface = ModeSwitchInterface(self, short_name)
             self.addElement(switch_interface)
         return self.getElement(short_name, ModeSwitchInterface)
 
     def createSwcTiming(self, short_name: str) -> SwcTiming:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingExtensions import SwcTiming
+
         if not self.IsElementExists(short_name, SwcTiming):
             timing = SwcTiming(self, short_name)
             self.addElement(timing)
         return self.getElement(short_name, SwcTiming)
 
     def createLinCluster(self, short_name: str) -> LinCluster:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import LinCluster
+
         if not self.IsElementExists(short_name, LinCluster):
             cluster = LinCluster(self, short_name)
             self.addElement(cluster)
         return self.getElement(short_name, LinCluster)
 
     def createCanCluster(self, short_name: str) -> CanCluster:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CanCluster
+
         if not self.IsElementExists(short_name, CanCluster):
             cluster = CanCluster(self, short_name)
             self.addElement(cluster)
         return self.getElement(short_name, CanCluster)
 
     def createLinUnconditionalFrame(self, short_name: str) -> LinUnconditionalFrame:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommunication import LinUnconditionalFrame
+
         if not self.IsElementExists(short_name, LinUnconditionalFrame):
             frame = LinUnconditionalFrame(self, short_name)
             self.addElement(frame)
         return self.getElement(short_name, LinUnconditionalFrame)
 
     def createNmPdu(self, short_name: str) -> NmPdu:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import NmPdu
+
         if not self.IsElementExists(short_name, NmPdu):
             element = NmPdu(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, NmPdu)
 
     def createNPdu(self, short_name: str) -> NPdu:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import NPdu
+
         if not self.IsElementExists(short_name, NPdu):
             element = NPdu(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, NPdu)
 
     def createDcmIPdu(self, short_name: str) -> DcmIPdu:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import DcmIPdu
+
         if not self.IsElementExists(short_name, DcmIPdu):
             element = DcmIPdu(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, DcmIPdu)
 
     def createSecuredIPdu(self, short_name: str) -> SecuredIPdu:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SecuredIPdu
+
         if not self.IsElementExists(short_name, SecuredIPdu):
             element = SecuredIPdu(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, SecuredIPdu)
 
     def createNmConfig(self, short_name: str) -> NmConfig:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import NmConfig
+
         if not self.IsElementExists(short_name, NmConfig):
             element = NmConfig(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, NmConfig)
 
     def createCanTpConfig(self, short_name: str) -> CanTpConfig:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import CanTpConfig
+
         if not self.IsElementExists(short_name, CanTpConfig):
             element = CanTpConfig(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, CanTpConfig)
 
     def createLinTpConfig(self, short_name: str) -> LinTpConfig:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import LinTpConfig
+
         if not self.IsElementExists(short_name, LinTpConfig):
             element = LinTpConfig(self, short_name)
             self.addElement(element)
@@ -1173,6 +1710,8 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing CanFrame instance
         """
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame
+
         if not self.IsElementExists(short_name, CanFrame):
             element = CanFrame(self, short_name)
             self.addElement(element)
@@ -1193,18 +1732,24 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing EcuInstance instance
         """
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import EcuInstance
+
         if not self.IsElementExists(short_name, EcuInstance):
             element = EcuInstance(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, EcuInstance)
 
     def createGateway(self, short_name: str) -> Gateway:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform import Gateway
+
         if not self.IsElementExists(short_name, Gateway):
             element = Gateway(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, Gateway)
 
     def createISignal(self, short_name: str) -> ISignal:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignal
+
         if not self.IsElementExists(short_name, ISignal):
             element = ISignal(self, short_name)
             self.addElement(element)
@@ -1225,126 +1770,168 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing SystemSignal instance
         """
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SystemSignal
+
         if not self.IsElementExists(short_name, SystemSignal):
             element = SystemSignal(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, SystemSignal)
 
     def createSystemSignalGroup(self, short_name: str) -> SystemSignalGroup:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SystemSignalGroup
+
         if not self.IsElementExists(short_name, SystemSignalGroup):
             element = SystemSignalGroup(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, SystemSignalGroup)
 
     def createSignalServiceTranslationPropsSet(self, short_name: str) -> SignalServiceTranslationPropsSet:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.SignalServiceTranslation import SignalServiceTranslationPropsSet
+
         if not self.IsElementExists(short_name, SignalServiceTranslationPropsSet):
             element = SignalServiceTranslationPropsSet(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, SignalServiceTranslationPropsSet)
 
     def createISignalIPdu(self, short_name: str) -> ISignalIPdu:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignalIPdu
+
         if not self.IsElementExists(short_name, ISignalIPdu):
             element = ISignalIPdu(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, ISignalIPdu)
 
     def createEcucValueCollection(self, short_name: str) -> EcucValueCollection:
+        from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import EcucValueCollection
+
         if not self.IsElementExists(short_name, EcucValueCollection):
             element = EcucValueCollection(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, EcucValueCollection)
 
     def createEcucModuleConfigurationValues(self, short_name: str) -> EcucModuleConfigurationValues:
+        from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import EcucModuleConfigurationValues
+
         if not self.IsElementExists(short_name, EcucModuleConfigurationValues):
             element = EcucModuleConfigurationValues(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, EcucModuleConfigurationValues)
 
     def createEcucModuleDef(self, short_name: str) -> EcucModuleDef:
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucModuleDef
+
         if not self.IsElementExists(short_name, EcucModuleDef):
             element = EcucModuleDef(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, EcucModuleDef)
 
     def createEcucDefinitionCollection(self, short_name: str) -> EcucDefinitionCollection:
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucDefinitionCollection
+
         if not self.IsElementExists(short_name, EcucDefinitionCollection):
             element = EcucDefinitionCollection(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, EcucDefinitionCollection)
 
     def createEcucDestinationUriDefSet(self, short_name: str) -> EcucDestinationUriDefSet:
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucDestinationUriDefSet
+
         if not self.IsElementExists(short_name, EcucDestinationUriDefSet):
             element = EcucDestinationUriDefSet(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, EcucDestinationUriDefSet)
 
     def createSwSystemConst(self, short_name: str) -> SwSystemconst:
+        from armodel.models.M2.MSR.DataDictionary.SystemConstant import SwSystemconst
+
         if not self.IsElementExists(short_name, SwSystemconst):
             element = SwSystemconst(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, SwSystemconst)
 
     def createSwSystemconstantValueSet(self, short_name: str) -> SwSystemconstantValueSet:
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import SwSystemconstantValueSet
+
         if not self.IsElementExists(short_name, SwSystemconstantValueSet):
             element = SwSystemconstantValueSet(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, SwSystemconstantValueSet)
 
     def createPredefinedVariant(self, short_name: str) -> PredefinedVariant:
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import PredefinedVariant
+
         if not self.IsElementExists(short_name, PredefinedVariant):
             element = PredefinedVariant(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, PredefinedVariant)
 
     def createPostBuildVariantCriterion(self, short_name: str) -> PostBuildVariantCriterion:
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import PostBuildVariantCriterion
+
         if not self.IsElementExists(short_name, PostBuildVariantCriterion):
             element = PostBuildVariantCriterion(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, PostBuildVariantCriterion)
 
     def createPhysicalDimension(self, short_name: str) -> PhysicalDimension:
+        from armodel.models.M2.MSR.AsamHdo.Units import PhysicalDimension
+
         if not self.IsElementExists(short_name, PhysicalDimension):
             element = PhysicalDimension(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, PhysicalDimension)
 
     def createISignalGroup(self, short_name: str) -> ISignalGroup:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignalGroup
+
         if not self.IsElementExists(short_name, ISignalGroup):
             element = ISignalGroup(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, ISignalGroup)
 
     def createISignalIPduGroup(self, short_name: str) -> ISignalIPduGroup:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignalIPduGroup
+
         if not self.IsElementExists(short_name, ISignalIPduGroup):
             element = ISignalIPduGroup(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, ISignalIPduGroup)
 
     def createSystem(self, short_name: str) -> System:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate import System
+
         if not self.IsElementExists(short_name, System):
             element = System(self, short_name)
             self.addElement(element)
         return self.getElement(short_name, System)
 
     def createFlatMap(self, short_name: str) -> FlatMap:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.FlatMap import FlatMap
+
         if not self.IsElementExists(short_name, FlatMap):
             map = FlatMap(self, short_name)
             self.addElement(map)
         return self.getElement(short_name, FlatMap)
 
     def createPortInterfaceMappingSet(self, short_name: str) -> PortInterfaceMappingSet:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import PortInterfaceMappingSet
+
         if not self.IsElementExists(short_name, PortInterfaceMappingSet):
             map_set = PortInterfaceMappingSet(self, short_name)
             self.addElement(map_set)
         return self.getElement(short_name, PortInterfaceMappingSet)
 
     def createEthernetCluster(self, short_name: str) -> EthernetCluster:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetTopology import EthernetCluster
+
         if not self.IsElementExists(short_name, EthernetCluster):
             cluster = EthernetCluster(self, short_name)
             self.addElement(cluster)
         return self.getElement(short_name, EthernetCluster)
 
     def createDiagnosticConnection(self, short_name: str) -> DiagnosticConnection:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection
+
         if not self.IsElementExists(short_name, DiagnosticConnection):
             connection = DiagnosticConnection(self, short_name)
             self.addElement(connection)
@@ -1365,126 +1952,168 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing DiagnosticServiceTable instance
         """
+        from armodel.models.M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticContribution import DiagnosticServiceTable
+
         if not self.IsElementExists(short_name, DiagnosticServiceTable):
             table = DiagnosticServiceTable(self, short_name)
             self.addElement(table)
         return self.getElement(short_name, DiagnosticServiceTable)
 
     def createMultiplexedIPdu(self, short_name: str) -> MultiplexedIPdu:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import MultiplexedIPdu
+
         if not self.IsElementExists(short_name, MultiplexedIPdu):
             ipdu = MultiplexedIPdu(self, short_name)
             self.addElement(ipdu)
         return self.getElement(short_name, MultiplexedIPdu)
 
     def createUserDefinedIPdu(self, short_name: str) -> UserDefinedIPdu:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import UserDefinedIPdu
+
         if not self.IsElementExists(short_name, UserDefinedIPdu):
             ipdu = UserDefinedIPdu(self, short_name)
             self.addElement(ipdu)
         return self.getElement(short_name, UserDefinedIPdu)
 
     def createUserDefinedPdu(self, short_name: str) -> UserDefinedPdu:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import UserDefinedPdu
+
         if not self.IsElementExists(short_name, UserDefinedPdu):
             pdu = UserDefinedPdu(self, short_name)
             self.addElement(pdu)
         return self.getElement(short_name, UserDefinedPdu)
 
     def createGeneralPurposeIPdu(self, short_name: str) -> GeneralPurposeIPdu:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import GeneralPurposeIPdu
+
         if not self.IsElementExists(short_name, GeneralPurposeIPdu):
             i_pdu = GeneralPurposeIPdu(self, short_name)
             self.addElement(i_pdu)
         return self.getElement(short_name, GeneralPurposeIPdu)
 
     def createGeneralPurposePdu(self, short_name: str) -> GeneralPurposePdu:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import GeneralPurposePdu
+
         if not self.IsElementExists(short_name, GeneralPurposePdu):
             pdu = GeneralPurposePdu(self, short_name)
             self.addElement(pdu)
         return self.getElement(short_name, GeneralPurposePdu)
 
     def createSecureCommunicationPropsSet(self, short_name: str) -> SecureCommunicationPropsSet:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SecureCommunicationPropsSet
+
         if not self.IsElementExists(short_name, SecureCommunicationPropsSet):
             props_set = SecureCommunicationPropsSet(self, short_name)
             self.addElement(props_set)
         return self.getElement(short_name, SecureCommunicationPropsSet)
 
     def createSoAdRoutingGroup(self, short_name: str) -> SoAdRoutingGroup:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ObsoleteModel import SoAdRoutingGroup
+
         if not self.IsElementExists(short_name, SoAdRoutingGroup):
             group = SoAdRoutingGroup(self, short_name)
             self.addElement(group)
         return self.getElement(short_name, SoAdRoutingGroup)
 
     def createTcpOptionFilterSet(self, short_name: str) -> TcpOptionFilterSet:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.TcpOptionFilterSet import TcpOptionFilterSet
+
         if not self.IsElementExists(short_name, TcpOptionFilterSet):
             tcp_option_filter_set = TcpOptionFilterSet(self, short_name)
             self.addElement(tcp_option_filter_set)
         return self.getElement(short_name, TcpOptionFilterSet)
 
     def createCanXlProps(self, short_name: str) -> CanXlProps:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import CanXlProps
+
         if not self.IsElementExists(short_name, CanXlProps):
             can_xl_props = CanXlProps(self, short_name)
             self.addElement(can_xl_props)
         return self.getElement(short_name, CanXlProps)
 
     def createSomeipSdClientServiceInstanceConfig(self, short_name: str) -> SomeipSdClientServiceInstanceConfig:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import SomeipSdClientServiceInstanceConfig
+
         if not self.IsElementExists(short_name, SomeipSdClientServiceInstanceConfig):
             config = SomeipSdClientServiceInstanceConfig(self, short_name)
             self.addElement(config)
         return self.getElement(short_name, SomeipSdClientServiceInstanceConfig)
 
     def createSomeipSdClientEventGroupTimingConfig(self, short_name: str) -> SomeipSdClientEventGroupTimingConfig:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import SomeipSdClientEventGroupTimingConfig
+
         if not self.IsElementExists(short_name, SomeipSdClientEventGroupTimingConfig):
             config = SomeipSdClientEventGroupTimingConfig(self, short_name)
             self.addElement(config)
         return self.getElement(short_name, SomeipSdClientEventGroupTimingConfig)
 
     def createSomeipSdServerEventGroupTimingConfig(self, short_name: str) -> SomeipSdServerEventGroupTimingConfig:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import SomeipSdServerEventGroupTimingConfig
+
         if not self.IsElementExists(short_name, SomeipSdServerEventGroupTimingConfig):
             config = SomeipSdServerEventGroupTimingConfig(self, short_name)
             self.addElement(config)
         return self.getElement(short_name, SomeipSdServerEventGroupTimingConfig)
 
     def createDoIpTpConfig(self, short_name: str) -> DoIpTpConfig:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import DoIpTpConfig
+
         if not self.IsElementExists(short_name, DoIpTpConfig):
             tp_config = DoIpTpConfig(self, short_name)
             self.addElement(tp_config)
         return self.getElement(short_name, DoIpTpConfig)
 
     def createHwElement(self, short_name: str) -> HwElement:
+        from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwElement
+
         if not self.IsElementExists(short_name, HwElement):
             hw_element = HwElement(self, short_name)
             self.addElement(hw_element)
         return self.getElement(short_name, HwElement)
 
     def createHwCategory(self, short_name: str) -> HwCategory:
+        from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwCategory
+
         if not self.IsElementExists(short_name, HwCategory):
             hw_category = HwCategory(self, short_name)
             self.addElement(hw_category)
         return self.getElement(short_name, HwCategory)
 
     def createHwType(self, short_name: str) -> HwType:
+        from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwType
+
         if not self.IsElementExists(short_name, HwType):
             hw_category = HwType(self, short_name)
             self.addElement(hw_category)
         return self.getElement(short_name, HwType)
 
     def createFlexrayFrame(self, short_name: str) -> FlexrayFrame:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import FlexrayFrame
+
         if not self.IsElementExists(short_name, FlexrayFrame):
             frame = FlexrayFrame(self, short_name)
             self.addElement(frame)
         return self.getElement(short_name, FlexrayFrame)
 
     def createFlexrayCluster(self, short_name: str) -> FlexrayCluster:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology import FlexrayCluster
+
         if not self.IsElementExists(short_name, FlexrayCluster):
             frame = FlexrayCluster(self, short_name)
             self.addElement(frame)
         return self.getElement(short_name, FlexrayCluster)
 
     def createDataTransformationSet(self, short_name: str) -> DataTransformationSet:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import DataTransformationSet
+
         if not self.IsElementExists(short_name, DataTransformationSet):
             transform_set = DataTransformationSet(self, short_name)
             self.addElement(transform_set)
         return self.getElement(short_name, DataTransformationSet)
 
     def createE2EProfileCompatibilityProps(self, short_name: str) -> E2EProfileCompatibilityProps:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import E2EProfileCompatibilityProps
+
         if not self.IsElementExists(short_name, E2EProfileCompatibilityProps):
             props = E2EProfileCompatibilityProps(self, short_name)
             self.addElement(props)
@@ -1499,81 +2128,127 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, Collection)
 
     def createKeywordSet(self, short_name: str) -> KeywordSet:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword import KeywordSet
+
         if not self.IsElementExists(short_name, KeywordSet):
             keyword_set = KeywordSet(self, short_name)
             self.addElement(keyword_set)
         return self.getElement(short_name, KeywordSet)
 
     def createPortPrototypeBlueprint(self, short_name: str) -> PortPrototypeBlueprint:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint import PortPrototypeBlueprint
+
         if not self.IsElementExists(short_name, PortPrototypeBlueprint):
             keyword_set = PortPrototypeBlueprint(self, short_name)
             self.addElement(keyword_set)
         return self.getElement(short_name, PortPrototypeBlueprint)
 
     def createModeDeclarationMappingSet(self, short_name: str) -> ModeDeclarationMappingSet:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ModeDeclarationMappingSet
+
         if not self.IsElementExists(short_name, ModeDeclarationMappingSet):
             mapping_set = ModeDeclarationMappingSet(self, short_name)
             self.addElement(mapping_set)
         return self.getElement(short_name, ModeDeclarationMappingSet)
 
     def getApplicationPrimitiveDataTypes(self) -> List[ApplicationPrimitiveDataType]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationPrimitiveDataType
+
         return list(sorted(filter(lambda a: isinstance(a, ApplicationPrimitiveDataType), self.elements), key=lambda o: o.short_name))
 
     def getApplicationDataType(self) -> List[ApplicationDataType]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationDataType
+
         return list(sorted(filter(lambda a: isinstance(a, ApplicationDataType), self.elements), key=lambda o: o.short_name))
 
     def getImplementationDataTypes(self) -> List[ImplementationDataType]:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes import ImplementationDataType
+
         return list(sorted(filter(lambda a: isinstance(a, ImplementationDataType), self.elements), key=lambda o: o.short_name))
 
     def getSwBaseTypes(self) -> List[SwBaseType]:
+        from armodel.models.M2.MSR.AsamHdo.BaseTypes import SwBaseType
+
         return list(filter(lambda a: isinstance(a, SwBaseType), self.elements))
 
     def getSwComponentTypes(self) -> List[SwComponentType]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SwComponentType
+
         return list(filter(lambda a: isinstance(a, SwComponentType), self.elements))
 
     def getSensorActuatorSwComponentType(self) -> List[SensorActuatorSwComponentType]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SensorActuatorSwComponentType
+
         return list(filter(lambda a: isinstance(a, SensorActuatorSwComponentType), self.elements))
 
     def getAtomicSwComponentTypes(self) -> List[AtomicSwComponentType]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import AtomicSwComponentType
+
         return list(filter(lambda a: isinstance(a, AtomicSwComponentType), self.elements))
 
     def getCompositionSwComponentTypes(self) -> List[CompositionSwComponentType]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition import CompositionSwComponentType
+
         return list(filter(lambda a: isinstance(a, CompositionSwComponentType), self.elements))
 
     def getComplexDeviceDriverSwComponentTypes(self) -> List[ComplexDeviceDriverSwComponentType]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ComplexDeviceDriverSwComponentType
+
         return list(sorted(filter(lambda a: isinstance(a, ComplexDeviceDriverSwComponentType), self.elements), key=lambda a: a.short_name))
 
     def getSenderReceiverInterfaces(self) -> List[SenderReceiverInterface]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import SenderReceiverInterface
+
         return list(sorted(filter(lambda a: isinstance(a, SenderReceiverInterface), self.elements), key=lambda a: a.short_name))
 
     def getParameterInterfaces(self) -> List[ParameterInterface]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ParameterInterface
+
         return list(sorted(filter(lambda a: isinstance(a, ParameterInterface), self.elements), key=lambda a: a.short_name))
 
     def getClientServerInterfaces(self) -> List[ClientServerInterface]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ClientServerInterface
+
         return list(sorted(filter(lambda a: isinstance(a, ClientServerInterface), self.elements), key=lambda a: a.short_name))
 
     def getDataTypeMappingSets(self) -> List[DataTypeMappingSet]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import DataTypeMappingSet
+
         return list(sorted(filter(lambda a: isinstance(a, DataTypeMappingSet), self.elements), key=lambda a: a.short_name))
 
     def getCompuMethods(self) -> List[CompuMethod]:
+        from armodel.models.M2.MSR.AsamHdo.ComputationMethod import CompuMethod
+
         return list(filter(lambda a: isinstance(a, CompuMethod), self.elements))
 
     def getBswModuleDescriptions(self) -> List[BswModuleDescription]:
+        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import BswModuleDescription
+
         return list(filter(lambda a: isinstance(a, BswModuleDescription), self.elements))
 
     def getBswModuleEntries(self) -> List[BswModuleEntry]:
+        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleEntry
+
         return list(filter(lambda a: isinstance(a, BswModuleEntry), self.elements))
 
     def getBswImplementations(self) -> List[BswImplementation]:
+        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import BswImplementation
+
         return list(filter(lambda a: isinstance(a, BswImplementation), self.elements))
 
     def getSwcImplementations(self) -> List[SwcImplementation]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation import SwcImplementation
+
         return list(filter(lambda a: isinstance(a, SwcImplementation), self.elements))
 
     def getImplementations(self) -> List[Implementation]:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation import Implementation
+
         return list(filter(lambda a: isinstance(a, Implementation), self.elements))
 
     def getSwcBswMappings(self) -> List[SwcBswMapping]:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping import SwcBswMapping
+
         return list(filter(lambda a: isinstance(a, SwcBswMapping), self.elements))
 
     def getMcFunctions(self) -> List[McFunction]:
@@ -1583,6 +2258,8 @@ class ARPackage(CollectableElement):
         Returns:
             List of McFunction instances
         """
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import McFunction
+
         return list(filter(lambda a: isinstance(a, McFunction), self.elements))
 
     def getMcGroups(self) -> List[McGroup]:
@@ -1592,96 +2269,158 @@ class ARPackage(CollectableElement):
         Returns:
             List of McGroup instances
         """
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.McGroups import McGroup
+
         return list(filter(lambda a: isinstance(a, McGroup), self.elements))
 
     def getConstantSpecifications(self) -> List[ConstantSpecification]:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure import ConstantSpecification
+
         return list(filter(lambda a: isinstance(a, ConstantSpecification), self.elements))
 
     def getDataConstrs(self) -> List[DataConstr]:
+        from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import DataConstr
+
         return list(filter(lambda a: isinstance(a, DataConstr), self.elements))
 
     def getUnits(self) -> List[Unit]:
+        from armodel.models.M2.MSR.AsamHdo.Units import Unit
+
         return list(filter(lambda a: isinstance(a, Unit), self.elements))
 
     def getApplicationArrayDataTypes(self) -> List[ApplicationArrayDataType]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationArrayDataType
+
         return list(sorted(filter(lambda a: isinstance(a, ApplicationArrayDataType), self.elements), key=lambda a: a.short_name))
 
     def getSwRecordLayouts(self) -> List[SwRecordLayout]:
+        from armodel.models.M2.MSR.DataDictionary.RecordLayout import SwRecordLayout
+
         return list(sorted(filter(lambda a: isinstance(a, SwRecordLayout), self.elements), key=lambda a: a.short_name))
 
     def getSwAddrMethods(self) -> List[SwAddrMethod]:
+        from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod
+
         return list(sorted(filter(lambda a: isinstance(a, SwAddrMethod), self.elements), key=lambda a: a.short_name))
 
     def getTriggerInterfaces(self) -> List[TriggerInterface]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import TriggerInterface
+
         return list(sorted(filter(lambda a: isinstance(a, TriggerInterface), self.elements), key=lambda a: a.short_name))
 
     def getModeDeclarationGroups(self) -> List[ModeDeclarationGroup]:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import ModeDeclarationGroup
+
         return list(sorted(filter(lambda a: isinstance(a, ModeDeclarationGroup), self.elements), key=lambda a: a.short_name))
 
     def getModeSwitchInterfaces(self) -> List[ModeSwitchInterface]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ModeSwitchInterface
+
         return list(sorted(filter(lambda a: isinstance(a, ModeSwitchInterface), self.elements), key=lambda a: a.short_name))
 
     def getSwcTimings(self) -> List[SwcTiming]:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingExtensions import SwcTiming
+
         return list(sorted(filter(lambda a: isinstance(a, SwcTiming), self.elements), key=lambda a: a.short_name))
 
     def getLinClusters(self) -> List[LinCluster]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import LinCluster
+
         return list(sorted(filter(lambda a: isinstance(a, LinCluster), self.elements), key=lambda a: a.short_name))
 
     def getCanClusters(self) -> List[CanCluster]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CanCluster
+
         return list(sorted(filter(lambda a: isinstance(a, CanCluster), self.elements), key=lambda a: a.short_name))
 
     def getLinUnconditionalFrames(self) -> List[LinUnconditionalFrame]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommunication import LinUnconditionalFrame
+
         return list(sorted(filter(lambda a: isinstance(a, LinUnconditionalFrame), self.elements), key=lambda a: a.short_name))
 
     def getNmPdus(self) -> List[NmPdu]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import NmPdu
+
         return list(sorted(filter(lambda a: isinstance(a, NmPdu), self.elements), key=lambda a: a.short_name))
 
     def getNPdus(self) -> List[NPdu]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import NPdu
+
         return list(sorted(filter(lambda a: isinstance(a, NPdu), self.elements), key=lambda a: a.short_name))
 
     def getDcmIPdus(self) -> List[DcmIPdu]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import DcmIPdu
+
         return list(sorted(filter(lambda a: isinstance(a, DcmIPdu), self.elements), key=lambda a: a.short_name))
 
     def getSecuredIPdus(self) -> List[SecuredIPdu]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SecuredIPdu
+
         return list(sorted(filter(lambda a: isinstance(a, SecuredIPdu), self.elements), key=lambda a: a.short_name))
 
     def getNmConfigs(self) -> List[NmConfig]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import NmConfig
+
         return list(sorted(filter(lambda a: isinstance(a, NmConfig), self.elements), key=lambda a: a.short_name))
 
     def getCanTpConfigs(self) -> List[CanTpConfig]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import CanTpConfig
+
         return list(sorted(filter(lambda a: isinstance(a, CanTpConfig), self.elements), key=lambda a: a.short_name))
 
     def getCanFrames(self) -> List[CanFrame]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame
+
         return list(sorted(filter(lambda a: isinstance(a, CanFrame), self.elements), key=lambda a: a.short_name))
 
     def getEcuInstances(self) -> List[EcuInstance]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import EcuInstance
+
         return list(sorted(filter(lambda a: isinstance(a, EcuInstance), self.elements), key=lambda a: a.short_name))
 
     def getGateways(self) -> List[Gateway]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform import Gateway
+
         return list(sorted(filter(lambda a: isinstance(a, Gateway), self.elements), key=lambda a: a.short_name))
 
     def getISignals(self) -> List[ISignal]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignal
+
         return list(sorted(filter(lambda a: isinstance(a, ISignal), self.elements), key=lambda a: a.short_name))
 
     def getEcucValueCollections(self) -> List[EcucValueCollection]:
+        from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import EcucValueCollection
+
         return list(sorted(filter(lambda a: isinstance(a, EcucValueCollection), self.elements), key=lambda a: a.short_name))
 
     def getEcucModuleConfigurationValues(self) -> List[EcucModuleConfigurationValues]:
+        from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import EcucModuleConfigurationValues
+
         return list(sorted(filter(lambda a: isinstance(a, EcucModuleConfigurationValues), self.elements), key=lambda a: a.short_name))
 
     def getEcucModuleDefs(self) -> List[EcucModuleDef]:
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucModuleDef
+
         return list(sorted(filter(lambda a: isinstance(a, EcucModuleDef), self.elements), key=lambda a: a.short_name))
 
     def getEcucDefinitionCollections(self) -> List[EcucDefinitionCollection]:
+        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucDefinitionCollection
+
         return list(sorted(filter(lambda a: isinstance(a, EcucDefinitionCollection), self.elements), key=lambda a: a.short_name))
 
     def getSwSystemConsts(self) -> List[SwSystemconst]:
+        from armodel.models.M2.MSR.DataDictionary.SystemConstant import SwSystemconst
+
         return list(sorted(filter(lambda a: isinstance(a, SwSystemconst), self.elements), key=lambda a: a.short_name))
 
     def getSwSystemconstantValueSets(self) -> List[SwSystemconstantValueSet]:
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import SwSystemconstantValueSet
+
         return list(sorted(filter(lambda a: isinstance(a, SwSystemconstantValueSet), self.elements), key=lambda a: a.short_name))
 
     def getPredefinedVariants(self) -> List[PredefinedVariant]:
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import PredefinedVariant
+
         return list(
             sorted(
                 filter(lambda a: isinstance(a, PredefinedVariant), self.elements),
@@ -1690,6 +2429,8 @@ class ARPackage(CollectableElement):
         )
 
     def getPostBuildVariantCriterions(self) -> List[PostBuildVariantCriterion]:
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import PostBuildVariantCriterion
+
         return list(
             sorted(
                 filter(lambda a: isinstance(a, PostBuildVariantCriterion), self.elements),
@@ -1698,33 +2439,53 @@ class ARPackage(CollectableElement):
         )
 
     def getEcucPhysicalDimensions(self) -> List[PhysicalDimension]:
+        from armodel.models.M2.MSR.AsamHdo.Units import PhysicalDimension
+
         return list(sorted(filter(lambda a: isinstance(a, PhysicalDimension), self.elements), key=lambda a: a.short_name))
 
     def getISignalGroups(self) -> List[ISignalGroup]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignalGroup
+
         return list(sorted(filter(lambda a: isinstance(a, ISignalGroup), self.elements), key=lambda a: a.short_name))
 
     def getSystemSignals(self) -> List[SystemSignal]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SystemSignal
+
         return list(sorted(filter(lambda a: isinstance(a, SystemSignal), self.elements), key=lambda a: a.short_name))
 
     def getSystemSignalGroups(self) -> List[SystemSignalGroup]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SystemSignalGroup
+
         return list(sorted(filter(lambda a: isinstance(a, SystemSignalGroup), self.elements), key=lambda a: a.short_name))
 
     def getISignalIPdus(self) -> List[ISignalIPdu]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignalIPdu
+
         return list(sorted(filter(lambda a: isinstance(a, ISignalIPdu), self.elements), key=lambda a: a.short_name))
 
     def getSystems(self) -> List[System]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate import System
+
         return list(sorted(filter(lambda a: isinstance(a, System), self.elements), key=lambda a: a.short_name))
 
     def getHwElements(self) -> List[HwElement]:
+        from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwElement
+
         return list(sorted(filter(lambda a: isinstance(a, HwElement), self.elements), key=lambda a: a.short_name))
 
     def getHwCategories(self) -> List[HwCategory]:
+        from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwCategory
+
         return list(sorted(filter(lambda a: isinstance(a, HwCategory), self.elements), key=lambda a: a.short_name))
 
     def getFlexrayFrames(self) -> List[FlexrayFrame]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import FlexrayFrame
+
         return list(sorted(filter(lambda a: isinstance(a, FlexrayFrame), self.elements), key=lambda a: a.short_name))
 
     def getDataTransformationSets(self) -> List[DataTransformationSet]:
+        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import DataTransformationSet
+
         return list(sorted(filter(lambda a: isinstance(a, DataTransformationSet), self.elements), key=lambda a: a.short_name))
 
     def getCollections(self) -> List["Collection"]:
@@ -1733,12 +2494,18 @@ class ARPackage(CollectableElement):
         return list(sorted(filter(lambda a: isinstance(a, Collection), self.elements), key=lambda a: a.short_name))
 
     def getKeywordSets(self) -> List[KeywordSet]:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword import KeywordSet
+
         return list(sorted(filter(lambda a: isinstance(a, KeywordSet), self.elements), key=lambda a: a.short_name))
 
     def getPortPrototypeBlueprints(self) -> List[PortPrototypeBlueprint]:
+        from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint import PortPrototypeBlueprint
+
         return list(sorted(filter(lambda a: isinstance(a, PortPrototypeBlueprint), self.elements), key=lambda a: a.short_name))
 
     def getModeDeclarationMappingSets(self) -> List[ModeDeclarationMappingSet]:
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ModeDeclarationMappingSet
+
         return list(sorted(filter(lambda a: isinstance(a, ModeDeclarationMappingSet), self.elements), key=lambda a: a.short_name))
 
     def getReferenceBases(self):

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage.py
@@ -16,239 +16,7 @@ if TYPE_CHECKING:
     from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import (
         Collection,
     )
-
-    # Names re-exported lazily at runtime via _LAZY_IMPORTS; imported here only
-    # so that deferred annotations (PEP 563) resolve for static analysis.
-    from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import (
-        BswImplementation,
-    )
-    from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import (
-        BswModuleEntry,
-    )
-    from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import (
-        BswModuleDescription,
-    )
-    from armodel.models.M2.AUTOSARTemplates.CommonStructure import (
-        ConstantSpecification,
-    )
-    from armodel.models.M2.AUTOSARTemplates.CommonStructure.FlatMap import (
-        FlatMap,
-    )
-    from armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation import (
-        Implementation,
-    )
-    from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes import (
-        ImplementationDataType,
-    )
-    from armodel.models.M2.AUTOSARTemplates.CommonStructure.McGroups import (
-        McGroup,
-    )
-    from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import (
-        McFunction,
-    )
-    from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import (
-        ModeDeclarationGroup,
-    )
-    from armodel.models.M2.AUTOSARTemplates.CommonStructure.SignalServiceTranslation import (
-        SignalServiceTranslationPropsSet,
-    )
-    from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint import (
-        PortPrototypeBlueprint,
-    )
-    from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword import (
-        KeywordSet,
-    )
-    from armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping import (
-        SwcBswMapping,
-    )
-    from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingExtensions import (
-        SwcTiming,
-    )
-    from armodel.models.M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticContribution import (
-        DiagnosticServiceTable,
-    )
-    from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import (
-        EcucModuleConfigurationValues,
-        EcucValueCollection,
-    )
-    from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
-        EcucDefinitionCollection,
-        EcucDestinationUriDefSet,
-        EcucModuleDef,
-    )
-    from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import (
-        HwElement,
-    )
-    from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import (
-        HwCategory,
-        HwType,
-    )
-    from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import (
-        Documentation,
-    )
-    from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import (
-        LifeCycleInfoSet,
-    )
-    from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (
-        PostBuildVariantCriterion,
-        PredefinedVariant,
-        SwSystemconstantValueSet,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import (
-        ApplicationSwComponentType,
-        AtomicSwComponentType,
-        ComplexDeviceDriverSwComponentType,
-        EcuAbstractionSwComponentType,
-        NvBlockSwComponentType,
-        SensorActuatorSwComponentType,
-        ServiceProxySwComponentType,
-        ServiceSwComponentType,
-        SwComponentType,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition import (
-        CompositionSwComponentType,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import (
-        ApplicationArrayDataType,
-        ApplicationDataType,
-        ApplicationPrimitiveDataType,
-        ApplicationRecordDataType,
-        DataTypeMappingSet,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection import (
-        EndToEndProtectionSet,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import (
-        ConsistencyNeeds,
-        DataPrototypeGroup,
-        RunnableEntityGroup,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import (
-        ClientServerInterface,
-        ModeDeclarationMappingSet,
-        ModeSwitchInterface,
-        NvDataInterface,
-        ParameterInterface,
-        PortInterfaceMappingSet,
-        SenderReceiverInterface,
-        TriggerInterface,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation import (
-        SwcImplementation,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate import (
-        System,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import (
-        DiagnosticConnection,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import (
-        CanFrame,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import (
-        CanXlProps,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetFrame import (
-        GenericEthernetFrame,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetTopology import (
-        EthernetCluster,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ObsoleteModel import (
-        SoAdRoutingGroup,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import (
-        SomeipSdClientEventGroupTimingConfig,
-        SomeipSdClientServiceInstanceConfig,
-        SomeipSdServerEventGroupTimingConfig,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.TcpOptionFilterSet import (
-        TcpOptionFilterSet,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import (
-        FlexrayFrame,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology import (
-        FlexrayCluster,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommunication import (
-        LinUnconditionalFrame,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import (
-        LinCluster,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform import (
-        Gateway,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (
-        DcmIPdu,
-        GeneralPurposeIPdu,
-        GeneralPurposePdu,
-        ISignal,
-        ISignalGroup,
-        ISignalIPdu,
-        ISignalIPduGroup,
-        MultiplexedIPdu,
-        NPdu,
-        NmPdu,
-        SecureCommunicationPropsSet,
-        SecuredIPdu,
-        SystemSignal,
-        SystemSignalGroup,
-        UserDefinedIPdu,
-        UserDefinedPdu,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import (
-        CanCluster,
-        EcuInstance,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import (
-        NmConfig,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import (
-        DataTransformationSet,
-        E2EProfileCompatibilityProps,
-    )
-    from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import (
-        CanTpConfig,
-        DoIpTpConfig,
-        LinTpConfig,
-    )
-    from armodel.models.M2.MSR.AsamHdo.AdminData import (
-        AdminData,
-    )
-    from armodel.models.M2.MSR.AsamHdo.BaseTypes import (
-        SwBaseType,
-    )
-    from armodel.models.M2.MSR.AsamHdo.ComputationMethod import (
-        CompuMethod,
-    )
-    from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import (
-        DataConstr,
-    )
-    from armodel.models.M2.MSR.AsamHdo.Units import (
-        PhysicalDimension,
-        Unit,
-    )
-    from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import (
-        SwAddrMethod,
-    )
-    from armodel.models.M2.MSR.DataDictionary.RecordLayout import (
-        SwRecordLayout,
-    )
-    from armodel.models.M2.MSR.DataDictionary.SystemConstant import (
-        SwSystemconst,
-    )
-    from armodel.models.M2.MSR.Documentation.Annotation import (
-        Annotation,
-    )
-    from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import (
-        DocumentationBlock,
-    )
-    from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import (
-        MultiLanguageOverviewParagraph,
-        MultilanguageLongName,
-    )
+    from armodel.models.M2.MSR.AsamHdo.BaseTypes import SwBaseType
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, Referrable
@@ -294,123 +62,13 @@ import armodel.models.M2.AUTOSARTemplates.CommonStructure  # noqa: F401,E402
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ElementCollection import CollectableElement  # noqa: E402
 
-
-# Element-class names are re-exported lazily (PEP 562) so that `from ARPackage import X`
-# and wildcard imports keep working; each element module imports ARElement from this
-# module, so eager imports here would create a 2-ring deadlock.
+# Names NOT eagerly imported at the end of this module (import-time 2-rings) are
+# re-exported lazily via PEP 562; `from ARPackage import X` and wildcard imports
+# keep working because __getattr__ only fires for names missing from module globals.
 from importlib import import_module as _import_module  # noqa: E402
 
 _LAZY_IMPORTS = {
-    "AdminData": "armodel.models.M2.MSR.AsamHdo.AdminData",
-    "Annotation": "armodel.models.M2.MSR.Documentation.Annotation",
-    "ApplicationArrayDataType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes",
-    "ApplicationDataType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes",
-    "ApplicationPrimitiveDataType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes",
-    "ApplicationRecordDataType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes",
-    "ApplicationSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
-    "AtomicSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
-    "BswImplementation": "armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation",
-    "BswModuleDescription": "armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview",
-    "BswModuleEntry": "armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces",
-    "CanCluster": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology",
-    "CanFrame": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication",
-    "CanTpConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols",
-    "CanXlProps": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology",
-    "ClientServerInterface": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
-    "ComplexDeviceDriverSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
-    "CompositionSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition",
-    "CompuMethod": "armodel.models.M2.MSR.AsamHdo.ComputationMethod",
-    "ConsistencyNeeds": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior",
-    "ConstantSpecification": "armodel.models.M2.AUTOSARTemplates.CommonStructure",
-    "DataConstr": "armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints",
-    "DataPrototypeGroup": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior",
-    "DataTransformationSet": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer",
-    "DataTypeMappingSet": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes",
-    "DcmIPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "DiagnosticConnection": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection",
-    "DiagnosticServiceTable": "armodel.models.M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticContribution",
-    "DoIpTpConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols",
-    "Documentation": "armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1",
-    "DocumentationBlock": "armodel.models.M2.MSR.Documentation.TextModel.BlockElements",
-    "E2EProfileCompatibilityProps": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer",
-    "EcuAbstractionSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
-    "EcuInstance": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology",
-    "EcucDefinitionCollection": "armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate",
-    "EcucDestinationUriDefSet": "armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate",
-    "EcucModuleConfigurationValues": "armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate",
-    "EcucModuleDef": "armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate",
-    "EcucValueCollection": "armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate",
-    "EndToEndProtectionSet": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection",
-    "EthernetCluster": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetTopology",
-    "FlatMap": "armodel.models.M2.AUTOSARTemplates.CommonStructure.FlatMap",
-    "FlexrayCluster": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology",
-    "FlexrayFrame": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication",
-    "Gateway": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform",
-    "GeneralPurposeIPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "GeneralPurposePdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "GenericEthernetFrame": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetFrame",
-    "HwCategory": "armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory",
-    "HwElement": "armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate",
-    "HwType": "armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory",
-    "ISignal": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "ISignalGroup": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "ISignalIPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "ISignalIPduGroup": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "Implementation": "armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation",
-    "ImplementationDataType": "armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes",
-    "KeywordSet": "armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword",
-    "LifeCycleInfoSet": "armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles",
-    "LinCluster": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology",
-    "LinTpConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols",
-    "LinUnconditionalFrame": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommunication",
-    "McFunction": "armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport",
-    "McGroup": "armodel.models.M2.AUTOSARTemplates.CommonStructure.McGroups",
-    "ModeDeclarationGroup": "armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration",
-    "ModeDeclarationMappingSet": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
-    "ModeSwitchInterface": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
-    "MultiLanguageOverviewParagraph": "armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData",
-    "MultilanguageLongName": "armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData",
-    "MultiplexedIPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "NPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "NmConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement",
-    "NmPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "NvBlockSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
-    "NvDataInterface": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
-    "ParameterInterface": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
-    "PhysicalDimension": "armodel.models.M2.MSR.AsamHdo.Units",
-    "PortInterfaceMappingSet": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
-    "PortPrototypeBlueprint": "armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint",
-    "PostBuildVariantCriterion": "armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling",
-    "PredefinedVariant": "armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling",
-    "RunnableEntityGroup": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior",
-    "SecureCommunicationPropsSet": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "SecuredIPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "SenderReceiverInterface": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
-    "SensorActuatorSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
-    "ServiceProxySwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
-    "ServiceSwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
-    "SignalServiceTranslationPropsSet": "armodel.models.M2.AUTOSARTemplates.CommonStructure.SignalServiceTranslation",
-    "SoAdRoutingGroup": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ObsoleteModel",
-    "SomeipSdClientEventGroupTimingConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances",
-    "SomeipSdClientServiceInstanceConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances",
-    "SomeipSdServerEventGroupTimingConfig": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances",
-    "SwAddrMethod": "armodel.models.M2.MSR.DataDictionary.AuxillaryObjects",
     "SwBaseType": "armodel.models.M2.MSR.AsamHdo.BaseTypes",
-    "SwComponentType": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components",
-    "SwRecordLayout": "armodel.models.M2.MSR.DataDictionary.RecordLayout",
-    "SwSystemconst": "armodel.models.M2.MSR.DataDictionary.SystemConstant",
-    "SwSystemconstantValueSet": "armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling",
-    "SwcBswMapping": "armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping",
-    "SwcImplementation": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation",
-    "SwcTiming": "armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingExtensions",
-    "System": "armodel.models.M2.AUTOSARTemplates.SystemTemplate",
-    "SystemSignal": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "SystemSignalGroup": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "TcpOptionFilterSet": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.TcpOptionFilterSet",
-    "TriggerInterface": "armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface",
-    "Unit": "armodel.models.M2.MSR.AsamHdo.Units",
-    "UserDefinedIPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
-    "UserDefinedPdu": "armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication",
 }
 
 
@@ -946,7 +604,6 @@ class ARPackage(CollectableElement):
             parent: The parent ARObject that contains this package
             short_name: The unique identifier for this package within its parent
         """
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 
         # Initialize CollectableElement (which inherits from ARObject)
 
@@ -1108,7 +765,6 @@ class ARPackage(CollectableElement):
         Returns:
             self for method chaining
         """
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import CategoryString
 
         if isinstance(value, str):
             self.category = CategoryString().setValue(value)
@@ -1205,7 +861,6 @@ class ARPackage(CollectableElement):
         return CollectableElement.getElement(self, short_name, type)
 
     def createEcuAbstractionSwComponentType(self, short_name: str) -> EcuAbstractionSwComponentType:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import EcuAbstractionSwComponentType
 
         if not self.IsElementExists(short_name, EcuAbstractionSwComponentType):
             sw_component = EcuAbstractionSwComponentType(self, short_name)
@@ -1227,7 +882,6 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing ApplicationSwComponentType instance
         """
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ApplicationSwComponentType
 
         if not self.IsElementExists(short_name, ApplicationSwComponentType):
             sw_component = ApplicationSwComponentType(self, short_name)
@@ -1235,7 +889,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ApplicationSwComponentType)
 
     def createComplexDeviceDriverSwComponentType(self, short_name: str) -> ComplexDeviceDriverSwComponentType:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ComplexDeviceDriverSwComponentType
 
         if not self.IsElementExists(short_name, ComplexDeviceDriverSwComponentType):
             sw_component = ComplexDeviceDriverSwComponentType(self, short_name)
@@ -1243,7 +896,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ComplexDeviceDriverSwComponentType)
 
     def createServiceSwComponentType(self, short_name: str) -> ServiceSwComponentType:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ServiceSwComponentType
 
         if not self.IsElementExists(short_name, ServiceSwComponentType):
             sw_component = ServiceSwComponentType(self, short_name)
@@ -1251,7 +903,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ServiceSwComponentType)
 
     def createSensorActuatorSwComponentType(self, short_name: str) -> SensorActuatorSwComponentType:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SensorActuatorSwComponentType
 
         if not self.IsElementExists(short_name, SensorActuatorSwComponentType):
             sw_component = SensorActuatorSwComponentType(self, short_name)
@@ -1259,7 +910,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SensorActuatorSwComponentType)
 
     def createNvBlockSwComponentType(self, short_name: str) -> NvBlockSwComponentType:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import NvBlockSwComponentType
 
         if not self.IsElementExists(short_name, NvBlockSwComponentType):
             sw_component = NvBlockSwComponentType(self, short_name)
@@ -1267,7 +917,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, NvBlockSwComponentType)
 
     def createServiceProxySwComponentType(self, short_name: str) -> ServiceProxySwComponentType:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ServiceProxySwComponentType
 
         if not self.IsElementExists(short_name, ServiceProxySwComponentType):
             sw_component = ServiceProxySwComponentType(self, short_name)
@@ -1275,7 +924,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ServiceProxySwComponentType)
 
     def createCompositionSwComponentType(self, short_name: str) -> CompositionSwComponentType:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition import CompositionSwComponentType
 
         if not self.IsElementExists(short_name, CompositionSwComponentType):
             sw_component = CompositionSwComponentType(self, short_name)
@@ -1297,7 +945,6 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing SenderReceiverInterface instance
         """
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import SenderReceiverInterface
 
         if not self.IsElementExists(short_name, SenderReceiverInterface):
             sr_interface = SenderReceiverInterface(self, short_name)
@@ -1305,7 +952,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SenderReceiverInterface)
 
     def createParameterInterface(self, short_name: str) -> ParameterInterface:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ParameterInterface
 
         if not self.IsElementExists(short_name, ParameterInterface):
             sr_interface = ParameterInterface(self, short_name)
@@ -1313,7 +959,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ParameterInterface)
 
     def createNvDataInterface(self, short_name: str) -> NvDataInterface:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import NvDataInterface
 
         if not self.IsElementExists(short_name, NvDataInterface):
             nv_interface = NvDataInterface(self, short_name)
@@ -1321,7 +966,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, NvDataInterface)
 
     def createGenericEthernetFrame(self, short_name: str) -> GenericEthernetFrame:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetFrame import GenericEthernetFrame
 
         if not self.IsElementExists(short_name, GenericEthernetFrame):
             frame = GenericEthernetFrame(self, short_name)
@@ -1329,7 +973,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, GenericEthernetFrame)
 
     def createLifeCycleInfoSet(self, short_name: str) -> LifeCycleInfoSet:
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import LifeCycleInfoSet
 
         if not self.IsElementExists(short_name, LifeCycleInfoSet):
             set = LifeCycleInfoSet(self, short_name)
@@ -1337,7 +980,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, LifeCycleInfoSet)
 
     def createDocumentation(self, short_name: str) -> Documentation:
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import Documentation
 
         if not self.IsElementExists(short_name, Documentation):
             documentation = Documentation(self, short_name)
@@ -1345,7 +987,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, Documentation)
 
     def createClientServerInterface(self, short_name: str) -> ClientServerInterface:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ClientServerInterface
 
         if not self.IsElementExists(short_name, ClientServerInterface):
             cs_interface = ClientServerInterface(self, short_name)
@@ -1353,7 +994,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ClientServerInterface)
 
     def createApplicationPrimitiveDataType(self, short_name: str) -> ApplicationPrimitiveDataType:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationPrimitiveDataType
 
         if not self.IsElementExists(short_name, ApplicationPrimitiveDataType):
             data_type = ApplicationPrimitiveDataType(self, short_name)
@@ -1361,7 +1001,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ApplicationPrimitiveDataType)
 
     def createApplicationRecordDataType(self, short_name: str) -> ApplicationPrimitiveDataType:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationRecordDataType
 
         if not self.IsElementExists(short_name, ApplicationRecordDataType):
             data_type = ApplicationRecordDataType(self, short_name)
@@ -1383,7 +1022,6 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing ImplementationDataType instance
         """
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes import ImplementationDataType
 
         if not self.IsElementExists(short_name, ImplementationDataType):
             data_type = ImplementationDataType(self, short_name)
@@ -1391,7 +1029,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ImplementationDataType)
 
     def createSwBaseType(self, short_name: str) -> SwBaseType:
-        from armodel.models.M2.MSR.AsamHdo.BaseTypes import SwBaseType
 
         if not self.IsElementExists(short_name, SwBaseType):
             base_type = SwBaseType(self, short_name)
@@ -1399,7 +1036,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SwBaseType)
 
     def createDataTypeMappingSet(self, short_name: str) -> DataTypeMappingSet:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import DataTypeMappingSet
 
         if not self.IsElementExists(short_name, DataTypeMappingSet):
             mapping_set = DataTypeMappingSet(self, short_name)
@@ -1407,7 +1043,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, DataTypeMappingSet)
 
     def createCompuMethod(self, short_name: str) -> CompuMethod:
-        from armodel.models.M2.MSR.AsamHdo.ComputationMethod import CompuMethod
 
         if not self.IsElementExists(short_name, CompuMethod):
             compu_method = CompuMethod(self, short_name)
@@ -1429,7 +1064,6 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing BswModuleDescription instance
         """
-        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import BswModuleDescription
 
         if not self.IsElementExists(short_name, BswModuleDescription):
             desc = BswModuleDescription(self, short_name)
@@ -1437,7 +1071,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, BswModuleDescription)
 
     def createBswModuleEntry(self, short_name: str) -> BswModuleEntry:
-        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleEntry
 
         if not self.IsElementExists(short_name, BswModuleEntry):
             entry = BswModuleEntry(self, short_name)
@@ -1445,7 +1078,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, BswModuleEntry)
 
     def createBswImplementation(self, short_name: str) -> BswImplementation:
-        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import BswImplementation
 
         if not self.IsElementExists(short_name, BswImplementation):
             impl = BswImplementation(self, short_name)
@@ -1453,7 +1085,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, BswImplementation)
 
     def createSwcImplementation(self, short_name: str) -> SwcImplementation:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation import SwcImplementation
 
         if not self.IsElementExists(short_name, SwcImplementation):
             impl = SwcImplementation(self, short_name)
@@ -1461,7 +1092,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SwcImplementation)
 
     def createSwcBswMapping(self, short_name: str) -> SwcBswMapping:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping import SwcBswMapping
 
         if not self.IsElementExists(short_name, SwcBswMapping):
             mapping = SwcBswMapping(self, short_name)
@@ -1479,7 +1109,6 @@ class ARPackage(CollectableElement):
         Returns:
             The created (or existing) McFunction
         """
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import McFunction
 
         if not self.IsElementExists(short_name, McFunction):
             func = McFunction(self, short_name)
@@ -1497,7 +1126,6 @@ class ARPackage(CollectableElement):
         Returns:
             The created (or existing) McGroup
         """
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.McGroups import McGroup
 
         if not self.IsElementExists(short_name, McGroup):
             group = McGroup(self, short_name)
@@ -1505,7 +1133,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, McGroup)
 
     def createConstantSpecification(self, short_name: str) -> ConstantSpecification:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure import ConstantSpecification
 
         if not self.IsElementExists(short_name, ConstantSpecification):
             spec = ConstantSpecification(self, short_name)
@@ -1513,7 +1140,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ConstantSpecification)
 
     def createDataConstr(self, short_name: str) -> DataConstr:
-        from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import DataConstr
 
         if not self.IsElementExists(short_name, DataConstr):
             constr = DataConstr(self, short_name)
@@ -1521,7 +1147,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, DataConstr)
 
     def createUnit(self, short_name: str) -> Unit:
-        from armodel.models.M2.MSR.AsamHdo.Units import Unit
 
         if not self.IsElementExists(short_name, Unit):
             unit = Unit(self, short_name)
@@ -1529,7 +1154,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, Unit)
 
     def createEndToEndProtectionSet(self, short_name: str) -> EndToEndProtectionSet:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection import EndToEndProtectionSet
 
         if not self.IsElementExists(short_name, EndToEndProtectionSet):
             e2d_set = EndToEndProtectionSet(self, short_name)
@@ -1537,7 +1161,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, EndToEndProtectionSet)
 
     def createApplicationArrayDataType(self, short_name: str) -> ApplicationArrayDataType:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationArrayDataType
 
         if not self.IsElementExists(short_name, ApplicationArrayDataType):
             data_type = ApplicationArrayDataType(self, short_name)
@@ -1545,7 +1168,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ApplicationArrayDataType)
 
     def createSwRecordLayout(self, short_name: str) -> SwRecordLayout:
-        from armodel.models.M2.MSR.DataDictionary.RecordLayout import SwRecordLayout
 
         if not self.IsElementExists(short_name, SwRecordLayout):
             layout = SwRecordLayout(self, short_name)
@@ -1553,7 +1175,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SwRecordLayout)
 
     def createSwAddrMethod(self, short_name: str) -> SwAddrMethod:
-        from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod
 
         if not self.IsElementExists(short_name, SwAddrMethod):
             method = SwAddrMethod(self, short_name)
@@ -1561,7 +1182,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SwAddrMethod)
 
     def createTriggerInterface(self, short_name: str) -> TriggerInterface:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import TriggerInterface
 
         if not self.IsElementExists(short_name, TriggerInterface):
             trigger_interface = TriggerInterface(self, short_name)
@@ -1569,7 +1189,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, TriggerInterface)
 
     def createDataPrototypeGroup(self, short_name: str) -> DataPrototypeGroup:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import DataPrototypeGroup
 
         if not self.IsElementExists(short_name, DataPrototypeGroup):
             data_group = DataPrototypeGroup(self, short_name)
@@ -1577,7 +1196,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, DataPrototypeGroup)
 
     def createRunnableEntityGroup(self, short_name: str) -> RunnableEntityGroup:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import RunnableEntityGroup
 
         if not self.IsElementExists(short_name, RunnableEntityGroup):
             runnable_group = RunnableEntityGroup(self, short_name)
@@ -1585,7 +1203,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, RunnableEntityGroup)
 
     def createConsistencyNeeds(self, short_name: str) -> ConsistencyNeeds:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import ConsistencyNeeds
 
         if not self.IsElementExists(short_name, ConsistencyNeeds):
             consistency_needs = ConsistencyNeeds(self, short_name)
@@ -1593,7 +1210,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ConsistencyNeeds)
 
     def createModeDeclarationGroup(self, short_name: str) -> ModeDeclarationGroup:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import ModeDeclarationGroup
 
         if not self.IsElementExists(short_name, ModeDeclarationGroup):
             group = ModeDeclarationGroup(self, short_name)
@@ -1601,7 +1217,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ModeDeclarationGroup)
 
     def createModeSwitchInterface(self, short_name: str) -> ModeSwitchInterface:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ModeSwitchInterface
 
         if not self.IsElementExists(short_name, ModeSwitchInterface):
             switch_interface = ModeSwitchInterface(self, short_name)
@@ -1609,7 +1224,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ModeSwitchInterface)
 
     def createSwcTiming(self, short_name: str) -> SwcTiming:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingExtensions import SwcTiming
 
         if not self.IsElementExists(short_name, SwcTiming):
             timing = SwcTiming(self, short_name)
@@ -1617,7 +1231,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SwcTiming)
 
     def createLinCluster(self, short_name: str) -> LinCluster:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import LinCluster
 
         if not self.IsElementExists(short_name, LinCluster):
             cluster = LinCluster(self, short_name)
@@ -1625,7 +1238,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, LinCluster)
 
     def createCanCluster(self, short_name: str) -> CanCluster:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CanCluster
 
         if not self.IsElementExists(short_name, CanCluster):
             cluster = CanCluster(self, short_name)
@@ -1633,7 +1245,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, CanCluster)
 
     def createLinUnconditionalFrame(self, short_name: str) -> LinUnconditionalFrame:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommunication import LinUnconditionalFrame
 
         if not self.IsElementExists(short_name, LinUnconditionalFrame):
             frame = LinUnconditionalFrame(self, short_name)
@@ -1641,7 +1252,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, LinUnconditionalFrame)
 
     def createNmPdu(self, short_name: str) -> NmPdu:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import NmPdu
 
         if not self.IsElementExists(short_name, NmPdu):
             element = NmPdu(self, short_name)
@@ -1649,7 +1259,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, NmPdu)
 
     def createNPdu(self, short_name: str) -> NPdu:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import NPdu
 
         if not self.IsElementExists(short_name, NPdu):
             element = NPdu(self, short_name)
@@ -1657,7 +1266,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, NPdu)
 
     def createDcmIPdu(self, short_name: str) -> DcmIPdu:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import DcmIPdu
 
         if not self.IsElementExists(short_name, DcmIPdu):
             element = DcmIPdu(self, short_name)
@@ -1665,7 +1273,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, DcmIPdu)
 
     def createSecuredIPdu(self, short_name: str) -> SecuredIPdu:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SecuredIPdu
 
         if not self.IsElementExists(short_name, SecuredIPdu):
             element = SecuredIPdu(self, short_name)
@@ -1673,7 +1280,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SecuredIPdu)
 
     def createNmConfig(self, short_name: str) -> NmConfig:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import NmConfig
 
         if not self.IsElementExists(short_name, NmConfig):
             element = NmConfig(self, short_name)
@@ -1681,7 +1287,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, NmConfig)
 
     def createCanTpConfig(self, short_name: str) -> CanTpConfig:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import CanTpConfig
 
         if not self.IsElementExists(short_name, CanTpConfig):
             element = CanTpConfig(self, short_name)
@@ -1689,7 +1294,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, CanTpConfig)
 
     def createLinTpConfig(self, short_name: str) -> LinTpConfig:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import LinTpConfig
 
         if not self.IsElementExists(short_name, LinTpConfig):
             element = LinTpConfig(self, short_name)
@@ -1710,7 +1314,6 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing CanFrame instance
         """
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame
 
         if not self.IsElementExists(short_name, CanFrame):
             element = CanFrame(self, short_name)
@@ -1732,7 +1335,6 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing EcuInstance instance
         """
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import EcuInstance
 
         if not self.IsElementExists(short_name, EcuInstance):
             element = EcuInstance(self, short_name)
@@ -1740,7 +1342,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, EcuInstance)
 
     def createGateway(self, short_name: str) -> Gateway:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform import Gateway
 
         if not self.IsElementExists(short_name, Gateway):
             element = Gateway(self, short_name)
@@ -1748,7 +1349,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, Gateway)
 
     def createISignal(self, short_name: str) -> ISignal:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignal
 
         if not self.IsElementExists(short_name, ISignal):
             element = ISignal(self, short_name)
@@ -1770,7 +1370,6 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing SystemSignal instance
         """
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SystemSignal
 
         if not self.IsElementExists(short_name, SystemSignal):
             element = SystemSignal(self, short_name)
@@ -1778,7 +1377,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SystemSignal)
 
     def createSystemSignalGroup(self, short_name: str) -> SystemSignalGroup:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SystemSignalGroup
 
         if not self.IsElementExists(short_name, SystemSignalGroup):
             element = SystemSignalGroup(self, short_name)
@@ -1786,7 +1384,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SystemSignalGroup)
 
     def createSignalServiceTranslationPropsSet(self, short_name: str) -> SignalServiceTranslationPropsSet:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.SignalServiceTranslation import SignalServiceTranslationPropsSet
 
         if not self.IsElementExists(short_name, SignalServiceTranslationPropsSet):
             element = SignalServiceTranslationPropsSet(self, short_name)
@@ -1794,7 +1391,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SignalServiceTranslationPropsSet)
 
     def createISignalIPdu(self, short_name: str) -> ISignalIPdu:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignalIPdu
 
         if not self.IsElementExists(short_name, ISignalIPdu):
             element = ISignalIPdu(self, short_name)
@@ -1802,7 +1398,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ISignalIPdu)
 
     def createEcucValueCollection(self, short_name: str) -> EcucValueCollection:
-        from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import EcucValueCollection
 
         if not self.IsElementExists(short_name, EcucValueCollection):
             element = EcucValueCollection(self, short_name)
@@ -1810,7 +1405,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, EcucValueCollection)
 
     def createEcucModuleConfigurationValues(self, short_name: str) -> EcucModuleConfigurationValues:
-        from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import EcucModuleConfigurationValues
 
         if not self.IsElementExists(short_name, EcucModuleConfigurationValues):
             element = EcucModuleConfigurationValues(self, short_name)
@@ -1818,7 +1412,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, EcucModuleConfigurationValues)
 
     def createEcucModuleDef(self, short_name: str) -> EcucModuleDef:
-        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucModuleDef
 
         if not self.IsElementExists(short_name, EcucModuleDef):
             element = EcucModuleDef(self, short_name)
@@ -1826,7 +1419,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, EcucModuleDef)
 
     def createEcucDefinitionCollection(self, short_name: str) -> EcucDefinitionCollection:
-        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucDefinitionCollection
 
         if not self.IsElementExists(short_name, EcucDefinitionCollection):
             element = EcucDefinitionCollection(self, short_name)
@@ -1834,7 +1426,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, EcucDefinitionCollection)
 
     def createEcucDestinationUriDefSet(self, short_name: str) -> EcucDestinationUriDefSet:
-        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucDestinationUriDefSet
 
         if not self.IsElementExists(short_name, EcucDestinationUriDefSet):
             element = EcucDestinationUriDefSet(self, short_name)
@@ -1842,7 +1433,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, EcucDestinationUriDefSet)
 
     def createSwSystemConst(self, short_name: str) -> SwSystemconst:
-        from armodel.models.M2.MSR.DataDictionary.SystemConstant import SwSystemconst
 
         if not self.IsElementExists(short_name, SwSystemconst):
             element = SwSystemconst(self, short_name)
@@ -1850,7 +1440,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SwSystemconst)
 
     def createSwSystemconstantValueSet(self, short_name: str) -> SwSystemconstantValueSet:
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import SwSystemconstantValueSet
 
         if not self.IsElementExists(short_name, SwSystemconstantValueSet):
             element = SwSystemconstantValueSet(self, short_name)
@@ -1858,7 +1447,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SwSystemconstantValueSet)
 
     def createPredefinedVariant(self, short_name: str) -> PredefinedVariant:
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import PredefinedVariant
 
         if not self.IsElementExists(short_name, PredefinedVariant):
             element = PredefinedVariant(self, short_name)
@@ -1866,7 +1454,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, PredefinedVariant)
 
     def createPostBuildVariantCriterion(self, short_name: str) -> PostBuildVariantCriterion:
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import PostBuildVariantCriterion
 
         if not self.IsElementExists(short_name, PostBuildVariantCriterion):
             element = PostBuildVariantCriterion(self, short_name)
@@ -1874,7 +1461,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, PostBuildVariantCriterion)
 
     def createPhysicalDimension(self, short_name: str) -> PhysicalDimension:
-        from armodel.models.M2.MSR.AsamHdo.Units import PhysicalDimension
 
         if not self.IsElementExists(short_name, PhysicalDimension):
             element = PhysicalDimension(self, short_name)
@@ -1882,7 +1468,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, PhysicalDimension)
 
     def createISignalGroup(self, short_name: str) -> ISignalGroup:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignalGroup
 
         if not self.IsElementExists(short_name, ISignalGroup):
             element = ISignalGroup(self, short_name)
@@ -1890,7 +1475,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ISignalGroup)
 
     def createISignalIPduGroup(self, short_name: str) -> ISignalIPduGroup:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignalIPduGroup
 
         if not self.IsElementExists(short_name, ISignalIPduGroup):
             element = ISignalIPduGroup(self, short_name)
@@ -1898,7 +1482,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ISignalIPduGroup)
 
     def createSystem(self, short_name: str) -> System:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate import System
 
         if not self.IsElementExists(short_name, System):
             element = System(self, short_name)
@@ -1906,7 +1489,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, System)
 
     def createFlatMap(self, short_name: str) -> FlatMap:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.FlatMap import FlatMap
 
         if not self.IsElementExists(short_name, FlatMap):
             map = FlatMap(self, short_name)
@@ -1914,7 +1496,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, FlatMap)
 
     def createPortInterfaceMappingSet(self, short_name: str) -> PortInterfaceMappingSet:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import PortInterfaceMappingSet
 
         if not self.IsElementExists(short_name, PortInterfaceMappingSet):
             map_set = PortInterfaceMappingSet(self, short_name)
@@ -1922,7 +1503,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, PortInterfaceMappingSet)
 
     def createEthernetCluster(self, short_name: str) -> EthernetCluster:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetTopology import EthernetCluster
 
         if not self.IsElementExists(short_name, EthernetCluster):
             cluster = EthernetCluster(self, short_name)
@@ -1930,7 +1510,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, EthernetCluster)
 
     def createDiagnosticConnection(self, short_name: str) -> DiagnosticConnection:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection
 
         if not self.IsElementExists(short_name, DiagnosticConnection):
             connection = DiagnosticConnection(self, short_name)
@@ -1952,7 +1531,6 @@ class ARPackage(CollectableElement):
         Returns:
             The newly created or existing DiagnosticServiceTable instance
         """
-        from armodel.models.M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticContribution import DiagnosticServiceTable
 
         if not self.IsElementExists(short_name, DiagnosticServiceTable):
             table = DiagnosticServiceTable(self, short_name)
@@ -1960,7 +1538,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, DiagnosticServiceTable)
 
     def createMultiplexedIPdu(self, short_name: str) -> MultiplexedIPdu:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import MultiplexedIPdu
 
         if not self.IsElementExists(short_name, MultiplexedIPdu):
             ipdu = MultiplexedIPdu(self, short_name)
@@ -1968,7 +1545,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, MultiplexedIPdu)
 
     def createUserDefinedIPdu(self, short_name: str) -> UserDefinedIPdu:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import UserDefinedIPdu
 
         if not self.IsElementExists(short_name, UserDefinedIPdu):
             ipdu = UserDefinedIPdu(self, short_name)
@@ -1976,7 +1552,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, UserDefinedIPdu)
 
     def createUserDefinedPdu(self, short_name: str) -> UserDefinedPdu:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import UserDefinedPdu
 
         if not self.IsElementExists(short_name, UserDefinedPdu):
             pdu = UserDefinedPdu(self, short_name)
@@ -1984,7 +1559,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, UserDefinedPdu)
 
     def createGeneralPurposeIPdu(self, short_name: str) -> GeneralPurposeIPdu:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import GeneralPurposeIPdu
 
         if not self.IsElementExists(short_name, GeneralPurposeIPdu):
             i_pdu = GeneralPurposeIPdu(self, short_name)
@@ -1992,7 +1566,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, GeneralPurposeIPdu)
 
     def createGeneralPurposePdu(self, short_name: str) -> GeneralPurposePdu:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import GeneralPurposePdu
 
         if not self.IsElementExists(short_name, GeneralPurposePdu):
             pdu = GeneralPurposePdu(self, short_name)
@@ -2000,7 +1573,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, GeneralPurposePdu)
 
     def createSecureCommunicationPropsSet(self, short_name: str) -> SecureCommunicationPropsSet:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SecureCommunicationPropsSet
 
         if not self.IsElementExists(short_name, SecureCommunicationPropsSet):
             props_set = SecureCommunicationPropsSet(self, short_name)
@@ -2008,7 +1580,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SecureCommunicationPropsSet)
 
     def createSoAdRoutingGroup(self, short_name: str) -> SoAdRoutingGroup:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ObsoleteModel import SoAdRoutingGroup
 
         if not self.IsElementExists(short_name, SoAdRoutingGroup):
             group = SoAdRoutingGroup(self, short_name)
@@ -2016,7 +1587,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SoAdRoutingGroup)
 
     def createTcpOptionFilterSet(self, short_name: str) -> TcpOptionFilterSet:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.TcpOptionFilterSet import TcpOptionFilterSet
 
         if not self.IsElementExists(short_name, TcpOptionFilterSet):
             tcp_option_filter_set = TcpOptionFilterSet(self, short_name)
@@ -2024,7 +1594,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, TcpOptionFilterSet)
 
     def createCanXlProps(self, short_name: str) -> CanXlProps:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import CanXlProps
 
         if not self.IsElementExists(short_name, CanXlProps):
             can_xl_props = CanXlProps(self, short_name)
@@ -2032,7 +1601,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, CanXlProps)
 
     def createSomeipSdClientServiceInstanceConfig(self, short_name: str) -> SomeipSdClientServiceInstanceConfig:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import SomeipSdClientServiceInstanceConfig
 
         if not self.IsElementExists(short_name, SomeipSdClientServiceInstanceConfig):
             config = SomeipSdClientServiceInstanceConfig(self, short_name)
@@ -2040,7 +1608,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SomeipSdClientServiceInstanceConfig)
 
     def createSomeipSdClientEventGroupTimingConfig(self, short_name: str) -> SomeipSdClientEventGroupTimingConfig:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import SomeipSdClientEventGroupTimingConfig
 
         if not self.IsElementExists(short_name, SomeipSdClientEventGroupTimingConfig):
             config = SomeipSdClientEventGroupTimingConfig(self, short_name)
@@ -2048,7 +1615,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SomeipSdClientEventGroupTimingConfig)
 
     def createSomeipSdServerEventGroupTimingConfig(self, short_name: str) -> SomeipSdServerEventGroupTimingConfig:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import SomeipSdServerEventGroupTimingConfig
 
         if not self.IsElementExists(short_name, SomeipSdServerEventGroupTimingConfig):
             config = SomeipSdServerEventGroupTimingConfig(self, short_name)
@@ -2056,7 +1622,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, SomeipSdServerEventGroupTimingConfig)
 
     def createDoIpTpConfig(self, short_name: str) -> DoIpTpConfig:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import DoIpTpConfig
 
         if not self.IsElementExists(short_name, DoIpTpConfig):
             tp_config = DoIpTpConfig(self, short_name)
@@ -2064,7 +1629,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, DoIpTpConfig)
 
     def createHwElement(self, short_name: str) -> HwElement:
-        from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwElement
 
         if not self.IsElementExists(short_name, HwElement):
             hw_element = HwElement(self, short_name)
@@ -2072,7 +1636,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, HwElement)
 
     def createHwCategory(self, short_name: str) -> HwCategory:
-        from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwCategory
 
         if not self.IsElementExists(short_name, HwCategory):
             hw_category = HwCategory(self, short_name)
@@ -2080,7 +1643,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, HwCategory)
 
     def createHwType(self, short_name: str) -> HwType:
-        from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwType
 
         if not self.IsElementExists(short_name, HwType):
             hw_category = HwType(self, short_name)
@@ -2088,7 +1650,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, HwType)
 
     def createFlexrayFrame(self, short_name: str) -> FlexrayFrame:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import FlexrayFrame
 
         if not self.IsElementExists(short_name, FlexrayFrame):
             frame = FlexrayFrame(self, short_name)
@@ -2096,7 +1657,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, FlexrayFrame)
 
     def createFlexrayCluster(self, short_name: str) -> FlexrayCluster:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology import FlexrayCluster
 
         if not self.IsElementExists(short_name, FlexrayCluster):
             frame = FlexrayCluster(self, short_name)
@@ -2104,7 +1664,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, FlexrayCluster)
 
     def createDataTransformationSet(self, short_name: str) -> DataTransformationSet:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import DataTransformationSet
 
         if not self.IsElementExists(short_name, DataTransformationSet):
             transform_set = DataTransformationSet(self, short_name)
@@ -2112,7 +1671,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, DataTransformationSet)
 
     def createE2EProfileCompatibilityProps(self, short_name: str) -> E2EProfileCompatibilityProps:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import E2EProfileCompatibilityProps
 
         if not self.IsElementExists(short_name, E2EProfileCompatibilityProps):
             props = E2EProfileCompatibilityProps(self, short_name)
@@ -2128,7 +1686,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, Collection)
 
     def createKeywordSet(self, short_name: str) -> KeywordSet:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword import KeywordSet
 
         if not self.IsElementExists(short_name, KeywordSet):
             keyword_set = KeywordSet(self, short_name)
@@ -2136,7 +1693,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, KeywordSet)
 
     def createPortPrototypeBlueprint(self, short_name: str) -> PortPrototypeBlueprint:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint import PortPrototypeBlueprint
 
         if not self.IsElementExists(short_name, PortPrototypeBlueprint):
             keyword_set = PortPrototypeBlueprint(self, short_name)
@@ -2144,7 +1700,6 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, PortPrototypeBlueprint)
 
     def createModeDeclarationMappingSet(self, short_name: str) -> ModeDeclarationMappingSet:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ModeDeclarationMappingSet
 
         if not self.IsElementExists(short_name, ModeDeclarationMappingSet):
             mapping_set = ModeDeclarationMappingSet(self, short_name)
@@ -2152,102 +1707,82 @@ class ARPackage(CollectableElement):
         return self.getElement(short_name, ModeDeclarationMappingSet)
 
     def getApplicationPrimitiveDataTypes(self) -> List[ApplicationPrimitiveDataType]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationPrimitiveDataType
 
         return list(sorted(filter(lambda a: isinstance(a, ApplicationPrimitiveDataType), self.elements), key=lambda o: o.short_name))
 
     def getApplicationDataType(self) -> List[ApplicationDataType]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationDataType
 
         return list(sorted(filter(lambda a: isinstance(a, ApplicationDataType), self.elements), key=lambda o: o.short_name))
 
     def getImplementationDataTypes(self) -> List[ImplementationDataType]:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes import ImplementationDataType
 
         return list(sorted(filter(lambda a: isinstance(a, ImplementationDataType), self.elements), key=lambda o: o.short_name))
 
     def getSwBaseTypes(self) -> List[SwBaseType]:
-        from armodel.models.M2.MSR.AsamHdo.BaseTypes import SwBaseType
 
         return list(filter(lambda a: isinstance(a, SwBaseType), self.elements))
 
     def getSwComponentTypes(self) -> List[SwComponentType]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SwComponentType
 
         return list(filter(lambda a: isinstance(a, SwComponentType), self.elements))
 
     def getSensorActuatorSwComponentType(self) -> List[SensorActuatorSwComponentType]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SensorActuatorSwComponentType
 
         return list(filter(lambda a: isinstance(a, SensorActuatorSwComponentType), self.elements))
 
     def getAtomicSwComponentTypes(self) -> List[AtomicSwComponentType]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import AtomicSwComponentType
 
         return list(filter(lambda a: isinstance(a, AtomicSwComponentType), self.elements))
 
     def getCompositionSwComponentTypes(self) -> List[CompositionSwComponentType]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition import CompositionSwComponentType
 
         return list(filter(lambda a: isinstance(a, CompositionSwComponentType), self.elements))
 
     def getComplexDeviceDriverSwComponentTypes(self) -> List[ComplexDeviceDriverSwComponentType]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import ComplexDeviceDriverSwComponentType
 
         return list(sorted(filter(lambda a: isinstance(a, ComplexDeviceDriverSwComponentType), self.elements), key=lambda a: a.short_name))
 
     def getSenderReceiverInterfaces(self) -> List[SenderReceiverInterface]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import SenderReceiverInterface
 
         return list(sorted(filter(lambda a: isinstance(a, SenderReceiverInterface), self.elements), key=lambda a: a.short_name))
 
     def getParameterInterfaces(self) -> List[ParameterInterface]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ParameterInterface
 
         return list(sorted(filter(lambda a: isinstance(a, ParameterInterface), self.elements), key=lambda a: a.short_name))
 
     def getClientServerInterfaces(self) -> List[ClientServerInterface]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ClientServerInterface
 
         return list(sorted(filter(lambda a: isinstance(a, ClientServerInterface), self.elements), key=lambda a: a.short_name))
 
     def getDataTypeMappingSets(self) -> List[DataTypeMappingSet]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import DataTypeMappingSet
 
         return list(sorted(filter(lambda a: isinstance(a, DataTypeMappingSet), self.elements), key=lambda a: a.short_name))
 
     def getCompuMethods(self) -> List[CompuMethod]:
-        from armodel.models.M2.MSR.AsamHdo.ComputationMethod import CompuMethod
 
         return list(filter(lambda a: isinstance(a, CompuMethod), self.elements))
 
     def getBswModuleDescriptions(self) -> List[BswModuleDescription]:
-        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import BswModuleDescription
 
         return list(filter(lambda a: isinstance(a, BswModuleDescription), self.elements))
 
     def getBswModuleEntries(self) -> List[BswModuleEntry]:
-        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleEntry
 
         return list(filter(lambda a: isinstance(a, BswModuleEntry), self.elements))
 
     def getBswImplementations(self) -> List[BswImplementation]:
-        from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import BswImplementation
 
         return list(filter(lambda a: isinstance(a, BswImplementation), self.elements))
 
     def getSwcImplementations(self) -> List[SwcImplementation]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation import SwcImplementation
 
         return list(filter(lambda a: isinstance(a, SwcImplementation), self.elements))
 
     def getImplementations(self) -> List[Implementation]:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation import Implementation
 
         return list(filter(lambda a: isinstance(a, Implementation), self.elements))
 
     def getSwcBswMappings(self) -> List[SwcBswMapping]:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping import SwcBswMapping
 
         return list(filter(lambda a: isinstance(a, SwcBswMapping), self.elements))
 
@@ -2258,7 +1793,6 @@ class ARPackage(CollectableElement):
         Returns:
             List of McFunction instances
         """
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import McFunction
 
         return list(filter(lambda a: isinstance(a, McFunction), self.elements))
 
@@ -2269,157 +1803,126 @@ class ARPackage(CollectableElement):
         Returns:
             List of McGroup instances
         """
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.McGroups import McGroup
 
         return list(filter(lambda a: isinstance(a, McGroup), self.elements))
 
     def getConstantSpecifications(self) -> List[ConstantSpecification]:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure import ConstantSpecification
 
         return list(filter(lambda a: isinstance(a, ConstantSpecification), self.elements))
 
     def getDataConstrs(self) -> List[DataConstr]:
-        from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import DataConstr
 
         return list(filter(lambda a: isinstance(a, DataConstr), self.elements))
 
     def getUnits(self) -> List[Unit]:
-        from armodel.models.M2.MSR.AsamHdo.Units import Unit
 
         return list(filter(lambda a: isinstance(a, Unit), self.elements))
 
     def getApplicationArrayDataTypes(self) -> List[ApplicationArrayDataType]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import ApplicationArrayDataType
 
         return list(sorted(filter(lambda a: isinstance(a, ApplicationArrayDataType), self.elements), key=lambda a: a.short_name))
 
     def getSwRecordLayouts(self) -> List[SwRecordLayout]:
-        from armodel.models.M2.MSR.DataDictionary.RecordLayout import SwRecordLayout
 
         return list(sorted(filter(lambda a: isinstance(a, SwRecordLayout), self.elements), key=lambda a: a.short_name))
 
     def getSwAddrMethods(self) -> List[SwAddrMethod]:
-        from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod
 
         return list(sorted(filter(lambda a: isinstance(a, SwAddrMethod), self.elements), key=lambda a: a.short_name))
 
     def getTriggerInterfaces(self) -> List[TriggerInterface]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import TriggerInterface
 
         return list(sorted(filter(lambda a: isinstance(a, TriggerInterface), self.elements), key=lambda a: a.short_name))
 
     def getModeDeclarationGroups(self) -> List[ModeDeclarationGroup]:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import ModeDeclarationGroup
 
         return list(sorted(filter(lambda a: isinstance(a, ModeDeclarationGroup), self.elements), key=lambda a: a.short_name))
 
     def getModeSwitchInterfaces(self) -> List[ModeSwitchInterface]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ModeSwitchInterface
 
         return list(sorted(filter(lambda a: isinstance(a, ModeSwitchInterface), self.elements), key=lambda a: a.short_name))
 
     def getSwcTimings(self) -> List[SwcTiming]:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingExtensions import SwcTiming
 
         return list(sorted(filter(lambda a: isinstance(a, SwcTiming), self.elements), key=lambda a: a.short_name))
 
     def getLinClusters(self) -> List[LinCluster]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import LinCluster
 
         return list(sorted(filter(lambda a: isinstance(a, LinCluster), self.elements), key=lambda a: a.short_name))
 
     def getCanClusters(self) -> List[CanCluster]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CanCluster
 
         return list(sorted(filter(lambda a: isinstance(a, CanCluster), self.elements), key=lambda a: a.short_name))
 
     def getLinUnconditionalFrames(self) -> List[LinUnconditionalFrame]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommunication import LinUnconditionalFrame
 
         return list(sorted(filter(lambda a: isinstance(a, LinUnconditionalFrame), self.elements), key=lambda a: a.short_name))
 
     def getNmPdus(self) -> List[NmPdu]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import NmPdu
 
         return list(sorted(filter(lambda a: isinstance(a, NmPdu), self.elements), key=lambda a: a.short_name))
 
     def getNPdus(self) -> List[NPdu]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import NPdu
 
         return list(sorted(filter(lambda a: isinstance(a, NPdu), self.elements), key=lambda a: a.short_name))
 
     def getDcmIPdus(self) -> List[DcmIPdu]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import DcmIPdu
 
         return list(sorted(filter(lambda a: isinstance(a, DcmIPdu), self.elements), key=lambda a: a.short_name))
 
     def getSecuredIPdus(self) -> List[SecuredIPdu]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SecuredIPdu
 
         return list(sorted(filter(lambda a: isinstance(a, SecuredIPdu), self.elements), key=lambda a: a.short_name))
 
     def getNmConfigs(self) -> List[NmConfig]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import NmConfig
 
         return list(sorted(filter(lambda a: isinstance(a, NmConfig), self.elements), key=lambda a: a.short_name))
 
     def getCanTpConfigs(self) -> List[CanTpConfig]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import CanTpConfig
 
         return list(sorted(filter(lambda a: isinstance(a, CanTpConfig), self.elements), key=lambda a: a.short_name))
 
     def getCanFrames(self) -> List[CanFrame]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame
 
         return list(sorted(filter(lambda a: isinstance(a, CanFrame), self.elements), key=lambda a: a.short_name))
 
     def getEcuInstances(self) -> List[EcuInstance]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import EcuInstance
 
         return list(sorted(filter(lambda a: isinstance(a, EcuInstance), self.elements), key=lambda a: a.short_name))
 
     def getGateways(self) -> List[Gateway]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform import Gateway
 
         return list(sorted(filter(lambda a: isinstance(a, Gateway), self.elements), key=lambda a: a.short_name))
 
     def getISignals(self) -> List[ISignal]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignal
 
         return list(sorted(filter(lambda a: isinstance(a, ISignal), self.elements), key=lambda a: a.short_name))
 
     def getEcucValueCollections(self) -> List[EcucValueCollection]:
-        from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import EcucValueCollection
 
         return list(sorted(filter(lambda a: isinstance(a, EcucValueCollection), self.elements), key=lambda a: a.short_name))
 
     def getEcucModuleConfigurationValues(self) -> List[EcucModuleConfigurationValues]:
-        from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import EcucModuleConfigurationValues
 
         return list(sorted(filter(lambda a: isinstance(a, EcucModuleConfigurationValues), self.elements), key=lambda a: a.short_name))
 
     def getEcucModuleDefs(self) -> List[EcucModuleDef]:
-        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucModuleDef
 
         return list(sorted(filter(lambda a: isinstance(a, EcucModuleDef), self.elements), key=lambda a: a.short_name))
 
     def getEcucDefinitionCollections(self) -> List[EcucDefinitionCollection]:
-        from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucDefinitionCollection
 
         return list(sorted(filter(lambda a: isinstance(a, EcucDefinitionCollection), self.elements), key=lambda a: a.short_name))
 
     def getSwSystemConsts(self) -> List[SwSystemconst]:
-        from armodel.models.M2.MSR.DataDictionary.SystemConstant import SwSystemconst
 
         return list(sorted(filter(lambda a: isinstance(a, SwSystemconst), self.elements), key=lambda a: a.short_name))
 
     def getSwSystemconstantValueSets(self) -> List[SwSystemconstantValueSet]:
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import SwSystemconstantValueSet
 
         return list(sorted(filter(lambda a: isinstance(a, SwSystemconstantValueSet), self.elements), key=lambda a: a.short_name))
 
     def getPredefinedVariants(self) -> List[PredefinedVariant]:
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import PredefinedVariant
 
         return list(
             sorted(
@@ -2429,7 +1932,6 @@ class ARPackage(CollectableElement):
         )
 
     def getPostBuildVariantCriterions(self) -> List[PostBuildVariantCriterion]:
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import PostBuildVariantCriterion
 
         return list(
             sorted(
@@ -2439,52 +1941,42 @@ class ARPackage(CollectableElement):
         )
 
     def getEcucPhysicalDimensions(self) -> List[PhysicalDimension]:
-        from armodel.models.M2.MSR.AsamHdo.Units import PhysicalDimension
 
         return list(sorted(filter(lambda a: isinstance(a, PhysicalDimension), self.elements), key=lambda a: a.short_name))
 
     def getISignalGroups(self) -> List[ISignalGroup]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignalGroup
 
         return list(sorted(filter(lambda a: isinstance(a, ISignalGroup), self.elements), key=lambda a: a.short_name))
 
     def getSystemSignals(self) -> List[SystemSignal]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SystemSignal
 
         return list(sorted(filter(lambda a: isinstance(a, SystemSignal), self.elements), key=lambda a: a.short_name))
 
     def getSystemSignalGroups(self) -> List[SystemSignalGroup]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import SystemSignalGroup
 
         return list(sorted(filter(lambda a: isinstance(a, SystemSignalGroup), self.elements), key=lambda a: a.short_name))
 
     def getISignalIPdus(self) -> List[ISignalIPdu]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import ISignalIPdu
 
         return list(sorted(filter(lambda a: isinstance(a, ISignalIPdu), self.elements), key=lambda a: a.short_name))
 
     def getSystems(self) -> List[System]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate import System
 
         return list(sorted(filter(lambda a: isinstance(a, System), self.elements), key=lambda a: a.short_name))
 
     def getHwElements(self) -> List[HwElement]:
-        from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwElement
 
         return list(sorted(filter(lambda a: isinstance(a, HwElement), self.elements), key=lambda a: a.short_name))
 
     def getHwCategories(self) -> List[HwCategory]:
-        from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import HwCategory
 
         return list(sorted(filter(lambda a: isinstance(a, HwCategory), self.elements), key=lambda a: a.short_name))
 
     def getFlexrayFrames(self) -> List[FlexrayFrame]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import FlexrayFrame
 
         return list(sorted(filter(lambda a: isinstance(a, FlexrayFrame), self.elements), key=lambda a: a.short_name))
 
     def getDataTransformationSets(self) -> List[DataTransformationSet]:
-        from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import DataTransformationSet
 
         return list(sorted(filter(lambda a: isinstance(a, DataTransformationSet), self.elements), key=lambda a: a.short_name))
 
@@ -2494,17 +1986,14 @@ class ARPackage(CollectableElement):
         return list(sorted(filter(lambda a: isinstance(a, Collection), self.elements), key=lambda a: a.short_name))
 
     def getKeywordSets(self) -> List[KeywordSet]:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword import KeywordSet
 
         return list(sorted(filter(lambda a: isinstance(a, KeywordSet), self.elements), key=lambda a: a.short_name))
 
     def getPortPrototypeBlueprints(self) -> List[PortPrototypeBlueprint]:
-        from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint import PortPrototypeBlueprint
 
         return list(sorted(filter(lambda a: isinstance(a, PortPrototypeBlueprint), self.elements), key=lambda a: a.short_name))
 
     def getModeDeclarationMappingSets(self) -> List[ModeDeclarationMappingSet]:
-        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import ModeDeclarationMappingSet
 
         return list(sorted(filter(lambda a: isinstance(a, ModeDeclarationMappingSet), self.elements), key=lambda a: a.short_name))
 
@@ -2514,3 +2003,147 @@ class ARPackage(CollectableElement):
     def addReferenceBase(self, value):
         self.referenceBases.append(value)
         return self
+
+
+# Element-class names are re-exported eagerly. Every models/ module that imports
+# from this module only needs ARElement/PackageableElement, which are defined above,
+# so partial-module initialization resolves the cycle without lazy machinery.
+from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswImplementation import BswImplementation  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import BswModuleEntry  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.BswModuleTemplate.BswOverview import BswModuleDescription  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.CommonStructure import ConstantSpecification  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.FlatMap import FlatMap  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation import Implementation  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes import ImplementationDataType  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.McGroups import McGroup  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport import McFunction  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import ModeDeclarationGroup  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.SignalServiceTranslation import SignalServiceTranslationPropsSet  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.BlueprintDedicated.PortPrototypeBlueprint import PortPrototypeBlueprint  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.StandardizationTemplate.Keyword import KeywordSet  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.SwcBswMapping import SwcBswMapping  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.CommonStructure.Timing.TimingExtensions import SwcTiming  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticContribution import DiagnosticServiceTable  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import (  # noqa: E402
+    EcucModuleConfigurationValues,
+    EcucValueCollection,
+)
+from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (  # noqa: E402
+    EcucDefinitionCollection,
+    EcucDestinationUriDefSet,
+    EcucModuleDef,
+)
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate import HwElement  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory import (  # noqa: E402
+    HwCategory,
+    HwType,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.DocumentationOnM1 import Documentation  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.LifeCycles import LifeCycleInfoSet  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import (  # noqa: E402
+    PostBuildVariantCriterion,
+    PredefinedVariant,
+    SwSystemconstantValueSet,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import (  # noqa: E402
+    ApplicationSwComponentType,
+    AtomicSwComponentType,
+    ComplexDeviceDriverSwComponentType,
+    EcuAbstractionSwComponentType,
+    NvBlockSwComponentType,
+    SensorActuatorSwComponentType,
+    ServiceProxySwComponentType,
+    ServiceSwComponentType,
+    SwComponentType,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition import CompositionSwComponentType  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import (  # noqa: E402
+    ApplicationArrayDataType,
+    ApplicationDataType,
+    ApplicationPrimitiveDataType,
+    ApplicationRecordDataType,
+    DataTypeMappingSet,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.EndToEndProtection import EndToEndProtectionSet  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import (  # noqa: E402
+    ConsistencyNeeds,
+    DataPrototypeGroup,
+    RunnableEntityGroup,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface import (  # noqa: E402
+    ClientServerInterface,
+    ModeDeclarationMappingSet,
+    ModeSwitchInterface,
+    NvDataInterface,
+    ParameterInterface,
+    PortInterfaceMappingSet,
+    SenderReceiverInterface,
+    TriggerInterface,
+)
+from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcImplementation import SwcImplementation  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate import System  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.DiagnosticConnection import DiagnosticConnection  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanCommunication import CanFrame  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology import CanXlProps  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetFrame import GenericEthernetFrame  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetTopology import EthernetCluster  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ObsoleteModel import SoAdRoutingGroup  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.ServiceInstances import (  # noqa: E402
+    SomeipSdClientEventGroupTimingConfig,
+    SomeipSdClientServiceInstanceConfig,
+    SomeipSdServerEventGroupTimingConfig,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.TcpOptionFilterSet import TcpOptionFilterSet  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayCommunication import FlexrayFrame  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Flexray.FlexrayTopology import FlexrayCluster  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinCommunication import LinUnconditionalFrame  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Lin.LinTopology import LinCluster  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Multiplatform import Gateway  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication import (  # noqa: E402
+    DcmIPdu,
+    GeneralPurposeIPdu,
+    GeneralPurposePdu,
+    ISignal,
+    ISignalGroup,
+    ISignalIPdu,
+    ISignalIPduGroup,
+    MultiplexedIPdu,
+    NPdu,
+    NmPdu,
+    SecureCommunicationPropsSet,
+    SecuredIPdu,
+    SystemSignal,
+    SystemSignalGroup,
+    UserDefinedIPdu,
+    UserDefinedPdu,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import (  # noqa: E402
+    CanCluster,
+    EcuInstance,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.NetworkManagement import NmConfig  # noqa: E402
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Transformer import (  # noqa: E402
+    DataTransformationSet,
+    E2EProfileCompatibilityProps,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.TransportProtocols import (  # noqa: E402
+    CanTpConfig,
+    DoIpTpConfig,
+    LinTpConfig,
+)
+from armodel.models.M2.MSR.AsamHdo.AdminData import AdminData  # noqa: E402
+from armodel.models.M2.MSR.AsamHdo.ComputationMethod import CompuMethod  # noqa: E402
+from armodel.models.M2.MSR.AsamHdo.Constraints.GlobalConstraints import DataConstr  # noqa: E402
+from armodel.models.M2.MSR.AsamHdo.Units import (  # noqa: E402
+    PhysicalDimension,
+    Unit,
+)
+from armodel.models.M2.MSR.DataDictionary.AuxillaryObjects import SwAddrMethod  # noqa: E402
+from armodel.models.M2.MSR.DataDictionary.RecordLayout import SwRecordLayout  # noqa: E402
+from armodel.models.M2.MSR.DataDictionary.SystemConstant import SwSystemconst  # noqa: E402
+from armodel.models.M2.MSR.Documentation.Annotation import Annotation  # noqa: E402
+from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock  # noqa: E402
+from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData import (  # noqa: E402
+    MultiLanguageOverviewParagraph,
+    MultilanguageLongName,
+)

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ArObject.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ArObject.py
@@ -1,31 +1,79 @@
 """
-This module contains the base ARObject class for AUTOSAR models
-in the GenericStructure module.
+Abstract base class of all AUTOSAR objects.
 """
 
 from abc import ABC
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
+
+if TYPE_CHECKING:
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+        DateTime,
+        String,
+    )
 
 
 class ARObject(ABC):
     """
-    Abstract base class for all AUTOSAR objects.
-    This class provides the basic structure and functionality for all AUTOSAR objects.
+    Abstract base class of all AUTOSAR meta-classes
+    (AUTOSAR_FO_TPS_GenericStructureTemplate, Table 6.1).
     """
 
     # ARObject method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [x] getTagName                   [x] impl  [x] docstring  [x] test
+    # Spec verified: R23-11
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 6.1, p.192
+    # Columns: impl / docstring / test / reader / writer / release   ([—] = no XML element)
+    # [x] __init__      [x] impl  [x] docstring  [x] test  [—] reader  [—] writer  R23-11
+    # [x] setChecksum   [x] impl  [x] docstring  [x] test  [x] reader  [—] writer  R23-11
+    # [x] getChecksum   [x] impl  [x] docstring  [x] test  [—] reader  [x] writer  R23-11
+    # [x] setTimestamp  [x] impl  [x] docstring  [x] test  [x] reader  [—] writer  R23-11
+    # [x] getTimestamp  [x] impl  [x] docstring  [x] test  [—] reader  [x] writer  R23-11
+    #
+    # Internal members (no spec counterpart, cf. CollectableElement decision):
+    #   parent     — structural link to the owning object
+    #   uuid       — py-armodel extension for UUID duplicate checking (read/written as UUID attribute)
+    #   getTagName — parser helper for namespace-stripped tag names
 
     def __init__(self):
         if type(self) is ARObject:
             raise TypeError("ARObject is an abstract class.")
 
         self.parent: Optional["ARObject"] = None
-        self.checksum: Optional[str] = None
 
-        self.timestamp: Optional[str] = None
+        # Checksum calculated by the user's tool environment for an ArObject. May be used in an own tool environment to determine if an ArObject has changed. The checksum has no semantic meaning for an AUTOSAR model and there is no requirement for AUTOSAR tools to manage the checksum.
+        self.checksum: Optional["String"] = None
+
+        # Timestamp calculated by the user's tool environment for an ArObject. May be used in an own tool environment to determine the last change of an ArObject. The timestamp has no semantic meaning for an AUTOSAR model and there is no requirement for AUTOSAR tools to manage the timestamp.
+        self.timestamp: Optional["DateTime"] = None
+
         self.uuid: Optional[str] = None
+
+    def getChecksum(self) -> Optional["String"]:
+        """
+        Checksum calculated by the user's tool environment for an ArObject. May be used in an own tool environment to determine if an ArObject has changed. The checksum has no semantic meaning for an AUTOSAR model and there is no requirement for AUTOSAR tools to manage the checksum.
+        """
+        return self.checksum
+
+    def setChecksum(self, value: Optional["String"]) -> "ARObject":
+        """
+        Checksum calculated by the user's tool environment for an ArObject. May be used in an own tool environment to determine if an ArObject has changed. The checksum has no semantic meaning for an AUTOSAR model and there is no requirement for AUTOSAR tools to manage the checksum. A None value is a no-op and does not overwrite an existing checksum.
+        """
+        if value is not None:
+            self.checksum = value
+        return self
+
+    def getTimestamp(self) -> Optional["DateTime"]:
+        """
+        Timestamp calculated by the user's tool environment for an ArObject. May be used in an own tool environment to determine the last change of an ArObject. The timestamp has no semantic meaning for an AUTOSAR model and there is no requirement for AUTOSAR tools to manage the timestamp.
+        """
+        return self.timestamp
+
+    def setTimestamp(self, value: Optional["DateTime"]) -> "ARObject":
+        """
+        Timestamp calculated by the user's tool environment for an ArObject. May be used in an own tool environment to determine the last change of an ArObject. The timestamp has no semantic meaning for an AUTOSAR model and there is no requirement for AUTOSAR tools to manage the timestamp. A None value is a no-op and does not overwrite an existing timestamp.
+        """
+        if value is not None:
+            self.timestamp = value
+        return self
 
     def getTagName(self, tag: str, nsmap: Dict) -> str:
         """

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/Identifiable.py
@@ -503,38 +503,6 @@ class Identifiable(MultilanguageReferrable, ABC):
         return self.annotations
 
 
-class PackageableElement(Identifiable, ABC):
-    """
-    This meta-class specifies the ability to be a member of an AUTOSAR package.
-    """
-
-    # PackageableElement method parity checklist:
-    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.2, p.54
-    # Spec verified: R23-11
-    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
-    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-
-    def __init__(self, parent: ARObject, short_name: str):
-        if type(self) is PackageableElement:
-            raise TypeError("PackageableElement is an abstract class.")
-        super().__init__(parent, short_name)
-
-
-class ARElement(PackageableElement, ABC):
-    """
-    Abstract class for AUTOSAR elements.
-    This class represents the basic structure for all AUTOSAR model elements.
-    """
-
-    # ARElement method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-
-    def __init__(self, parent: ARObject, short_name: str):
-        if type(self) is ARElement:
-            raise TypeError("ARElement is an abstract class.")
-        super().__init__(parent, short_name)
-
-
 # Initialize the CommonStructure package before any import that transitively touches
 # AbstractStructure: AbstractStructure's own import of AbstractBlueprintStructure requires
 # the CommonStructure package to be present in sys.modules (Task 15 bootstrap-cycle fix).

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/LifeCycles.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/LifeCycles.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType, RevisionLabelString
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 
 
 class LifeCyclePeriod(ARObject):

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/__init__.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType, ARNumerical, Identifier, Integer
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from abc import ABC
 from typing import List, Optional, TYPE_CHECKING
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpPrototype, AtpStructureElement, AtpType
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs import InnerPortGroupInCompositionInstanceRef
-from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior import SwcInternalBehavior
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.NvBlockComponent import BulkNvDataDescriptor, NvBlockDescriptor
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation import ImplementationProps
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import (
@@ -35,11 +33,17 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttribute
 )
 
 if TYPE_CHECKING:
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs import (
+        InnerPortGroupInCompositionInstanceRef,
+    )
     from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ImplicitCommunicationBehavior import (
         ConsistencyNeeds,
     )
     from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SoftwareComponentDocumentation import (
         SwComponentDocumentation,
+    )
+    from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior import (
+        SwcInternalBehavior,
     )
 
 
@@ -829,6 +833,8 @@ class AtomicSwComponentType(SwComponentType, ABC):
         Returns:
             The created (or existing) SwcInternalBehavior
         """
+        from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior import SwcInternalBehavior
+
         if not self.IsElementExists(short_name, SwcInternalBehavior):
             behavior = SwcInternalBehavior(self, short_name)
             self.addElement(behavior)

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
@@ -7,7 +7,7 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceR
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior import SwcInternalBehavior
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.NvBlockComponent import BulkNvDataDescriptor, NvBlockDescriptor
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation import ImplementationProps
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import (
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import (
     ARElement as ARElement,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import (

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Datatype/Datatypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Datatype/Datatypes.py
@@ -231,6 +231,7 @@ class DataTypeMap(ARObject):
     # [ ] setImplementationDataTypeRef [x] impl  [ ] docstring  [ ] test
 
     def __init__(self):
+        super().__init__()
 
         self.applicationDataTypeRef: RefType = None
         self.implementationDataTypeRef: RefType = None

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/EndToEndProtection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/EndToEndProtection.py
@@ -6,7 +6,7 @@ used to ensure data integrity in communication systems.
 """
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import NameToken, PositiveInteger
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.InstanceRefs import VariableDataPrototypeInSystemInstanceRef

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DiagnosticConnection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DiagnosticConnection.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Referrable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology.py
@@ -7,7 +7,7 @@ from typing import Optional
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, Float, Integer, PositiveInteger
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveUnlimitedInteger, TimeValue
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology import CommunicationConnector, CommunicationController, PhysicalChannel
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances.py
@@ -16,7 +16,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     TimeValue,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.TagWithOptionalValue import TagWithOptionalValue
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Ethernet.EthernetCommunication import SocketConnectionBundle

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/TcpOptionFilterSet.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/TcpOptionFilterSet.py
@@ -5,7 +5,7 @@ from typing import List
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import List, Optional, TYPE_CHECKING
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, Describable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARLiteral, ARNumerical, ARPositiveInteger, Boolean, ByteOrderEnum
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer, PositiveInteger, RefType, ARBoolean, String

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/__init__.py
@@ -5,7 +5,7 @@ This module contains the direct members of the FibexCore package.
 from abc import ABC
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import PackageableElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import PackageableElement
 
 
 class FibexElement(PackageableElement, ABC):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SecureCommunication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SecureCommunication.py
@@ -14,7 +14,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     TimeValue,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 
 
 class CryptoServiceMapping(Identifiable, ABC):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/__init__.py
@@ -8,7 +8,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType, String
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Describable, Identifiable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import TransformationComSpecProps
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/__init__.py
@@ -8,7 +8,7 @@ from armodel.models.M2.AUTOSARTemplates.SystemTemplate.ECUResourceMapping import
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.InstanceRefs import ComponentInSystemInstanceRef
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.SWmapping import ApplicationPartitionToEcuPartitionMapping, SwcToImplMapping
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import (
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import (
     ARElement as ARElement,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import (

--- a/src/armodel/models/M2/MSR/AsamHdo/BaseTypes.py
+++ b/src/armodel/models/M2/MSR/AsamHdo/BaseTypes.py
@@ -2,7 +2,7 @@ from abc import ABC
 from typing import Optional
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     BaseTypeEncodingString,
     ByteOrderEnum,

--- a/src/armodel/models/M2/MSR/AsamHdo/Units.py
+++ b/src/armodel/models/M2/MSR/AsamHdo/Units.py
@@ -8,7 +8,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     RefType,
     ARLiteral,
 )
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 
 
 class PhysicalDimension(ARElement):

--- a/src/armodel/models/M2/MSR/DataDictionary/RecordLayout.py
+++ b/src/armodel/models/M2/MSR/DataDictionary/RecordLayout.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import ARElement
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral
 
 

--- a/src/armodel/parser/abstract_arxml_parser.py
+++ b/src/armodel/parser/abstract_arxml_parser.py
@@ -2,7 +2,7 @@ import logging
 import re
 import xml.etree.ElementTree as ET
 from abc import ABC
-from typing import List
+from typing import List, Optional
 
 from colorama import Fore
 
@@ -110,7 +110,7 @@ class AbstractARXMLParser(ABC):
             results.append(literal)
         return results
 
-    def getChildElementOptionalLiteral(self, element: ET.Element, key: str) -> ARLiteral:
+    def getChildElementOptionalLiteral(self, element: ET.Element, key: str) -> Optional[ARLiteral]:
         child_element = self.find(element, key)
         literal = None
         if child_element is not None:
@@ -354,24 +354,23 @@ class AbstractARXMLParser(ABC):
         return None
 
     def readARObjectAttributes(self, element: ET.Element, ar_object: ARObject):
-        ar_object.timestamp = self.readElementOptionalAttrib(element, "T")  # read the timestamp
+        if isinstance(ar_object, ARObject):
+            checksum = self.readElementOptionalAttrib(element, "S")  # read the checksum
+            if checksum is not None:
+                checksum_value = String()
+                checksum_value.setValue(checksum)
+                ar_object.setChecksum(checksum_value)
+            timestamp = self.readElementOptionalAttrib(element, "T")  # read the timestamp
+            if timestamp is not None:
+                timestamp_value = DateTime()
+                timestamp_value.setValue(timestamp)
+                ar_object.setTimestamp(timestamp_value)
+        else:
+            # The ARType hierarchy carries the timestamp as a plain string (duck-typed)
+            ar_object.timestamp = self.readElementOptionalAttrib(element, "T")
         ar_object.uuid = self.readElementOptionalAttrib(element, "UUID")  # read the uuid
 
         AUTOSAR.getInstance().addARObject(ar_object)
-
-        # if ar_object.timestamp is not None:
-        #    self.logger.debug("Timestamp: %s" % ar_object.timestamp)
-
-        """
-        if ar_object.uuid is not None:
-            instance = AUTOSAR.getInstance()
-            old_ar_object = instance.getARObjectByUUID(ar_object.uuid)
-            if old_ar_object is not None:
-                self.logger.warning(Fore.YELLOW + "Duplicate UUID <%s> / type <%s>" % (ar_object.uuid, type(old_ar_object)) + Fore.WHITE)
-            else:
-                instance.addARObject(ar_object)
-            # self.logger.debug("UUID: %s" % ar_object.uuid)
-        """
 
     def getAUTOSARInfo(self, element: ET.Element, document: AUTOSAR):
         key = "{http://www.w3.org/2001/XMLSchema-instance}schemaLocation"

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -955,7 +955,7 @@ class ARXMLParser(AbstractARXMLParser):
     def __init__(self, options=None) -> None:
         super().__init__(options)
 
-    def getRxIdentifierRange(self, element: ET.Element, key: str) -> RxIdentifierRange:
+    def getRxIdentifierRange(self, element: ET.Element, key: str) -> Optional[RxIdentifierRange]:
         child_element = self.find(element, key)
         range = None
         if child_element is not None:
@@ -964,7 +964,7 @@ class ARXMLParser(AbstractARXMLParser):
             range.setUpperCanId(self.getChildElementOptionalPositiveInteger(child_element, "UPPER-CAN-ID"))
         return range
 
-    def getJ1939NodeName(self, element: ET.Element, key: str) -> J1939NodeName:
+    def getJ1939NodeName(self, element: ET.Element, key: str) -> Optional[J1939NodeName]:
         child_element = self.find(element, key)
         node_name = None
         if child_element is not None:
@@ -5179,7 +5179,7 @@ class ARXMLParser(AbstractARXMLParser):
         access.setAccessedVariableRef(self.getAutosarVariableRef(element, "ACCESSED-VARIABLE"))
         access.setScope(self.getChildElementOptionalLiteral(element, "SCOPE"))
 
-    def getTransformationComSpecProps(self, element: ET.Element) -> TransformationComSpecProps:
+    def getTransformationComSpecProps(self, element: ET.Element) -> Optional[TransformationComSpecProps]:
         child = self.find(element, "*")
         if child is None:
             return None
@@ -5195,7 +5195,7 @@ class ARXMLParser(AbstractARXMLParser):
         self.notImplemented("Unsupported TransformationComSpecProps <%s>" % tag_name)
         return None
 
-    def getSwValues(self, element: ET.Element, key: str) -> SwValues:
+    def getSwValues(self, element: ET.Element, key: str) -> Optional[SwValues]:
         child_element = self.find(element, key)
         if child_element is None:
             return None
@@ -5211,7 +5211,7 @@ class ARXMLParser(AbstractARXMLParser):
             sw_values.addVtf(self.getNumericalOrText(vtf_element))
         return sw_values
 
-    def getValueGroup(self, element: ET.Element, key: str) -> ValueGroup:
+    def getValueGroup(self, element: ET.Element, key: str) -> Optional[ValueGroup]:
         value_group = None
         child_element = self.find(element, key)
         if child_element is not None:
@@ -5234,7 +5234,7 @@ class ARXMLParser(AbstractARXMLParser):
                 value_group.setVgContents(contents)
         return value_group
 
-    def getValueList(self, element: ET.Element, key: str) -> ValueList:
+    def getValueList(self, element: ET.Element, key: str) -> Optional[ValueList]:
         value_list = None
         child_element = self.find(element, key)
         if child_element is not None:
@@ -5248,7 +5248,7 @@ class ARXMLParser(AbstractARXMLParser):
                     value_list.addVf(vf)
         return value_list
 
-    def getSwValueCont(self, element: ET.Element) -> SwValueCont:
+    def getSwValueCont(self, element: ET.Element) -> Optional[SwValueCont]:
         cont = None
         child_element = self.find(element, "SW-VALUE-CONT")
         if child_element is not None:

--- a/src/armodel/writer/abstract_arxml_writer.py
+++ b/src/armodel/writer/abstract_arxml_writer.py
@@ -67,9 +67,15 @@ class AbstractARXMLWriter(ABC):
             raise NotImplementedError(error_msg)
 
     def writeARObjectAttributes(self, element: ET.Element, ar_obj: ARObject):
-        if ar_obj.timestamp is not None:
-            # self.logger.debug("Timestamp: %s" % ar_obj.timestamp)
-            element.attrib["T"] = ar_obj.timestamp
+        if isinstance(ar_obj, ARObject):
+            if ar_obj.getChecksum() is not None:
+                element.attrib["S"] = ar_obj.getChecksum().getValue()
+            if ar_obj.getTimestamp() is not None:
+                element.attrib["T"] = ar_obj.getTimestamp().getValue()
+        else:
+            # The ARType hierarchy carries the timestamp as a plain string (duck-typed)
+            if ar_obj.timestamp is not None:
+                element.attrib["T"] = ar_obj.timestamp
         if ar_obj.uuid is not None:
             # self.logger.debug("UUID: %s" % ar_obj.uuid)
             element.attrib["UUID"] = ar_obj.uuid

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_ARPackage.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_ARPackage.py
@@ -794,6 +794,10 @@ class TestPackageableElement:
 class TestARElement:
     """
     Test class for ARElement functionality.
+
+    Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table 4.3, p.55
+    ARElement is an abstract class without own attributes; all members are
+    inherited from the base chain (PackageableElement -> Identifiable -> ...).
     """
 
     def test_abstract_initialization(self):
@@ -807,3 +811,30 @@ class TestARElement:
             assert False, "ARElement should not be instantiable"
         except TypeError:
             pass  # Expected behavior
+
+    def test_concrete_subclass_initialization(self):
+        """
+        Test that a concrete ARElement subclass initializes the base chain.
+        """
+
+        class ConcreteARElement(ARElement):
+            pass
+
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        obj = ConcreteARElement(ar_root, "TestElement")
+
+        assert obj.getShortName() == "TestElement"
+        assert obj.parent is ar_root
+
+    def test_inheritance_chain(self):
+        """
+        Test that ARElement derives from PackageableElement (most-derived base)
+        and the transitive base chain of Table 4.3.
+        """
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
+
+        assert issubclass(ARElement, PackageableElement)
+        assert issubclass(ARElement, Identifiable)
+        assert issubclass(ARElement, ARObject)

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_ArObject.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_ArObject.py
@@ -1,77 +1,75 @@
 """
-This module contains comprehensive tests for the ArObject.py file
-in the AUTOSAR GenericStructure module.
+Tests for the ARObject class (AUTOSAR_FO_TPS_GenericStructureTemplate, Table 6.1).
 """
 
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
+import pytest
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
+    ARObject,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    DateTime,
+    String,
+)
+
+
+class ConcreteARObject(ARObject):
+    pass
 
 
 class TestARObject:
-    """
-    Test class for ARObject functionality.
-    """
-
     def test_abstract_initialization(self):
         """
-        Test that ARObject cannot be instantiated directly (abstract class).
+        ARObject is abstract and cannot be instantiated directly.
         """
-        try:
-            _obj = ARObject()
-            assert False, "ARObject should not be instantiable"
-        except TypeError as e:
-            # The error message should indicate it's abstract
-            assert "abstract class" in str(e) or "ARObject is an abstract class" in str(e)
+        with pytest.raises(TypeError):
+            ARObject()
 
-    def test_concrete_implementation_initialization(self):
+    def test_initialization(self):
         """
-        Test that a concrete implementation of ARObject can be instantiated and initializes properties correctly.
+        A concrete ARObject initializes all members to None.
         """
-
-        class ConcreteARObject(ARObject):
-            def __init__(self):
-                super().__init__()  # This should work since type(self) is not ARObject
-
         obj = ConcreteARObject()
 
-        # Properties should be initialized to None (or appropriate defaults)
+        assert obj.getChecksum() is None
+        assert obj.getTimestamp() is None
         assert obj.parent is None
-        assert obj.checksum is None
-        assert obj.timestamp is None
         assert obj.uuid is None
+
+    def test_get_set_checksum(self):
+        """
+        Round-trips the checksum member; None is a no-op.
+        """
+        obj = ConcreteARObject()
+
+        value = String()
+        value.setValue("abc123")
+        obj.setChecksum(value)
+        assert obj.getChecksum() is value
+
+        obj.setChecksum(None)
+        assert obj.getChecksum() is value
+
+    def test_get_set_timestamp(self):
+        """
+        Round-trips the timestamp member; None is a no-op.
+        """
+        obj = ConcreteARObject()
+
+        value = DateTime()
+        value.setValue("2009-07-23T13:38:00Z")
+        obj.setTimestamp(value)
+        assert obj.getTimestamp() is value
+
+        obj.setTimestamp(None)
+        assert obj.getTimestamp() is value
 
     def test_get_tag_name(self):
         """
-        Test getTagName method functionality.
+        getTagName strips the namespace prefix from a tag name.
         """
-
-        class ConcreteARObject(ARObject):
-            def __init__(self):
-                super().__init__()
-
         obj = ConcreteARObject()
 
-        # Test with a tag that has a namespace
-        tag_with_ns = "{http://www.example.com/ns}elementName"
         nsmap = {"xmlns": "http://www.example.com/ns"}
-
-        result = obj.getTagName(tag_with_ns, nsmap)
-        assert result == "elementName"
-
-        # Test with different namespace
-        tag_with_ns2 = "{http://another.com/schema}testTag"
-        nsmap2 = {"xmlns": "http://another.com/schema"}
-
-        result2 = obj.getTagName(tag_with_ns2, nsmap2)
-        assert result2 == "testTag"
-
-        # Test with tag that doesn't match namespace (should still work with replace)
-        tag_with_ns3 = "{http://different.com/ns}otherTag"
-        nsmap3 = {"xmlns": "http://different.com/ns"}
-
-        result3 = obj.getTagName(tag_with_ns3, nsmap3)
-        assert result3 == "otherTag"
-
-        # Test with tag that has no namespace prefix (edge case)
-        tag_no_ns = "simpleTag"
-        result4 = obj.getTagName(tag_no_ns, nsmap)
-        assert result4 == "simpleTag"
+        assert obj.getTagName("{http://www.example.com/ns}elementName", nsmap) == "elementName"
+        assert obj.getTagName("simpleTag", nsmap) == "simpleTag"

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_Identifiable.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_Identifiable.py
@@ -4,13 +4,7 @@ in the AUTOSAR GenericStructure module.
 """
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import (
-    Describable,
-    Identifiable,
-    MultilanguageReferrable,
-    Referrable,
-    ShortNameFragment,
-)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Describable, Identifiable, MultilanguageReferrable, Referrable, ShortNameFragment
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import CategoryString, Identifier
 from armodel.models.M2.MSR.AsamHdo.AdminData import AdminData
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation

--- a/tests/test_armodel/parser/test_ar_object_attributes.py
+++ b/tests/test_armodel/parser/test_ar_object_attributes.py
@@ -1,0 +1,50 @@
+"""
+Tests for reading ARObject XML attributes (S checksum, T timestamp) — Table 6.1.
+"""
+
+import xml.etree.ElementTree as ET
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
+    ARObject,
+)
+from armodel.parser.arxml_parser import ARXMLParser
+
+
+class ConcreteARObject(ARObject):
+    pass
+
+
+class TestReadARObjectAttributes:
+    def test_read_checksum_timestamp_uuid(self):
+        parser = ARXMLParser(options={"warning": True})
+        element = ET.Element("SHORT-NAME", {"S": "checksum-1", "T": "2009-07-23T13:38:00Z", "UUID": "uuid-1"})
+
+        obj = ConcreteARObject()
+        parser.readARObjectAttributes(element, obj)
+
+        assert obj.getChecksum() is not None
+        assert obj.getChecksum().getValue() == "checksum-1"
+        assert obj.getTimestamp() is not None
+        assert obj.getTimestamp().getValue() == "2009-07-23T13:38:00Z"
+        assert obj.uuid == "uuid-1"
+
+    def test_read_attributes_absent(self):
+        parser = ARXMLParser(options={"warning": True})
+        element = ET.Element("SHORT-NAME")
+
+        obj = ConcreteARObject()
+        parser.readARObjectAttributes(element, obj)
+
+        assert obj.getChecksum() is None
+        assert obj.getTimestamp() is None
+        assert obj.uuid is None
+
+    def test_read_checksum_only(self):
+        parser = ARXMLParser(options={"warning": True})
+        element = ET.Element("SHORT-NAME", {"S": "only-checksum"})
+
+        obj = ConcreteARObject()
+        parser.readARObjectAttributes(element, obj)
+
+        assert obj.getChecksum().getValue() == "only-checksum"
+        assert obj.getTimestamp() is None

--- a/tests/test_armodel/parser/test_arxml_parser_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_handlers.py
@@ -264,7 +264,7 @@ class TestAdminDataAndReferrableHandlers:
         elem = ET.fromstring(f"<ELEM xmlns='{NS}' UUID='abc' T='2024-01-01T00:00:00'/>")
         parser.readReferrable(elem, obj)
         assert obj.uuid == "abc"
-        assert obj.timestamp == "2024-01-01T00:00:00"
+        assert obj.getTimestamp().getValue() == "2024-01-01T00:00:00"
 
     def test_readMultilanguageReferrable_sets_longName(self, parser):
         # Use a concrete MultilanguageReferrable subclass (Unit extends ARElement

--- a/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_network_handlers.py
@@ -2928,7 +2928,7 @@ class TestReadTransformationISignalProps:
             f"<END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-CONDITIONAL " f"xmlns='{NS}' T='2024-01-01T00:00:00' UUID='abc-123'>" f"</END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-CONDITIONAL>"
         )
         parser.readTransformationISignalProps(element, props)
-        assert props.timestamp == "2024-01-01T00:00:00"
+        assert props.getTimestamp().getValue() == "2024-01-01T00:00:00"
         assert props.uuid == "abc-123"
 
     def test_without_arobject_attributes(self, parser):

--- a/tests/test_armodel/parser/test_arxml_parser_snippets.py
+++ b/tests/test_armodel/parser/test_arxml_parser_snippets.py
@@ -282,7 +282,7 @@ class TestReadMethods:
         )
         ar_obj = Modification()
         parser.readARObjectAttributes(element, ar_obj)
-        assert ar_obj.timestamp == "2023-01-01T00:00:00+08:00"
+        assert ar_obj.getTimestamp().getValue() == "2023-01-01T00:00:00+08:00"
 
     def test_readARObjectAttributes_with_uuid(self, parser):
         """Test readARObjectAttributes with UUID attribute."""

--- a/tests/test_armodel/parser/test_runnable_entity.py
+++ b/tests/test_armodel/parser/test_runnable_entity.py
@@ -130,7 +130,7 @@ class TestRunnableEntity:
 
         written_var = runnable_entity.getWrittenLocalVariables()[0]
         assert written_var.getShortName() == "CurrentCounterValue4"
-        assert written_var.getAccessedVariableRef().timestamp == "2020-08-03T07:59:25+02:00"
+        assert written_var.getAccessedVariableRef().getTimestamp().getValue() == "2020-08-03T07:59:25+02:00"
         assert written_var.getAccessedVariableRef().getLocalVariableRef().getDest() == "VARIABLE-DATA-PROTOTYPE"
         assert written_var.getAccessedVariableRef().getLocalVariableRef().getValue() == "/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/CurrentCounterValue"
 

--- a/tests/test_armodel/writer/test_abstract_arxml_writer.py
+++ b/tests/test_armodel/writer/test_abstract_arxml_writer.py
@@ -94,7 +94,9 @@ class TestAbstractARXMLWriter:
         writer = ConcreteARXMLWriter()
         parent = ET.Element("parent")
         ar_obj = ConcreteTestARObject(None, "TestObj")
-        ar_obj.timestamp = "2024-01-01T00:00:00"
+        timestamp = DateTime()
+        timestamp.setValue("2024-01-01T00:00:00")
+        ar_obj.setTimestamp(timestamp)
 
         writer.writeARObjectAttributes(parent, ar_obj)
         assert parent.attrib["T"] == "2024-01-01T00:00:00"
@@ -114,7 +116,9 @@ class TestAbstractARXMLWriter:
         writer = ConcreteARXMLWriter()
         parent = ET.Element("parent")
         ar_obj = ConcreteTestARObject(None, "TestObj")
-        ar_obj.timestamp = "2024-01-01T00:00:00"
+        timestamp = DateTime()
+        timestamp.setValue("2024-01-01T00:00:00")
+        ar_obj.setTimestamp(timestamp)
         ar_obj.uuid = "12345678-1234-1234-1234-123456789012"
 
         writer.writeARObjectAttributes(parent, ar_obj)

--- a/tests/test_armodel/writer/test_ar_object_attributes.py
+++ b/tests/test_armodel/writer/test_ar_object_attributes.py
@@ -1,0 +1,67 @@
+"""
+Tests for writing ARObject XML attributes (S checksum, T timestamp) — Table 6.1.
+"""
+
+import xml.etree.ElementTree as ET
+
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import (
+    ARObject,
+)
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    DateTime,
+    String,
+)
+from armodel.writer.abstract_arxml_writer import AbstractARXMLWriter
+
+
+class ConcreteARObject(ARObject):
+    pass
+
+
+def _make_writer():
+    return AbstractARXMLWriter.__new__(AbstractARXMLWriter)
+
+
+class TestWriteARObjectAttributes:
+    def test_write_checksum_timestamp_uuid(self):
+        writer = _make_writer()
+        element = ET.Element("SHORT-NAME")
+
+        obj = ConcreteARObject()
+        checksum = String()
+        checksum.setValue("checksum-1")
+        timestamp = DateTime()
+        timestamp.setValue("2009-07-23T13:38:00Z")
+        obj.setChecksum(checksum)
+        obj.setTimestamp(timestamp)
+        obj.uuid = "uuid-1"
+
+        writer.writeARObjectAttributes(element, obj)
+
+        assert element.attrib["S"] == "checksum-1"
+        assert element.attrib["T"] == "2009-07-23T13:38:00Z"
+        assert element.attrib["UUID"] == "uuid-1"
+
+    def test_write_attributes_absent(self):
+        writer = _make_writer()
+        element = ET.Element("SHORT-NAME")
+
+        writer.writeARObjectAttributes(element, ConcreteARObject())
+
+        assert "S" not in element.attrib
+        assert "T" not in element.attrib
+        assert "UUID" not in element.attrib
+
+    def test_write_timestamp_only(self):
+        writer = _make_writer()
+        element = ET.Element("SHORT-NAME")
+
+        obj = ConcreteARObject()
+        timestamp = DateTime()
+        timestamp.setValue("2009-07-23")
+        obj.setTimestamp(timestamp)
+
+        writer.writeARObjectAttributes(element, obj)
+
+        assert element.attrib["T"] == "2009-07-23"
+        assert "S" not in element.attrib

--- a/tests/test_armodel/writer/test_writer_common_structure.py
+++ b/tests/test_armodel/writer/test_writer_common_structure.py
@@ -1076,7 +1076,9 @@ class TestWriteDescribable:
     def test_writes_attributes(self, writer):
         parent = _parent()
         desc = ConcreteDescribable()
-        desc.timestamp = "2024-01-01T00:00:00"
+        timestamp = DateTime()
+        timestamp.setValue("2024-01-01T00:00:00")
+        desc.setTimestamp(timestamp)
         writer.writeDescribable(parent, desc)
         assert parent.attrib["T"] == "2024-01-01T00:00:00"
 


### PR DESCRIPTION
Closes #695

## Summary
- Add `docs/examples/sync_class_groups.md`: 7 dependency-ordered batches (206 entries) for running sync-autosar-class, plus per-group session checklists in `docs/plan/sync-todo/Group1-7.md`
- Sync the core framework model classes to the AUTOSAR R23-11 specification (per `docs/development/class_check_rules.md`), following those dependency-ordered groups
- Replace the lazy re-export machinery in `models/M2/**` with eager imports

## Changes
- **ARObject** — synced to R23-11 spec (Table 6.1)
- **ARElement** — synced to R23-11 spec (Table 4.3)
- **ARPackage** — synced members, bases and attributes to R23-11 spec (Table 4.1, ~600 lines changed)
- **refactor(models)** — replaced lazy re-export machinery with eager imports across `models/M2/**`; adjusted `abstract_arxml_parser.py`, `arxml_parser.py`, `abstract_arxml_writer.py` accordingly
- **docs** — updated method deviation tracker (`method_deviation_by_class_v2.md`) and Group1 sync todo progress

## Files Modified
- `docs/examples/sync_class_groups.md`, `docs/plan/sync-todo/Group1-7.md`
- `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/` (ArObject.py, ARPackage.py, Identifiable.py)
- Import refactoring across ~30 `models/M2/**` files
- `src/armodel/parser/abstract_arxml_parser.py`, `arxml_parser.py`, `writer/abstract_arxml_writer.py`
- `AGENTS.md`, `docs/examples/method_deviation_by_class_v2.md`

## Test Coverage
- New unit tests: `test_ARPackage.py`, `test_ar_object_attributes.py` (parser + writer round-trip); updated ArObject/Identifiable/writer tests
- Quality gates: full suite **8176 tests passed**, lint (flake8 + ruff) clean

## Commits
- `fc226ecf` docs: add dependency-ordered sync class groups and per-group sync todo lists
- `78ae363c` feat(models): sync ARObject class to R23-11 spec (Table 6.1)
- `61c85fa7` feat(models): sync ARElement class to R23-11 spec (Table 4.3)
- `3a5f8e1a` refactor(models): replace lazy re-export machinery with eager imports
- `71e19a4b` docs: record ARPackage Step 1 spec facts in Group1 sync todo