### PR TITLE
rename AR* primitive types to AUTOSAR standard names

### DIFF
--- a/docs/examples/method_deviation_by_class_v2.md
+++ b/docs/examples/method_deviation_by_class_v2.md
@@ -783,7 +783,7 @@ the Python sources. Classes whose checklist carries `# Spec verified: R<YY>-<MM>
 
 | Name in source code | Type (source) | Member name (spec) | Type (PDF) | Kind | Deviation |
 |---|---|---|---|---|---|
-| `mayBeUnconnected` | `ARBoolean` | `mayBeUnconnected` | ``Boolean`` | attr | type (PDF Boolean vs py ARBoolean) |
+| `mayBeUnconnected` | `Boolean` | `mayBeUnconnected` | ``Boolean`` | attr | — |
 | `requiredInterfaceTRef` | `TRefType` | `requiredInterface` | ``PortInterface`` | tref | type (PDF PortInterface vs py TRefType) |
 
 ## `PortGroup`
@@ -1887,7 +1887,6 @@ the Python sources. Classes whose checklist carries `# Spec verified: R<YY>-<MM>
 - `XmlSpaceEnum` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::Enumerations`)
 - `ARType` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
 - `ARNumerical` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
-- `ARFloat` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
 - `Float` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
 - `TimeValue` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
 - `ARLiteral` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
@@ -1895,8 +1894,6 @@ the Python sources. Classes whose checklist carries `# Spec verified: R<YY>-<MM>
 - `AlignmentType` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
 - `CseCodeType` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
 - `ReferrableSubtypesEnum` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
-- `ARPositiveInteger` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
-- `ARBoolean` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
 - `NameToken` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
 - `PositiveInteger` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)
 - `PositiveUnlimitedInteger` (`M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes`)

--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior.py
@@ -22,7 +22,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation import Im
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.InternalBehavior import AbstractEvent, ApiPrincipleEnum, ExecutableEntity, InternalBehavior
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import RoleBasedDataAssignment, ServiceDependency, ServiceNeeds
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARFloat, Boolean
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Float, Boolean
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger, String, TimeValue, Identifier
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
@@ -1497,14 +1497,14 @@ class BswModeSwitchAckRequest(ARObject):
         super().__init__()
 
         # Timeout value for the mode switch acknowledgment
-        self.timeout: ARFloat = None
+        self.timeout: Float = None
 
     def getTimeout(self):
         """
         Gets the timeout value for the mode switch acknowledgment.
 
         Returns:
-            ARFloat representing the timeout value
+            Float representing the timeout value
         """
         return self.timeout
 

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ImplementationDataTypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ImplementationDataTypes.py
@@ -2,7 +2,7 @@ from abc import ABC
 from typing import List, Optional
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.AbstractStructure import AtpStructureElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, AREnum, ARLiteral, ARNumerical, NameToken, String
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, AREnum, ARLiteral, ARNumerical, NameToken, String
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes import AutosarDataType
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SymbolProps
@@ -55,7 +55,7 @@ class ImplementationDataTypeElement(AbstractImplementationDataTypeElement):
         self.arraySize: ARNumerical = None
         self.arraySizeHandling: ARLiteral = None
         self.arraySizeSemantics: ARLiteral = None
-        self.isOptional: ARBoolean = None
+        self.isOptional: Boolean = None
         self.subElements: List[ImplementationDataTypeElement] = []
         self.swDataDefProps: SwDataDefProps = None
 
@@ -182,7 +182,7 @@ class ImplementationDataType(AbstractImplementationDataType):
         # Indicates that the ImplementationDataType has been created with the
         # intention to define at least one element of the structure as
         # optional.
-        self.isStructWithOptionalElement: Optional[ARBoolean] = None
+        self.isStructWithOptionalElement: Optional[Boolean] = None
         # Specifies an element of an array, struct, or union data type.
         self.subElements: List[ImplementationDataTypeElement] = []
         # The SymbolProps for the ImplementationDataType.
@@ -217,18 +217,18 @@ class ImplementationDataType(AbstractImplementationDataType):
             self.dynamicArraySizeProfile = value
         return self
 
-    def getIsStructWithOptionalElement(self) -> Optional[ARBoolean]:
+    def getIsStructWithOptionalElement(self) -> Optional[Boolean]:
         """
         Gets the flag indicating whether the ImplementationDataType has been
         created with the intention to define at least one element of the
         structure as optional.
 
         Returns:
-            ARBoolean: The flag for optional elements in the structure
+            Boolean: The flag for optional elements in the structure
         """
         return self.isStructWithOptionalElement
 
-    def setIsStructWithOptionalElement(self, value: Optional[ARBoolean]) -> "ImplementationDataType":
+    def setIsStructWithOptionalElement(self, value: Optional[Boolean]) -> "ImplementationDataType":
         """
         Sets the flag indicating whether the ImplementationDataType has been
         created with the intention to define at least one element of the

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/PrimitiveTypes.py
@@ -179,16 +179,18 @@ class ARNumerical(ARType):
         return self.shortLabel
 
 
-class ARFloat(ARNumerical):
+class Float(ARNumerical):
     """
-    Base class for floating-point AUTOSAR types.
-    This class provides functionality for floating-point values in AUTOSAR models.
+    An instance of Float is an element from the set of real numbers.
+
+    Tags:
+        * xml.xsd.customType=FLOAT
+        * xml.xsd.type=double
     """
 
-    # ARFloat method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [x] test
+    # Float method parity checklist:
+    # [ ] __init__                     [x] impl  [x] docstring  [x] test
     # [ ] value                        [x] impl  [x] docstring  [ ] test
-    # [ ] value                        [x] impl  [ ] docstring  [ ] test
     # [ ] __str__                      [x] impl  [ ] docstring  [ ] test
 
     def __init__(self) -> None:
@@ -220,22 +222,7 @@ class ARFloat(ARNumerical):
             return str(self._value)
 
 
-class Float(ARFloat):
-    """
-    An instance of Float is an element from the set of real numbers.
-    Tags:
-        * xml.xsd.customType=FLOAT
-        * xml.xsd.type=double
-    """
-
-    # Float method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [x] test
-
-    def __init__(self):
-        super().__init__()
-
-
-class TimeValue(ARFloat):
+class TimeValue(Float):
     """
     This primitive type is taken for expressing time values. The numerical value is supposed to be interpreted
     in the physical unit second.
@@ -527,16 +514,22 @@ class ReferrableSubtypesEnum(ARLiteral):
         super().__init__()
 
 
-class ARPositiveInteger(ARNumerical):
+class PositiveInteger(ARNumerical):
     """
-    Base class for positive integer AUTOSAR types.
-    This class provides functionality for positive integer values in AUTOSAR models.
+    This is a positive integer which can be denoted in decimal, binary, octal and hexadecimal. The value is between 0 and 4294967295.
+
+    Tags:
+        * xml.xsd.customType=POSITIVE-INTEGER
+        * xml.xsd.pattern=0|[\\+]?[1-9][0-9]*|0[xX][0-9a-fA-F]+|0[bB][0-1]+|0[0-7]+
+        * xml.xsd.type=string
     """
 
-    # ARPositiveInteger method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [x] test
-    # [ ] value                        [x] impl  [x] docstring  [ ] test
-    # [ ] value                        [x] impl  [ ] docstring  [ ] test
+    # PositiveInteger method parity checklist:
+    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table E.64, p.459
+    # Spec verified: R23-11
+    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
+    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
+    # [ ] value                        [x] impl  [x] docstring  [ ] test  [—] reader  [—] writer
 
     def __init__(self) -> None:
         super().__init__()
@@ -559,18 +552,22 @@ class ARPositiveInteger(ARNumerical):
             raise ValueError("Unsupported Type <%s>", type(val))
 
 
-class ARBoolean(ARType):
+class Boolean(ARType):
     """
-    Base class for boolean AUTOSAR types.
-    This class provides functionality for boolean values in AUTOSAR models.
+    A Boolean value denotes a logical condition that is either 'true' or 'false'. It can be one of "0", "1", "true",
+    "false"
+
+    Tags:
+        * xml.xsd.customType=BOOLEAN
+        * xml.xsd.pattern=0|1|true|false
+        * xml.xsd.type=string
     """
 
-    # ARBoolean method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [x] test
+    # Boolean method parity checklist:
+    # [x] __init__                     [x] impl  [x] docstring  [x] test
     # [x] _convertNumberToBoolean      [x] impl  [x] docstring  [x] test
     # [x] _convertStringToBoolean      [x] impl  [x] docstring  [x] test
     # [ ] value                        [x] impl  [x] docstring  [ ] test
-    # [ ] value                        [x] impl  [ ] docstring  [ ] test
     # [ ] __str__                      [x] impl  [ ] docstring  [ ] test
 
     def __init__(self) -> None:
@@ -659,27 +656,7 @@ class NameToken(ARLiteral):
         super().__init__()
 
 
-class PositiveInteger(ARPositiveInteger):
-    """
-    This is a positive integer which can be denoted in decimal, binary, octal and hexadecimal. The value is between 0 and 4294967295.
-
-    Tags:
-        * xml.xsd.customType=POSITIVE-INTEGER
-        * xml.xsd.pattern=0|[\\+]?[1-9][0-9]*|0[xX][0-9a-fA-F]+|0[bB][0-1]+|0[0-7]+
-        * xml.xsd.type=string
-    """
-
-    # PositiveInteger method parity checklist:
-    # Spec: AUTOSAR_FO_TPS_GenericStructureTemplate.pdf, Table E.64, p.459
-    # Spec verified: R23-11
-    # Columns: impl / docstring / test / reader / writer   ([—] = no XML element)
-    # [x] __init__                     [x] impl  [x] docstring  [x] test  [—] reader  [—] writer
-
-    def __init__(self):
-        super().__init__()
-
-
-class PositiveUnlimitedInteger(ARPositiveInteger):
+class PositiveUnlimitedInteger(PositiveInteger):
     r"""
     This is a positive unlimited integer which can be denoted in decimal, binary, octal and hexadecimal.
 
@@ -727,24 +704,6 @@ class UnlimitedInteger(Integer):
     """
 
     # UnlimitedInteger method parity checklist:
