### PR TITLE
sync RPortPrototype to R23-11 spec Table 3.5

### DIFF
--- a/docs/plan/sync-todo/Group2.md
+++ b/docs/plan/sync-todo/Group2.md
@@ -68,7 +68,7 @@ Input: `Group 2 — PortInterface sets, components, SWC behavior, datatypes` of 
   - [x] Step 7 — Update checklist comment
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
-- [ ] `RPortPrototype` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.5)
+- [x] `RPortPrototype` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.5) — commit `2cd6f3c4`
   - [x] Step 1 — Sync members & description from spec — Note: "Component port requiring a certain port interface."; mayBeUnconnected (Boolean 0..1 attr), requiredInterface (PortInterface 0..1 tref); markdown table sits above the title line
   - [x] Step 2 — Write model class unit test (Red) — TestRPortPrototype: 3 failed (docstring, None guards)
   - [x] Step 3 — Implement model class (Green) — Optional annotations, None no-op guards, verbatim docstrings

--- a/docs/plan/sync-todo/Group2.md
+++ b/docs/plan/sync-todo/Group2.md
@@ -69,15 +69,15 @@ Input: `Group 2 — PortInterface sets, components, SWC behavior, datatypes` of 
   - [x] Step 8 — Deviations
   - [x] Step 9 — Verify (9a) + confirm (9b)
 - [ ] `RPortPrototype` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.5)
-  - [ ] Step 1 — Sync members & description from spec
-  - [ ] Step 2 — Write model class unit test (Red)
-  - [ ] Step 3 — Implement model class (Green)
-  - [ ] Step 4 — Sync docstrings (wipe + rewrite)
-  - [ ] Step 5 — Write reader/writer round-trip test (Red)
-  - [ ] Step 6 — Update parser & writer (Green)
-  - [ ] Step 7 — Update checklist comment
-  - [ ] Step 8 — Deviations
-  - [ ] Step 9 — Verify (9a) + confirm (9b)
+  - [x] Step 1 — Sync members & description from spec — Note: "Component port requiring a certain port interface."; mayBeUnconnected (Boolean 0..1 attr), requiredInterface (PortInterface 0..1 tref); markdown table sits above the title line
+  - [x] Step 2 — Write model class unit test (Red) — TestRPortPrototype: 3 failed (docstring, None guards)
+  - [x] Step 3 — Implement model class (Green) — Optional annotations, None no-op guards, verbatim docstrings
+  - [x] Step 4 — Sync docstrings (wipe + rewrite)
+  - [x] Step 5 — Write reader/writer round-trip test (Red) — REQUIRED-INTERFACE-TREF + REQUIRED-COM-SPECS already green; MAY-BE-UNCONNECTED added
+  - [x] Step 6 — Update parser & writer (Green) — added MAY-BE-UNCONNECTED parse/write (was silently dropped)
+  - [x] Step 7 — Update checklist comment — 6-col, 5 rows
+  - [x] Step 8 — Deviations — existing RPortPrototype entry accurate (Boolean vs ARBoolean, PortInterface vs TRefType)
+  - [x] Step 9 — Verify (9a) + confirm (9b) — 8293 tests / ruff / black green; Rule 0007 passed
 - [ ] `PRPortPrototype` (tracker input · R23-11 markdown · AUTOSAR_CP_TPS_SoftwareComponentTemplate · Table 3.7)
   - [ ] Step 1 — Sync members & description from spec
   - [ ] Step 2 — Write model class unit test (Red)

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
@@ -698,13 +698,13 @@ class PPortPrototype(AbstractProvidedPortPrototype):
         # The interface that this port provides. Stereotypes: isOfType
         self.providedInterfaceTRef: Optional[TRefType] = None
 
-    def getProvidedInterfaceTRef(self):
+    def getProvidedInterfaceTRef(self) -> Optional[TRefType]:
         """
         The interface that this port provides. Stereotypes: isOfType
         """
         return self.providedInterfaceTRef
 
-    def setProvidedInterfaceTRef(self, value: Optional[TRefType]):
+    def setProvidedInterfaceTRef(self, value: Optional[TRefType]) -> "PPortPrototype":
         """
         The interface that this port provides. Stereotypes: isOfType
         """
@@ -714,31 +714,55 @@ class PPortPrototype(AbstractProvidedPortPrototype):
 
 
 class RPortPrototype(AbstractRequiredPortPrototype):
+    """
+    Component port requiring a certain port interface.
+    """
+
     # RPortPrototype method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-    # [ ] getMayBeUnconnected          [x] impl  [ ] docstring  [ ] test
