### PR TITLE
Add AUTOSAR R4.3.1 standard reference docs via Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# AUTOSAR R4.3.1 standard reference docs — large binary/text files tracked via Git LFS
+autosar/R4.3.1/pdf/** filter=lfs diff=lfs merge=lfs -text
+autosar/R4.3.1/markdown/** filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,3 @@ uv.lock
 .codebuddy
 # pdf_page.py per-PDF table cache
 .pdf_table_cache.json
-# Large AUTOSAR reference docs (markdown/PDF) are not tracked
-autosar/R4.3.1/markdown/
-autosar/R4.3.1/pdf/

--- a/autosar/R4.3.1/markdown/AUTOSAR_RS_BSWModuleDescriptionTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_RS_BSWModuleDescriptionTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1adee68656cebf84a7bc29a16da477d78877c86e3c1227bd4724c3e979a7d282
+size 1552403

--- a/autosar/R4.3.1/markdown/AUTOSAR_RS_DiagnosticExtractTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_RS_DiagnosticExtractTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8f2d513355c82a7e1650ca4ad188b5f015c5275acff12f4d87e72c7c2f78b22
+size 613507

--- a/autosar/R4.3.1/markdown/AUTOSAR_RS_ECUConfiguration.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_RS_ECUConfiguration.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1820857acaa3aa3b90e9c592628b2324a50d85c13ba3f732b83685be5eaebcf
+size 521921

--- a/autosar/R4.3.1/markdown/AUTOSAR_RS_ECUResourceTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_RS_ECUResourceTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2b5107fcd3eacc0696f63eebf1fc328fa7689656ea214b08735abe501327dd6
+size 225915

--- a/autosar/R4.3.1/markdown/AUTOSAR_RS_FeatureModelExchangeFormat.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_RS_FeatureModelExchangeFormat.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcf790571b79242fa391c5382ae2bf313ea2b741ce958ff07294e7d250893c0f
+size 555191

--- a/autosar/R4.3.1/markdown/AUTOSAR_RS_MethodologyAndTemplatesGeneral.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_RS_MethodologyAndTemplatesGeneral.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97625486b44282e07d82c96dc5a65e3fd355eb64153983b5727b0c02916fe623
+size 264389

--- a/autosar/R4.3.1/markdown/AUTOSAR_RS_SoftwareComponentTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_RS_SoftwareComponentTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f486febf81c933162724d845953e16528a182f47196b1d5eb55b47dfdb5347d8
+size 753031

--- a/autosar/R4.3.1/markdown/AUTOSAR_RS_StandardizationTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_RS_StandardizationTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89b918daa687b4ef1f4b82ad38b2478392f0f05941e29990c8a6318c8e100539
+size 832412

--- a/autosar/R4.3.1/markdown/AUTOSAR_RS_SystemTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_RS_SystemTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d04a67b9347475338d3b4e7da6d10be3246701bc721cd55f7defc73c9fe9d7e
+size 491958

--- a/autosar/R4.3.1/markdown/AUTOSAR_RS_TimingExtensions.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_RS_TimingExtensions.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5724bbac9f3f5fb177b0ffcea48d51811bc7ddd07609ac7ea9b7f36fd3bb59bf
+size 1027720

--- a/autosar/R4.3.1/markdown/AUTOSAR_TPS_ARXMLSerializationRules.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TPS_ARXMLSerializationRules.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c44da9d6acc714000dc5a02319c8462e68f7e4fe238706d78e14f90dfed763b7
+size 783402

--- a/autosar/R4.3.1/markdown/AUTOSAR_TPS_BSWModuleDescriptionTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TPS_BSWModuleDescriptionTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d7baf00550ccf126280076d6666b210874bc8c5e5c766ce7370d001da165c92
+size 15492117

--- a/autosar/R4.3.1/markdown/AUTOSAR_TPS_DiagnosticExtractTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TPS_DiagnosticExtractTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc490008035c8e83e3773e9a2f425aac91ea09987432bfb0249bcea626882c30
+size 23009994

--- a/autosar/R4.3.1/markdown/AUTOSAR_TPS_ECUConfiguration.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TPS_ECUConfiguration.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18e411ec9d1086ee6bfbe04abd7278930afcd3ac1e648a27bf5a0256842d6989
+size 14369994

--- a/autosar/R4.3.1/markdown/AUTOSAR_TPS_ECUResourceTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TPS_ECUResourceTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e77eb84dfa3205d23c30001b5b59a81d4f5071104133b2159dcd057e3441b4cf
+size 1341686

--- a/autosar/R4.3.1/markdown/AUTOSAR_TPS_FeatureModelExchangeFormat.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TPS_FeatureModelExchangeFormat.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31402f99cc15a97d4ab0683328bd11f508642471b65df94458c9fd768837873d
+size 2316195

--- a/autosar/R4.3.1/markdown/AUTOSAR_TPS_GenericStructureTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TPS_GenericStructureTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:469869880378d35e747d73c4a7fe6bea51ae01b41442ed59dfc7ef2b0a876b76
+size 16260096

--- a/autosar/R4.3.1/markdown/AUTOSAR_TPS_SoftwareComponentTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TPS_SoftwareComponentTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f13cb853691a6f692d2abdb96a4a013e185c88ad4fa36fba539deee5b60d5257
+size 59925918

--- a/autosar/R4.3.1/markdown/AUTOSAR_TPS_StandardizationTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TPS_StandardizationTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68161c4a0c409a21858d2846d9f26e759ddbc1c90d73cdef9312f7b79f270231
+size 9774569

--- a/autosar/R4.3.1/markdown/AUTOSAR_TPS_SystemTemplate.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TPS_SystemTemplate.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2be4378165b3481d2595676f5873106dbdd2c16c5faa762ac9c14e879759e93
+size 68105393

--- a/autosar/R4.3.1/markdown/AUTOSAR_TPS_TimingExtensions.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TPS_TimingExtensions.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05de01805d350d7e9a7379942927b041443f32ed813708a0c111653a6046b6c8
+size 12605191

--- a/autosar/R4.3.1/markdown/AUTOSAR_TPS_XMLSchemaProductionRules.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TPS_XMLSchemaProductionRules.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cffeaccd2a623d3a62fca11d300e6083ca0d4ea7b69366e52cf9638382c2487
+size 7174449

--- a/autosar/R4.3.1/markdown/AUTOSAR_TR_AutosarModelConstraints.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TR_AutosarModelConstraints.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b680ceae52b7650d7665d35d37c0ce0fc64cbe2bdf35c06e943e8773f7c3d0
+size 3008349

--- a/autosar/R4.3.1/markdown/AUTOSAR_TR_FrancaIntegration.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TR_FrancaIntegration.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfdfa2c1ebb852926fc54d66add4ffe64d1a90ad4876ffd177e049af9c0dcec2
+size 2193464

--- a/autosar/R4.3.1/markdown/AUTOSAR_TR_GeneralBlueprintsSupplement.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TR_GeneralBlueprintsSupplement.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ade40a9443034d3bb99e9a1197f1a45ff08b2763d8283a7857efcbbc0a095ac9
+size 4186920

--- a/autosar/R4.3.1/markdown/AUTOSAR_TR_Methodology.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TR_Methodology.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afbf4ea2e9f2e8ca7ff24019f9f28c7ee9781f83da5405c67ee6e0b137edf602
+size 31942542

--- a/autosar/R4.3.1/markdown/AUTOSAR_TR_ModelingShowCases.md
+++ b/autosar/R4.3.1/markdown/AUTOSAR_TR_ModelingShowCases.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8e1bd729633c108ca3e621841b8208e0359870de00e16054585079a868d9792
+size 4217325

--- a/autosar/R4.3.1/pdf/AUTOSAR_RS_BSWModuleDescriptionTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_RS_BSWModuleDescriptionTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e1dcc323d944298963c8bb66a835bbfe4b2852b28ded8f42e0cd24b215ceb29
+size 283197

--- a/autosar/R4.3.1/pdf/AUTOSAR_RS_DiagnosticExtractTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_RS_DiagnosticExtractTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25922560e47dc541b567c1a94c262766f01f8cbc8c12329ee9d9bebb5d6ce7d8
+size 265254

--- a/autosar/R4.3.1/pdf/AUTOSAR_RS_ECUConfiguration.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_RS_ECUConfiguration.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e53598ac9b08cb89f326d0757ae79251e6822503f5246c671627d5a6fd72cfb
+size 209105

--- a/autosar/R4.3.1/pdf/AUTOSAR_RS_ECUResourceTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_RS_ECUResourceTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1d2a011f0901202e4ead17aa95ce1e1e3416241b58f6b49c3fd5d9fe1236518
+size 112737

--- a/autosar/R4.3.1/pdf/AUTOSAR_RS_FeatureModelExchangeFormat.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_RS_FeatureModelExchangeFormat.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3b210fc18a14e854ec4cc095f9043e80cc57c91084a08f82f85983f8e08f75e
+size 170848

--- a/autosar/R4.3.1/pdf/AUTOSAR_RS_MethodologyAndTemplatesGeneral.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_RS_MethodologyAndTemplatesGeneral.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b229d5ab57eb8ea8d651675ff0a8f7b69257d42975eace6899297de22a8bdd1
+size 115279

--- a/autosar/R4.3.1/pdf/AUTOSAR_RS_SoftwareComponentTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_RS_SoftwareComponentTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:198f262276fc9898919b82c21bb62a7dcf33faee70f807e11d96a4aef651427c
+size 318591

--- a/autosar/R4.3.1/pdf/AUTOSAR_RS_StandardizationTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_RS_StandardizationTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5300d914dd814a73852e65694cad126487df66b08452981029c1ed454bdc8dba
+size 387596

--- a/autosar/R4.3.1/pdf/AUTOSAR_RS_SystemTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_RS_SystemTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a6b8363d25db794b8bb7369b79b82c2009e65b250fa3ec9df5a0ab33061c570
+size 239229

--- a/autosar/R4.3.1/pdf/AUTOSAR_RS_TimingExtensions.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_RS_TimingExtensions.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0866a233dd9be52d349732021740f61699650d26cc30902c89fc835d860c9430
+size 223581

--- a/autosar/R4.3.1/pdf/AUTOSAR_TPS_ARXMLSerializationRules.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TPS_ARXMLSerializationRules.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3346336762c475affc7fd2e4617a2937cb7702431a16396a49171642ef70f4ea
+size 274680

--- a/autosar/R4.3.1/pdf/AUTOSAR_TPS_BSWModuleDescriptionTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TPS_BSWModuleDescriptionTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f2ec98d930ed13faa9733d407f2036696a9dfb329cb491ef88ca0554675ff3b
+size 2766135

--- a/autosar/R4.3.1/pdf/AUTOSAR_TPS_DiagnosticExtractTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TPS_DiagnosticExtractTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91796123d82f79a38f31edc63eb4368e91da45854cc1a964fd4ad188f2b4c151
+size 3791181

--- a/autosar/R4.3.1/pdf/AUTOSAR_TPS_ECUConfiguration.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TPS_ECUConfiguration.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c57cddc2681ed77e23f7fa435bcd876ffc291eae09dc6500f70e2734d69c0eaa
+size 2941152

--- a/autosar/R4.3.1/pdf/AUTOSAR_TPS_ECUResourceTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TPS_ECUResourceTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed2026dba38c400433080a3315604914d38702826aaa463a01c5e82d6faeabec
+size 478002

--- a/autosar/R4.3.1/pdf/AUTOSAR_TPS_FeatureModelExchangeFormat.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TPS_FeatureModelExchangeFormat.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:949728bb70f772bca69a7b229f03d313cb0048fdf78b4e3663153b4909978038
+size 954392

--- a/autosar/R4.3.1/pdf/AUTOSAR_TPS_GenericStructureTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TPS_GenericStructureTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acac07ec46239d5d8bf05fcdcb74854a17cf9c8d236e2ab3e2bbe06072d9ef9f
+size 3706412

--- a/autosar/R4.3.1/pdf/AUTOSAR_TPS_SoftwareComponentTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TPS_SoftwareComponentTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dc66beeeac8ebb708168be64fd881f00dece8d09e4255f854e5503697f45425
+size 12178855

--- a/autosar/R4.3.1/pdf/AUTOSAR_TPS_StandardizationTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TPS_StandardizationTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7aefc9907dffbdd98b10a5a32bf76ed6e2eab74136f5aab67008d4ad3453fbb2
+size 3493674

--- a/autosar/R4.3.1/pdf/AUTOSAR_TPS_SystemTemplate.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TPS_SystemTemplate.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5633caa9d5d4c4da1acf94ee1969ab095bfb11a97ca952c1aba7eac0b5a61ce
+size 11980345

--- a/autosar/R4.3.1/pdf/AUTOSAR_TPS_TimingExtensions.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TPS_TimingExtensions.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:933afb0c84c3491916bcd7f80a9f7046dc81eb9aec69ab657589a3047e0d6b50
+size 2627328

--- a/autosar/R4.3.1/pdf/AUTOSAR_TPS_XMLSchemaProductionRules.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TPS_XMLSchemaProductionRules.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:675d07ee46656b9240889f7b9dc9cf18237e18413ac5ffc63c031988395cc6c1
+size 1432396

--- a/autosar/R4.3.1/pdf/AUTOSAR_TR_AutosarModelConstraints.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TR_AutosarModelConstraints.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c6ab9a50d35ae6c255f62d5d14e65b4d07e329751a59e557318f13334feb783
+size 1024025

--- a/autosar/R4.3.1/pdf/AUTOSAR_TR_FrancaIntegration.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TR_FrancaIntegration.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14cf4a3ac7f92af15df032c73e29713a514ad05d78d7d38e0f5f15d8c5f7dcda
+size 747206

--- a/autosar/R4.3.1/pdf/AUTOSAR_TR_GeneralBlueprintsSupplement.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TR_GeneralBlueprintsSupplement.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a285be59d023f6abcc0f24af1623dbef79905c671f34d22f6c356ba2c5a4b90
+size 656667

--- a/autosar/R4.3.1/pdf/AUTOSAR_TR_Methodology.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TR_Methodology.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95656dd48d64dec9ac156a647906c6305d7a1e6f6ed045f07db94a6903c3962b
+size 4363167

--- a/autosar/R4.3.1/pdf/AUTOSAR_TR_ModelingShowCases.pdf
+++ b/autosar/R4.3.1/pdf/AUTOSAR_TR_ModelingShowCases.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f3f25ac916b8620a418c65d222b01da66bf10bc940446e82061dd9d44da8be3
+size 1854888

--- a/docs/examples/method_deviation_by_class_v2.md
+++ b/docs/examples/method_deviation_by_class_v2.md
@@ -767,6 +767,15 @@ the Python sources. Classes whose checklist carries `# Spec verified: R<YY>-<MM>
 |---|---|---|---|---|---|
 | — *(missing)* | `—` | `-` | ``-`` | - | missing |
 
+## `PPortPrototype`
+- **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** —  | **table:** Table 3.6
+- **Package:** `M2::AUTOSARTemplates::SWComponentTemplate::Components`
+- **Source:** `src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py`
+
+| Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
+|---|---|---|---|---|---|
+| `providedInterfaceTRef` | `TRefType` | `providedInterface` | ``PortInterface`` | tref | type (PDF PortInterface vs py TRefType) |
+
 ## `RPortPrototype`
 - **PDF:** `AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf`  | **page:** —  | **table:** Table 3.5
 - **Package:** `M2::AUTOSARTemplates::SWComponentTemplate::Components`

--- a/docs/plan/sync-todo/Group2.md
+++ b/docs/plan/sync-todo/Group2.md
@@ -58,7 +58,7 @@ Input: `Group 2 — PortInterface sets, components, SWC behavior, datatypes` of 
   - [x] Step 7 — Update checklist comment — 6-col, single __init__ row ([—] reader / [—] writer: no own XML members; symbol rows live on the stamped base ImplementationProps Table 5.20 checklist) with `# Spec: R23-11/AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 5.21, p.288 (R23-11)`; marker deferred to 9b
   - [x] Step 8 — Deviations — none; no placeholders; no Step-3 referenced missing classes (member types: CIdentifier primitive only)
   - [ ] Step 9 — Verify (9a) + confirm (9b)
-- [ ] `PPortPrototype` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.6)
+- [x] `PPortPrototype` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.6) — commit `09273330`
   - [x] Step 1 — Sync members & description from spec
   - [x] Step 2 — Write model class unit test (Red)
   - [x] Step 3 — Implement model class (Green)

--- a/docs/plan/sync-todo/Group2.md
+++ b/docs/plan/sync-todo/Group2.md
@@ -59,15 +59,15 @@ Input: `Group 2 — PortInterface sets, components, SWC behavior, datatypes` of 
   - [x] Step 8 — Deviations — none; no placeholders; no Step-3 referenced missing classes (member types: CIdentifier primitive only)
   - [ ] Step 9 — Verify (9a) + confirm (9b)
 - [ ] `PPortPrototype` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.6)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 1 — Sync members & description from spec
+  - [x] Step 2 — Write model class unit test (Red)
+  - [x] Step 3 — Implement model class (Green)
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red)
+  - [x] Step 6 — Update parser & writer (Green)
+  - [x] Step 7 — Update checklist comment
+  - [x] Step 8 — Deviations
+  - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] `RPortPrototype` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.5)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
@@ -680,21 +680,36 @@ class AbstractRequiredPortPrototype(PortPrototype):
 
 
 class PPortPrototype(AbstractProvidedPortPrototype):
+    """
+    Component port providing a certain port interface.
+    """
+
     # PPortPrototype method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getProvidedInterfaceTRef     [x] impl  [ ] docstring  [ ] test
-    # [ ] setProvidedInterfaceTRef     [x] impl  [ ] docstring  [ ] test
+    # Spec: R23-11/AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 3.6, p.68 (R23-11)
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer / release   ([—] = no XML element)
+    # [x] __init__                        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer  R23-11
+    # [x] getProvidedInterfaceTRef        [x] impl  [x] docstring  [x] test  [x] reader  [x] writer  R23-11
+    # [x] setProvidedInterfaceTRef        [x] impl  [x] docstring  [x] test  [x] reader  [x] writer  R23-11
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.providedInterfaceTRef = None  # type: TRefType
+        # The interface that this port provides. Stereotypes: isOfType
+        self.providedInterfaceTRef: Optional[TRefType] = None
 
     def getProvidedInterfaceTRef(self):
+        """
+        The interface that this port provides. Stereotypes: isOfType
+        """
         return self.providedInterfaceTRef
 
-    def setProvidedInterfaceTRef(self, value):
-        self.providedInterfaceTRef = value
+    def setProvidedInterfaceTRef(self, value: Optional[TRefType]):
+        """
+        The interface that this port provides. Stereotypes: isOfType
+        """
+        if value is not None:
+            self.providedInterfaceTRef = value
         return self
 
 

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -5370,22 +5370,22 @@ class ARXMLParser(AbstractARXMLParser):
                 self.raiseError("Unsupported RequiredComSpec <%s>" % tag_name)
 
     def readAbstractRequiredPortPrototype(self, element: ET.Element, prototype: AbstractRequiredPortPrototype):
-        self.readProvidedComSpec(element, prototype)
+        self.readRequiredComSpec(element, prototype)
 
     def readPPortPrototype(self, element: ET.Element, prototype: PPortPrototype):
         # self.logger.debug("Read PPortPrototype %s" % prototype.getShortName())
         self.readIdentifiable(element, prototype)
-        self.readAbstractRequiredPortPrototype(element, prototype)
+        self.readAbstractProvidedPortPrototype(element, prototype)
         prototype.setProvidedInterfaceTRef(self.getChildElementOptionalRefType(element, "PROVIDED-INTERFACE-TREF"))
         self.readPortPrototype(element, prototype)
 
     def readAbstractProvidedPortPrototype(self, element: ET.Element, prototype: AbstractProvidedPortPrototype):
-        self.readRequiredComSpec(element, prototype)
+        self.readProvidedComSpec(element, prototype)
 
     def readRPortPrototype(self, element: ET.Element, prototype: RPortPrototype):
         # self.logger.debug("Read RPortPrototype %s" % prototype.getShortName())
         self.readIdentifiable(element, prototype)
-        self.readAbstractProvidedPortPrototype(element, prototype)
+        self.readAbstractRequiredPortPrototype(element, prototype)
         prototype.setRequiredInterfaceTRef(self.getChildElementOptionalRefType(element, "REQUIRED-INTERFACE-TREF"))
         self.readPortPrototype(element, prototype)
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/test___init__.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/test___init__.py
@@ -4,7 +4,10 @@ AUTOSAR SWComponentTemplate module.
 """
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    RefType,
+    TRefType,
+)
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import (
     PortGroup,
     PPortPrototype,
@@ -125,3 +128,32 @@ class TestSwComponentType:
         assert ref in obj.getUnitGroupRefs()
         obj.addUnitGroupRef(None)
         assert len(obj.getUnitGroupRefs()) == 1
+
+
+class TestPPortPrototype:
+    """
+    Test class for PPortPrototype functionality (Table 3.6).
+    """
+
+    def _create_prototype(self) -> PPortPrototype:
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        return PPortPrototype(ar_root, "TestPPort")
+
+    def test_initialization(self):
+        obj = self._create_prototype()
+        assert obj.getShortName() == "TestPPort"
+        assert obj.getProvidedInterfaceTRef() is None
+
+    def test_class_docstring_is_spec_note_verbatim(self):
+        assert PPortPrototype.__doc__.strip() == "Component port providing a certain port interface."
+
+    def test_get_set_providedInterfaceTRef(self):
+        obj = self._create_prototype()
+        tref = TRefType()
+        tref.setValue("/AUTOSAR/SomeInterface")
+        tref.setDest("ASYNCHRONOUS-SERVER-CALL-RESULT-POINT")
+        assert obj.setProvidedInterfaceTRef(tref) is obj
+        assert obj.getProvidedInterfaceTRef() == tref
+        obj.setProvidedInterfaceTRef(None)
+        assert obj.getProvidedInterfaceTRef() == tref

--- a/tests/test_armodel/writer/test_writer_sw_component.py
+++ b/tests/test_armodel/writer/test_writer_sw_component.py
@@ -899,7 +899,14 @@ class TestSwComponentTypeRoundTrip:
         document.setARRelease("R23-11")
         pkg = document.createARPackage("Swcs")
         app = pkg.createApplicationSwComponentType("App")
-        app.createPPortPrototype("PPort")
+        p_port = app.createPPortPrototype("PPort")
+        p_tref = TRefType()
+        p_tref.setValue("/If/SR")
+        p_tref.setDest("SENDER-RECEIVER-INTERFACE")
+        p_port.setProvidedInterfaceTRef(p_tref)
+        p_com_spec = NonqueuedSenderComSpec()
+        p_com_spec.setDataElementRef(_ref())
+        p_port.addProvidedComSpec(p_com_spec)
         app.createRPortPrototype("RPort")
         app.createPRPortPrototype("PRPort")
         app.createPortGroup("PG")
@@ -923,6 +930,12 @@ class TestSwComponentTypeRoundTrip:
         assert swc.getShortName() == "App"
         assert len(swc.getPorts()) == 3
         assert len(swc.getPPortPrototypes()) == 1
+        reloaded_p_port = swc.getPPortPrototypes()[0]
+        assert reloaded_p_port.getShortName() == "PPort"
+        assert reloaded_p_port.getProvidedInterfaceTRef().getValue() == "/If/SR"
+        assert reloaded_p_port.getProvidedInterfaceTRef().getDest() == "SENDER-RECEIVER-INTERFACE"
+        assert len(reloaded_p_port.getProvidedComSpecs()) == 1
+        assert reloaded_p_port.getProvidedComSpecs()[0].getDataElementRef().getValue() == "/Pkg/Elem"
         assert len(swc.getRPortPrototypes()) == 1
         assert len(swc.getPRPortPrototypes()) == 1
         assert len(swc.getPortGroups()) == 1


### PR DESCRIPTION
## Summary
- Enable Git LFS for AUTOSAR R4.3.1 standard documents (`.gitattributes` patterns scoped to `autosar/R4.3.1/{markdown,pdf}/**`)
- Remove `.gitignore` exclusions for R4.3.1 markdown/PDF reference docs
- Add 27 markdown specifications (~270MB) and 27 PDF documents (~55MB) as LFS objects (341MB total)

## Commits
1. `5931c0f7` chore: enable Git LFS for AUTOSAR R4.3.1 standard docs
2. `c45be5ee` docs: add AUTOSAR R4.3.1 standard markdown specifications via LFS
3. `d31a0119` docs: add AUTOSAR R4.3.1 standard PDF documents via LFS

## Notes
- No source code changes — reference documentation only
- LFS upload verified: 54/54 objects on GitHub