-    # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
-
-    def __init__(self):
-        super().__init__()
-
-
-class Boolean(ARBoolean):
-    """
-    A Boolean value denotes a logical condition that is either 'true' or 'false'. It can be one of "0", "1", "true",
-    "false"
-
-    Tags:
-        * xml.xsd.customType=BOOLEAN
-        * xml.xsd.pattern=0|1|true|false
-        * xml.xsd.type=string
-    """
-
-    # Boolean method parity checklist:
     # [ ] __init__                     [x] impl  [ ] docstring  [ ] test
 
     def __init__(self):

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ApplicationAttributes/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ApplicationAttributes/__init__.py
@@ -4,7 +4,7 @@ This module contains application attribute classes for AUTOSAR software componen
 
 from typing import Optional
 
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARBoolean, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Boolean, RefType
 from armodel.models.M2.MSR.Documentation.Annotation import GeneralAnnotation
 
 
@@ -167,7 +167,7 @@ class SenderReceiverAnnotation(GeneralAnnotation):
         super().__init__()
 
         # Flag whether this data element was not measured directly but instead was calculated from possibly several other measured or calculated values.
-        self.computed: Optional[ARBoolean] = None
+        self.computed: Optional[Boolean] = None
 
         # The instance of VariableDataPrototype annotated.
         self.dataElementRef: Optional[RefType] = None
@@ -178,22 +178,22 @@ class SenderReceiverAnnotation(GeneralAnnotation):
         # This attribute controls how data is processed according to the possible values of ProcessingKindEnum.
         self.processingKind: Optional[ProcessingKindEnum] = None
 
-    def getComputed(self) -> Optional[ARBoolean]:
+    def getComputed(self) -> Optional[Boolean]:
         """
         Gets the flag whether this data element was not measured directly but instead was calculated from possibly several other measured or calculated values.
 
         Returns:
-            ARBoolean flag, or None if not set
+            Boolean flag, or None if not set
         """
         return self.computed
 
-    def setComputed(self, value: Optional[ARBoolean]) -> "SenderReceiverAnnotation":
+    def setComputed(self, value: Optional[Boolean]) -> "SenderReceiverAnnotation":
         """
         Sets the flag whether this data element was not measured directly but instead was calculated from possibly several other measured or calculated values.
         A None value is a no-op and does not overwrite an existing value.
 
         Args:
-            value: The ARBoolean flag to set
+            value: The Boolean flag to set
 
         Returns:
             self for method chaining

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Communication.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Communication.py
@@ -12,9 +12,8 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import ValueSpecification
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARPositiveInteger, Boolean
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger, TimeValue
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, PositiveInteger, Boolean
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import TimeValue
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import RefType
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface.InstanceRefs import ApplicationCompositeElementInPortInterfaceInstanceRef
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.Filter import DataFilter
@@ -976,7 +975,7 @@ class ReceiverComSpec(RPortComSpec, ABC):
         self.transformationComSpecProps: List[TransformationComSpecProps] = []
 
         # This indicates whether the corresponding dataElement shall be transmitted using end-to-end protection. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach.
-        self.usesEndToEndProtection: Optional[ARBoolean] = None
+        self.usesEndToEndProtection: Optional[Boolean] = None
 
     def addCompositeNetworkRepresentation(self, representation: CompositeNetworkRepresentation) -> "ReceiverComSpec":
         """
@@ -1143,13 +1142,13 @@ class ReceiverComSpec(RPortComSpec, ABC):
         """
         return self.transformationComSpecProps
 
-    def getUsesEndToEndProtection(self) -> Optional[ARBoolean]:
+    def getUsesEndToEndProtection(self) -> Optional[Boolean]:
         """
         This indicates whether the corresponding dataElement shall be transmitted using end-to-end protection. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
         """
         return self.usesEndToEndProtection
 
-    def setUsesEndToEndProtection(self, value: Optional[ARBoolean]) -> "ReceiverComSpec":
+    def setUsesEndToEndProtection(self, value: Optional[Boolean]) -> "ReceiverComSpec":
         """
         This indicates whether the corresponding dataElement shall be transmitted using end-to-end protection. Caveat: The E2E wrapper approach involves technologies that are not subjected to the AUTOSAR standard and is superseded by the superior E2E transformer approach (which is fully standardized by AUTOSAR). Hence, new projects (without legacy constraints due to carry-over parts) shall use the fully standardized E2E transformer approach. Stereotypes: atpVariation Tags: vh.latestBindingTime=preCompileTime
         A None value is a no-op and does not overwrite an existing usesEndToEndProtection.
@@ -1218,17 +1217,17 @@ class ModeSwitchSenderComSpec(PPortComSpec):
     def __init__(self):
         super().__init__()
 
-        self.enhancedModeApi: ARBoolean = None
+        self.enhancedModeApi: Boolean = None
         self.modeGroupRef: RefType = None
         self.modeSwitchedAck: ModeSwitchedAckRequest = None
-        self.queueLength: ARPositiveInteger = None
+        self.queueLength: PositiveInteger = None
 
     def getEnhancedModeApi(self):
         """
         Gets whether the enhanced mode API is enabled.
 
         Returns:
-            ARBoolean: True if enhanced mode API is enabled
+            Boolean: True if enhanced mode API is enabled
         """
         return self.enhancedModeApi
 
@@ -1297,7 +1296,7 @@ class ModeSwitchSenderComSpec(PPortComSpec):
         Gets the length of the mode switch queue.
 
         Returns:
-            ARPositiveInteger: The queue length
+            PositiveInteger: The queue length
         """
         return self.queueLength
 
@@ -1606,16 +1605,16 @@ class NonqueuedReceiverComSpec(ReceiverComSpec):
         self.aliveTimeout: Optional[TimeValue] = None
 
         # This attribute controls whether application code is entitled to check whether the value of the corresponding Variable DataPrototype has been updated.
-        self.enableUpdate: Optional[ARBoolean] = None
+        self.enableUpdate: Optional[Boolean] = None
 
         # The applicable filter algorithm for filtering the value of the corresponding dataElement.
         self.filter: Optional[DataFilter] = None
 
         # If this attribute is set to true, then the Rte_IStatus API shall exist. If the attribute does not exist or is set to false, then the Rte_IStatus API may still exist in response to the existence of further conditions.
-        self.handleDataStatus: Optional[ARBoolean] = None
+        self.handleDataStatus: Optional[Boolean] = None
 
         # This attribute specifies whether for the corresponding VariableDataPrototype the "never received" flag is available. If yes, the RTE is supposed to assume that initially the VariableDataPrototype has not been received before. After the first reception of the corresponding VariableDataPrototype the flag is cleared. • If the value of this attribute is set to "true" the flag is required. • If set to "false", the RTE shall not support the "never received" functionality for the corresponding Variable DataPrototype.
-        self.handleNeverReceived: Optional[ARBoolean] = None
+        self.handleNeverReceived: Optional[Boolean] = None
 
         # This attribute controls the behavior with respect to the handling of timeouts.
         self.handleTimeoutType: Optional["HandleTimeoutEnum"] = None
@@ -1641,13 +1640,13 @@ class NonqueuedReceiverComSpec(ReceiverComSpec):
             self.aliveTimeout = value
         return self
 
-    def getEnableUpdate(self) -> Optional[ARBoolean]:
+    def getEnableUpdate(self) -> Optional[Boolean]:
         """
         This attribute controls whether application code is entitled to check whether the value of the corresponding Variable DataPrototype has been updated.
         """
         return self.enableUpdate
 
-    def setEnableUpdate(self, value: Optional[ARBoolean]) -> "NonqueuedReceiverComSpec":
+    def setEnableUpdate(self, value: Optional[Boolean]) -> "NonqueuedReceiverComSpec":
         """
         This attribute controls whether application code is entitled to check whether the value of the corresponding Variable DataPrototype has been updated.
         A None value is a no-op and does not overwrite an existing enableUpdate.
@@ -1671,13 +1670,13 @@ class NonqueuedReceiverComSpec(ReceiverComSpec):
             self.filter = value
         return self
 
-    def getHandleDataStatus(self) -> Optional[ARBoolean]:
+    def getHandleDataStatus(self) -> Optional[Boolean]:
         """
         If this attribute is set to true, then the Rte_IStatus API shall exist. If the attribute does not exist or is set to false, then the Rte_IStatus API may still exist in response to the existence of further conditions.
         """
         return self.handleDataStatus
 
-    def setHandleDataStatus(self, value: Optional[ARBoolean]) -> "NonqueuedReceiverComSpec":
+    def setHandleDataStatus(self, value: Optional[Boolean]) -> "NonqueuedReceiverComSpec":
         """
         If this attribute is set to true, then the Rte_IStatus API shall exist. If the attribute does not exist or is set to false, then the Rte_IStatus API may still exist in response to the existence of further conditions.
         A None value is a no-op and does not overwrite an existing handleDataStatus.
@@ -1686,13 +1685,13 @@ class NonqueuedReceiverComSpec(ReceiverComSpec):
             self.handleDataStatus = value
         return self
 
-    def getHandleNeverReceived(self) -> Optional[ARBoolean]:
+    def getHandleNeverReceived(self) -> Optional[Boolean]:
         """
         This attribute specifies whether for the corresponding VariableDataPrototype the "never received" flag is available. If yes, the RTE is supposed to assume that initially the VariableDataPrototype has not been received before. After the first reception of the corresponding VariableDataPrototype the flag is cleared. • If the value of this attribute is set to "true" the flag is required. • If set to "false", the RTE shall not support the "never received" functionality for the corresponding Variable DataPrototype.
         """
         return self.handleNeverReceived
 
-    def setHandleNeverReceived(self, value: Optional[ARBoolean]) -> "NonqueuedReceiverComSpec":
+    def setHandleNeverReceived(self, value: Optional[Boolean]) -> "NonqueuedReceiverComSpec":
         """
         This attribute specifies whether for the corresponding VariableDataPrototype the "never received" flag is available. If yes, the RTE is supposed to assume that initially the VariableDataPrototype has not been received before. After the first reception of the corresponding VariableDataPrototype the flag is cleared. • If the value of this attribute is set to "true" the flag is required. • If set to "false", the RTE shall not support the "never received" functionality for the corresponding Variable DataPrototype.
         A None value is a no-op and does not overwrite an existing handleNeverReceived.
@@ -1760,14 +1759,14 @@ class QueuedReceiverComSpec(ReceiverComSpec):
     def __init__(self):
         super().__init__()
 
-        self.queueLength: ARPositiveInteger = None
+        self.queueLength: PositiveInteger = None
 
     def getQueueLength(self):
         """
         Gets the length of queue for received events.
 
         Returns:
-            ARPositiveInteger: The queue length
+            PositiveInteger: The queue length
         """
         return self.queueLength
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/__init__.py
@@ -13,8 +13,8 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
-    TRefType as TRefType,
-    ARBoolean as ARBoolean,
+    TRefType,
+    Boolean,
     RefType,
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import ClientComSpec, ModeSwitchReceiverComSpec, ModeSwitchSenderComSpec
@@ -732,18 +732,18 @@ class RPortPrototype(AbstractRequiredPortPrototype):
         super().__init__(parent, short_name)
 
         # If set to true, this attribute indicates that the enclosing RPortPrototype may be left unconnected and that this aspect has explicitly been considered in the software-component's design.