-    # [ ] setMayBeUnconnected          [x] impl  [ ] docstring  [ ] test
-    # [ ] getRequiredInterfaceTRef     [x] impl  [ ] docstring  [ ] test
-    # [ ] setRequiredInterfaceTRef     [x] impl  [ ] docstring  [ ] test
+    # Spec: R23-11/AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf, Table 3.5, p.68 (R23-11)
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer / release   ([—] = no XML element)
+    # [x] __init__                        [x] impl  [x] docstring  [x] test  [—] reader  [—] writer  R23-11
+    # [x] getMayBeUnconnected             [x] impl  [x] docstring  [x] test  [x] reader  [x] writer  R23-11
+    # [x] setMayBeUnconnected             [x] impl  [x] docstring  [x] test  [x] reader  [x] writer  R23-11
+    # [x] getRequiredInterfaceTRef        [x] impl  [x] docstring  [x] test  [x] reader  [x] writer  R23-11
+    # [x] setRequiredInterfaceTRef        [x] impl  [x] docstring  [x] test  [x] reader  [x] writer  R23-11
 
     def __init__(self, parent: ARObject, short_name: str):
         super().__init__(parent, short_name)
 
-        self.mayBeUnconnected = None  # type: ARBoolean
-        self.requiredInterfaceTRef = None  # type: TRefType
+        # If set to true, this attribute indicates that the enclosing RPortPrototype may be left unconnected and that this aspect has explicitly been considered in the software-component's design.
+        self.mayBeUnconnected: Optional[ARBoolean] = None
 
-    def getMayBeUnconnected(self):
+        # The interface that this port requires. Stereotypes: isOfType
+        self.requiredInterfaceTRef: Optional[TRefType] = None
+
+    def getMayBeUnconnected(self) -> Optional[ARBoolean]:
+        """
+        If set to true, this attribute indicates that the enclosing RPortPrototype may be left unconnected and that this aspect has explicitly been considered in the software-component's design.
+        """
         return self.mayBeUnconnected
 
-    def setMayBeUnconnected(self, value):
-        self.mayBeUnconnected = value
+    def setMayBeUnconnected(self, value: Optional[ARBoolean]) -> "RPortPrototype":
+        """
+        If set to true, this attribute indicates that the enclosing RPortPrototype may be left unconnected and that this aspect has explicitly been considered in the software-component's design.
+        """
+        if value is not None:
+            self.mayBeUnconnected = value
         return self
 
-    def getRequiredInterfaceTRef(self):
+    def getRequiredInterfaceTRef(self) -> Optional[TRefType]:
+        """
+        The interface that this port requires. Stereotypes: isOfType
+        """
         return self.requiredInterfaceTRef
 
-    def setRequiredInterfaceTRef(self, value):
-        self.requiredInterfaceTRef = value
+    def setRequiredInterfaceTRef(self, value: Optional[TRefType]) -> "RPortPrototype":
+        """
+        The interface that this port requires. Stereotypes: isOfType
+        """
+        if value is not None:
+            self.requiredInterfaceTRef = value
         return self
 
 

--- a/src/armodel/parser/arxml_parser.py
+++ b/src/armodel/parser/arxml_parser.py
@@ -5386,6 +5386,7 @@ class ARXMLParser(AbstractARXMLParser):
         # self.logger.debug("Read RPortPrototype %s" % prototype.getShortName())
         self.readIdentifiable(element, prototype)
         self.readAbstractRequiredPortPrototype(element, prototype)
+        prototype.setMayBeUnconnected(self.getChildElementOptionalBooleanValue(element, "MAY-BE-UNCONNECTED"))
         prototype.setRequiredInterfaceTRef(self.getChildElementOptionalRefType(element, "REQUIRED-INTERFACE-TREF"))
         self.readPortPrototype(element, prototype)
 

--- a/src/armodel/writer/arxml_writer.py
+++ b/src/armodel/writer/arxml_writer.py
@@ -1643,6 +1643,7 @@ class ARXMLWriter(AbstractARXMLWriter):
         prototype_tag = ET.SubElement(ports_tag, "R-PORT-PROTOTYPE")
         self.writeIdentifiable(prototype_tag, prototype)
         self.setAbstractRequiredPortPrototype(prototype_tag, prototype)
+        self.setChildElementOptionalBooleanValue(prototype_tag, "MAY-BE-UNCONNECTED", prototype.getMayBeUnconnected())
         self.setChildElementOptionalRefType(prototype_tag, "REQUIRED-INTERFACE-TREF", prototype.getRequiredInterfaceTRef())
         self.setPortPrototype(prototype_tag, prototype)
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/test___init__.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/test___init__.py
@@ -5,6 +5,7 @@ AUTOSAR SWComponentTemplate module.
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
+    ARBoolean,
     RefType,
     TRefType,
 )
@@ -157,3 +158,42 @@ class TestPPortPrototype:
         assert obj.getProvidedInterfaceTRef() == tref
         obj.setProvidedInterfaceTRef(None)
         assert obj.getProvidedInterfaceTRef() == tref
