### PR TITLE
fix(skill): sync-autosar-class audit fixes (v1.9.2)

### DIFF
--- a/.agents/skills/sync-autosar-class/SKILL.md
+++ b/.agents/skills/sync-autosar-class/SKILL.md
@@ -5,7 +5,7 @@ author: melodypapa
 repository: https://github.com/melodypapa/py-armodel
 license: MIT
 metadata:
-  version: "1.9.1"
+  version: "1.9.2"
   keywords:
     - AUTOSAR
     - model-class
@@ -47,7 +47,7 @@ document = AUTOSAR.getInstance()
 document.setARRelease('R23-11')
 ```
 
-Detailed rules live in **`rules.md`** (*Rule 0001*–*Rule 0018*); this skill is
+Detailed rules live in **`rules.md`** (*Rule 0001*–*Rule 0019*); this skill is
 self-contained (no external rules document). Each step below points into `rules.md` for
 the detail — do not re-derive it here.
 
@@ -123,7 +123,10 @@ session** (Rule 0017).
 - **One class per session.** Never sync two classes in one session, even when the
   context still feels fresh — the 9b verbatim-diff work degrades silently under a
   loaded context. After a class finishes (below), stop and tell the user to start
-  a new session.
+  a new session. Sole exception — **autonomous mode (Rule 0017.5)**: when the user
+  asks the sync to run automatically, the orchestrator chains classes via isolated
+  per-class subagents and skips only the between-class pause; the 9b confirmation
+  stays mandatory for every class, in every mode.
 - **Mirror the 9 steps into the session todo list (Rule 0018).** After taking the
   `[ ]` row and before Step 1, create **9 session todos — one per workflow step**
   (`Step 1 — Sync members & description from spec` … `Step 9 — Verify (9a) +
@@ -189,7 +192,7 @@ round-trip) certifies a class as reviewed.
 | writer test | `tests/test_armodel/writer/test_*.py` → `class Test*` (set → save → reload round-trip; Step 5) |
 | spec markdown | `grep "Table N.M: <ClassName>" autosar/R23-11/markdown/AUTOSAR_*_TPS_*.md` — **primary source for all text**: `Note` (→ docstrings), `Attribute`/`Base`, `Table N.M` id, table name (via filename). Covers **both** `CP_TPS` (Classic) and `FO_TPS` (Foundation); a class with **no** R23-11 table falls back to `grep ... autosar/R4.3.1/markdown/AUTOSAR_TPS_*.md` (pre-split naming — no `CP_`/`FO_` prefix; Rule 0016.3) |
 | spec PDF | `autosar/R23-11/pdf/AUTOSAR_*_TPS_*.pdf` (R4.3.1 fallback: `autosar/R4.3.1/pdf/AUTOSAR_TPS_*.pdf`) — **opened only to read the page number** (`p.NN`); the markdown carries no page numbers |