-        self.mayBeUnconnected: Optional[ARBoolean] = None
+        self.mayBeUnconnected: Optional[Boolean] = None
 
         # The interface that this port requires. Stereotypes: isOfType
         self.requiredInterfaceTRef: Optional[TRefType] = None
 
-    def getMayBeUnconnected(self) -> Optional[ARBoolean]:
+    def getMayBeUnconnected(self) -> Optional[Boolean]:
         """
         If set to true, this attribute indicates that the enclosing RPortPrototype may be left unconnected and that this aspect has explicitly been considered in the software-component's design.
         """
         return self.mayBeUnconnected
 
-    def setMayBeUnconnected(self, value: Optional[ARBoolean]) -> "RPortPrototype":
+    def setMayBeUnconnected(self, value: Optional[Boolean]) -> "RPortPrototype":
         """
         If set to true, this attribute indicates that the enclosing RPortPrototype may be left unconnected and that this aspect has explicitly been considered in the software-component's design.
         """

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/PortAPIOptions.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/PortAPIOptions.py
@@ -5,7 +5,7 @@ in software component internal behavior templates.
 
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import ValueSpecification
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, RefType, TRefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, RefType, TRefType
 from typing import List
 
 
@@ -98,9 +98,9 @@ class PortAPIOption(ARObject):
     def __init__(self):
         super().__init__()
 
-        self.enableTakeAddress: ARBoolean = None
+        self.enableTakeAddress: Boolean = None
         self.errorHandling = None
-        self.indirectAPI: ARBoolean = None
+        self.indirectAPI: Boolean = None
         self.portRef: RefType = None
         self.portArgValues: List["PortDefinedArgumentValue"] = []
         self.supportedFeatures = []
@@ -111,7 +111,7 @@ class PortAPIOption(ARObject):
         Gets whether the address-taking feature is enabled.
 
         Returns:
-            ARBoolean: True if address-taking is enabled
+            Boolean: True if address-taking is enabled
         """
         return self.enableTakeAddress
 
@@ -155,7 +155,7 @@ class PortAPIOption(ARObject):
         Gets whether indirect API is used.
 
         Returns:
-            ARBoolean: True if indirect API is used
+            Boolean: True if indirect API is used
         """
         return self.indirectAPI
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/__init__.py
@@ -14,9 +14,8 @@ from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.ServiceMapping import SwcServiceDependency
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     ARLiteral,
-    Boolean as Boolean,
-    RefType as RefType,
-    ARBoolean,
+    RefType,
+    Boolean,
 )
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.DataElements import ParameterAccess, VariableAccess
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.ServerCall import (
@@ -103,7 +102,7 @@ class RunnableEntity(ExecutableEntity):
 
         # If the value of this attribute is set to "true" the enclosing RunnableEntity can be invoked concurrently (even for one instance of the corresponding AtomicSwComponentType).
         # This implies that it is the responsibility of the implementation of the RunnableEntity to take care of this form of concurrency.
-        self.canBeInvokedConcurrently: ARBoolean = None
+        self.canBeInvokedConcurrently: Boolean = None
 
         # RunnableEntity has implicit read access to dataElement of a sender-receiver PortPrototype or nv data of a nv data PortPrototype.
         # The aggregation of dataReadAccess is subject to variability with the purpose to support the conditional existence of sender receiver ports or the variant existence of dataReadAccess in the implementation.
@@ -194,17 +193,17 @@ class RunnableEntity(ExecutableEntity):
             self.arguments.append(value)
         return self
 
-    def getCanBeInvokedConcurrently(self) -> Optional[ARBoolean]:
+    def getCanBeInvokedConcurrently(self) -> Optional[Boolean]:
         """
         If the value of this attribute is set to "true" the enclosing RunnableEntity can be invoked concurrently (even for one instance of the corresponding AtomicSwComponentType).
         This implies that it is the responsibility of the implementation of the RunnableEntity to take care of this form of concurrency.
 
         Returns:
-            Optional[ARBoolean]: The concurrency flag, or None if not set
+            Optional[Boolean]: The concurrency flag, or None if not set
         """
         return self.canBeInvokedConcurrently
 
-    def setCanBeInvokedConcurrently(self, value: Optional[ARBoolean]) -> "RunnableEntity":
+    def setCanBeInvokedConcurrently(self, value: Optional[Boolean]) -> "RunnableEntity":
         """
         If the value of this attribute is set to "true" the enclosing RunnableEntity can be invoked concurrently (even for one instance of the corresponding AtomicSwComponentType).
         This implies that it is the responsibility of the implementation of the RunnableEntity to take care of this form of concurrency.

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Multiplatform.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Multiplatform.py
@@ -3,7 +3,7 @@ from typing import List
 from armodel.models.M2.MSR.Documentation.TextModel.BlockElements import DocumentationBlock
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer, RefType
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARPositiveInteger
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import PositiveInteger
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore import FibexElement
 
 
@@ -211,7 +211,7 @@ class IPduMapping(ARObject):
         super().__init__()
 
         self.introduction: DocumentationBlock = None
-        self.pdurTpChunkSize: ARPositiveInteger = None
+        self.pdurTpChunkSize: PositiveInteger = None
         self.sourceIpduRef: RefType = None
         self.targetIPdu: TargetIPduRef = None
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/__init__.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/__init__.py
@@ -5,8 +5,8 @@ from typing import List, Optional, TYPE_CHECKING
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable, Describable
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARElement
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARLiteral, ARNumerical, ARPositiveInteger, Boolean, ByteOrderEnum
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer, PositiveInteger, RefType, ARBoolean, String
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARLiteral, ARNumerical, PositiveInteger, Boolean, ByteOrderEnum
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Integer, RefType, String
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import TimeValue, UnlimitedInteger
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.Filter import DataFilter
@@ -198,8 +198,8 @@ class ContainedIPduProps(ARObject):
         super().__init__()
 
         self.collectionSemantics: ARLiteral = None
-        self.headerIdLongHeader: ARPositiveInteger = None
-        self.headerIdShortHeader: ARPositiveInteger = None
+        self.headerIdLongHeader: PositiveInteger = None
+        self.headerIdShortHeader: PositiveInteger = None
         self.offset: ARNumerical = None
         self.timeout: ARNumerical = None
         self.trigger: ARLiteral = None
@@ -1737,7 +1737,7 @@ class SystemSignal(ARElement):
     def __init__(self, parent, short_name):
         super().__init__(parent, short_name)
 
-        self.dynamicLength: ARBoolean = None
+        self.dynamicLength: Boolean = None
         self.physicalProps: SwDataDefProps = None
 
     def getDynamicLength(self):

--- a/src/armodel/models/M2/MSR/AsamHdo/Units.py
+++ b/src/armodel/models/M2/MSR/AsamHdo/Units.py
@@ -3,7 +3,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     ARObject,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
-    ARFloat,
+    Float,
     ARNumerical,
     RefType,
     ARLiteral,
@@ -200,10 +200,10 @@ class Unit(ARElement):
         self.displayName: Optional[SingleLanguageUnitNames] = None
 
         # This is the factor for the conversion from SI Units to units. The inverse is used for conversion from units to SI Units.
-        self.factorSiToUnit: Optional[ARFloat] = None
+        self.factorSiToUnit: Optional[Float] = None
 
         # This is the offset for the conversion from and to siUnits.
-        self.offsetSiToUnit: Optional[ARFloat] = None
+        self.offsetSiToUnit: Optional[Float] = None
 
         # This association represents the physical dimension to which the unit belongs to. Note that only values with units of the same physical dimensions might be converted.
         self.physicalDimensionRef: Optional[RefType] = None
@@ -222,13 +222,13 @@ class Unit(ARElement):
             self.displayName = value
         return self
 
-    def getFactorSiToUnit(self) -> Optional[ARFloat]:
+    def getFactorSiToUnit(self) -> Optional[Float]:
         """
         This is the factor for the conversion from SI Units to units. The inverse is used for conversion from units to SI Units.
         """
         return self.factorSiToUnit
 
-    def setFactorSiToUnit(self, value: Optional[ARFloat]) -> "Unit":
+    def setFactorSiToUnit(self, value: Optional[Float]) -> "Unit":
         """
         This is the factor for the conversion from SI Units to units. The inverse is used for conversion from units to SI Units. A None value is a no-op and does not overwrite an existing factorSiToUnit.
         """
@@ -236,13 +236,13 @@ class Unit(ARElement):
             self.factorSiToUnit = value
         return self
 
-    def getOffsetSiToUnit(self) -> Optional[ARFloat]:
+    def getOffsetSiToUnit(self) -> Optional[Float]:
         """
         This is the offset for the conversion from and to siUnits.
         """
         return self.offsetSiToUnit
 
-    def setOffsetSiToUnit(self, value: Optional[ARFloat]) -> "Unit":
+    def setOffsetSiToUnit(self, value: Optional[Float]) -> "Unit":
         """
         This is the offset for the conversion from and to siUnits. A None value is a no-op and does not overwrite an existing offsetSiToUnit.
         """

--- a/src/armodel/models/M2/MSR/DataDictionary/CalibrationParameter.py
+++ b/src/armodel/models/M2/MSR/DataDictionary/CalibrationParameter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List, Optional
 from abc import ABC
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, ARFloat, DisplayFormatString, MonotonyEnum
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import AREnum, Float, DisplayFormatString, MonotonyEnum
 
 if TYPE_CHECKING:
     from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwCalibrationAccessEnum
@@ -61,18 +61,18 @@ class SwCalprmAxisTypeProps(ARObject, ABC):
         super().__init__()
 
         # This attribute defines the maximum permissible gradient for an adjustable object (curve, map or cuboid) with respect to a specific axis. MaxGrad = maximum( absolute((Value i,k - Value i-1,k)/(Axis Point i - Axis Point i-1)) )
-        self.maxGradient: Optional[ARFloat] = None
+        self.maxGradient: Optional[Float] = None
 
         # This attribute specifies the monotony constraint for an adjustable object (curve, map or cuboid) with respect to a specific axis. This information can be used by MCD system to verify whether the monotony constraint is fulfilled and to prevent from changes violating the constraint.
         self.monotony: Optional[MonotonyEnum] = None
 
-    def getMaxGradient(self) -> Optional[ARFloat]:
+    def getMaxGradient(self) -> Optional[Float]:
         """
         This attribute defines the maximum permissible gradient for an adjustable object (curve, map or cuboid) with respect to a specific axis. MaxGrad = maximum( absolute((Value i,k - Value i-1,k)/(Axis Point i - Axis Point i-1)) )
         """
         return self.maxGradient
 
-    def setMaxGradient(self, value: Optional[ARFloat]) -> SwCalprmAxisTypeProps:
+    def setMaxGradient(self, value: Optional[Float]) -> SwCalprmAxisTypeProps:
         """
         This attribute defines the maximum permissible gradient for an adjustable object (curve, map or cuboid) with respect to a specific axis. MaxGrad = maximum( absolute((Value i,k - Value i-1,k)/(Axis Point i - Axis Point i-1)) ) A None value is a no-op and does not overwrite an existing maxGradient.
         """

--- a/src/armodel/models/M2/MSR/DataDictionary/DataDefProperties.py
+++ b/src/armodel/models/M2/MSR/DataDictionary/DataDefProperties.py
@@ -7,7 +7,7 @@ from armodel.models.M2.MSR.DataDictionary.DatadictionaryProxies import SwCalprmR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     AREnum,
     ARNumerical,
-    ARFloat,
+    Float,
     AlignmentType,
     Boolean,
     Identifier,
@@ -384,7 +384,7 @@ class SwDataDefProps(ARObject):
         self.displayPresentation: Optional[DisplayPresentationEnum] = None
 
         # This attribute can be used to define a value which is added to or subtracted from the value of a DataPrototype when using up/down keys while calibrating.
-        self.stepSize: Optional[ARFloat] = None
+        self.stepSize: Optional[Float] = None
 
         # This attribute is used to specify the dimensions of a value block (VAL_BLK) for the case that that value block has more than one dimension. The dimensions given in this attribute are ordered such that the first entry represents the first dimension, the second entry represents the second dimension, and so on. For one-dimensional value blocks the attribute swValueBlockSize shall be used and this attribute shall not exist.
         self.swValueBlockSizeMults: List[ARNumerical] = []
@@ -484,13 +484,13 @@ class SwDataDefProps(ARObject):
             self.displayPresentation = value
         return self
 
-    def getStepSize(self) -> Optional[ARFloat]:
+    def getStepSize(self) -> Optional[Float]:
         """
         This attribute can be used to define a value which is added to or subtracted from the value of a DataPrototype when using up/down keys while calibrating.
         """
         return self.stepSize
 
-    def setStepSize(self, value: Optional[ARFloat]) -> "SwDataDefProps":
+    def setStepSize(self, value: Optional[Float]) -> "SwDataDefProps":
         """
         This attribute can be used to define a value which is added to or subtracted from the value of a DataPrototype when using up/down keys while calibrating. A None value is a no-op and does not overwrite an existing stepSize.
         """

--- a/src/armodel/parser/abstract_arxml_parser.py
+++ b/src/armodel/parser/abstract_arxml_parser.py
@@ -9,12 +9,12 @@ from colorama import Fore
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
-    ARFloat,
     ARLiteral,
     ARNumerical,
     ARType,
     Boolean,
     DateTime,
+    Float,
     Identifier,
     Integer,
     IntervalTypeEnum,
@@ -187,20 +187,20 @@ class AbstractARXMLParser(ABC):
             return True
         return False
 
-    def getChildElementOptionalFloatValue(self, element: ET.Element, key: str) -> ARFloat:
+    def getChildElementOptionalFloatValue(self, element: ET.Element, key: str) -> Float:
         child_element = self.find(element, key)
         float_value = None
         if (child_element is not None) and (child_element.text is not None):
-            float_value = ARFloat()
+            float_value = Float()
             self.readARType(child_element, float_value)
             float_value.setValue(child_element.text)
         return float_value
 
-    def getChildElementFloatValueList(self, element: ET.Element, key: str) -> ARFloat:
+    def getChildElementFloatValueList(self, element: ET.Element, key: str) -> Float:
         child_elements = self.findall(element, key)
         results = []
         for child_element in child_elements:
-            float_value = ARFloat()
+            float_value = Float()
             float_value.setValue(child_element.text)
             results.append(float_value)
         return results

--- a/src/armodel/writer/abstract_arxml_writer.py
+++ b/src/armodel/writer/abstract_arxml_writer.py
@@ -9,12 +9,12 @@ from colorama import Fore
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
-    ARBoolean,
-    ARFloat,
     ARLiteral,
     ARNumerical,
     ARType,
+    Boolean,
     DateTime,
+    Float,
     Identifier,
     Integer,
     Numerical,
@@ -129,7 +129,7 @@ class AbstractARXMLWriter(ABC):
             if ref.value is not None:
                 child_tag.text = ref.value
 
-    def setChildElementOptionalFloatValue(self, element: ET.Element, key: str, value: ARFloat):
+    def setChildElementOptionalFloatValue(self, element: ET.Element, key: str, value: Float):
         if value is not None:
             child_element = ET.SubElement(element, key)
             self.writeARType(child_element, value)
@@ -138,7 +138,7 @@ class AbstractARXMLWriter(ABC):
     def setChildElementOptionalTimeValue(self, element: ET.Element, key: str, value: TimeValue):
         self.setChildElementOptionalFloatValue(element, key, value)
 
-    def setChildElementOptionalBooleanValue(self, element: ET.Element, key: str, value: ARBoolean) -> ET.Element:
+    def setChildElementOptionalBooleanValue(self, element: ET.Element, key: str, value: Boolean) -> ET.Element:
         if value is not None:
             child_element = ET.SubElement(element, key)
             self.writeARType(child_element, value)

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswBehavior.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/test_BswBehavior.py
@@ -50,7 +50,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration import M
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import BswMgrNeeds, RoleBasedDataAssignment, SymbolicNameProps
 from armodel.models.M2.AUTOSARTemplates.DiagnosticExtract.DiagnosticMapping.ServiceMapping import BswServiceDependencyIdent
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Referrable
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARFloat, ARNumerical, Identifier, PositiveInteger, RefType, TimeValue
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARNumerical, Float, Identifier, PositiveInteger, RefType, TimeValue
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.ServiceMapping import RoleBasedDataTypeAssignment
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwImplPolicyEnum
 
@@ -1005,7 +1005,7 @@ class TestBswModeSwitchAckRequest:
     def test_set_timeout(self):
         ack_request = BswModeSwitchAckRequest()
 
-        timeout = ARFloat()
+        timeout = Float()
         timeout.setValue(5.0)
         result = ack_request.setTimeout(timeout)
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_ImplementationDataTypes.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/CommonStructure/test_ImplementationDataTypes.py
@@ -8,7 +8,7 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes 
     ImplementationDataType,
     ImplementationDataTypeElement,
 )
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, ARLiteral, ARNumerical, Boolean, NameToken, String
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, ARNumerical, Boolean, NameToken, String
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Components import SymbolProps
 from armodel.models.M2.MSR.DataDictionary.DataDefProperties import SwDataDefProps
 
@@ -171,7 +171,7 @@ class TestImplementationDataTypeElement:
         parent = AUTOSAR.getInstance()
         ar_root = parent.createARPackage("AUTOSAR")
         element = ImplementationDataTypeElement(ar_root, "TestElement")
-        test_value = ARBoolean().setValue(True)
+        test_value = Boolean().setValue(True)
         result = element.setIsOptional(test_value)
         assert result is element
         assert element.getIsOptional() == test_value
@@ -253,7 +253,7 @@ class TestImplementationDataTypeElement:
         element.setArraySize(ARNumerical().setValue(10))
         element.setArraySizeHandling(ARLiteral().setValue("HANDLING"))
         element.setArraySizeSemantics(ARLiteral().setValue("FIXED-SIZE"))
-        element.setIsOptional(ARBoolean().setValue(True))
+        element.setIsOptional(Boolean().setValue(True))
         element.setSwDataDefProps(SwDataDefProps())
 
         # Verify all properties are set

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_PrimitiveTypes.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/test_PrimitiveTypes.py
@@ -9,13 +9,10 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     AlignmentType,
     AnyServiceInstanceId,
     AnyVersionString,
-    ARBoolean,
     AREnum,
-    ARFloat,
     ArgumentDirectionEnum,
     ARLiteral,
     ARNumerical,
-    ARPositiveInteger,
     ARType,
     Boolean,
     ByteOrderEnum,
@@ -185,16 +182,16 @@ class TestARNumerical:
         assert numerical.getShortLabel() == "TestLabel"
 
 
-class TestARFloat:
+class TestFloat:
     """
-    Test class for ARFloat functionality.
+    Test class for Float functionality.
     """
 
     def test_initialization(self):
         """
-        Test ARFloat initialization.
+        Test Float initialization.
         """
-        ar_float = ARFloat()
+        ar_float = Float()
 
         # Verify basic properties
         assert ar_float is not None
@@ -205,7 +202,7 @@ class TestARFloat:
         """
         Test value property with float values.
         """
-        ar_float = ARFloat()
+        ar_float = Float()
 
         # Set float value
         ar_float.value = 42.5
@@ -216,7 +213,7 @@ class TestARFloat:
         """
         Test value property with integer values (should convert to float).
         """
-        ar_float = ARFloat()
+        ar_float = Float()
 
         # Set integer value
         ar_float.value = 42
@@ -227,29 +224,12 @@ class TestARFloat:
         """
         Test value property with string values.
         """
-        ar_float = ARFloat()
+        ar_float = Float()
 
         # Set string value that converts to float
         ar_float.value = "42.5"
         assert ar_float.value == 42.5
         assert str(ar_float) == "42.5"
-
-
-class TestFloat:
-    """
-    Test class for Float functionality.
-    """
-
-    def test_initialization(self):
-        """
-        Test Float initialization.
-        """
-        float_val = Float()
-
-        # Verify basic properties
-        assert float_val is not None
-        assert float_val._text is None
-        assert float_val._value is None
 
 
 class TestTimeValue:
@@ -527,164 +507,6 @@ class TestReferrableSubtypesEnum:
         assert enum._value is None
 
 
-class TestARPositiveInteger:
-    """
-    Test class for ARPositiveInteger functionality.
-    """
-
-    def test_initialization(self):
-        """
-        Test ARPositiveInteger initialization.
-        """
-        pos_int = ARPositiveInteger()
-
-        # Verify basic properties
-        assert pos_int is not None
-        assert pos_int.shortLabel is None
-        assert pos_int._text is None
-        assert pos_int._value is None
-
-    def test_value_property_positive(self):
-        """
-        Test value property with positive integer values.
-        """
-        pos_int = ARPositiveInteger()
-
-        # Set positive integer value
-        pos_int.value = 42
-        assert pos_int.value == 42
-        assert str(pos_int) == "42"
-
-    def test_value_property_string(self):
-        """
-        Test value property with string values.
-        """
-        pos_int = ARPositiveInteger()
-
-        # Set string value that converts to positive integer
-        pos_int.value = "42"
-        assert pos_int.value == 42
-        assert str(pos_int) == "42"
-
-    def test_negative_value_error(self):
-        """
-        Test that negative integer values raise an error.
-        """
-        pos_int = ARPositiveInteger()
-        try:
-            pos_int.value = -5
-            assert False, "Should raise ValueError for negative value"
-        except ValueError:
-            pass  # Expected behavior
-
-
-class TestARBoolean:
-    """
-    Test class for ARBoolean functionality.
-    """
-
-    def test_initialization(self):
-        """
-        Test ARBoolean initialization.
-        """
-        boolean = ARBoolean()
-
-        # Verify basic properties
-        assert boolean is not None
-        assert boolean._text is None
-        assert boolean._value is None
-
-    def test_value_property_bool(self):
-        """
-        Test value property with boolean values.
-        """
-        boolean = ARBoolean()
-
-        # Set boolean value
-        boolean.value = True
-        assert boolean.value is True
-        assert str(boolean) == "true"
-
-        boolean.value = False
-        assert boolean.value is False
-        assert str(boolean) == "false"
-
-    def test_value_property_int(self):
-        """
-        Test value property with integer values.
-        """
-        boolean = ARBoolean()
-
-        # Set integer value
-        boolean.value = 1
-        assert boolean.value is True
-        assert str(boolean) == "1"
-
-        boolean.value = 0
-        assert boolean.value is False
-        assert str(boolean) == "0"
-
-    def test_value_property_string(self):
-        """
-        Test value property with string values.
-        """
-        boolean = ARBoolean()
-
-        # Set string values that convert to boolean
-        boolean.value = "true"
-        assert boolean.value is True
-        assert str(boolean) == "true"
-
-        boolean.value = "false"
-        assert boolean.value is False
-        assert str(boolean) == "false"
-
-        boolean.value = "1"
-        assert boolean.value is True
-
-        boolean.value = "0"
-        assert boolean.value is False
-
-    def test_convert_number_to_boolean(self):
-        """
-        Test _convertNumberToBoolean method.
-        """
-        boolean = ARBoolean()
-
-        assert boolean._convertNumberToBoolean(0) is False
-        assert boolean._convertNumberToBoolean(1) is True
-        assert boolean._convertNumberToBoolean(42) is True
-
-    def test_convert_string_to_boolean(self):
-        """
-        Test _convertStringToBoolean method.
-        """
-        boolean = ARBoolean()
-
-        assert boolean._convertStringToBoolean("true") is True
-        assert boolean._convertStringToBoolean("TRUE") is True
-        assert boolean._convertStringToBoolean("1") is True
-        assert boolean._convertStringToBoolean("false") is False
-        assert boolean._convertStringToBoolean("FALSE") is False
-        assert boolean._convertStringToBoolean("0") is False
-
-
-class TestNameToken:
-    """
-    Test class for NameToken functionality.
-    """
-
-    def test_initialization(self):
-        """
-        Test NameToken initialization.
-        """
-        name_token = NameToken()
-
-        # Verify basic properties
-        assert name_token is not None
-        assert name_token._value is None
-
-
 class TestPositiveInteger:
     """
     Test class for PositiveInteger functionality.
@@ -701,6 +523,39 @@ class TestPositiveInteger:
         assert pos_int.shortLabel is None
         assert pos_int._text is None
         assert pos_int._value is None
+
+    def test_value_property_positive(self):
+        """
+        Test value property with positive integer values.
+        """
+        pos_int = PositiveInteger()
+
+        # Set positive integer value
+        pos_int.value = 42
+        assert pos_int.value == 42
+        assert str(pos_int) == "42"
+
+    def test_value_property_string(self):
+        """
+        Test value property with string values.
+        """
+        pos_int = PositiveInteger()
+
+        # Set string value that converts to positive integer
+        pos_int.value = "42"
+        assert pos_int.value == 42
+        assert str(pos_int) == "42"
+
+    def test_negative_value_error(self):
+        """
+        Test that negative integer values raise an error.
+        """
+        pos_int = PositiveInteger()
+        try:
+            pos_int.value = -5
+            assert False, "Should raise ValueError for negative value"
+        except ValueError:
+            pass  # Expected behavior
 
     def test_set_value_string(self):
         """Test setValue with decimal string round-trip and method chaining."""
@@ -731,6 +586,113 @@ class TestPositiveInteger:
         """Test that a negative value is rejected."""
         with pytest.raises(ValueError):
             PositiveInteger().setValue(-1)
+
+
+class TestBoolean:
+    """
+    Test class for Boolean functionality.
+    """
+
+    def test_initialization(self):
+        """
+        Test Boolean initialization.
+        """
+        boolean = Boolean()
+
+        # Verify basic properties
+        assert boolean is not None
+        assert boolean._text is None
+        assert boolean._value is None
+
+    def test_value_property_bool(self):
+        """
+        Test value property with boolean values.
+        """
+        boolean = Boolean()
+
+        # Set boolean value
+        boolean.value = True
+        assert boolean.value is True
+        assert str(boolean) == "true"
+
+        boolean.value = False
+        assert boolean.value is False
+        assert str(boolean) == "false"
+
+    def test_value_property_int(self):
+        """
+        Test value property with integer values.
+        """
+        boolean = Boolean()
+
+        # Set integer value
+        boolean.value = 1
+        assert boolean.value is True
+        assert str(boolean) == "1"
+
+        boolean.value = 0
+        assert boolean.value is False
+        assert str(boolean) == "0"
+
+    def test_value_property_string(self):
+        """
+        Test value property with string values.
+        """
+        boolean = Boolean()
+
+        # Set string values that convert to boolean
+        boolean.value = "true"
+        assert boolean.value is True
+        assert str(boolean) == "true"
+
+        boolean.value = "false"
+        assert boolean.value is False
+        assert str(boolean) == "false"
+
+        boolean.value = "1"
+        assert boolean.value is True
+
+        boolean.value = "0"
+        assert boolean.value is False
+
+    def test_convert_number_to_boolean(self):
+        """
+        Test _convertNumberToBoolean method.
+        """
+        boolean = Boolean()
+
+        assert boolean._convertNumberToBoolean(0) is False
+        assert boolean._convertNumberToBoolean(1) is True
+        assert boolean._convertNumberToBoolean(42) is True
+
+    def test_convert_string_to_boolean(self):
+        """
+        Test _convertStringToBoolean method.
+        """
+        boolean = Boolean()
+
+        assert boolean._convertStringToBoolean("true") is True
+        assert boolean._convertStringToBoolean("TRUE") is True
+        assert boolean._convertStringToBoolean("1") is True
+        assert boolean._convertStringToBoolean("false") is False
+        assert boolean._convertStringToBoolean("FALSE") is False
+        assert boolean._convertStringToBoolean("0") is False
+
+
+class TestNameToken:
+    """
+    Test class for NameToken functionality.
+    """
+
+    def test_initialization(self):
+        """
+        Test NameToken initialization.
+        """
+        name_token = NameToken()
+
+        # Verify basic properties
+        assert name_token is not None
+        assert name_token._value is None
 
 
 class TestIntervalTypeEnum:
@@ -1047,9 +1009,9 @@ class TestCIdentifier:
 
     def test_arfloat_unsupported_type(self):
         """
-        Test ARFloat with unsupported type to cover line 191.
+        Test Float with unsupported type to cover line 191.
         """
-        ar_float = ARFloat()
+        ar_float = Float()
 
         # Try to set value with unsupported type
         try:
@@ -1073,9 +1035,9 @@ class TestCIdentifier:
 
     def test_arpositiveinteger_unsupported_type(self):
         """
-        Test ARPositiveInteger with unsupported type to cover line 351.
+        Test PositiveInteger with unsupported type to cover line 351.
         """
-        pos_int = ARPositiveInteger()
+        pos_int = PositiveInteger()
 
         try:
             pos_int.value = object()  # object is not supported
@@ -1085,9 +1047,9 @@ class TestCIdentifier:
 
     def test_arboolean_unsupported_type(self):
         """
-        Test ARBoolean with unsupported type to cover line 413.
+        Test Boolean with unsupported type to cover line 413.
         """
-        boolean = ARBoolean()
+        boolean = Boolean()
 
         try:
             boolean.value = set([1, 2, 3])  # set is not supported
@@ -1097,9 +1059,9 @@ class TestCIdentifier:
 
     def test_arboolean_convert_string_to_boolean_invalid(self):
         """
-        Test ARBoolean _convertStringToBoolean with invalid string to cover line 395.
+        Test Boolean _convertStringToBoolean with invalid string to cover line 395.
         """
-        boolean = ARBoolean()
+        boolean = Boolean()
 
         # This should trigger the recursive call to convertNumberToBoolean with a string that needs to be converted to int first
         result = boolean._convertStringToBoolean("42")

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ApplicationAttributes/test_ApplicationAttributes.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ApplicationAttributes/test_ApplicationAttributes.py
@@ -1,6 +1,6 @@
 """Tests for the PortPrototype annotation classes (ApplicationAttributes)."""
 
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, ARLiteral, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARLiteral, Boolean, RefType
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
     ClientServerAnnotation,
     DataLimitKindEnum,
@@ -32,7 +32,7 @@ def _literal(text="val"):
 
 
 def _bool(value=True):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue("true" if value else "false")
     return b
 

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/test_Components.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/test_Components.py
@@ -6,7 +6,7 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.Implementation import ImplementationProps
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, CIdentifier, RefType, TRefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, CIdentifier, RefType, TRefType
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
     ClientServerAnnotation,
     DelegatedPortAnnotation,
@@ -176,7 +176,7 @@ class Test_M2_AUTOSARTemplates_SWComponentTemplate_Components:
         assert r_port.requiredInterfaceTRef is None
 
         # Test setters and getters
-        ar_bool = ARBoolean()
+        ar_bool = Boolean()
         ar_bool.setValue(True)
         r_port.setMayBeUnconnected(ar_bool)
         assert r_port.getMayBeUnconnected().getValue() is True

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/test___init__.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/test___init__.py
@@ -5,7 +5,7 @@ AUTOSAR SWComponentTemplate module.
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
-    ARBoolean,
+    Boolean,
     RefType,
     TRefType,
 )