+
+
+class TestRPortPrototype:
+    """
+    Test class for RPortPrototype functionality (Table 3.5).
+    """
+
+    def _create_prototype(self) -> RPortPrototype:
+        parent = AUTOSAR.getInstance()
+        ar_root = parent.createARPackage("AUTOSAR")
+        return RPortPrototype(ar_root, "TestRPort")
+
+    def test_initialization(self):
+        obj = self._create_prototype()
+        assert obj.getShortName() == "TestRPort"
+        assert obj.getMayBeUnconnected() is None
+        assert obj.getRequiredInterfaceTRef() is None
+
+    def test_class_docstring_is_spec_note_verbatim(self):
+        assert RPortPrototype.__doc__.strip() == "Component port requiring a certain port interface."
+
+    def test_get_set_mayBeUnconnected(self):
+        obj = self._create_prototype()
+        value = ARBoolean()
+        value.setValue(False)
+        assert obj.setMayBeUnconnected(value) is obj
+        assert obj.getMayBeUnconnected() == value
+        obj.setMayBeUnconnected(None)
+        assert obj.getMayBeUnconnected() == value
+
+    def test_get_set_requiredInterfaceTRef(self):
+        obj = self._create_prototype()
+        tref = TRefType()
+        tref.setValue("/AUTOSAR/SomeInterface")
+        tref.setDest("SENDER-RECEIVER-INTERFACE")
+        assert obj.setRequiredInterfaceTRef(tref) is obj
+        assert obj.getRequiredInterfaceTRef() == tref
+        obj.setRequiredInterfaceTRef(None)
+        assert obj.getRequiredInterfaceTRef() == tref

--- a/tests/test_armodel/writer/test_writer_sw_component.py
+++ b/tests/test_armodel/writer/test_writer_sw_component.py
@@ -908,6 +908,17 @@ class TestSwComponentTypeRoundTrip:
         p_com_spec.setDataElementRef(_ref())
         p_port.addProvidedComSpec(p_com_spec)
         app.createRPortPrototype("RPort")
+        r_port = app.createRPortPrototype("RPort2")
+        r_tref = TRefType()
+        r_tref.setValue("/If/SR")
+        r_tref.setDest("SENDER-RECEIVER-INTERFACE")
+        r_port.setRequiredInterfaceTRef(r_tref)
+        r_may_be_unconnected = ARBoolean()
+        r_may_be_unconnected.setValue(True)
+        r_port.setMayBeUnconnected(r_may_be_unconnected)
+        r_com_spec = ClientComSpec()
+        r_com_spec.setOperationRef(_ref(dest="CLIENT-SERVER-OPERATION"))
+        r_port.addRequiredComSpec(r_com_spec)
         app.createPRPortPrototype("PRPort")
         app.createPortGroup("PG")
         app.addSwcMappingConstraintRef(_ref("/Mapping/Const1"))
@@ -928,7 +939,7 @@ class TestSwComponentTypeRoundTrip:
         swc = reloaded.find("/Swcs/App")
         assert swc is not None
         assert swc.getShortName() == "App"
-        assert len(swc.getPorts()) == 3
+        assert len(swc.getPorts()) == 4
         assert len(swc.getPPortPrototypes()) == 1
         reloaded_p_port = swc.getPPortPrototypes()[0]
         assert reloaded_p_port.getShortName() == "PPort"
@@ -936,7 +947,13 @@ class TestSwComponentTypeRoundTrip:
         assert reloaded_p_port.getProvidedInterfaceTRef().getDest() == "SENDER-RECEIVER-INTERFACE"
         assert len(reloaded_p_port.getProvidedComSpecs()) == 1
         assert reloaded_p_port.getProvidedComSpecs()[0].getDataElementRef().getValue() == "/Pkg/Elem"
-        assert len(swc.getRPortPrototypes()) == 1
+        assert len(swc.getRPortPrototypes()) == 2
+        reloaded_r_port = next(p for p in swc.getRPortPrototypes() if p.getShortName() == "RPort2")
+        assert reloaded_r_port.getRequiredInterfaceTRef().getValue() == "/If/SR"
+        assert reloaded_r_port.getRequiredInterfaceTRef().getDest() == "SENDER-RECEIVER-INTERFACE"
+        assert reloaded_r_port.getMayBeUnconnected().getValue() is True
+        assert len(reloaded_r_port.getRequiredComSpecs()) == 1
+        assert reloaded_r_port.getRequiredComSpecs()[0].getOperationRef().getValue() == "/Pkg/Elem"
         assert len(swc.getPRPortPrototypes()) == 1
         assert len(swc.getPortGroups()) == 1
         assert [r.getValue() for r in swc.getSwcMappingConstraintsRefs()] == ["/Mapping/Const1", "/Mapping/Const2"]


### PR DESCRIPTION
## Summary
- Sync RPortPrototype to R23-11 spec Table 3.5 (spec-verbatim docstrings, Optional annotations, getter return types, setter chaining annotations, None no-op guards)
- Add MAY-BE-UNCONNECTED parse/write coverage in parser/writer (was silently dropped in round-trip)
- Apply the same return-type annotations to PPortPrototype for consistency
- Extend round-trip test coverage (REQUIRED-INTERFACE-TREF, REQUIRED-COM-SPECS, MAY-BE-UNCONNECTED)

## Test plan
- [x] `uv run pytest -q --no-cov` — 8293 passed
- [x] `npm run lint` — ruff clean
- [x] `npm run black-check` — 784 files unchanged