-| page-number script | `python .codebuddy/skills/sync-autosar-class/pdf_page.py <ClassName> [--pdf PATH] [--table <N.M>]` — finds `Table N.M: <ClassName>` across every `autosar/R*/pdf/` corpus (R23-11, R4.3.1) and prints `p.NN` (cached per-PDF index; `--refresh` rescans). Use it in Steps 1/4 whenever the `# Spec:` line needs `p.NN` |
+| page-number script | `python .claude/skills/sync-autosar-class/pdf_page.py <ClassName>` — **the only way to get `p.NN`**. Scans every `autosar/R*/pdf/*.pdf` (R23-11, R4.3.1, R4.4.0, …) and prints one line per match: `<release>/<pdf> | Table N.M: <ClassName> | p.<page>`. `--pdf PATH` searches one PDF (any path); `--table <N.M>` searches by table id; the per-PDF index is cached (`.pdf_table_cache.json` at the repo root, keyed by the PDF's mtime) and `--refresh` rebuilds it after corpus updates. Use it in Steps 1/4 whenever the `# Spec:` line needs `p.NN` |
 | deviation records | the project deviation tracker (format in *Rule 0014*) |
 | XSD ground truth | per synced release: `autosar/R23-11/xsd/AUTOSAR_00052.xsd` · `autosar/R4.3.1/xsd/AUTOSAR_00044.xsd` |
 
@@ -215,7 +218,7 @@ as each step finishes (*Rule 0018*).
 
 **Essence per step** (full detail in `rules.md`):
 
-- **1** — Extract `Note`/`Base`/`Attribute` rows in displayed order; confirm Class-vs-Enumeration header. Run `python .codebuddy/skills/sync-autosar-class/pdf_page.py <ClassName>` for the `p.NN` page (the PDF is opened only for the page number). *Rule 0015* arbitrates XSD-vs-PDF/markdown attribute conflicts (the PDF/markdown table wins — model nothing the PDF lacks).
+- **1** — Extract `Note`/`Base`/`Attribute` rows in displayed order; confirm Class-vs-Enumeration header. Run `python .claude/skills/sync-autosar-class/pdf_page.py <ClassName>` for the `p.NN` page (the PDF is opened only for the page number — always via the script). *Rule 0015* arbitrates XSD-vs-PDF/markdown attribute conflicts (the PDF/markdown table wins — model nothing the PDF lacks).
 - **2** — `test_initialization` (defaults), `test_get_set_*` (round-trip + **None no-op**), `create*`/`add*` (append, duplicate returns existing). Abstract class → test `__init__` + base accessors via a concrete subclass.
 - **3** — Most-derived base from the `Base` chain; dedicated typed-list fields for `*` `aggr` (never registry filters); `createXxx` only for `Referrable` children; collect referenced missing classes and report in Step 8 (don't block). Enum (`AREnum`) → literals, not accessors.
 - **4** — **Wipe first, then rewrite.** Remove **all** existing docstrings — the class docstring, every method docstring (`__init__`, getters, setters, `create*`/`add*`), and every inline `__init__` member comment — so no stale wording survives a re-sync on renamed/removed/overlooked members (*Rule 0012.2.3*); keep the code, the `# Spec:` checklist block, and placeholder comments. Then copy the spec `Note` **verbatim from the markdown** into the **class docstring** (the class-level `Note` — **not** into `__init__`, which has no docstring), inline `__init__` **comments**, and getter/setter docstrings (page number via `pdf_page.py`, above); guarded setters append the None-no-op sentence. `__init__` members are declared as **PEP 526 annotated assignments** directly under their note comment — `self.foo: Optional[T] = None` / `self.foo: List[T] = []` — **never** a trailing `# type:` comment (*Rule 0003*).
@@ -223,7 +226,7 @@ as each step finishes (*Rule 0018*).
 - **6** — Reader populates via mutators (`readXxx`→`set/create/addXxx`), writer reads via getters (`writeXxx`→`getXxx`); cover wrapper lists + polymorphic five-place dispatch; **no chained mutator calls**. All types form matched name pairs across layers — model `setX`/`getX`, structure `readX`/`writeX`, element `getX`/`setX`, leaf `getChildElementOptional<T>`/`setChildElementOptional<T>` (*Rule 0013.2*); a cross pair (`setX1` ↔ `getX2`) is incorrect.
 - **7** — One row per method, source order, all `[x]`, 6-column format below (the last column is the per-row `release`). Writes the `# Spec:` line + method rows **only** — the `# Spec verified:` marker is added in Step 9b, never here.
 - **8** — Record deviations; the `# Spec verified:` marker (added in 9b) is **withheld** while any placeholder/deviation remains; report the Step-3 referenced classes here.
-- **9** — **(9a automated)** `pytest` + `flake8` + `ruff check` + `black-check` + the set-based script + a lossless integration round-trip (`npm run flake8` / `ruff-check` / `black-check` are the cross-platform forms). **Stop on any failure.** **(9b confirm — gate)** then present the **complete pre-stamp** rule-compliance checklist covering every check automation is blind to — element kind + every spec attr modeled (*0001.1*), most-derived base (*0001.2*), no fabrication/flattening + PDF-typed fields (*0001.3*), **Kind-suffix naming** `ref`→Ref/Refs·`tref`→TRef·`iref`→IRef/IRefs + singular `*`→plural (*0001.5*), create/set/add shape (*0001.6*), **reader+writer coverage** for every kept attr (*0001.7*), **member order** (*0011*), docstrings = spec `Note` **verbatim by diff** (*0012* **and** *0001.4* — every attribute's inline `__init__` comment + getter docstring + setter docstring must be the spec `Note` copied verbatim, not a "Gets/Sets the…" paraphrase or a truncated summary that drops the spec's full sentence), deviations resolved/removed (*0014*), stamp decision (*0012.1*) — and get explicit user confirmation; **when all pass, write the `# Spec verified:` marker in this step (9b)** — never in Step 4/7/8. Fix & re-present on any failure (*Rule 0006.1* has the full checklist). **Then finish the class per Rule 0017**: commit to the feature branch, flip the todo row to `[x]` with the commit hash, and stop the session (or, if all rows are `[x]`, report the sync complete).
+- **9** — **(9a automated)** `pytest` + `flake8` + `ruff check` + `black-check` + the set-based script + a lossless integration round-trip (`npm run flake8` / `ruff-check` / `black-check` are the cross-platform forms). **Stop on any failure.** **(9b confirm — gate)** then present the **complete pre-stamp** rule-compliance checklist covering every check automation is blind to — element kind + every spec attr modeled (*0001.1*), most-derived base (*0001.2*), no fabrication/flattening + PDF-typed fields (*0001.3*), **Kind-suffix naming** `ref`→Ref/Refs·`tref`→TRef·`iref`→IRef/IRefs + singular `*`→plural (*0001.5*), create/set/add shape (*0001.6*), **reader+writer coverage** for every kept attr (*0001.7*), **member order** (*0001.11*), docstrings = spec `Note` **verbatim by diff** (*0012* **and** *0001.4* — every attribute's inline `__init__` comment + getter docstring + setter docstring must be the spec `Note` copied verbatim, not a "Gets/Sets the…" paraphrase or a truncated summary that drops the spec's full sentence), deviations resolved/removed (*0014*), stamp decision (*0012.1*) — and get explicit user confirmation; **when all pass, write the `# Spec verified:` marker in this step (9b)** — never in Step 4/7/8. Fix & re-present on any failure (*Rule 0006.1* has the full checklist). **Then finish the class per Rule 0017**: commit to the feature branch, flip the todo row to `[x]` with the commit hash, and stop the session (or, if all rows are `[x]`, report the sync complete).
 
 **Workflow adaptations** (which steps still apply):
 
@@ -446,7 +449,7 @@ detail: *Rule 0002*.
 
 ## References
 
-- **Rules (self-contained):** `rules.md` in this skill folder — *Rule 0001*–*Rule 0018*.
+- **Rules (self-contained):** `rules.md` in this skill folder — *Rule 0001*–*Rule 0019*.
 - Coding standards: `docs/development/coding_rules.md`.
 - Spec markdown (primary — source of all text: `Note`, `Table N.M` id, table name): `autosar/R23-11/markdown/AUTOSAR_*_TPS_*.md` (`CP_TPS` + `FO_TPS`); R4.3.1 corpus: `autosar/R4.3.1/markdown/` (pre-split naming — no platform prefix; `TPS`/`RS`/`TR`).
 - Spec PDFs (opened only for the `p.NN` page number): `autosar/R23-11/pdf/AUTOSAR_*_TPS_*.pdf`; R4.3.1: `autosar/R4.3.1/pdf/`.

--- a/.agents/skills/sync-autosar-class/evals/evals.json
+++ b/.agents/skills/sync-autosar-class/evals/evals.json
@@ -50,7 +50,7 @@
     "Output checks field<->spec in both directions (for the enum: members vs Literal rows, no extra/missing)",
     "Output checks docstrings/comments copy the spec Note verbatim (verified by diff, not status)",
     "Output states the stamp decision: # Spec verified placed only if no unresolved deviation/placeholder remains",
-    "Output checks member order (Rule 0011) for the enum literals",
+    "Output checks member order (Rule 0001.11) for the enum literals",
     "Output states the 9b checklist is the complete pre-stamp sign-off (when all items pass, # Spec verified is warranted)",
     "Output asks the user to confirm before stamping the class or advancing to the next queue item",
     "No source files under src/armodel/models/ were modified"
@@ -59,12 +59,12 @@
   {
    "id": 5,
    "prompt": "Using the sync-autosar-class skill, you have just finished implementing the sync of the AUTOSAR class `NmNode` (CP SystemTemplate Table 6.303, abstract, base Identifiable) in py-armodel: Steps 1 through 9a are complete and all automated checks (pytest, flake8, ruff, black-check, set-based checklist script, round-trip) pass. Now perform Step 9b: present the post-sync rule-compliance confirmation for NmNode against its spec table. The current source is src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement.py and the spec markdown is autosar/R23-11/markdown/AUTOSAR_CP_TPS_SystemTemplate.md (Table 6.303). Do NOT modify any source files; just produce the confirmation. Repo root: /Users/ray/Workspace/py-armodel.",
-   "expected_output": "A Step 9b complete pre-stamp checklist for NmNode. It must flag at least: (a) the Kind-suffix/naming deviation TxNmPduRefs -> txNmPduRefs (and addTxNmPduRefs -> addTxNmPduRef) per Rule 0001.5; (b) the type drift nmCoordCluster ARNumerical->PositiveInteger and/or nmCoordinatorRole ARLiteral->NmCoordinatorRoleEnum and/or nmNodeId ARNumerical->Integer per Rule 0001.3; and it must check member order (Rule 0011) and reader/writer coverage (Rule 0001.7). It must conclude that # Spec verified may NOT be stamped while any 9b item fails, and ask the user to confirm.",
+   "expected_output": "A Step 9b complete pre-stamp checklist for NmNode. It must flag at least: (a) the Kind-suffix/naming deviation TxNmPduRefs -> txNmPduRefs (and addTxNmPduRefs -> addTxNmPduRef) per Rule 0001.5; (b) the type drift nmCoordCluster ARNumerical->PositiveInteger and/or nmCoordinatorRole ARLiteral->NmCoordinatorRoleEnum and/or nmNodeId ARNumerical->Integer per Rule 0001.3; and it must check member order (Rule 0001.11) and reader/writer coverage (Rule 0001.7). It must conclude that # Spec verified may NOT be stamped while any 9b item fails, and ask the user to confirm.",
    "expectations": [
     "Output presents a Step 9b complete pre-stamp rule-compliance checklist (not just 'tests pass')",
     "Output flags the Kind-suffix/naming deviation TxNmPduRefs (should be txNmPduRefs) under Rule 0001.5",
     "Output flags type drift vs the PDF (e.g. nmCoordCluster ARNumerical vs PositiveInteger, or nmCoordinatorRole ARLiteral vs NmCoordinatorRoleEnum) under Rule 0001.3",
-    "Output checks member order (Rule 0011) and reader/writer coverage (Rule 0001.7)",
+    "Output checks member order (Rule 0001.11) and reader/writer coverage (Rule 0001.7)",
     "Output concludes # Spec verified may NOT be stamped while any 9b item fails, and asks the user to confirm",
     "No source files under src/armodel/models/ were modified"
    ]

--- a/.agents/skills/sync-autosar-class/pdf_page.py
+++ b/.agents/skills/sync-autosar-class/pdf_page.py
@@ -14,8 +14,9 @@ Usage:
 Output (one line per match):
   <release>/<pdf filename> | Table <N.M>: <ClassName> | p.<page>
 
-A per-PDF text index is cached in `.pdf_table_cache.json` next to this script,
-keyed by the PDF's mtime, so repeated lookups do not re-scan the PDFs.
+A per-PDF text index is cached in `.pdf_table_cache.json` at the repo root (shared by
+every copy of this script), keyed by the PDF's mtime, so repeated lookups do not
+re-scan the PDFs.
 """
 
 from __future__ import annotations
@@ -26,7 +27,8 @@ import os
 import re
 import sys
 
-CACHE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".pdf_table_cache.json")
+_REPO_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..")
+CACHE_FILE = os.path.join(_REPO_ROOT, ".pdf_table_cache.json")
 AUTOSAR_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "autosar")
 
 
@@ -45,7 +47,7 @@ def scan_pdf(pdf_path):
         text = _pypdf_text(reader, i)
         if "Table" not in text:
             continue
-        for m in re.finditer(r"Table\s+(\d+\.\d+)\s*:\s*([A-Za-z0-9]+)", text):
+        for m in re.finditer(r"Table\s+(\d+\.\d+)\s*:\s*([A-Za-z0-9][A-Za-z0-9_\-]*)", text):
             tid, cls = m.group(1), m.group(2)
             if tid not in tables:
                 tables[tid] = [cls, i + 1, "Table %s: %s" % (tid, cls)]

--- a/.agents/skills/sync-autosar-class/rules.md
+++ b/.agents/skills/sync-autosar-class/rules.md
@@ -3,8 +3,9 @@
 Self-contained rule reference for syncing any AUTOSAR model class in py-armodel.
 `ClassName` denotes the class under check:
 
-- source: `src/armodel/models/M2/AUTOSARTemplates/<package>/<ClassName>.py`
-  (or `<package>/<ClassName>/__init__.py`)
+- source: `src/armodel/models/M2/AUTOSARTemplates/<package>/<Pkg>.py`
+  (leaf package → file named after the package tail; non-leaf package →
+  `<package>/__init__.py`; never a class-named submodule — Rule 0007)
 - mirrored test: `tests/test_armodel/models/M2/AUTOSARTemplates/<package>/test_<ClassName>.py`
 - spec table: the class's attribute table (markdown
   `autosar/R23-11/markdown/AUTOSAR_*_TPS_*.md` (covers `CP_TPS` + `FO_TPS`), derived from PDF
@@ -15,7 +16,10 @@ Self-contained rule reference for syncing any AUTOSAR model class in py-armodel.
   `AUTOSAR_00044.xsd`). **All text** —
   `Note`, `Attribute`, `Base`, the `Table N.M` id, and the table name (from the markdown
   filename) — **is read from the markdown**; the **PDF is opened only for the page
-  number** (`p.NN`), because the markdown carries no page numbers.
+  number** (`p.NN`), because the markdown carries no page numbers — look it up with the
+  page-number script `python .claude/skills/sync-autosar-class/pdf_page.py <ClassName>`
+  (`--pdf PATH` for a single PDF, `--table N.M` by table id, `--refresh` to rescan;
+  Rule 0012.2.1).
 
 **IDs:** rules carry contiguous 4-digit IDs (`Rule 0001` …). Each notes its former
 number for traceability. The 9-step workflow in `SKILL.md` references these IDs.
@@ -414,7 +418,7 @@ next sync/drift pass (Rule 0012.3), which adds it.
 - Every row fully `[x]` (impl **and** docstring **and** test **and** reader/writer as
   applicable); a `[ ]` whose obligation is actually done is stale — cross it. A row is
   `[x]` only when all obligations are complete and verified.
-- Rows in **source order** matching the methods (Rule 0011).
+- Rows in **source order** matching the methods (Rule 0001.11).
 - The `# Spec:` line names the correct PDF/table/page — the table name and the `Table
   N.M` id are read from the **markdown** (`autosar/R23-11/markdown/AUTOSAR_*_TPS_*.md`, `CP_TPS` or
   `FO_TPS`); only the **`p.NN` page number** is read from the **PDF**
@@ -594,9 +598,9 @@ python -m pytest tests/test_armodel/models/M2/AUTOSARTemplates/<package>/test_<C
 # Step 5 reader/writer tests live in their own folders — run the files you touched:
 #   tests/test_armodel/parser/test_<feature>.py   and   tests/test_armodel/writer/test_writer_<feature>.py
 python -m pytest tests/test_armodel/parser/ tests/test_armodel/writer/ -q
-PATH=".venv/Scripts:$PATH" flake8 --exclude=.venv,build --select=E9,F63,F7,F82 \
+flake8 --exclude=.venv,build --select=E9,F63,F7,F82 \
   src/armodel/models/M2/AUTOSARTemplates/<package>/<ClassName>.py
-PATH=".venv/Scripts:$PATH" ruff check \
+ruff check \
   src/armodel/models/M2/AUTOSARTemplates/<package>/<ClassName>.py
 npm run ruff-check && npm run black-check
 ```
@@ -622,7 +626,7 @@ assert not untested, f"methods without test coverage: {untested}"
 # Marker check — run AFTER Step 9b (the marker is written there on user-confirmation;
 # during 9a it is legitimately absent).
 if "# Spec:" in src and "not yet implemented" not in src and "carried as a" not in src:
-    assert re.search(r"# Spec verified: R\d\d-\d\d|# XSD verified: \S+\.xsd", src), "missing # Spec verified / # XSD verified (with XSD filename) marker"
+    assert re.search(r"# Spec verified: (R\d\d-\d\d|R4\.3\.1)|# XSD verified: \S+\.xsd", src), "missing # Spec verified / # XSD verified (with XSD filename) marker"
 ```
 
 ### 0006.1 Post-sync rule-compliance confirmation (gate)
@@ -664,7 +668,7 @@ end user's explicit confirmation. When every item passes, the `# Spec verified:
   existence is not evidence a given aggregator calls it). The names also form the
   matched pairs of **Rule 0013.2** at every layer — a cross pair (`setX1` ↔ `getX2`)
   fails this check.
-- **Rule 0011 (member order)** — fields, accessor groups, and checklist rows are in
+- **Rule 0001.11 (member order)** — fields, accessor groups, and checklist rows are in
   displayed PDF row order.
 - **Rule 0012 (docstrings & comments)** — checked **one by one for every member**
   (walk the Rule 0012.2 per-attribute loop): the class docstring, then for **each**
@@ -896,10 +900,13 @@ is one ordered procedure per class (Rule 0006's mechanical check only confirms t
    carries `# Spec: … <xsd-file> line <NNNN> (XSD-only; …)` and
    `# XSD verified: <xsd-file>` (Rule 0002) and the workflow is done — treat it like a
    `Spec verified` class. Otherwise continue.
-1. Locate the spec table in the **markdown** (`grep "Table N.M: <ClassName>
-   autosar/R23-11/markdown/*.md`) — its `Note`/`Attribute`/`Base` text and the `Table N.M` id are
-   the extraction source; then read **only the page number** from the **PDF** via `pypdf`
-   (matching the printed footer) for the `p.NN` citation.
+1. Locate the spec table in the **markdown** (`grep "Table N.M: <ClassName>" autosar/R23-11/markdown/AUTOSAR_*_TPS_*.md`) — its `Note`/`Attribute`/`Base` text and the `Table N.M` id are
+   the extraction source; then read **only the page number** for the `p.NN` citation with the
+   page-number script: `python .claude/skills/sync-autosar-class/pdf_page.py <ClassName>`
+   (prints one line per match: `<release>/<pdf> | Table N.M: <ClassName> | p.<page>`; scan every
+   `autosar/R*/pdf/*.pdf` by default, or pass `--pdf <path>` to search one PDF and `--table <N.M>`
+   to search by table id; the per-PDF index is cached in `.pdf_table_cache.json` at the repo root,
+   keyed by the PDF's mtime — run with `--refresh` after replacing corpus PDFs).
 2. Add the `# Spec:` citation line (the `# Spec verified:` marker is **not** added here —
    it is written in Step 9b after the user confirms).
 3. **Wipe ALL existing docstrings & member comments first.** Before writing any new
@@ -921,7 +928,7 @@ is one ordered procedure per class (Rule 0006's mechanical check only confirms t
 5. **Per-attribute loop** (all five, per attribute, before the next):
    1. Referenced type must exist and be synced before typing (Rule 0010/0011); its
       `# Spec:` cites its **own** table, independent of the owning class.
-2. Inline `__init__` **comment** (not a docstring — `__init__` has no docstring): the
+   2. Inline `__init__` **comment** (not a docstring — `__init__` has no docstring): the
        attribute's `Note` (markdown) semantic sentence, copied verbatim (drop
        `Stereotypes:`/`Tags:` tail); append any `constr_*` wording + id. The member is
        then declared **directly below the comment** as a PEP 526 annotated assignment —
@@ -1177,7 +1184,7 @@ For each class K in the closure:
    `FO_TPS`).
 2. Found → record `source = markdown`, capture `Table N.M` id, table name, `Note`,
    `Attribute` rows, `Base` column.
-3. Not found in R23-11 markdown → open `autosar/R23-11/pdf/AUTOSAR_*_TPS_*.pdf` (search via `pypdf`)
+3. Not found in R23-11 markdown → search the PDFs with the page-number script (`python .claude/skills/sync-autosar-class/pdf_page.py <ClassName>` — it scans `autosar/R23-11/pdf/AUTOSAR_*_TPS_*.pdf`)
    for K's table.
 4. Found in PDF only → record `source = pdf` and re-extract via the same markdown
    convention; if the PDF is the only carrier, mark `source = pdf-only`.
@@ -1392,6 +1399,28 @@ row exists.
 - Marking `[x]` without a commit hash, or deferring commits to the end (17.2).
 - Re-running Phase 0 when the todo file already exists (17.1).
 
+### 17.5 Autonomous mode — chaining classes
+
+When the user asks the sync to run **automatically** (e.g. "continue the sync
+automatically", "do the remaining classes in one go"), automation relaxes exactly
+**one** thing: the **between-class session pause** (17.1). Everything else is
+unchanged:
+
+- **9b stays mandatory for every class, in every mode.** Present the complete 9b
+  checklist to the user and wait for explicit confirmation before writing
+  `# Spec verified:` — automation never self-stamps from subagent evidence
+  (user correction, 2026-08-21).
+- **Chaining = isolated per-class subagents.** The orchestrator dispatches one
+  subagent per class — a fresh context each, which is what preserves 17.1's
+  no-degradation property — applies the subagent's result, then presents 9b to
+  the user itself. The orchestrator session never runs a second class's 9-step
+  workflow in its own context.
+- After the user confirms 9b for a class: write the stamp, do the 17.2 commit,
+  flip the todo row to `[x]` with the hash, then dispatch the next class
+  **without** asking the user to start a new session.
+- Any subagent failure, missing confirmation, or unanswered gate **stops the
+  chain** — never skip or defer a gate to keep the loop moving.
+
 ## Rule 0018 — Step-level session todos (per class)
 
 While running the 9-step workflow, mirror the steps into the **session todo
@@ -1523,8 +1552,8 @@ column; all other rows stay `<TARGET>`:
 
 (R4.3.1 markdown tables render table bodies **before** their captions — the body rows
 for `Table N.M` may sit under the preceding caption; verify Class/Package/Note rows
-belong to the class before copying, and take page numbers from the older PDF via
-`pypdf`.)
+belong to the class before copying, and take page numbers from the older PDF with
+`python .claude/skills/sync-autosar-class/pdf_page.py <ClassName> --pdf autosar/R4.3.1/pdf/<name>.pdf`.)
 
 **Deviation (Rule 0014) — accepted reason code:**
 `legacy (<OLDER> Table N.M, pp.X-Y); removed in <TARGET>` — one row per merged


### PR DESCRIPTION
Closes #699

## Summary
Applies the full audit of the `sync-autosar-class` skill (v1.9.1 → v1.9.2). Scope is skill-infra only — 4 files under `.agents/skills/sync-autosar-class/`; no `src/` or `tests/` changes.

## Changes
**Bugs**
- 9a marker assert now accepts `R4.3.1` stamps (`# Spec verified: (R\d\d-\d\d|R4\.3\.1)`) — legitimate Rule 0016.3 fallback classes previously failed the set-based check
- member-order refs corrected `Rule 0011` → `Rule 0001.11` (member order never was Rule 0011 — that's Enum Specification Sync)
- rules.md header source path aligned with Rule 0007 (no class-named submodule)
- fixed broken grep in Rule 0012.2.1 (unclosed quote, wrong glob)
- rule range statements updated to 0001–0019

**Gaps closed**
- New **Rule 0017.5 — autonomous mode**: chaining classes relaxes only the between-class session pause; per-class subagents stay isolated; **9b user confirmation remains mandatory in every mode**
- `pdf_page.py` documented as the sole page-number tool (no more manual pypdf instructions); `--pdf PATH` / `--table N.M` / `--refresh` usage spelled out

**Improvements**
- pdf_page.py: shared repo-root cache (one `.pdf_table_cache.json` instead of 3 per-copy caches); hyphenated class names (`CAN-XL-PROPS`) now match
- Minor: `.claude` script paths, 0012.2.5 list indent, stale Windows venv `PATH` removed

## Test plan
- [x] YAML frontmatter parses
- [x] `py_compile` on pdf_page.py
- [x] `evals.json` valid JSON
- [x] pdf_page.py smoke test: `NmNode` → `R23-11 ... Table 6.303 | p.676`, `CanTpChannelModeType` → `R4.3.1 ... Table 6.200 | p.389` (root cache reused)
- [x] marker regex unit-checked against `R23-11` / `R4.3.1` / XSD forms
- [x] skill copies under `.claude/` + `.codebuddy/` are hardlinks — verified identical via `diff`