@@ -181,7 +181,7 @@ class TestRPortPrototype:
 
     def test_get_set_mayBeUnconnected(self):
         obj = self._create_prototype()
-        value = ARBoolean()
+        value = Boolean()
         value.setValue(False)
         assert obj.setMayBeUnconnected(value) is obj
         assert obj.getMayBeUnconnected() == value

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/test_PortAPIOptions.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/test_PortAPIOptions.py
@@ -48,9 +48,9 @@ class TestPortAPIOption:
         assert port_api_option.transformerStatusForwarding is None
 
         # Test enableTakeAddress methods
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean
 
-        enable_take = ARBoolean()
+        enable_take = Boolean()
         enable_take.setValue(True)
         port_api_option.setEnableTakeAddress(enable_take)
         assert port_api_option.getEnableTakeAddress() == enable_take
@@ -61,7 +61,7 @@ class TestPortAPIOption:
         assert port_api_option.getErrorHandling() == error_handling
 
         # Test indirectAPI methods
-        indirect_api = ARBoolean()
+        indirect_api = Boolean()
         indirect_api.setValue(False)
         port_api_option.setIndirectAPI(indirect_api)
         assert port_api_option.getIndirectAPI() == indirect_api

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/test_SwcInternalBehavior.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/test_SwcInternalBehavior.py
@@ -142,9 +142,9 @@ class TestRunnableEntity:
         assert runnable.writtenLocalVariables == []
 
         # Test canBeInvokedConcurrently methods
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean
 
-        can_invoke = ARBoolean()
+        can_invoke = Boolean()
         can_invoke.setValue(True)
         runnable.setCanBeInvokedConcurrently(can_invoke)
         assert runnable.getCanBeInvokedConcurrently() == can_invoke

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_Communication.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_Communication.py
@@ -7,7 +7,7 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.CommonStructure import TextValueSpecification
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.Filter import DataFilter
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, ARPositiveInteger, PositiveInteger, RefType, TimeValue
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, PositiveInteger, RefType, TimeValue
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.Communication import (
     ClientComSpec,
     CompositeNetworkRepresentation,
@@ -172,7 +172,7 @@ class TestSenderComSpec:
         sender.setTransmissionProps(None)
         assert sender.getTransmissionProps() is transmission_props
 
-        uses_e2e = ARBoolean()
+        uses_e2e = Boolean()
         uses_e2e.setValue(True)
         assert sender.setUsesEndToEndProtection(uses_e2e) is sender
         assert sender.getUsesEndToEndProtection() is uses_e2e
@@ -304,7 +304,7 @@ class TestModeSwitchReceiverComSpec:
         assert receiver.supportsAsynchronousModeSwitch is None
 
         # Test setters and getters
-        api = ARBoolean()
+        api = Boolean()
         api.setValue(True)
         receiver.setEnhancedModeApi(api)
         assert receiver.getEnhancedModeApi() == api
@@ -314,7 +314,7 @@ class TestModeSwitchReceiverComSpec:
         receiver.setModeGroupRef(ref)
         assert receiver.getModeGroupRef() == ref
 
-        async_mode = ARBoolean()
+        async_mode = Boolean()
         async_mode.setValue(False)
         receiver.setSupportsAsynchronousModeSwitch(async_mode)
         assert receiver.getSupportsAsynchronousModeSwitch() == async_mode
@@ -414,7 +414,7 @@ class TestReceiverComSpec:
         receiver.setMaxNoNewOrRepeatedData(max_new)
         assert receiver.getMaxNoNewOrRepeatedData() == max_new
 
-        e2e = ARBoolean()
+        e2e = Boolean()
         e2e.setValue(True)
         receiver.setUsesEndToEndProtection(e2e)
         assert receiver.getUsesEndToEndProtection() == e2e
@@ -507,7 +507,7 @@ class TestModeSwitchSenderComSpec:
         assert sender.queueLength is None
 
         # Test setters and getters
-        api = ARBoolean()
+        api = Boolean()
         api.setValue(True)
         sender.setEnhancedModeApi(api)
         assert sender.getEnhancedModeApi() == api
@@ -521,7 +521,7 @@ class TestModeSwitchSenderComSpec:
         sender.setModeSwitchedAck(ack_request)
         assert sender.getModeSwitchedAck() == ack_request
 
-        queue_len = ARPositiveInteger()
+        queue_len = PositiveInteger()
         queue_len.setValue(5)
         sender.setQueueLength(queue_len)
         assert sender.getQueueLength() == queue_len
@@ -651,17 +651,17 @@ class TestEndToEndTransformationComSpecProps:
         assert e2e.windowSizeValid is None
 
         # Test setters and getters
-        clear_valid = ARBoolean()
+        clear_valid = Boolean()
         clear_valid.setValue(True)
         e2e.setClearFromValidToInvalid(clear_valid)
         assert e2e.getClearFromValidToInvalid() == clear_valid
 
-        disable_check = ARBoolean()
+        disable_check = Boolean()
         disable_check.setValue(False)
         e2e.setDisableEndToEndCheck(disable_check)
         assert e2e.getDisableEndToEndCheck() == disable_check
 
-        disable_sm = ARBoolean()
+        disable_sm = Boolean()
         disable_sm.setValue(True)
         e2e.setDisableEndToEndStateMachine(disable_sm)
         assert e2e.getDisableEndToEndStateMachine() == disable_sm
@@ -824,7 +824,7 @@ class TestNonqueuedReceiverComSpec:
         receiver.setAliveTimeout(alive_timeout)
         assert receiver.getAliveTimeout() == alive_timeout
 
-        enable_updated = ARBoolean()
+        enable_updated = Boolean()
         enable_updated.setValue(True)
         receiver.setEnableUpdate(enable_updated)
         assert receiver.getEnableUpdate() == enable_updated
@@ -835,12 +835,12 @@ class TestNonqueuedReceiverComSpec:
         receiver.setFilter(filter_value)
         assert receiver.getFilter() == filter_value
 
-        handle_data = ARBoolean()
+        handle_data = Boolean()
         handle_data.setValue(True)
         receiver.setHandleDataStatus(handle_data)
         assert receiver.getHandleDataStatus() == handle_data
 
-        handle_never = ARBoolean()
+        handle_never = Boolean()
         handle_never.setValue(False)
         receiver.setHandleNeverReceived(handle_never)
         assert receiver.getHandleNeverReceived() == handle_never
@@ -872,7 +872,7 @@ class TestNonqueuedReceiverComSpec:
     def test_enable_update_none_noop(self):
         """Test setEnableUpdate with None is a no-op."""
         receiver = NonqueuedReceiverComSpec()
-        enable = ARBoolean()
+        enable = Boolean()
         enable.setValue(True)
         receiver.setEnableUpdate(enable)
         receiver.setEnableUpdate(None)
@@ -935,7 +935,7 @@ class TestQueuedReceiverComSpec:
         assert receiver.queueLength is None
 
         # Test setters and getters
-        queue_len = ARPositiveInteger()
+        queue_len = PositiveInteger()
         queue_len.setValue(5)
         receiver.setQueueLength(queue_len)
         assert receiver.getQueueLength() == queue_len

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_Components.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/test_Components.py
@@ -254,9 +254,9 @@ class TestRPortPrototype:
         assert r_port.requiredInterfaceTRef is None
 
         # Test mayBeUnconnected methods
-        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean
+        from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean
 
-        may_be_unconnected = ARBoolean()
+        may_be_unconnected = Boolean()
         may_be_unconnected.setValue(True)
         r_port.setMayBeUnconnected(may_be_unconnected)
         assert r_port.getMayBeUnconnected() == may_be_unconnected

--- a/tests/test_armodel/models/M2/AUTOSARTemplates/test_ECUCDescriptionTemplate.py
+++ b/tests/test_armodel/models/M2/AUTOSARTemplates/test_ECUCDescriptionTemplate.py
@@ -20,7 +20,7 @@ from armodel.models.M2.AUTOSARTemplates.ECUCDescriptionTemplate import (
     EcucValueCollection,
 )
 from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import EcucConfigurationVariantEnum
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, Boolean, RefType, RevisionLabelString
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, RefType, RevisionLabelString
 from armodel.models.M2.MSR.Documentation.Annotation import Annotation
 
 
@@ -96,7 +96,7 @@ class TestEcucModuleConfigurationValues:
 
     def test_set_post_build_variant_used(self):
         obj = _instantiate(EcucModuleConfigurationValues, "EcucModuleConfigurationValues")
-        value = ARBoolean().setValue(True)
+        value = Boolean().setValue(True)
         result = obj.setPostBuildVariantUsed(value)
         assert result is obj
         assert obj.getPostBuildVariantUsed() == value

--- a/tests/test_armodel/models/M2/MSR/AsamHdo/test_Units.py
+++ b/tests/test_armodel/models/M2/MSR/AsamHdo/test_Units.py
@@ -3,7 +3,7 @@ This module contains tests for the Units module in MSR.AsamHdo.
 """
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage import ARPackage
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARFloat, ARNumerical, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARNumerical, Float, RefType
 from armodel.models.M2.MSR.AsamHdo.Units import (
     PhysicalDimension,
     SingleLanguageUnitNames,
@@ -151,7 +151,7 @@ class TestUnit:
     def test_unit_factor_si_to_unit_methods(self):
         """Test the factorSiToUnit getter and setter including None no-op."""
         unit = self._make()
-        factor = ARFloat()
+        factor = Float()
 
         result = unit.setFactorSiToUnit(factor)
         assert unit.getFactorSiToUnit() == factor
@@ -162,7 +162,7 @@ class TestUnit:
     def test_unit_offset_si_to_unit_methods(self):
         """Test the offsetSiToUnit getter and setter including None no-op."""
         unit = self._make()
-        offset = ARFloat()
+        offset = Float()
 
         result = unit.setOffsetSiToUnit(offset)
         assert unit.getOffsetSiToUnit() == offset

--- a/tests/test_armodel/models/M2/MSR/DataDictionary/test_CalibrationParameter.py
+++ b/tests/test_armodel/models/M2/MSR/DataDictionary/test_CalibrationParameter.py
@@ -4,7 +4,7 @@ This module contains tests for the CalibrationParameter module in MSR.DataDictio
 
 import pytest
 
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARFloat, DisplayFormatString, MonotonyEnum
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import DisplayFormatString, Float, MonotonyEnum
 from armodel.models.M2.MSR.DataDictionary.CalibrationParameter import (
     CalprmAxisCategoryEnum,
     SwCalprmAxis,
@@ -60,7 +60,7 @@ class TestSwCalprmAxisTypeProps:
                 super().__init__()
 
         props = ConcreteSwCalprmAxisTypeProps()
-        gradient = ARFloat()
+        gradient = Float()
         gradient.setValue(1.5)
         assert props.setMaxGradient(gradient) is props
         assert props.getMaxGradient() is gradient
@@ -88,7 +88,7 @@ class TestSwCalprmAxisTypeProps:
                 super().__init__()
 
         props = ConcreteSwCalprmAxisTypeProps()
-        gradient = ARFloat()
+        gradient = Float()
         gradient.setValue(1.5)
         props.setMaxGradient(gradient)
         monotony = MonotonyEnum()

--- a/tests/test_armodel/models/M2/MSR/DataDictionary/test_DataDefProperties.py
+++ b/tests/test_armodel/models/M2/MSR/DataDictionary/test_DataDefProperties.py
@@ -7,10 +7,10 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     AlignmentType,
-    ARFloat,
     ARNumerical,
     Boolean,
     DisplayFormatString,
+    Float,
     Identifier,
     Integer,
     NativeDeclarationString,
@@ -303,7 +303,7 @@ class TestSwDataDefProps:
 
     def test_sw_data_def_props_step_size_methods(self):
         sw_data_def_props = SwDataDefProps()
-        step_size = ARFloat().setValue("0.5")
+        step_size = Float().setValue("0.5")
         result = sw_data_def_props.setStepSize(step_size)
         assert sw_data_def_props.getStepSize() == step_size
         assert result == sw_data_def_props

--- a/tests/test_armodel/parser/test_arxml_parser_handlers.py
+++ b/tests/test_armodel/parser/test_arxml_parser_handlers.py
@@ -523,7 +523,7 @@ class TestDataTypeAndValueSpecHandlers:
         element = _snip("<SW-ARRAYSIZE><V>4</V></SW-ARRAYSIZE>", root_tag="PARENT")
         value_list = parser.getValueList(element, "SW-ARRAYSIZE")
         assert value_list is not None
-        # ValueList stores a single V (ARFloat).
+        # ValueList stores a single V (Float).
         assert value_list.getV() is not None
         assert float(value_list.getV().getValue()) == 4.0
 

--- a/tests/test_armodel/parser/test_port_prototype_annotations.py
+++ b/tests/test_armodel/parser/test_port_prototype_annotations.py
@@ -3,7 +3,7 @@
 import tempfile
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean, RefType
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean, RefType
 from armodel.models.M2.AUTOSARTemplates.SWComponentTemplate.ApplicationAttributes import (
     ClientServerAnnotation,
     DataLimitKindEnum,
@@ -31,7 +31,7 @@ def _ref(value, dest):
 
 
 def _bool(value):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue("true" if value else "false")
     return b
 

--- a/tests/test_armodel/writer/test_abstract_arxml_writer.py
+++ b/tests/test_armodel/writer/test_abstract_arxml_writer.py
@@ -7,13 +7,13 @@ import pytest
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Identifiable
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
-    ARBoolean,
-    ARFloat,
     ARLiteral,
     ARNumerical,
-    ARPositiveInteger,
+    Boolean,
     DateTime,
+    Float,
     Integer,
+    PositiveInteger,
     RefType,
     RevisionLabelString,
     TimeValue,
@@ -191,7 +191,7 @@ class TestAbstractARXMLWriter:
         """Test setChildElementOptionalPositiveInteger"""
         writer = ConcreteARXMLWriter()
         parent = ET.Element("parent")
-        pos_int = ARPositiveInteger()
+        pos_int = PositiveInteger()
         pos_int.setValue(100)
         pos_int._text = "100"  # Set the text attribute used by writer
 
@@ -280,7 +280,7 @@ class TestAbstractARXMLWriter:
         """Test setChildElementOptionalFloatValue"""
         writer = ConcreteARXMLWriter()
         parent = ET.Element("parent")
-        float_val = ARFloat()
+        float_val = Float()
         float_val.setValue(3.14)
 
         writer.setChildElementOptionalFloatValue(parent, "test-float", float_val)
@@ -304,7 +304,7 @@ class TestAbstractARXMLWriter:
         """Test setChildElementOptionalBooleanValue with True"""
         writer = ConcreteARXMLWriter()
         parent = ET.Element("parent")
-        bool_val = ARBoolean()
+        bool_val = Boolean()
         bool_val.setValue(True)
 
         result = writer.setChildElementOptionalBooleanValue(parent, "test-bool", bool_val)
@@ -317,7 +317,7 @@ class TestAbstractARXMLWriter:
         """Test setChildElementOptionalBooleanValue with False"""
         writer = ConcreteARXMLWriter()
         parent = ET.Element("parent")
-        bool_val = ARBoolean()
+        bool_val = Boolean()
         bool_val.setValue(False)
 
         writer.setChildElementOptionalBooleanValue(parent, "test-bool", bool_val)

--- a/tests/test_armodel/writer/test_arxml_writer.py
+++ b/tests/test_armodel/writer/test_arxml_writer.py
@@ -19,11 +19,11 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.Constants import (
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable import Referrable, ShortNameFragment
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
-    ARFloat,
     ARLiteral,
     ARNumerical,
     DateTime,
     DisplayFormatString,
+    Float,
     Identifier,
     IntervalTypeEnum,
     Limit,
@@ -725,8 +725,8 @@ class TestARXMLWriterValueSpecMethods:
         parent = ET.Element("parent")
 
         value_spec = NumericalValueSpecification()
-        # Use ARFloat instead of Compu
-        float_val = ARFloat()
+        # Use Float instead of Compu
+        float_val = Float()
         float_val.setValue(123.45)
         float_val._text = "123.45"  # Set internal text representation
         value_spec.setValue(float_val)
@@ -949,7 +949,7 @@ class TestARXMLWriterSwCalprmAxisMethods:
     def _build_individual_axis(self) -> SwCalprmAxis:
         axis = SwCalprmAxis()
         props = SwAxisIndividual()
-        gradient = ARFloat()
+        gradient = Float()
         gradient.setValue(2.5)
         props.setMaxGradient(gradient)
         monotony = MonotonyEnum()
@@ -1080,7 +1080,7 @@ class TestARXMLWriterSwSystemconstantValueSetMethods:
         ref.setValue("/Constants/MySystemConstant")
         value.setSwSystemconstRef(ref)
 
-        num = ARFloat()
+        num = Float()
         num.setValue(42)
         num._text = "42"
         value.setValue(num)

--- a/tests/test_armodel/writer/test_writer_arpackage_dispatch.py
+++ b/tests/test_armodel/writer/test_writer_arpackage_dispatch.py
@@ -11,8 +11,8 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     ReferenceBase,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
-    ARBoolean,
     ARLiteral,
+    Boolean,
     RefType,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.VariantHandling import PostBuildVariantCriterion
@@ -47,7 +47,7 @@ def _literal(text):
 
 
 def _boolean(val):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue(val)
     return b
 

--- a/tests/test_armodel/writer/test_writer_bsw_module.py
+++ b/tests/test_armodel/writer/test_writer_bsw_module.py
@@ -24,9 +24,9 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import (
     SymbolicNameProps,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa E501
-    ARBoolean,
     ARLiteral,
     ARNumerical,
+    Boolean,
     CIdentifier,
     PositiveInteger,
     RefType,
@@ -71,7 +71,7 @@ def _literal(value):
 
 
 def _bool(value):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue(value)
     return b
 
@@ -826,7 +826,7 @@ class TestWriterBswServiceDependency:
 
         dependency = BswServiceDependency()
         needs = DiagnosticIoControlNeeds(dependency, "needs")
-        needs.setFreezeCurrentStateSupported(ARBoolean().setValue(True))
+        needs.setFreezeCurrentStateSupported(Boolean().setValue(True))
         dependency.setServiceNeeds(needs)
 
         parent = _parent()

--- a/tests/test_armodel/writer/test_writer_controllers_ecu.py
+++ b/tests/test_armodel/writer/test_writer_controllers_ecu.py
@@ -6,8 +6,8 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa E501
-    ARBoolean,
     ARLiteral,
+    Boolean,
     Float,
     Integer,
     PositiveInteger,
@@ -58,7 +58,7 @@ def _literal(value):
 
 
 def _bool(value):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue(value)
     return b
 

--- a/tests/test_armodel/writer/test_writer_data_types.py
+++ b/tests/test_armodel/writer/test_writer_data_types.py
@@ -19,9 +19,9 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure import (
     TextValueSpecification,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
-    ARFloat,
     ARLiteral,
     ARNumerical,
+    Float,
     Identifier,
     Integer,
     IntervalTypeEnum,
@@ -113,7 +113,7 @@ def _verbatim(text):
 
 
 def _float(text):
-    num = ARFloat()
+    num = Float()
     num.value = text
     return num
 

--- a/tests/test_armodel/writer/test_writer_ecuc_def.py
+++ b/tests/test_armodel/writer/test_writer_ecuc_def.py
@@ -15,8 +15,8 @@ from armodel.models.M2.AUTOSARTemplates.ECUCParameterDefTemplate import (
     EcucValueConfigurationClass,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa E501
-    ARBoolean,
     ARLiteral,
+    Boolean,
     CIdentifier,
     Float,
     IntervalTypeEnum,
@@ -63,7 +63,7 @@ def _literal(value):
 
 
 def _bool(value):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue(value)
     return b
 

--- a/tests/test_armodel/writer/test_writer_ecuc_values_variant.py
+++ b/tests/test_armodel/writer/test_writer_ecuc_values_variant.py
@@ -17,7 +17,6 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     AnyInstanceRef,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa E501
-    ARBoolean,
     ARLiteral,
     ARNumerical,
     Boolean,

--- a/tests/test_armodel/writer/test_writer_frame_channel.py
+++ b/tests/test_armodel/writer/test_writer_frame_channel.py
@@ -7,8 +7,8 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa: E501
-    ARBoolean,
     ARLiteral,
+    Boolean,
     Float,
     Identifier,
     Integer,
@@ -123,7 +123,7 @@ def _literal(text):
 
 
 def _boolean(val):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue(val)
     return b
 

--- a/tests/test_armodel/writer/test_writer_hw_lin_flexray_transform.py
+++ b/tests/test_armodel/writer/test_writer_hw_lin_flexray_transform.py
@@ -16,7 +16,6 @@ from armodel.models.M2.AUTOSARTemplates.EcuResourceTemplate.HwElementCategory im
     HwType,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa E501
-    ARBoolean,
     ARLiteral,
     ARNumerical,
     Boolean,
@@ -88,7 +87,7 @@ def _literal(value):
 
 
 def _bool(value):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue(value)
     return b
 

--- a/tests/test_armodel/writer/test_writer_impl_e2e_ports.py
+++ b/tests/test_armodel/writer/test_writer_impl_e2e_ports.py
@@ -25,8 +25,8 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa: E501
     AlignmentType,
-    ARBoolean,
     ARLiteral,
+    Boolean,
     CIdentifier,
     Identifier,
     PositiveInteger,
@@ -703,7 +703,7 @@ class TestWriteSenderReceiverInterface:
         autosar = AUTOSAR.getInstance()
         pkg = autosar.createARPackage("Pkg")
         sr = pkg.createSenderReceiverInterface("SR")
-        is_service = ARBoolean()
+        is_service = Boolean()
         is_service.setValue("true")
         sr.setIsService(is_service)
         sr.createDataElement("Elem")

--- a/tests/test_armodel/writer/test_writer_impl_types_ports.py
+++ b/tests/test_armodel/writer/test_writer_impl_types_ports.py
@@ -28,9 +28,9 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     AutosarEngineeringObject,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
-    ARBoolean,
-    ARFloat,
     ARLiteral,
+    Boolean,
+    Float,
     Integer,
     PositiveInteger,
     RefType,
@@ -89,13 +89,13 @@ def _make_literal(text):
 
 
 def _make_bool(text):
-    val = ARBoolean()
+    val = Boolean()
     val.setValue(text)
     return val
 
 
 def _make_float(num, text):
-    val = ARFloat()
+    val = Float()
     val.setValue(num)
     val._text = text
     return val

--- a/tests/test_armodel/writer/test_writer_nm.py
+++ b/tests/test_armodel/writer/test_writer_nm.py
@@ -7,11 +7,10 @@ import pytest
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject import ARObject
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa: E501
-    ARBoolean,
-    ARFloat,
     ARLiteral,
     ARNumerical,
-    ARPositiveInteger,
+    Boolean,
+    Float,
     Integer,
     PositiveInteger,
     RefType,
@@ -92,7 +91,7 @@ def _ref(val="/path/ref", dest=None, base=None):
 
 
 def _bool(val=True):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue(val)
     return b
 
@@ -122,13 +121,13 @@ def _pos_int(val=1):
 
 
 def _ar_pos_int(val=1):
-    i = ARPositiveInteger()
+    i = PositiveInteger()
     i.setValue(val)
     return i
 
 
 def _float(val=1.5):
-    f = ARFloat()
+    f = Float()
     f.setValue(val)
     return f
 

--- a/tests/test_armodel/writer/test_writer_nv_block.py
+++ b/tests/test_armodel/writer/test_writer_nv_block.py
@@ -45,9 +45,9 @@ def _ref(value):
 
 
 def _bool(value):
-    from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARBoolean
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Boolean
 
-    b = ARBoolean()
+    b = Boolean()
     b.setValue(value)
     return b
 

--- a/tests/test_armodel/writer/test_writer_pdu_secure_soad.py
+++ b/tests/test_armodel/writer/test_writer_pdu_secure_soad.py
@@ -7,9 +7,9 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
-    ARBoolean,
     ARLiteral,
     ARNumerical,
+    Boolean,
     Integer,
     PositiveInteger,
     RefType,
@@ -77,7 +77,7 @@ def _pos_int(text):
 
 
 def _bool(text):
-    val = ARBoolean()
+    val = Boolean()
     val.setValue(text)
     return val
 

--- a/tests/test_armodel/writer/test_writer_pdu_tp.py
+++ b/tests/test_armodel/writer/test_writer_pdu_tp.py
@@ -9,8 +9,8 @@ from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import (
     AUTOSAR,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa: E501
-    ARBoolean,
     ARLiteral,
+    Boolean,
     Integer,
     PositiveInteger,
     RefType,
@@ -87,7 +87,7 @@ def _time(text):
 
 
 def _bool(text):
-    val = ARBoolean()
+    val = Boolean()
     val.setValue(text)
     return val
 

--- a/tests/test_armodel/writer/test_writer_signals_diagnostic.py
+++ b/tests/test_armodel/writer/test_writer_signals_diagnostic.py
@@ -6,8 +6,8 @@ import pytest
 
 from armodel.models.M2.AUTOSARTemplates.AutosarTopLevelStructure import AUTOSAR
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa: E501
-    ARBoolean,
     ARLiteral,
+    Boolean,
     PositiveInteger,
     RefType,
     RevisionLabelString,
@@ -62,7 +62,7 @@ def _literal(value):
 
 
 def _bool(value):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue(value)
     return b
 

--- a/tests/test_armodel/writer/test_writer_sw_component.py
+++ b/tests/test_armodel/writer/test_writer_sw_component.py
@@ -16,11 +16,11 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure import (
 )
 from armodel.models.M2.AUTOSARTemplates.CommonStructure.Filter import DataFilter
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa: E501
-    ARBoolean,
-    ARFloat,
     ARLiteral,
     ARNumerical,
-    ARPositiveInteger,
+    Boolean,
+    Float,
+    PositiveInteger,
     RefType,
     String,
     TimeValue,
@@ -126,13 +126,13 @@ def _literal(text="val"):
 
 
 def _boolean(val=True):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue(val)
     return b
 
 
 def _positive_int(val=1):
-    i = ARPositiveInteger()
+    i = PositiveInteger()
     i.setValue(val)
     return i
 
@@ -150,7 +150,7 @@ def _numerical(val=1):
 
 
 def _float(val=1.5):
-    f = ARFloat()
+    f = Float()
     f.setValue(val)
     return f
 
@@ -913,7 +913,7 @@ class TestSwComponentTypeRoundTrip:
         r_tref.setValue("/If/SR")
         r_tref.setDest("SENDER-RECEIVER-INTERFACE")
         r_port.setRequiredInterfaceTRef(r_tref)
-        r_may_be_unconnected = ARBoolean()
+        r_may_be_unconnected = Boolean()
         r_may_be_unconnected.setValue(True)
         r_port.setMayBeUnconnected(r_may_be_unconnected)
         r_com_spec = ClientComSpec()

--- a/tests/test_armodel/writer/test_writer_sw_data_def_props.py
+++ b/tests/test_armodel/writer/test_writer_sw_data_def_props.py
@@ -8,12 +8,12 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure import TextValueSpecific
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.MultidimensionalTime import MultidimensionalTime
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     AlignmentType,
-    ARFloat,
     ARLiteral,
     ARNumerical,
     Boolean,
     CseCodeType,
     DisplayFormatString,
+    Float,
     Identifier,
     Integer,
     NativeDeclarationString,
@@ -50,7 +50,7 @@ class TestSwDataDefPropsRoundTrip:
         props.setAdditionalNativeTypeQualifier(NativeDeclarationString().setValue("volatile"))
         props.setSwInterpolationMethod(Identifier().setValue("linear"))
         props.setSwImplPolicy(SwImplPolicyEnum().setValue(SwImplPolicyEnum.STANDARD))
-        props.setStepSize(ARFloat().setValue("0.5"))
+        props.setStepSize(Float().setValue("0.5"))
         props.setSwIntendedResolution(ARNumerical().setValue("0.01"))
         props.setSwValueBlockSize(ARNumerical().setValue("10"))
         props.addSwValueBlockSizeMult(ARNumerical().setValue("2"))

--- a/tests/test_armodel/writer/test_writer_swc_behavior.py
+++ b/tests/test_armodel/writer/test_writer_swc_behavior.py
@@ -15,8 +15,8 @@ from armodel.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds import (
     RoleBasedDataAssignment,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa E501
-    ARBoolean,
     ARLiteral,
+    Boolean,
     Integer,
     PositiveInteger,
     RefType,
@@ -106,7 +106,7 @@ def _time(value):
 
 
 def _bool(value):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue(value)
     return b
 

--- a/tests/test_armodel/writer/test_writer_system_mapping.py
+++ b/tests/test_armodel/writer/test_writer_system_mapping.py
@@ -15,10 +15,10 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
     AnyInstanceRef,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (  # noqa: E501
-    ARBoolean,
     ARLiteral,
     ARNumerical,
-    ARPositiveInteger,
+    Boolean,
+    PositiveInteger,
     RefType,
     RevisionLabelString,
 )
@@ -91,13 +91,13 @@ def _revision(value):
 
 
 def _boolean(val=True):
-    b = ARBoolean()
+    b = Boolean()
     b.setValue(val)
     return b
 
 
 def _positive_int(val=1):
-    i = ARPositiveInteger()
+    i = PositiveInteger()
     i.setValue(str(val))
     return i
 

--- a/tests/test_armodel/writer/test_writer_value_group.py
+++ b/tests/test_armodel/writer/test_writer_value_group.py
@@ -38,10 +38,10 @@ def _build_value_group():
     vg.setLabel(label)
 
     contents = SwValues()
-    from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARFloat
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Float
 
-    contents.addV(ARFloat().setValue(1.5))
-    contents.addV(ARFloat().setValue(2.5))
+    contents.addV(Float().setValue(1.5))
+    contents.addV(Float().setValue(2.5))
     vg.setVgContents(contents)
     return vg
 
@@ -83,11 +83,11 @@ def test_write_value_group_none_is_noop(writer):
 
 
 def test_write_sw_values_with_nested_vg_round_trip(writer):
-    from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import ARFloat
+    from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import Float
     from armodel.parser.arxml_parser import ARXMLParser
 
     sw_values = SwValues()
-    sw_values.addV(ARFloat().setValue(0.0))
+    sw_values.addV(Float().setValue(0.0))
     sw_values.setVg(_build_value_group())
 
     parent = _parent()


### PR DESCRIPTION
## Summary
- Replace ARBoolean/ARFloat/ARPositiveInteger with Boolean/Float/PositiveInteger as the real classes (inheritance inverted so standard names carry the implementation); former empty-shell subclasses removed
- Update all references across src, tests and scripts; merge duplicated test classes that previously tested the shell/implement pairs separately
- Keep ARLiteral, ARNumerical, AREnum, ARType (no corresponding standard simple-type names)
- Sync method_deviation_by_class_v2.md (mayBeUnconnected deviation resolved by the rename)

## Test plan
- [x] `uv run pytest -q --no-cov` — 8291 passed (2 fewer: duplicated test_initialization deduped)
- [x] `npm run lint` — ruff clean
- [x] `npm run black-check` — 784 files unchanged